### PR TITLE
Add new ser/deser for scann index

### DIFF
--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -78,7 +78,7 @@ class IvfIndexNode : public IndexNode {
             return false;
         }
         if constexpr (std::is_same<faiss::IndexScaNN, T>::value) {
-            return index_->with_raw_data;
+            return index_->with_raw_data();
         }
         if constexpr (std::is_same<faiss::IndexIVFScalarQuantizer, T>::value) {
             return false;
@@ -607,7 +607,7 @@ IvfIndexNode<T>::GetVectorByIds(const DataSet& dataset) const {
         }
     } else if constexpr (std::is_same<T, faiss::IndexScaNN>::value) {
         // we should never go here since we should call HasRawData() first
-        if (!index_->with_raw_data) {
+        if (!index_->with_raw_data()) {
             return expected<DataSetPtr>::Err(Status::not_implemented, "GetVectorByIds not implemented");
         }
         auto dim = Dim();

--- a/thirdparty/faiss/faiss/IndexRefine.cpp
+++ b/thirdparty/faiss/faiss/IndexRefine.cpp
@@ -43,23 +43,20 @@ IndexRefine::IndexRefine()
 
 void IndexRefine::train(idx_t n, const float* x) {
     base_index->train(n, x);
-    if (refine_index)
-        refine_index->train(n, x);
+    refine_index->train(n, x);
     is_trained = true;
 }
 
 void IndexRefine::add(idx_t n, const float* x) {
     FAISS_THROW_IF_NOT(is_trained);
     base_index->add(n, x);
-    if (refine_index)
-        refine_index->add(n, x);
+    refine_index->add(n, x);
     ntotal = base_index->ntotal;
 }
 
 void IndexRefine::reset() {
     base_index->reset();
-    if (refine_index)
-        refine_index->reset();
+    refine_index->reset();
     ntotal = 0;
 }
 
@@ -100,9 +97,6 @@ void IndexRefine::search(
         float* distances,
         idx_t* labels,
         const BitsetView bitset) const {
-    FAISS_THROW_IF_NOT(base_index);
-    FAISS_THROW_IF_NOT(refine_index);
-
     FAISS_THROW_IF_NOT(k > 0);
 
     FAISS_THROW_IF_NOT(is_trained);
@@ -159,19 +153,14 @@ void IndexRefine::search(
 }
 
 void IndexRefine::reconstruct(idx_t key, float* recons) const {
-    FAISS_THROW_IF_NOT(refine_index);
     refine_index->reconstruct(key, recons);
 }
 
 size_t IndexRefine::sa_code_size() const {
-    FAISS_THROW_IF_NOT(base_index);
-    FAISS_THROW_IF_NOT(refine_index);
     return base_index->sa_code_size() + refine_index->sa_code_size();
 }
 
 void IndexRefine::sa_encode(idx_t n, const float* x, uint8_t* bytes) const {
-    FAISS_THROW_IF_NOT(base_index);
-    FAISS_THROW_IF_NOT(refine_index);
     size_t cs1 = base_index->sa_code_size(), cs2 = refine_index->sa_code_size();
     std::unique_ptr<uint8_t[]> tmp1(new uint8_t[n * cs1]);
     base_index->sa_encode(n, x, tmp1.get());
@@ -185,8 +174,6 @@ void IndexRefine::sa_encode(idx_t n, const float* x, uint8_t* bytes) const {
 }
 
 void IndexRefine::sa_decode(idx_t n, const uint8_t* bytes, float* x) const {
-    FAISS_THROW_IF_NOT(base_index);
-    FAISS_THROW_IF_NOT(refine_index);
     size_t cs1 = base_index->sa_code_size(), cs2 = refine_index->sa_code_size();
     std::unique_ptr<uint8_t[]> tmp2(
             new uint8_t[n * refine_index->sa_code_size()]);
@@ -221,14 +208,10 @@ IndexRefineFlat::IndexRefineFlat(Index* base_index)
 
 IndexRefineFlat::IndexRefineFlat(Index* base_index, const float* xb)
         : IndexRefine(base_index, nullptr) {
-    is_trained = base_index->is_trained;
-    if (xb) {
-        refine_index = new IndexFlat(base_index->d, base_index->metric_type);
-        with_raw_data = true;
-    } else {
-        with_raw_data = false;
-    }
+    is_trained = base_index->is_trained;    
+    refine_index = new IndexFlat(base_index->d, base_index->metric_type);
     own_refine_index = true;
+    refine_index->add(base_index->ntotal, xb);
 }
 
 IndexRefineFlat::IndexRefineFlat() : IndexRefine() {
@@ -242,9 +225,6 @@ void IndexRefineFlat::search(
         float* distances,
         idx_t* labels,
         const BitsetView bitset) const {
-    FAISS_THROW_IF_NOT(base_index);
-    FAISS_THROW_IF_NOT(refine_index);
-    
     FAISS_THROW_IF_NOT(k > 0);
 
     FAISS_THROW_IF_NOT(is_trained);

--- a/thirdparty/faiss/faiss/IndexRefine.h
+++ b/thirdparty/faiss/faiss/IndexRefine.h
@@ -28,8 +28,6 @@ struct IndexRefine : Index {
     /// the base_index (should be >= 1)
     float k_factor = 1;
 
-    bool with_raw_data;
-
     /// initialize from empty index
     IndexRefine(Index* base_index, Index* refine_index);
 

--- a/thirdparty/faiss/faiss/IndexScaNN.h
+++ b/thirdparty/faiss/faiss/IndexScaNN.h
@@ -5,11 +5,21 @@
 
 namespace faiss {
 
-struct IndexScaNN : IndexRefineFlat {
+struct IndexScaNN : IndexRefine {
     explicit IndexScaNN(Index* base_index);
     IndexScaNN(Index* base_index, const float* xb);
 
     IndexScaNN();
+
+    void train(idx_t n, const float* x) override;
+
+    void add(idx_t n, const float* x) override;
+
+    void reset() override;
+
+    inline bool with_raw_data() const {
+        return (refine_index != nullptr);
+    }
 
     int64_t size();
 


### PR DESCRIPTION
In next releases, scann index will be **officially** supported instead of a **beta** version, we add a new ser/deser for scann index, which will minimize the impact scann index brings if we have any changes to `IndexRefine` in the future.
Revert changes bringed from #77 in `IndexRefine`.
/kind improvement