### PR TITLE
fix search on out-of-range id

### DIFF
--- a/include/knowhere/bitsetview.h
+++ b/include/knowhere/bitsetview.h
@@ -50,7 +50,8 @@ class BitsetView {
 
     bool
     test(int64_t index) const {
-        return bits_[index >> 3] & (0x1 << (index & 0x7));
+        // when index is larger than the max_offset, ignore it
+        return (index >= static_cast<int64_t>(num_bits_)) || (bits_[index >> 3] & (0x1 << (index & 0x7)));
     }
 
     size_t


### PR DESCRIPTION
#70 
fix the bug by ignoring all ids beyond the bitset size limit.