### PR TITLE
fix segment fault when use config load a list

### DIFF
--- a/include/knowhere/config.h
+++ b/include/knowhere/config.h
@@ -432,7 +432,7 @@ class Config {
 
                     return Status::type_conflict_in_json;
                 }
-                *ptr->val = CFG_LIST();
+                *ptr->val = CFG_LIST::value_type();
                 for (auto&& i : json[it.first]) {
                     ptr->val->value().push_back(i);
                 }


### PR DESCRIPTION
issue: #46

if code run at this line, will cause segment fault, val got a empty std::optional<list<int>>.