### PR TITLE
Add clang-format and clang-tidy to precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,16 @@ default_language_version:
 exclude: '^thirdparty'
 fail_fast: True
 repos:
+    # prepare-clang-tidy and clang-tidy run only in local machine, not on CI
+    - repo: local
+      hooks:
+        - id: prepare-clang-tidy
+          name: Prepare clang-tidy
+          entry: bash -c 'scripts/prepare_clang_tidy.sh'
+          language: system
+          types: [shell]
+          always_run: true
+          stages: [pre-push]
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.3.0
       hooks:
@@ -27,7 +37,11 @@ repos:
         - id: check-merge-conflict
         - id: end-of-file-fixer
         - id: trailing-whitespace
-    - repo: https://github.com/pre-commit/mirrors-clang-format
-      rev: v14.0.6
+    - repo: https://github.com/pocc/pre-commit-hooks
+      rev: master
       hooks:
         - id: clang-format
+          args: [-style=file]
+        - id: clang-tidy
+          args: ["--config-file=.clang-tidy", "-p=build/compile_commands.json"]
+          stages: [pre-push]

--- a/README.md
+++ b/README.md
@@ -111,3 +111,22 @@ rm -rf knowhere.egg-info
 rm knowhere/knowhere_wrap.cpp
 rm knowhere/swigknowhere.py
 ```
+
+## Contributing
+
+### Pre-Commit
+
+Before submitting a pull request, please make sure running pre-commit checks locally to ensure the code is ready for review. Use the following command to install pre-commit checks:
+
+```bash
+pip3 install pre-commit
+pre-commit install --hook-type pre-commit --hook-type pre-push
+
+# If clang-format and clang-tidy not already installed:
+# linux
+apt install clang-format clang-tidy
+# mac
+brew install llvm
+ln -s "$(brew --prefix llvm)/bin/clang-format" "/usr/local/bin/clang-format"
+ln -s "$(brew --prefix llvm)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
+```

--- a/scripts/prepare_clang_tidy.sh
+++ b/scripts/prepare_clang_tidy.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2019-2023 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under the License.
+
+# Exit immediately for non zero status
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+ROOT_DIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
+
+# recreate the symlink to the compile_commands.json file
+if [ -f "$ROOT_DIR/build/compile_commands.json" ]; then
+  rm "$ROOT_DIR/build/compile_commands.json"
+fi
+if [ -f "$ROOT_DIR/build/Release/compile_commands.json" ]; then
+  ln -sf "$ROOT_DIR/build/Release/compile_commands.json" "$ROOT_DIR/build/compile_commands.json"
+elif [ -f "$ROOT_DIR/build/Debug/compile_commands.json" ]; then
+  ln -sf "$ROOT_DIR/build/Debug/compile_commands.json" "$ROOT_DIR/build/compile_commands.json"
+else
+  echo "Error: No compile_commands.json file found in either $ROOT_DIR/build/Release or $ROOT_DIR/build/Debug"
+  echo "Please first build the project so precommit checks can run."
+  exit 1
+fi


### PR DESCRIPTION
#86 

This PR adds clang-format and clang-tidy pre-commit checks to git, and instructions to install the checks locally.

For clang-tidy to work correctly we must provide a `compile_commands.json` database file. In our setting this file may be generated in buid/Debug or build/Release, thus created a script that runs before clang-tidy to create a symlink to the `compile_commands.json` file.

clang-tidy will only run locally when a `git push` happens. 2 reasons to not run it on CI: 1. analyzer already runs clang-tidy on CI; 2. clang-tidy relies on `conan build ..` artifacts and presubmit on CI does not have it.

/kind improvement