### PR TITLE
change default stream size

### DIFF
--- a/src/common/raft/raft_utils.h
+++ b/src/common/raft/raft_utils.h
@@ -53,13 +53,13 @@ inline auto raft_mutex = std::mutex{};
 struct gpu_resources {
     gpu_resources(std::optional<std::size_t> streams_per_device = std::nullopt)
         : streams_per_device_{streams_per_device.value_or([]() {
-              auto result = std::size_t{1};
+              auto result = std::size_t{16};
               if (auto* env_str = std::getenv("KNOWHERE_STREAMS_PER_GPU")) {
                   auto str_stream = std::stringstream{env_str};
                   str_stream >> result;
                   if (str_stream.fail() || result == std::size_t{0}) {
                       LOG_KNOWHERE_WARNING_ << "KNOWHERE_STREAMS_PER_GPU env variable should be a positive integer";
-                      result = std::size_t{1};
+                      result = std::size_t{16};
                   } else {
                       LOG_KNOWHERE_INFO_ << "streams per gpu set to " << result;
                   }


### PR DESCRIPTION
issue: #29 

The execution threads in the gpu thread pool share the stream in the stream pool, and if the user does not set the KNOWHERE_STREAMS_PER_GPU environment variable, the stream pool with a default size of 1 is too small.