### PR TITLE
Fix clang asan warning

### DIFF
--- a/tests/ut/test_get_vector.cc
+++ b/tests/ut/test_get_vector.cc
@@ -27,7 +27,7 @@ TEST_CASE("Test Binary Get Vector By Ids", "[Binary GetVectorByIds]") {
     const auto metric_type = knowhere::metric::HAMMING;
     auto version = GenTestVersionList();
 
-    auto base_bin_gen = [&]() {
+    auto base_bin_gen = [=]() {
         knowhere::Json json;
         json[knowhere::meta::DIM] = dim;
         json[knowhere::meta::METRIC_TYPE] = metric_type;
@@ -35,14 +35,14 @@ TEST_CASE("Test Binary Get Vector By Ids", "[Binary GetVectorByIds]") {
         return json;
     };
 
-    auto bin_ivfflat_gen = [&base_bin_gen]() {
+    auto bin_ivfflat_gen = [base_bin_gen]() {
         knowhere::Json json = base_bin_gen();
         json[knowhere::indexparam::NLIST] = 16;
         json[knowhere::indexparam::NPROBE] = 4;
         return json;
     };
 
-    auto bin_hnsw_gen = [&base_bin_gen]() {
+    auto bin_hnsw_gen = [base_bin_gen]() {
         knowhere::Json json = base_bin_gen();
         json[knowhere::indexparam::HNSW_M] = 128;
         json[knowhere::indexparam::EFCONSTRUCTION] = 200;
@@ -104,7 +104,7 @@ TEST_CASE("Test Float Get Vector By Ids", "[Float GetVectorByIds]") {
     auto metric = GENERATE(as<std::string>{}, knowhere::metric::L2, knowhere::metric::COSINE);
     auto version = GenTestVersionList();
 
-    auto base_gen = [&]() {
+    auto base_gen = [=]() {
         knowhere::Json json;
         json[knowhere::meta::DIM] = dim;
         json[knowhere::meta::METRIC_TYPE] = metric;
@@ -112,7 +112,7 @@ TEST_CASE("Test Float Get Vector By Ids", "[Float GetVectorByIds]") {
         return json;
     };
 
-    auto hnsw_gen = [&base_gen]() {
+    auto hnsw_gen = [base_gen]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::HNSW_M] = 128;
         json[knowhere::indexparam::EFCONSTRUCTION] = 200;
@@ -120,20 +120,20 @@ TEST_CASE("Test Float Get Vector By Ids", "[Float GetVectorByIds]") {
         return json;
     };
 
-    auto ivfflat_gen = [&base_gen]() {
+    auto ivfflat_gen = [base_gen]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::NLIST] = 16;
         json[knowhere::indexparam::NPROBE] = 4;
         return json;
     };
 
-    auto ivfflatcc_gen = [&ivfflat_gen]() {
+    auto ivfflatcc_gen = [ivfflat_gen]() {
         knowhere::Json json = ivfflat_gen();
         json[knowhere::indexparam::SSIZE] = 48;
         return json;
     };
 
-    auto scann_gen = [&ivfflat_gen]() {
+    auto scann_gen = [ivfflat_gen]() {
         knowhere::Json json = ivfflat_gen();
         json[knowhere::indexparam::REORDER_K] = 10;
         json[knowhere::indexparam::WITH_RAW_DATA] = true;
@@ -141,7 +141,7 @@ TEST_CASE("Test Float Get Vector By Ids", "[Float GetVectorByIds]") {
     };
 
     // without raw data, can not get vector from index
-    auto scann_gen2 = [&scann_gen]() {
+    auto scann_gen2 = [scann_gen]() {
         knowhere::Json json = scann_gen();
         json[knowhere::indexparam::WITH_RAW_DATA] = false;
         return json;

--- a/tests/ut/test_mmap.cc
+++ b/tests/ut/test_mmap.cc
@@ -52,7 +52,7 @@ TEST_CASE("Search mmap", "[float metrics]") {
     auto metric = GENERATE(as<std::string>{}, knowhere::metric::L2, knowhere::metric::COSINE);
     auto version = GenTestVersionList();
 
-    auto base_gen = [&]() {
+    auto base_gen = [=]() {
         knowhere::Json json;
         json[knowhere::meta::DIM] = dim;
         json[knowhere::meta::METRIC_TYPE] = metric;
@@ -63,14 +63,14 @@ TEST_CASE("Search mmap", "[float metrics]") {
         return json;
     };
 
-    auto ivfflat_gen = [&base_gen]() {
+    auto ivfflat_gen = [base_gen]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::NLIST] = 16;
         json[knowhere::indexparam::NPROBE] = 8;
         return json;
     };
 
-    auto ivfflatcc_gen = [&ivfflat_gen]() {
+    auto ivfflatcc_gen = [ivfflat_gen]() {
         knowhere::Json json = ivfflat_gen();
         json[knowhere::indexparam::SSIZE] = 48;
         return json;
@@ -80,14 +80,14 @@ TEST_CASE("Search mmap", "[float metrics]") {
 
     auto flat_gen = base_gen;
 
-    auto ivfpq_gen = [&ivfflat_gen]() {
+    auto ivfpq_gen = [ivfflat_gen]() {
         knowhere::Json json = ivfflat_gen();
         json[knowhere::indexparam::M] = 4;
         json[knowhere::indexparam::NBITS] = 8;
         return json;
     };
 
-    auto hnsw_gen = [&base_gen]() {
+    auto hnsw_gen = [base_gen]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::HNSW_M] = 128;
         json[knowhere::indexparam::EFCONSTRUCTION] = 200;
@@ -215,7 +215,7 @@ TEST_CASE("Search binary mmap", "[float metrics]") {
 
     auto metric = GENERATE(as<std::string>{}, knowhere::metric::HAMMING, knowhere::metric::JACCARD);
     auto version = GenTestVersionList();
-    auto base_gen = [&]() {
+    auto base_gen = [=]() {
         knowhere::Json json;
         json[knowhere::meta::DIM] = dim;
         json[knowhere::meta::METRIC_TYPE] = metric;
@@ -226,14 +226,14 @@ TEST_CASE("Search binary mmap", "[float metrics]") {
     };
 
     auto flat_gen = base_gen;
-    auto ivfflat_gen = [&base_gen]() {
+    auto ivfflat_gen = [base_gen]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::NLIST] = 16;
         json[knowhere::indexparam::NPROBE] = 8;
         return json;
     };
 
-    auto hnsw_gen = [&base_gen]() {
+    auto hnsw_gen = [base_gen]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::HNSW_M] = 128;
         json[knowhere::indexparam::EFCONSTRUCTION] = 200;
@@ -320,7 +320,7 @@ TEST_CASE("Search binary mmap", "[bool metrics]") {
     auto metric = GENERATE(as<std::string>{}, knowhere::metric::SUPERSTRUCTURE, knowhere::metric::SUBSTRUCTURE);
     auto version = GenTestVersionList();
 
-    auto base_gen = [&]() {
+    auto base_gen = [=]() {
         knowhere::Json json;
         json[knowhere::meta::DIM] = dim;
         json[knowhere::meta::METRIC_TYPE] = metric;
@@ -330,7 +330,7 @@ TEST_CASE("Search binary mmap", "[bool metrics]") {
     };
 
     auto flat_gen = base_gen;
-    auto ivfflat_gen = [&base_gen]() {
+    auto ivfflat_gen = [base_gen]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::NLIST] = 16;
         json[knowhere::indexparam::NPROBE] = 8;

--- a/tests/ut/test_search.cc
+++ b/tests/ut/test_search.cc
@@ -37,7 +37,7 @@ TEST_CASE("Test Mem Index With Float Vector", "[float metrics]") {
     auto metric = GENERATE(as<std::string>{}, knowhere::metric::L2, knowhere::metric::COSINE);
     auto version = GenTestVersionList();
 
-    auto base_gen = [&]() {
+    auto base_gen = [=]() {
         knowhere::Json json;
         json[knowhere::meta::DIM] = dim;
         json[knowhere::meta::METRIC_TYPE] = metric;
@@ -47,14 +47,14 @@ TEST_CASE("Test Mem Index With Float Vector", "[float metrics]") {
         return json;
     };
 
-    auto ivfflat_gen = [&base_gen]() {
+    auto ivfflat_gen = [base_gen]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::NLIST] = 16;
         json[knowhere::indexparam::NPROBE] = 8;
         return json;
     };
 
-    auto ivfflatcc_gen = [&ivfflat_gen]() {
+    auto ivfflatcc_gen = [ivfflat_gen]() {
         knowhere::Json json = ivfflat_gen();
         json[knowhere::indexparam::SSIZE] = 48;
         return json;
@@ -64,14 +64,14 @@ TEST_CASE("Test Mem Index With Float Vector", "[float metrics]") {
 
     auto flat_gen = base_gen;
 
-    auto ivfpq_gen = [&ivfflat_gen]() {
+    auto ivfpq_gen = [ivfflat_gen]() {
         knowhere::Json json = ivfflat_gen();
         json[knowhere::indexparam::M] = 4;
         json[knowhere::indexparam::NBITS] = 8;
         return json;
     };
 
-    auto scann_gen = [&ivfflat_gen]() {
+    auto scann_gen = [ivfflat_gen]() {
         knowhere::Json json = ivfflat_gen();
         json[knowhere::indexparam::NPROBE] = 14;
         json[knowhere::indexparam::REORDER_K] = 500;
@@ -79,13 +79,13 @@ TEST_CASE("Test Mem Index With Float Vector", "[float metrics]") {
         return json;
     };
 
-    auto scann_gen2 = [&scann_gen]() {
+    auto scann_gen2 = [scann_gen]() {
         knowhere::Json json = scann_gen();
         json[knowhere::indexparam::WITH_RAW_DATA] = false;
         return json;
     };
 
-    auto hnsw_gen = [&base_gen]() {
+    auto hnsw_gen = [base_gen]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::HNSW_M] = 128;
         json[knowhere::indexparam::EFCONSTRUCTION] = 200;
@@ -274,7 +274,7 @@ TEST_CASE("Test Mem Index With Binary Vector", "[float metrics]") {
 
     auto metric = GENERATE(as<std::string>{}, knowhere::metric::HAMMING, knowhere::metric::JACCARD);
     auto version = GenTestVersionList();
-    auto base_gen = [&]() {
+    auto base_gen = [=]() {
         knowhere::Json json;
         json[knowhere::meta::DIM] = dim;
         json[knowhere::meta::METRIC_TYPE] = metric;
@@ -285,14 +285,14 @@ TEST_CASE("Test Mem Index With Binary Vector", "[float metrics]") {
     };
 
     auto flat_gen = base_gen;
-    auto ivfflat_gen = [&base_gen]() {
+    auto ivfflat_gen = [base_gen]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::NLIST] = 16;
         json[knowhere::indexparam::NPROBE] = 8;
         return json;
     };
 
-    auto hnsw_gen = [&base_gen]() {
+    auto hnsw_gen = [base_gen]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::HNSW_M] = 128;
         json[knowhere::indexparam::EFCONSTRUCTION] = 200;
@@ -383,7 +383,7 @@ TEST_CASE("Test Mem Index With Binary Vector", "[bool metrics]") {
     auto version = GenTestVersionList();
     auto metric = GENERATE(as<std::string>{}, knowhere::metric::SUPERSTRUCTURE, knowhere::metric::SUBSTRUCTURE);
 
-    auto base_gen = [&]() {
+    auto base_gen = [=]() {
         knowhere::Json json;
         json[knowhere::meta::DIM] = dim;
         json[knowhere::meta::METRIC_TYPE] = metric;
@@ -392,7 +392,7 @@ TEST_CASE("Test Mem Index With Binary Vector", "[bool metrics]") {
     };
 
     auto flat_gen = base_gen;
-    auto ivfflat_gen = [&base_gen]() {
+    auto ivfflat_gen = [base_gen]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::NLIST] = 16;
         json[knowhere::indexparam::NPROBE] = 8;


### PR DESCRIPTION
clang asan yields `AddressSanitizer: stack-use-after-return on address` error unless fixed

/kind improvement