### PR TITLE
Fix DiskANN LRU Set Invalid Medoid

### DIFF
--- a/thirdparty/DiskANN/src/pq_flash_index.cpp
+++ b/thirdparty/DiskANN/src/pq_flash_index.cpp
@@ -1452,7 +1452,7 @@ namespace diskann {
         }
       }
     }
-    if (k_search > 0) {
+    if (k_search > 0 && indices[0] != -1) {
       lru_cache.put(vec_hash, indices[0]);
     }
 


### PR DESCRIPTION
issue: #96 
/kind bug

Search the first time gets no results so the LRU put -1 which became overflowed uint32_t `4294967295` which led to the medoid being set to an invalid ID.

The entry points and points around are not connected to the desired area and the filter ratio is less than the brute-force threshold.

This issue is more likely to happen when the number of vectors is small.