### PR TITLE
Add another file to AVX2 code for PQFastScan

### DIFF
--- a/cmake/libs/libfaiss.cmake
+++ b/cmake/libs/libfaiss.cmake
@@ -11,7 +11,8 @@ knowhere_file_glob(GLOB FAISS_AVX2_SRCS
                    thirdparty/faiss/faiss/impl/pq4_fast_scan_search_1.cpp
                    thirdparty/faiss/faiss/impl/pq4_fast_scan_search_qbs.cpp
                    thirdparty/faiss/faiss/IndexPQFastScan.cpp
-                   thirdparty/faiss/faiss/IndexIVFPQFastScan.cpp)
+                   thirdparty/faiss/faiss/IndexIVFPQFastScan.cpp
+                   thirdparty/faiss/faiss/utils/partitioning.cpp)
 
 list(REMOVE_ITEM FAISS_SRCS ${FAISS_AVX512_SRCS})
 


### PR DESCRIPTION
Baseline
```
[9.631 s] sift-128-euclidean | SCANN | nlist=1024, nprobe=12, reorder_k=256, with_raw_data=1, k=100, R@=0.8000
================================================================================
  thread_num =  1, elapse =  2.228s, VPS = 4488.878
  thread_num =  2, elapse =  1.202s, VPS = 8320.244
  thread_num =  4, elapse =  0.822s, VPS = 12162.166
  thread_num =  8, elapse =  0.785s, VPS = 12739.955
================================================================================
[14.668 s] Test 'sift-128-euclidean/SCANN' done

```

Candidate
```
[7.929 s] sift-128-euclidean | SCANN | nlist=1024, nprobe=12, reorder_k=256, with_raw_data=1, k=100, R@=0.8000
================================================================================
  thread_num =  1, elapse =  1.635s, VPS = 6115.497
  thread_num =  2, elapse =  0.902s, VPS = 11088.023
  thread_num =  4, elapse =  0.636s, VPS = 15733.984
  thread_num =  8, elapse =  0.590s, VPS = 16959.154
================================================================================
[11.691 s] Test 'sift-128-euclidean/SCANN' done

```

/kind improvement
