### PR TITLE
Add iterator support to HNSW index

### DIFF
--- a/include/knowhere/bitsetview.h
+++ b/include/knowhere/bitsetview.h
@@ -98,7 +98,7 @@ class BitsetView {
 
  private:
     const uint8_t* bits_ = nullptr;
-    const size_t num_bits_ = 0;
+    size_t num_bits_ = 0;
 };
 }  // namespace knowhere
 

--- a/include/knowhere/bitsetview.h
+++ b/include/knowhere/bitsetview.h
@@ -98,7 +98,7 @@ class BitsetView {
 
  private:
     const uint8_t* bits_ = nullptr;
-    size_t num_bits_ = 0;
+    const size_t num_bits_ = 0;
 };
 }  // namespace knowhere
 

--- a/include/knowhere/comp/index_param.h
+++ b/include/knowhere/comp/index_param.h
@@ -80,6 +80,7 @@ constexpr const char* WITH_RAW_DATA = "with_raw_data";
 constexpr const char* EFCONSTRUCTION = "efConstruction";
 constexpr const char* HNSW_M = "M";
 constexpr const char* EF = "ef";
+constexpr const char* SEED_EF = "seed_ef";
 constexpr const char* OVERVIEW_LEVELS = "overview_levels";
 }  // namespace indexparam
 

--- a/include/knowhere/config.h
+++ b/include/knowhere/config.h
@@ -62,6 +62,7 @@ enum PARAM_TYPE {
     FEDER = 1 << 3,
     DESERIALIZE = 1 << 4,
     DESERIALIZE_FROM_FILE = 1 << 5,
+    ITERATOR = 1 << 6,
 };
 
 template <>
@@ -226,6 +227,12 @@ class EntryAccess {
     EntryAccess&
     for_range_search() {
         entry->type |= PARAM_TYPE::RANGE_SEARCH;
+        return *this;
+    }
+
+    EntryAccess&
+    for_iterator() {
+        entry->type |= PARAM_TYPE::ITERATOR;
         return *this;
     }
 
@@ -538,6 +545,11 @@ class BaseConfig : public Config {
 
     virtual Status
     CheckAndAdjustForRangeSearch() {
+        return Status::success;
+    }
+
+    virtual Status
+    CheckAndAdjustForIterator() {
         return Status::success;
     }
 

--- a/include/knowhere/index.h
+++ b/include/knowhere/index.h
@@ -127,6 +127,9 @@ class Index {
     expected<DataSetPtr>
     Search(const DataSet& dataset, const Json& json, const BitsetView& bitset) const;
 
+    expected<std::vector<std::shared_ptr<IndexNode::iterator>>>
+    AnnIterator(const DataSet& dataset, const Json& json, const BitsetView& bitset) const;
+
     expected<DataSetPtr>
     RangeSearch(const DataSet& dataset, const Json& json, const BitsetView& bitset) const;
 

--- a/include/knowhere/index_node.h
+++ b/include/knowhere/index_node.h
@@ -38,6 +38,22 @@ class IndexNode : public Object {
     virtual expected<DataSetPtr>
     Search(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const = 0;
 
+    // not thread safe.
+    class iterator {
+     public:
+        virtual std::pair<int64_t, float>
+        Next() = 0;
+        [[nodiscard]] virtual bool
+        HasNext() const = 0;
+        virtual ~iterator() {
+        }
+    };
+
+    virtual expected<std::vector<std::shared_ptr<iterator>>>
+    AnnIterator(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const {
+        throw std::runtime_error("annIterator not supported for current index type");
+    }
+
     virtual expected<DataSetPtr>
     RangeSearch(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const = 0;
 

--- a/include/knowhere/prometheus_client.h
+++ b/include/knowhere/prometheus_client.h
@@ -76,8 +76,10 @@ extern const std::unique_ptr<PrometheusClient> prometheusClient;
 
 DECLARE_PROMETHEUS_COUNTER(knowhere_build_count);
 DECLARE_PROMETHEUS_COUNTER(knowhere_search_count);
+DECLARE_PROMETHEUS_COUNTER(knowhere_ann_iterator_count);
 DECLARE_PROMETHEUS_COUNTER(knowhere_range_search_count);
 DECLARE_PROMETHEUS_HISTOGRAM(knowhere_search_topk);
 DECLARE_PROMETHEUS_HISTOGRAM(knowhere_search_latency);
+DECLARE_PROMETHEUS_HISTOGRAM(knowhere_ann_iterator_init_latency);
 DECLARE_PROMETHEUS_HISTOGRAM(knowhere_range_search_latency);
 }  // namespace knowhere

--- a/src/common/prometheus_client.cc
+++ b/src/common/prometheus_client.cc
@@ -27,9 +27,11 @@ const std::unique_ptr<PrometheusClient> prometheusClient = std::make_unique<Prom
  ******************************************************************************/
 DEFINE_PROMETHEUS_COUNTER(knowhere_build_count, "knowhere index build count")
 DEFINE_PROMETHEUS_COUNTER(knowhere_search_count, "knowhere search count")
+DEFINE_PROMETHEUS_COUNTER(knowhere_ann_iterator_count, "knowhere ann iterator count")
 DEFINE_PROMETHEUS_COUNTER(knowhere_range_search_count, "knowhere range search count")
 DEFINE_PROMETHEUS_HISTOGRAM(knowhere_search_topk, "knowhere search topk")
 DEFINE_PROMETHEUS_HISTOGRAM(knowhere_search_latency, "search latency in knowhere (ms)")
+DEFINE_PROMETHEUS_HISTOGRAM(knowhere_ann_iterator_init_latency, "ann iterator init latency in knowhere (ms)")
 DEFINE_PROMETHEUS_HISTOGRAM(knowhere_range_search_latency, "range search latency in knowhere (ms)")
 
 }  // namespace knowhere

--- a/src/index/hnsw/hnsw.cc
+++ b/src/index/hnsw/hnsw.cc
@@ -165,8 +165,7 @@ class HnswIndexNode : public IndexNode {
                  const BitsetView& bitset, const bool for_tuning = false, const size_t seed_ef = kIteratorSeedEf)
             : index_(index),
               transform_(transform),
-              bitset_(bitset),
-              workspace_(index_->getIteratorWorkspace(query, seed_ef, for_tuning)) {
+              workspace_(index_->getIteratorWorkspace(query, seed_ef, for_tuning, bitset)) {
             UpdateNext();
         }
 
@@ -185,7 +184,7 @@ class HnswIndexNode : public IndexNode {
      private:
         void
         UpdateNext() {
-            auto next = index_->getIteratorNext(workspace_.get(), bitset_);
+            auto next = index_->getIteratorNext(workspace_.get());
             if (next.has_value()) {
                 auto [dist, id] = next.value();
                 next_dist_ = transform_ ? (-dist) : dist;
@@ -197,7 +196,6 @@ class HnswIndexNode : public IndexNode {
         }
         const hnswlib::HierarchicalNSW<float>* index_;
         const bool transform_;
-        const BitsetView bitset_;
         std::unique_ptr<hnswlib::IteratorWorkspace> workspace_;
         bool has_next_;
         float next_dist_;

--- a/src/index/hnsw/hnsw_config.h
+++ b/src/index/hnsw/hnsw_config.h
@@ -79,14 +79,6 @@ class HnswConfig : public BaseConfig {
         }
         return Status::success;
     }
-
-    inline Status
-    CheckAndAdjustForIterator() override {
-        if (!seed_ef.has_value()) {
-            seed_ef = kIteratorSeedEf;
-        }
-        return Status::success;
-    }
 };
 
 }  // namespace knowhere

--- a/src/index/hnsw/hnsw_config.h
+++ b/src/index/hnsw/hnsw_config.h
@@ -19,6 +19,7 @@ namespace knowhere {
 
 namespace {
 
+constexpr const CFG_INT::value_type kIteratorSeedEf = 40;
 constexpr const CFG_INT::value_type kEfMinValue = 16;
 constexpr const CFG_INT::value_type kDefaultRangeSearchEf = 16;
 
@@ -29,6 +30,7 @@ class HnswConfig : public BaseConfig {
     CFG_INT M;
     CFG_INT efConstruction;
     CFG_INT ef;
+    CFG_INT seed_ef;
     CFG_INT overview_levels;
     KNOHWERE_DECLARE_CONFIG(HnswConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(M).description("hnsw M").set_default(30).set_range(1, 2048).for_train();
@@ -43,6 +45,11 @@ class HnswConfig : public BaseConfig {
             .set_range(1, std::numeric_limits<CFG_INT::value_type>::max())
             .for_search()
             .for_range_search();
+        KNOWHERE_CONFIG_DECLARE_FIELD(seed_ef)
+            .description("hnsw seed_ef when using iterator")
+            .set_default(kIteratorSeedEf)
+            .set_range(1, std::numeric_limits<CFG_INT::value_type>::max())
+            .for_iterator();
         KNOWHERE_CONFIG_DECLARE_FIELD(overview_levels)
             .description("hnsw overview levels for feder")
             .set_default(3)
@@ -69,6 +76,14 @@ class HnswConfig : public BaseConfig {
         if (!ef.has_value()) {
             // if ef is not set by user, set it to default
             ef = kDefaultRangeSearchEf;
+        }
+        return Status::success;
+    }
+
+    inline Status
+    CheckAndAdjustForIterator() override {
+        if (!seed_ef.has_value()) {
+            seed_ef = kIteratorSeedEf;
         }
         return Status::success;
     }

--- a/tests/ut/test_iterator.cc
+++ b/tests/ut/test_iterator.cc
@@ -1,0 +1,189 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#include "catch2/catch_approx.hpp"
+#include "catch2/catch_test_macros.hpp"
+#include "catch2/generators/catch_generators.hpp"
+#include "faiss/utils/binary_distances.h"
+#include "hnswlib/hnswalg.h"
+#include "knowhere/bitsetview.h"
+#include "knowhere/comp/brute_force.h"
+#include "knowhere/comp/index_param.h"
+#include "knowhere/comp/knowhere_config.h"
+#include "knowhere/factory.h"
+#include "knowhere/log.h"
+#include "utils.h"
+
+namespace {
+constexpr float kKnnRecallThreshold = 0.6f;
+constexpr float kBruteForceRecallThreshold = 0.99f;
+
+knowhere::DataSetPtr
+GetKNNResult(const std::vector<std::shared_ptr<knowhere::IndexNode::iterator>>& iterators, int k) {
+    int nq = iterators.size();
+    auto p_id = new int64_t[nq * k];
+    auto p_dist = new float[nq * k];
+    for (int i = 0; i < nq; ++i) {
+        auto& iter = iterators[i];
+        for (int j = 0; j < k; ++j) {
+            REQUIRE(iter->HasNext());
+            auto [id, dist] = iter->Next();
+            p_id[i * k + j] = id;
+            p_dist[i * k + j] = dist;
+        }
+    }
+    return knowhere::GenResultDataSet(nq, k, p_id, p_dist);
+}
+}  // namespace
+
+// use kNN search to test the correctness of iterator
+TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
+    using Catch::Approx;
+
+    const int64_t nb = 1000, nq = 10;
+    const int64_t dim = 128;
+    const int64_t topk = 5;
+
+    auto metric = GENERATE(as<std::string>{}, knowhere::metric::L2, knowhere::metric::COSINE);
+
+    auto base_gen = [&]() {
+        knowhere::Json json;
+        json[knowhere::meta::DIM] = dim;
+        json[knowhere::meta::METRIC_TYPE] = metric;
+        json[knowhere::meta::TOPK] = topk;
+        return json;
+    };
+
+    auto hnsw_gen = [&base_gen]() {
+        knowhere::Json json = base_gen();
+        json[knowhere::indexparam::HNSW_M] = 128;
+        json[knowhere::indexparam::EFCONSTRUCTION] = 200;
+        json[knowhere::indexparam::SEED_EF] = 64;
+        return json;
+    };
+
+    const auto train_ds = GenDataSet(nb, dim);
+    const auto query_ds = GenDataSet(nq, dim);
+
+    const knowhere::Json conf = {
+        {knowhere::meta::METRIC_TYPE, metric},
+        {knowhere::meta::TOPK, topk},
+    };
+    auto gt = knowhere::BruteForce::Search(train_ds, query_ds, conf, nullptr);
+
+    SECTION("Test Search using iterator") {
+        using std::make_tuple;
+        auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
+            make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),
+        }));
+        auto idx = knowhere::IndexFactory::Instance().Create(name);
+        auto cfg_json = gen().dump();
+        CAPTURE(name, cfg_json);
+        knowhere::Json json = knowhere::Json::parse(cfg_json);
+        REQUIRE(idx.Type() == name);
+        REQUIRE(idx.Build(*train_ds, json) == knowhere::Status::success);
+        REQUIRE(idx.Size() > 0);
+        REQUIRE(idx.Count() == nb);
+
+        knowhere::BinarySet bs;
+        REQUIRE(idx.Serialize(bs) == knowhere::Status::success);
+        REQUIRE(idx.Deserialize(bs) == knowhere::Status::success);
+        auto its = idx.AnnIterator(*query_ds, json, nullptr);
+        REQUIRE(its.has_value());
+        auto results = GetKNNResult(its.value(), topk);
+        float recall = GetKNNRecall(*gt.value(), *results);
+        REQUIRE(recall > kKnnRecallThreshold);
+    }
+
+    SECTION("Test Search with Bitset using iterator") {
+        using std::make_tuple;
+        auto [name, gen, threshold] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>, float>({
+            make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen, hnswlib::kHnswSearchKnnBFThreshold),
+        }));
+        auto idx = knowhere::IndexFactory::Instance().Create(name);
+        auto cfg_json = gen().dump();
+        CAPTURE(name, cfg_json);
+        knowhere::Json json = knowhere::Json::parse(cfg_json);
+        REQUIRE(idx.Type() == name);
+        REQUIRE(idx.Build(*train_ds, json) == knowhere::Status::success);
+
+        std::vector<std::function<std::vector<uint8_t>(size_t, size_t)>> gen_bitset_funcs = {
+            GenerateBitsetWithFirstTbitsSet, GenerateBitsetWithRandomTbitsSet};
+        const auto bitset_percentages = {0.4f, 0.98f};
+        for (const float percentage : bitset_percentages) {
+            for (const auto& gen_func : gen_bitset_funcs) {
+                auto bitset_data = gen_func(nb, percentage * nb);
+                knowhere::BitsetView bitset(bitset_data.data(), nb);
+                // Iterator doesn't have a fallback to bruteforce mechanism at high filter rate.
+                auto its = idx.AnnIterator(*query_ds, json, bitset);
+                REQUIRE(its.has_value());
+                auto results = GetKNNResult(its.value(), topk);
+                auto gt = knowhere::BruteForce::Search(train_ds, query_ds, json, bitset);
+                float recall = GetKNNRecall(*gt.value(), *results);
+                REQUIRE(recall > kKnnRecallThreshold);
+            }
+        }
+    }
+}
+
+TEST_CASE("Test Iterator Mem Index With Binary Vector", "[float metrics]") {
+    using Catch::Approx;
+
+    const int64_t nb = 1000, nq = 10;
+    const int64_t dim = 1024;
+    const int64_t topk = 5;
+
+    auto metric = GENERATE(as<std::string>{}, knowhere::metric::HAMMING, knowhere::metric::JACCARD);
+    auto base_gen = [&]() {
+        knowhere::Json json;
+        json[knowhere::meta::DIM] = dim;
+        json[knowhere::meta::METRIC_TYPE] = metric;
+        json[knowhere::meta::TOPK] = topk;
+        return json;
+    };
+
+    auto hnsw_gen = [&base_gen]() {
+        knowhere::Json json = base_gen();
+        json[knowhere::indexparam::HNSW_M] = 128;
+        json[knowhere::indexparam::EFCONSTRUCTION] = 200;
+        json[knowhere::indexparam::SEED_EF] = 64;
+        return json;
+    };
+    const auto train_ds = GenDataSet(nb, dim);
+    const auto query_ds = GenDataSet(nq, dim);
+
+    const knowhere::Json conf = {
+        {knowhere::meta::METRIC_TYPE, metric},
+        {knowhere::meta::TOPK, topk},
+    };
+
+    auto gt = knowhere::BruteForce::Search(train_ds, query_ds, conf, nullptr);
+    SECTION("Test Search using iterator") {
+        using std::make_tuple;
+        auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
+            make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),
+        }));
+        auto idx = knowhere::IndexFactory::Instance().Create(name);
+        auto cfg_json = gen().dump();
+        CAPTURE(name, cfg_json);
+        knowhere::Json json = knowhere::Json::parse(cfg_json);
+        REQUIRE(idx.Type() == name);
+        REQUIRE(idx.Build(*train_ds, json) == knowhere::Status::success);
+        REQUIRE(idx.Size() > 0);
+        REQUIRE(idx.Count() == nb);
+
+        auto its = idx.AnnIterator(*query_ds, json, nullptr);
+        REQUIRE(its.has_value());
+        auto results = GetKNNResult(its.value(), topk);
+        float recall = GetKNNRecall(*gt.value(), *results);
+        REQUIRE(recall > kKnnRecallThreshold);
+    }
+}

--- a/tests/ut/test_iterator.cc
+++ b/tests/ut/test_iterator.cc
@@ -53,7 +53,7 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
 
     const int64_t nb = 1000, nq = 10;
     const int64_t dim = 128;
-    const int64_t topk = 5;
+    auto topk = GENERATE(5, 10, 20);
 
     auto metric = GENERATE(as<std::string>{}, knowhere::metric::L2, knowhere::metric::COSINE);
 
@@ -73,7 +73,7 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
         return json;
     };
 
-    auto rand = GENERATE(1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 100, 1000, 10000);
+    auto rand = GENERATE(1, 2, 3, 5);
 
     const auto train_ds = GenDataSet(nb, dim, rand);
     const auto query_ds = GenDataSet(nq, dim, rand + 777);
@@ -137,39 +137,38 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
             }
         }
     }
-    // TODO: this test is currently flaky: when filter rate is high, accumulative_alpha could cause some points
-    // to be unreachable and not returned.
-    // SECTION("Test Search with Bitset using iterator insufficient results") {
-    //     using std::make_tuple;
-    //     auto [name, gen, threshold] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>, float>({
-    //         make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen, hnswlib::kHnswSearchKnnBFThreshold),
-    //     }));
-    //     auto idx = knowhere::IndexFactory::Instance().Create(name);
-    //     auto cfg_json = gen().dump();
-    //     CAPTURE(name, cfg_json);
-    //     knowhere::Json json = knowhere::Json::parse(cfg_json);
-    //     REQUIRE(idx.Type() == name);
-    //     REQUIRE(idx.Build(*train_ds, json) == knowhere::Status::success);
 
-    //     std::vector<std::function<std::vector<uint8_t>(size_t, size_t)>> gen_bitset_funcs = {
-    //         GenerateBitsetWithFirstTbitsSet, GenerateBitsetWithRandomTbitsSet};
-    //     // we want topk but after filtering we have only half of topk points.
-    //     const auto filter_remaining = topk / 2;
-    //     for (const auto& gen_func : gen_bitset_funcs) {
-    //         auto bitset_data = gen_func(nb, nb - filter_remaining);
-    //         knowhere::BitsetView bitset(bitset_data.data(), nb);
-    //         auto its = idx.AnnIterator(*query_ds, json, bitset);
-    //         REQUIRE(its.has_value());
-    //         auto results = GetKNNResult(its.value(), filter_remaining, &bitset);
-    //         // after get those remaining points, iterator should return false for HasNext.
-    //         for (const auto& it : its.value()) {
-    //             REQUIRE(!it->HasNext());
-    //         }
-    //         auto gt = knowhere::BruteForce::Search(train_ds, query_ds, json, bitset);
-    //         float recall = GetKNNRecall(*gt.value(), *results);
-    //         REQUIRE(recall > kKnnRecallThreshold);
-    //     }
-    // }
+    SECTION("Test Search with Bitset using iterator insufficient results") {
+        using std::make_tuple;
+        auto [name, gen, threshold] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>, float>({
+            make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen, hnswlib::kHnswSearchKnnBFThreshold),
+        }));
+        auto idx = knowhere::IndexFactory::Instance().Create(name);
+        auto cfg_json = gen().dump();
+        CAPTURE(name, cfg_json);
+        knowhere::Json json = knowhere::Json::parse(cfg_json);
+        REQUIRE(idx.Type() == name);
+        REQUIRE(idx.Build(*train_ds, json) == knowhere::Status::success);
+
+        std::vector<std::function<std::vector<uint8_t>(size_t, size_t)>> gen_bitset_funcs = {
+            GenerateBitsetWithFirstTbitsSet, GenerateBitsetWithRandomTbitsSet};
+        // we want topk but after filtering we have only half of topk points.
+        const auto filter_remaining = topk / 2;
+        for (const auto& gen_func : gen_bitset_funcs) {
+            auto bitset_data = gen_func(nb, nb - filter_remaining);
+            knowhere::BitsetView bitset(bitset_data.data(), nb);
+            auto its = idx.AnnIterator(*query_ds, json, bitset);
+            REQUIRE(its.has_value());
+            auto results = GetKNNResult(its.value(), filter_remaining, &bitset);
+            // after get those remaining points, iterator should return false for HasNext.
+            for (const auto& it : its.value()) {
+                REQUIRE(!it->HasNext());
+            }
+            auto gt = knowhere::BruteForce::Search(train_ds, query_ds, json, bitset);
+            float recall = GetKNNRecall(*gt.value(), *results);
+            REQUIRE(recall > kKnnRecallThreshold);
+        }
+    }
 }
 
 TEST_CASE("Test Iterator Mem Index With Binary Vector", "[float metrics]") {

--- a/tests/ut/test_iterator.cc
+++ b/tests/ut/test_iterator.cc
@@ -137,38 +137,39 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
             }
         }
     }
+    // TODO: this test is currently flaky: when filter rate is high, accumulative_alpha could cause some points
+    // to be unreachable and not returned.
+    // SECTION("Test Search with Bitset using iterator insufficient results") {
+    //     using std::make_tuple;
+    //     auto [name, gen, threshold] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>, float>({
+    //         make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen, hnswlib::kHnswSearchKnnBFThreshold),
+    //     }));
+    //     auto idx = knowhere::IndexFactory::Instance().Create(name);
+    //     auto cfg_json = gen().dump();
+    //     CAPTURE(name, cfg_json);
+    //     knowhere::Json json = knowhere::Json::parse(cfg_json);
+    //     REQUIRE(idx.Type() == name);
+    //     REQUIRE(idx.Build(*train_ds, json) == knowhere::Status::success);
 
-    SECTION("Test Search with Bitset using iterator insufficient results") {
-        using std::make_tuple;
-        auto [name, gen, threshold] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>, float>({
-            make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen, hnswlib::kHnswSearchKnnBFThreshold),
-        }));
-        auto idx = knowhere::IndexFactory::Instance().Create(name);
-        auto cfg_json = gen().dump();
-        CAPTURE(name, cfg_json);
-        knowhere::Json json = knowhere::Json::parse(cfg_json);
-        REQUIRE(idx.Type() == name);
-        REQUIRE(idx.Build(*train_ds, json) == knowhere::Status::success);
-
-        std::vector<std::function<std::vector<uint8_t>(size_t, size_t)>> gen_bitset_funcs = {
-            GenerateBitsetWithFirstTbitsSet, GenerateBitsetWithRandomTbitsSet};
-        // we want topk but after filtering we have only half of topk points.
-        const auto filter_remaining = topk / 2;
-        for (const auto& gen_func : gen_bitset_funcs) {
-            auto bitset_data = gen_func(nb, nb - filter_remaining);
-            knowhere::BitsetView bitset(bitset_data.data(), nb);
-            auto its = idx.AnnIterator(*query_ds, json, bitset);
-            REQUIRE(its.has_value());
-            auto results = GetKNNResult(its.value(), filter_remaining, &bitset);
-            // after get those remaining points, iterator should return false for HasNext.
-            for (const auto& it : its.value()) {
-                REQUIRE(!it->HasNext());
-            }
-            auto gt = knowhere::BruteForce::Search(train_ds, query_ds, json, bitset);
-            float recall = GetKNNRecall(*gt.value(), *results);
-            REQUIRE(recall > kKnnRecallThreshold);
-        }
-    }
+    //     std::vector<std::function<std::vector<uint8_t>(size_t, size_t)>> gen_bitset_funcs = {
+    //         GenerateBitsetWithFirstTbitsSet, GenerateBitsetWithRandomTbitsSet};
+    //     // we want topk but after filtering we have only half of topk points.
+    //     const auto filter_remaining = topk / 2;
+    //     for (const auto& gen_func : gen_bitset_funcs) {
+    //         auto bitset_data = gen_func(nb, nb - filter_remaining);
+    //         knowhere::BitsetView bitset(bitset_data.data(), nb);
+    //         auto its = idx.AnnIterator(*query_ds, json, bitset);
+    //         REQUIRE(its.has_value());
+    //         auto results = GetKNNResult(its.value(), filter_remaining, &bitset);
+    //         // after get those remaining points, iterator should return false for HasNext.
+    //         for (const auto& it : its.value()) {
+    //             REQUIRE(!it->HasNext());
+    //         }
+    //         auto gt = knowhere::BruteForce::Search(train_ds, query_ds, json, bitset);
+    //         float recall = GetKNNRecall(*gt.value(), *results);
+    //         REQUIRE(recall > kKnnRecallThreshold);
+    //     }
+    // }
 }
 
 TEST_CASE("Test Iterator Mem Index With Binary Vector", "[float metrics]") {


### PR DESCRIPTION
This PR adds iterator support to HNSW index. Issue: #61.

* Add iterator interface in IndexNode
* Add iterator support to HNSW index
* Add `seed_ef` config
* Add an integration test that simulates kNN using iterator

/kind improvement