### PR TITLE
ScaNN support with_raw_data build option

### DIFF
--- a/include/knowhere/comp/index_param.h
+++ b/include/knowhere/comp/index_param.h
@@ -74,6 +74,7 @@ constexpr const char* NBITS = "nbits";  // PQ/SQ
 constexpr const char* M = "m";          // PQ param for IVFPQ
 constexpr const char* SSIZE = "ssize";
 constexpr const char* REORDER_K = "reorder_k";
+constexpr const char* WITH_RAW_DATA = "with_raw_data";
 
 // HNSW Params
 constexpr const char* EFCONSTRUCTION = "efConstruction";

--- a/src/index/ivf/ivf_config.h
+++ b/src/index/ivf/ivf_config.h
@@ -60,12 +60,17 @@ class IvfPqConfig : public IvfConfig {
 class ScannConfig : public IvfFlatConfig {
  public:
     CFG_INT reorder_k;
+    CFG_BOOL with_raw_data;
     KNOHWERE_DECLARE_CONFIG(ScannConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(reorder_k)
             .description("reorder k used for refining")
             .allow_empty_without_default()
             .set_range(1, std::numeric_limits<CFG_INT::value_type>::max())
             .for_search();
+        KNOWHERE_CONFIG_DECLARE_FIELD(with_raw_data)
+            .description("with raw data in index")
+            .set_default(true)
+            .for_train();
     }
 
     inline Status

--- a/tests/python/test_index_random.py
+++ b/tests/python/test_index_random.py
@@ -53,6 +53,7 @@ test_data = [
             "nlist": 1024,
             "nprobe": 1024,
             "reorder_k": 1500,
+            "with_raw_data": True,
         },
     ),
 ]

--- a/tests/python/test_index_with_random.py
+++ b/tests/python/test_index_with_random.py
@@ -43,6 +43,7 @@ test_data = [
             "nlist": 1024,
             "nprobe": 1024,
             "reorder_k": 1500,
+            "with_raw_data": True,
         },
     ),
     # (

--- a/tests/python/test_index_with_sift.py
+++ b/tests/python/test_index_with_sift.py
@@ -91,6 +91,7 @@ test_data = [
             "m": 64,
             "nbits": 4,
             "reorder_k": 1000,
+            "with_raw_data": True,
         }
     )
     (

--- a/tests/ut/test_get_vector.cc
+++ b/tests/ut/test_get_vector.cc
@@ -134,6 +134,14 @@ TEST_CASE("Test Float Get Vector By Ids", "[Float GetVectorByIds]") {
     auto scann_gen = [&ivfflat_gen]() {
         knowhere::Json json = ivfflat_gen();
         json[knowhere::indexparam::REORDER_K] = 10;
+        json[knowhere::indexparam::WITH_RAW_DATA] = true;
+        return json;
+    };
+
+    // without raw data, can not get vector from index
+    auto scann_gen2 = [&scann_gen]() {
+        knowhere::Json json = scann_gen();
+        json[knowhere::indexparam::WITH_RAW_DATA] = false;
         return json;
     };
 
@@ -148,6 +156,7 @@ TEST_CASE("Test Float Get Vector By Ids", "[Float GetVectorByIds]") {
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFSQ8, base_gen),
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFPQ, base_gen),
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_SCANN, scann_gen),
+            make_tuple(knowhere::IndexEnum::INDEX_FAISS_SCANN, scann_gen2),
             make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),
         }));
         auto idx = knowhere::IndexFactory::Instance().Create(name);

--- a/thirdparty/faiss/faiss/IndexRefine.h
+++ b/thirdparty/faiss/faiss/IndexRefine.h
@@ -28,6 +28,8 @@ struct IndexRefine : Index {
     /// the base_index (should be >= 1)
     float k_factor = 1;
 
+    bool with_raw_data;
+
     /// initialize from empty index
     IndexRefine(Index* base_index, Index* refine_index);
 


### PR DESCRIPTION
issue #73 
Test on SIFT1M and GLOVE1M dataset
with `with_raw_data=True`, get recall=**0.9999/0.8613** for sift and glove dataset,
with `with_raw_data=False`, get recall=**0.9692/0.5378** for sift and glove dataset.
with_raw_data=True as the default option