### PR TITLE
Fix scann add_with_ids logic

### DIFF
--- a/thirdparty/faiss/faiss/IndexIVFPQFastScan.cpp
+++ b/thirdparty/faiss/faiss/IndexIVFPQFastScan.cpp
@@ -248,7 +248,7 @@ void IndexIVFPQFastScan::add_with_ids_impl(
                        size_t(i0),
                        size_t(i1));
             }
-            add_with_ids(i1 - i0, x + i0 * d, xids ? xids + i0 : nullptr);
+            add_with_ids_impl(i1 - i0, x + i0 * d, xids ? xids + i0 : nullptr);
         }
         return;
     }


### PR DESCRIPTION
related #44 
Test on glove-100 dataset, under the configuration of nlist=1024, nprobe=50, reorder_k=200, topk=100.
before this change, we get recall=0.3071
after this change, we get recall=0.9351