### PR TITLE
More fixes for clang-16 compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,13 @@ knowhere_option(WITH_COVERAGE "Build with coverage" OFF)
 knowhere_option(WITH_CCACHE "Build with ccache" ON)
 knowhere_option(WITH_PROFILER "Build with profiler" OFF)
 
+# this is needed for clang on ubuntu:20.04, otherwise
+#   the linked fails with 'undefined reference' error.
+# fmt v9 was used by the time the error was encountered.
+# clang on ubuntu:22.04 seems to be unaffected.
+# gcc seems to be unaffected.
+add_definitions(-DFMT_HEADER_ONLY)
+
 if(KNOWHERE_VERSION)
   message(STATUS "Building KNOWHERE version: ${KNOWHERE_VERSION}")
   add_definitions(-DKNOWHERE_VERSION=${KNOWHERE_VERSION})

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -37,6 +37,10 @@ macro(benchmark_test target file)
     set(FILE_SRCS ${file})
     add_executable(${target} ${FILE_SRCS})
     target_link_libraries(${target} ${depend_libs} ${unittest_libs})
+
+    # this is needed for clang in Debug compilation mode
+    target_link_libraries(${target} atomic)
+
     install(TARGETS ${target} DESTINATION unittest)
 endmacro()
 


### PR DESCRIPTION
This diff solves two problems.
1. Compilation of benchmarks with clang in Debug mode.
2. Compilation of unit tests and benchmarks with clang on ubuntu 20.04

/kind improvement