### PR TITLE
Add row number constraint for building scann index

### DIFF
--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -270,6 +270,15 @@ IvfIndexNode<T>::Train(const DataSet& dataset, const Config& cfg) {
     auto dim = dataset.GetDim();
     auto data = dataset.GetTensor();
 
+    // faiss scann needs at least 16 rows since nbits=4
+    constexpr int64_t SCANN_MIN_ROWS = 16;
+    if constexpr (std::is_same<faiss::IndexScaNN, T>::value) {
+        if (rows < SCANN_MIN_ROWS) {
+            LOG_KNOWHERE_ERROR_ << rows << " rows is not enough, scann needs at least 16 rows to build index";
+            return Status::faiss_inner_error;
+        }
+    }
+
     typename QuantizerT<T>::type* qzr = nullptr;
     faiss::IndexIVFPQFastScan* base_index = nullptr;
     std::unique_ptr<T> index;


### PR DESCRIPTION
Fix #183 
/kind bug
When people use milvus, index will not be built(brute force search) when rows < MinSegmentNumRowsToEnableIndex(1024),  https://github.com/milvus-io/milvus/blob/master/internal/datacoord/index_builder.go#L237