### PR TITLE
Fix clang-16 build of unit tests in debug mode

### DIFF
--- a/tests/ut/CMakeLists.txt
+++ b/tests/ut/CMakeLists.txt
@@ -35,3 +35,5 @@ if(WITH_DISKANN)
 else()
     target_link_libraries(knowhere_tests PRIVATE Catch2::Catch2WithMain knowhere)
 endif()
+
+target_link_libraries(knowhere_tests PRIVATE atomic)


### PR DESCRIPTION
The linker does not go ahead without the `atomic` library being linked, if `debug` build mode is used.  
/kind improvement