### PR TITLE
[do-not-merge] add an index-factory instantiated Faiss index

### DIFF
--- a/benchmark/hdf5/benchmark_knowhere.h
+++ b/benchmark/hdf5/benchmark_knowhere.h
@@ -94,6 +94,15 @@ class Benchmark_knowhere : public Benchmark_hdf5 {
         return ann_test_name_ + "_" + index_type_ + params_str + ".index";
     }
 
+    std::string
+    get_index_name_str(const std::vector<std::string>& params) {
+        std::string params_str = "";
+        for (size_t i = 0; i < params.size(); i++) {
+            params_str += "_" + params[i];
+        }
+        return ann_test_name_ + "_" + index_type_ + params_str + ".index";
+    }
+
     knowhere::Index<knowhere::IndexNode>
     create_index(const std::string& index_file_name, const knowhere::Json& conf) {
         auto version = knowhere::Version::GetCurrentVersion().VersionNumber();

--- a/include/knowhere/comp/index_param.h
+++ b/include/knowhere/comp/index_param.h
@@ -32,6 +32,8 @@ constexpr const char* INDEX_FAISS_IVFPQ = "IVF_PQ";
 constexpr const char* INDEX_FAISS_SCANN = "SCANN";
 constexpr const char* INDEX_FAISS_IVFSQ8 = "IVF_SQ8";
 
+constexpr const char* INDEX_FAISS = "FAISS";
+
 constexpr const char* INDEX_FAISS_GPU_IDMAP = "GPU_FAISS_FLAT";
 constexpr const char* INDEX_FAISS_GPU_IVFFLAT = "GPU_FAISS_IVF_FLAT";
 constexpr const char* INDEX_FAISS_GPU_IVFPQ = "GPU_FAISS_IVF_PQ";
@@ -87,6 +89,9 @@ constexpr const char* HNSW_M = "M";
 constexpr const char* EF = "ef";
 constexpr const char* SEED_EF = "seed_ef";
 constexpr const char* OVERVIEW_LEVELS = "overview_levels";
+
+// Faiss params
+constexpr const char* FACTORY_STRING = "factory_string";
 }  // namespace indexparam
 
 using MetricType = std::string;

--- a/include/knowhere/index_node.h
+++ b/include/knowhere/index_node.h
@@ -24,16 +24,16 @@ namespace knowhere {
 
 class IndexNode : public Object {
  public:
-    IndexNode(const int32_t ver) : versoin_(ver) {
+    IndexNode(const int32_t ver) : version_(ver) {
     }
 
-    IndexNode() : versoin_(Version::GetDefaultVersion()) {
+    IndexNode() : version_(Version::GetDefaultVersion()) {
     }
 
-    IndexNode(const IndexNode& other) : versoin_(other.versoin_) {
+    IndexNode(const IndexNode& other) : version_(other.version_) {
     }
 
-    IndexNode(const IndexNode&& other) : versoin_(other.versoin_) {
+    IndexNode(const IndexNode&& other) : version_(other.version_) {
     }
 
     virtual Status
@@ -107,7 +107,7 @@ class IndexNode : public Object {
     }
 
  protected:
-    Version versoin_;
+    Version version_;
 };
 
 }  // namespace knowhere

--- a/src/index/faiss/faiss.cc
+++ b/src/index/faiss/faiss.cc
@@ -1,0 +1,389 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#include "common/metric.h"
+#include "common/range_util.h"
+#include "faiss/index_io.h"
+#include "faiss/index_factory.h"
+#include "index/faiss/faiss_config.h"
+#include "io/memory_io.h"
+#include "knowhere/comp/thread_pool.h"
+#include "knowhere/factory.h"
+#include "knowhere/log.h"
+#include "knowhere/utils.h"
+
+namespace knowhere {
+
+class FaissIndexNode : public IndexNode {
+ public:
+    FaissIndexNode(const int32_t version, const Object& object);
+
+    Status
+    Train(const DataSet& dataset, const Config& cfg) override;
+
+    Status
+    Add(const DataSet& dataset, const Config& cfg) override;
+
+    expected<DataSetPtr>
+    Search(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const override;
+
+    expected<DataSetPtr>
+    RangeSearch(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const override;
+    
+    expected<DataSetPtr>
+    GetVectorByIds(const DataSet& dataset) const override;
+
+    bool
+    HasRawData(const std::string& metric_type) const override;
+
+    expected<DataSetPtr>
+    GetIndexMeta(const Config& cfg) const override;
+
+    Status
+    Serialize(BinarySet& binset) const override;
+
+    Status
+    Deserialize(const BinarySet& binset, const Config& config) override;
+
+    Status
+    DeserializeFromFile(const std::string& filename, const Config& config) override;
+
+    std::unique_ptr<BaseConfig>
+    CreateConfig() const override;
+
+    int64_t
+    Dim() const override;
+
+    int64_t
+    Size() const override;
+
+    int64_t
+    Count() const override;
+
+    std::string
+    Type() const override;
+
+ private:
+    std::unique_ptr<faiss::Index> index_;
+    std::shared_ptr<ThreadPool> search_pool_;    
+};
+
+//
+FaissIndexNode::FaissIndexNode(const int32_t version, const Object& object) : index_(nullptr) {
+    search_pool_ = ThreadPool::GetGlobalSearchThreadPool();
+}
+
+//
+Status
+FaissIndexNode::Train(const DataSet& dataset, const Config& cfg) {
+    const FaissConfig& f_cfg = static_cast<const FaissConfig&>(cfg);
+
+    auto metric = Str2FaissMetricType(f_cfg.metric_type.value());
+    if (!metric.has_value()) {
+        LOG_KNOWHERE_WARNING_ << "please check metric type: " << f_cfg.metric_type.value();
+        return metric.error();
+    }
+    if (!f_cfg.factory_string.has_value()) {
+        LOG_KNOWHERE_WARNING_ << "factory string for faiss index is undefined";
+        return Status::invalid_args;
+    }
+
+    index_.reset(faiss::index_factory(dataset.GetDim(), f_cfg.factory_string.value().c_str(), metric.value()));
+
+    auto rows = dataset.GetRows();
+    auto dim = dataset.GetDim();
+    auto data = dataset.GetTensor();
+
+    index_->train(rows, (const float*)data);
+    return Status::success;
+}
+
+//
+Status
+FaissIndexNode::Add(const DataSet& dataset, const Config& cfg) {
+    if (!this->index_) {
+        LOG_KNOWHERE_ERROR_ << "Can not add data to empty index.";
+        return Status::empty_index;
+    }
+    auto data = dataset.GetTensor();
+    auto rows = dataset.GetRows();
+    const BaseConfig& base_cfg = static_cast<const FaissConfig&>(cfg);
+    std::unique_ptr<ThreadPool::ScopedOmpSetter> setter;
+    if (base_cfg.num_build_thread.has_value()) {
+        setter = std::make_unique<ThreadPool::ScopedOmpSetter>(base_cfg.num_build_thread.value());
+    }
+    try {
+        index_->add(rows, (const float*)data);
+    } catch (std::exception& e) {
+        LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();
+        return Status::faiss_inner_error;
+    }
+    return Status::success;
+}
+
+//
+expected<DataSetPtr>
+FaissIndexNode::Search(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const {
+    if (!this->index_) {
+        LOG_KNOWHERE_WARNING_ << "search on empty index";
+        return expected<DataSetPtr>::Err(Status::empty_index, "index not loaded");
+    }
+    if (!this->index_->is_trained) {
+        LOG_KNOWHERE_WARNING_ << "index not trained";
+        return expected<DataSetPtr>::Err(Status::index_not_trained, "index not trained");
+    }
+
+    auto dim = dataset.GetDim();
+    auto rows = dataset.GetRows();
+    auto data = dataset.GetTensor();
+
+    const BaseConfig& base_cfg = static_cast<const BaseConfig&>(cfg);
+    bool is_cosine = IsMetricType(base_cfg.metric_type.value(), knowhere::metric::COSINE);
+
+    auto k = base_cfg.k.value();
+    //auto nprobe = ivf_cfg.nprobe.value();
+
+    faiss::Index::idx_t* ids(new (std::nothrow) faiss::Index::idx_t[rows * k]);
+    float* distances(new (std::nothrow) float[rows * k]);
+    try {
+        std::vector<folly::Future<folly::Unit>> futs;
+        futs.reserve(rows);
+        for (int i = 0; i < rows; ++i) {
+            futs.emplace_back(search_pool_->push([&, index = i] {
+                ThreadPool::ScopedOmpSetter setter(1);
+                auto cur_ids = ids + k * index;
+                auto cur_dis = distances + k * index;
+
+                std::unique_ptr<float[]> copied_query = nullptr;
+                auto cur_query = (const float*)data + index * dim;
+                if (is_cosine) {
+                    copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
+                    cur_query = copied_query.get();
+                }
+                index_->search(
+                    1, 
+                    cur_query, 
+                    k, 
+                    cur_dis, 
+                    cur_ids, 
+                    bitset);
+            }));
+        }
+        for (auto& fut : futs) {
+            fut.wait();
+        }
+    } catch (const std::exception& e) {
+        delete[] ids;
+        delete[] distances;
+        LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();
+        return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
+    }
+
+    auto res = GenResultDataSet(rows, k, ids, distances);
+    return res;
+}
+
+//
+expected<DataSetPtr>
+FaissIndexNode::RangeSearch(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const {
+    if (!this->index_) {
+        LOG_KNOWHERE_WARNING_ << "range search on empty index";
+        return expected<DataSetPtr>::Err(Status::empty_index, "index not loaded");
+    }
+    if (!this->index_->is_trained) {
+        LOG_KNOWHERE_WARNING_ << "index not trained";
+        return expected<DataSetPtr>::Err(Status::index_not_trained, "index not trained");
+    }
+
+    auto nq = dataset.GetRows();
+    auto xq = dataset.GetTensor();
+    auto dim = dataset.GetDim();
+
+    const BaseConfig& base_cfg = static_cast<const BaseConfig&>(cfg);
+    bool is_cosine = IsMetricType(base_cfg.metric_type.value(), knowhere::metric::COSINE);
+
+    float radius = base_cfg.radius.value();
+    float range_filter = base_cfg.range_filter.value();
+    bool is_ip = (index_->metric_type == faiss::METRIC_INNER_PRODUCT);
+
+    int64_t* ids = nullptr;
+    float* distances = nullptr;
+    size_t* lims = nullptr;
+
+    std::vector<std::vector<int64_t>> result_id_array(nq);
+    std::vector<std::vector<float>> result_dist_array(nq);
+    std::vector<size_t> result_size(nq);
+    std::vector<size_t> result_lims(nq + 1);
+
+    try {
+        std::vector<folly::Future<folly::Unit>> futs;
+        futs.reserve(nq);
+        for (int i = 0; i < nq; ++i) {
+            futs.emplace_back(search_pool_->push([&, index = i] {
+                ThreadPool::ScopedOmpSetter setter(1);
+                faiss::RangeSearchResult res(1);
+                std::unique_ptr<float[]> copied_query = nullptr;
+
+                auto cur_query = (const float*)xq + index * dim;
+                if (is_cosine) {
+                    copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
+                    cur_query = copied_query.get();
+                }
+
+                //
+                index_->range_search(1, cur_query, radius, &res, bitset);
+
+                auto elem_cnt = res.lims[1];
+                result_dist_array[index].resize(elem_cnt);
+                result_id_array[index].resize(elem_cnt);
+                result_size[index] = elem_cnt;
+                for (size_t j = 0; j < elem_cnt; j++) {
+                    result_dist_array[index][j] = res.distances[j];
+                    result_id_array[index][j] = res.labels[j];
+                }
+                if (range_filter != defaultRangeFilter) {
+                    FilterRangeSearchResultForOneNq(result_dist_array[index], result_id_array[index], is_ip, radius,
+                                                    range_filter);
+                }
+            }));
+        }
+        for (auto& fut : futs) {
+            fut.wait();
+        }
+        GetRangeSearchResult(result_dist_array, result_id_array, is_ip, nq, radius, range_filter, distances, ids, lims);
+    } catch (const std::exception& e) {
+        LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();
+        return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
+    }
+
+    return GenResultDataSet(nq, ids, distances, lims);
+}
+
+//
+expected<DataSetPtr>
+FaissIndexNode::GetVectorByIds(const DataSet& dataset) const {
+    return expected<DataSetPtr>::Err(Status::not_implemented, "not implemented for FaissIndex");
+}
+
+//
+bool
+FaissIndexNode::HasRawData(const std::string& metric_type) const {
+    // todo aguzhva: not implemented
+    return false;
+}
+
+//
+expected<DataSetPtr>
+FaissIndexNode::GetIndexMeta(const Config& cfg) const {
+    return expected<DataSetPtr>::Err(Status::not_implemented, "GetIndexMeta not implemented");
+}
+
+//
+Status
+FaissIndexNode::Serialize(BinarySet& binset) const {
+    try {
+        MemoryIOWriter writer;
+        faiss::write_index(index_.get(), &writer);
+        
+        std::shared_ptr<uint8_t[]> data(writer.data());
+        binset.Append(Type(), data, writer.tellg());
+        return Status::success;
+    } catch (const std::exception& e) {
+        LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();
+        return Status::faiss_inner_error;
+    }
+}
+
+//
+Status
+FaissIndexNode::Deserialize(const BinarySet& binset, const Config& config) {
+    std::vector<std::string> names = {Type()};
+    auto binary = binset.GetByNames(names);
+    if (binary == nullptr) {
+        LOG_KNOWHERE_ERROR_ << "Invalid binary set.";
+        return Status::invalid_binary_set;
+    }
+
+    MemoryIOReader reader(binary->data.get(), binary->size);
+    try {
+        index_.reset(faiss::read_index(&reader));
+    } catch (const std::exception& e) {
+        LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();
+        return Status::faiss_inner_error;
+    }
+    return Status::success;
+}
+
+//
+Status
+FaissIndexNode::DeserializeFromFile(const std::string& filename, const Config& config) {
+    auto cfg = static_cast<const knowhere::BaseConfig&>(config);
+
+    int io_flags = 0;
+    if (cfg.enable_mmap.value()) {
+        io_flags |= faiss::IO_FLAG_MMAP;
+    }
+    try {
+        index_.reset(faiss::read_index(filename.data(), io_flags));
+    } catch (const std::exception& e) {
+        LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();
+        return Status::faiss_inner_error;
+    }
+    return Status::success;
+}
+
+//
+std::unique_ptr<BaseConfig>
+FaissIndexNode::CreateConfig() const {
+    return std::make_unique<FaissConfig>();
+};
+
+//
+int64_t
+FaissIndexNode::Dim() const {
+    if (!index_) {
+        return -1;
+    }
+    return index_->d;
+};
+
+int64_t
+FaissIndexNode::Size() const {
+    if (!index_) {
+        return 0;
+    }
+
+    // slow and wrong, but universal way of estimating the size
+    faiss::VectorIOWriter writer;
+    faiss::write_index(index_.get(), &writer);
+
+    return writer.data.size();
+};
+
+int64_t
+FaissIndexNode::Count() const {
+    if (!index_) {
+        return 0;
+    }
+    return index_->ntotal;
+};
+
+std::string
+FaissIndexNode::Type() const {
+    return knowhere::IndexEnum::INDEX_FAISS;
+};
+
+KNOWHERE_REGISTER_GLOBAL(FAISS, [](const int32_t& version, const Object& object) {
+    return Index<FaissIndexNode>::Create(version, object);
+});
+
+}  // namespace knowhere
+

--- a/src/index/faiss/faiss_config.h
+++ b/src/index/faiss/faiss_config.h
@@ -1,0 +1,32 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#ifndef FAISS_CONFIG_H
+#define FAISS_CONFIG_H
+
+#include "knowhere/config.h"
+
+namespace knowhere {
+
+class FaissConfig : public BaseConfig {
+public:
+    CFG_STRING factory_string;
+    KNOHWERE_DECLARE_CONFIG(FaissConfig) {
+        KNOWHERE_CONFIG_DECLARE_FIELD(factory_string)
+            .set_default("Flat")
+            .description("FAISS factory string.")
+            .for_train();
+    }
+};
+
+}  // namespace knowhere
+
+#endif /* FLAT_CONFIG_H */

--- a/src/index/flat/flat.cc
+++ b/src/index/flat/flat.cc
@@ -237,7 +237,7 @@ class FlatIndexNode : public IndexNode {
     bool
     HasRawData(const std::string& metric_type) const override {
         if constexpr (std::is_same<T, faiss::IndexFlat>::value) {
-            if (versoin_ <= Version::GetMinimalVersion()) {
+            if (version_ <= Version::GetMinimalVersion()) {
                 return !IsMetricType(metric_type, metric::COSINE);
             } else {
                 return true;

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -680,8 +680,8 @@ Status
 IvfIndexNode<faiss::IndexIVFFlat>::Serialize(BinarySet& binset) const {
     try {
         MemoryIOWriter writer;
-        LOG_KNOWHERE_INFO_ << "request version " << versoin_.VersionNumber();
-        if (versoin_ <= Version::GetMinimalVersion()) {
+        LOG_KNOWHERE_INFO_ << "request version " << version_.VersionNumber();
+        if (version_ <= Version::GetMinimalVersion()) {
             faiss::write_index_nm(index_.get(), &writer);
             LOG_KNOWHERE_INFO_ << "write IVF_FLAT_NM, file size " << writer.tellg();
         } else {
@@ -692,7 +692,7 @@ IvfIndexNode<faiss::IndexIVFFlat>::Serialize(BinarySet& binset) const {
         binset.Append(Type(), index_data_ptr, writer.tellg());
 
         // append raw data for backward compatible
-        if (versoin_ <= Version::GetMinimalVersion()) {
+        if (version_ <= Version::GetMinimalVersion()) {
             size_t dim = index_->d;
             size_t rows = index_->ntotal;
             size_t raw_data_size = dim * rows * sizeof(float);
@@ -734,7 +734,7 @@ IvfIndexNode<T>::Deserialize(const BinarySet& binset, const Config& config) {
     MemoryIOReader reader(binary->data.get(), binary->size);
     try {
         if constexpr (std::is_same<T, faiss::IndexIVFFlat>::value) {
-            if (versoin_ <= Version::GetMinimalVersion()) {
+            if (version_ <= Version::GetMinimalVersion()) {
                 auto raw_binary = binset.GetByName("RAW_DATA");
                 const BaseConfig& base_cfg = static_cast<const BaseConfig&>(config);
                 ConvertIVFFlat(binset, base_cfg.metric_type.value(), raw_binary->data.get(), raw_binary->size);


### PR DESCRIPTION
A commit that helps testing various Faiss indices. The advantage is that it allows to instantiate very complex black magic indices using a factory string, such as `OPQ16_64,IVF262144(IVF512,PQ32x4fs,RFlat),PQ16x4fsr,Refine(OPQ56_112,PQ56)`. The drawback is that one has to configure its parameters inside the code.

This commit is never intended to be used in production.