### PR TITLE
Remove unused stats in PQFastScan

### DIFF
--- a/thirdparty/faiss/faiss/IndexIVFPQFastScan.h
+++ b/thirdparty/faiss/faiss/IndexIVFPQFastScan.h
@@ -230,25 +230,4 @@ struct IndexIVFPQFastScan : IndexIVF {
             const BitsetView bitset = nullptr) const;
 };
 
-struct IVFFastScanStats {
-    uint64_t times[10];
-    uint64_t t_compute_distance_tables, t_round;
-    uint64_t t_copy_pack, t_scan, t_to_flat;
-    uint64_t reservoir_times[4];
-
-    double Mcy_at(int i) {
-        return times[i] / (1000 * 1000.0);
-    }
-
-    double Mcy_reservoir_at(int i) {
-        return reservoir_times[i] / (1000 * 1000.0);
-    }
-    IVFFastScanStats() {
-        reset();
-    }
-    void reset() {
-        memset(this, 0, sizeof(*this));
-    }
-};
-
 } // namespace faiss

--- a/thirdparty/faiss/faiss/IndexPQFastScan.cpp
+++ b/thirdparty/faiss/faiss/IndexPQFastScan.cpp
@@ -408,15 +408,8 @@ void IndexPQFastScan::search_implem_12(
         if (!(skip & 8)) {
             handler.to_flat_arrays(distances, labels, normalizers.get());
         }
-
-        FastScan_stats.t0 += handler.times[0];
-        FastScan_stats.t1 += handler.times[1];
-        FastScan_stats.t2 += handler.times[2];
-        FastScan_stats.t3 += handler.times[3];
     }
 }
-
-FastScanStats FastScan_stats;
 
 template <class C>
 void IndexPQFastScan::search_implem_14(

--- a/thirdparty/faiss/faiss/IndexPQFastScan.h
+++ b/thirdparty/faiss/faiss/IndexPQFastScan.h
@@ -111,16 +111,4 @@ struct IndexPQFastScan : Index {
             int impl) const;
 };
 
-struct FastScanStats {
-    uint64_t t0, t1, t2, t3;
-    FastScanStats() {
-        reset();
-    }
-    void reset() {
-        memset(this, 0, sizeof(*this));
-    }
-};
-
-FAISS_API extern FastScanStats FastScan_stats;
-
 } // namespace faiss


### PR DESCRIPTION
Remove unused stats in PQFastScan, where milvus could fail on global variable initialization on an sse4_2 machine.