### PR TITLE
Make scann range search results more accurate

### DIFF
--- a/thirdparty/faiss/faiss/IndexIVFPQFastScan.cpp
+++ b/thirdparty/faiss/faiss/IndexIVFPQFastScan.cpp
@@ -1332,7 +1332,8 @@ void IndexIVFPQFastScan::range_search_implem_12(
     TIC;
 
     // prepare the result handlers
-    std::unique_ptr<RangeSearchResultHandler<C, true>> handler(new RangeSearchResultHandler<C, true>(result, radius, 0, bitset));
+    float radius_thresh = C::is_max ? radius * 1.2 : radius * 0.6;  // to make range search result more accurate
+    std::unique_ptr<RangeSearchResultHandler<C, true>> handler(new RangeSearchResultHandler<C, true>(result, radius_thresh, 0, bitset));
     handler->normalizers = normalizers.get();
     int qbs2 = this->qbs2 ? this->qbs2 : 11;
 


### PR DESCRIPTION
Related #171 
Range search's recall of ScaNN is poor due to quantization. Enlarge radius to take more candidates into consideration.

Before change
```
SCANN {"metric_type": "L2", "radius": 65.0} 0.0088
SCANN {"metric_type": "IP", "radius": 8.699999809265137} 0.003
SCANN {"metric_type": "COSINE", "radius": 0.20000000298023224} 0.0018
```
After
```
SCANN {"metric_type": "L2", "radius": 65.0} 0.2133
SCANN {"metric_type": "IP", "radius": 8.699999809265137} 0.0339
SCANN {"metric_type": "COSINE", "radius": 0.20000000298023224} 0.0272
```
