### PR TITLE
Add iterator support to pyknowhere interface.

### DIFF
--- a/python/knowhere/knowhere.i
+++ b/python/knowhere/knowhere.i
@@ -51,11 +51,13 @@ import_array();
 %include <std_pair.i>
 %include <std_map.i>
 %include <std_shared_ptr.i>
+%include <std_vector.i>
 %include <exception.i>
 %shared_ptr(knowhere::DataSet)
 %shared_ptr(knowhere::BinarySet)
 %template(DataSetPtr) std::shared_ptr<knowhere::DataSet>;
 %template(BinarySetPtr) std::shared_ptr<knowhere::BinarySet>;
+%template(int64_float_pair) std::pair<long long int, float>;
 %include <knowhere/expected.h>
 %include <knowhere/dataset.h>
 %include <knowhere/binaryset.h>
@@ -104,13 +106,32 @@ del Enum
 %inline %{
 
 class GILReleaser {
-public:
+ public:
     GILReleaser() : save(PyEval_SaveThread()) {
     }
     ~GILReleaser() {
         PyEval_RestoreThread(save);
     }
     PyThreadState* save;
+};
+
+class AnnIterator {
+ public:
+    AnnIterator(std::shared_ptr<IndexNode::iterator> it = nullptr) : it_(it) {
+    }
+    ~AnnIterator() {
+    }
+
+    bool HasNext() {
+        return it_ && it_->HasNext();
+    }
+
+    std::pair<int64_t, float> Next() {
+        return it_->Next();
+    }
+
+ private:
+    std::shared_ptr<IndexNode::iterator> it_;
 };
 
 class IndexWrap {
@@ -155,6 +176,22 @@ class IndexWrap {
             status = res.error();
             return nullptr;
         }
+    }
+
+    std::vector<AnnIterator>
+    GetAnnIterator(knowhere::DataSetPtr dataset, const std::string& json, const knowhere::BitsetView& bitset, knowhere::Status& status) {
+        GILReleaser rel;
+        auto res = idx.AnnIterator(*dataset, knowhere::Json::parse(json), bitset);
+        if (!res.has_value()) {
+            status = res.error();
+            return std::vector<AnnIterator>();
+        }
+        status = knowhere::Status::success;
+        std::vector<AnnIterator> result;
+        for (auto it : res.value()) {
+            result.emplace_back(it);
+        }
+        return result;
     }
 
     knowhere::DataSetPtr
@@ -468,3 +505,5 @@ SetSimdType(const std::string type) {
 }
 
 %}
+
+%template(AnnIteratorVector) std::vector<AnnIterator>;

--- a/python/knowhere/knowhere.i
+++ b/python/knowhere/knowhere.i
@@ -115,11 +115,11 @@ class GILReleaser {
     PyThreadState* save;
 };
 
-class AnnIterator {
+class AnnIteratorWrap {
  public:
-    AnnIterator(std::shared_ptr<IndexNode::iterator> it = nullptr) : it_(it) {
+    AnnIteratorWrap(std::shared_ptr<IndexNode::iterator> it = nullptr) : it_(it) {
     }
-    ~AnnIterator() {
+    ~AnnIteratorWrap() {
     }
 
     bool HasNext() {
@@ -178,16 +178,16 @@ class IndexWrap {
         }
     }
 
-    std::vector<AnnIterator>
+    std::vector<AnnIteratorWrap>
     GetAnnIterator(knowhere::DataSetPtr dataset, const std::string& json, const knowhere::BitsetView& bitset, knowhere::Status& status) {
         GILReleaser rel;
         auto res = idx.AnnIterator(*dataset, knowhere::Json::parse(json), bitset);
         if (!res.has_value()) {
             status = res.error();
-            return std::vector<AnnIterator>();
+            return std::vector<AnnIteratorWrap>();
         }
         status = knowhere::Status::success;
-        std::vector<AnnIterator> result;
+        std::vector<AnnIteratorWrap> result;
         for (auto it : res.value()) {
             result.emplace_back(it);
         }
@@ -506,4 +506,4 @@ SetSimdType(const std::string type) {
 
 %}
 
-%template(AnnIteratorVector) std::vector<AnnIterator>;
+%template(AnnIteratorWrapVector) std::vector<AnnIteratorWrap>;

--- a/python/knowhere/knowhere.i
+++ b/python/knowhere/knowhere.i
@@ -118,12 +118,15 @@ class GILReleaser {
 class AnnIteratorWrap {
  public:
     AnnIteratorWrap(std::shared_ptr<IndexNode::iterator> it = nullptr) : it_(it) {
+        if (it_ == nullptr) {
+            throw std::runtime_error("ann iterator must not be nullptr.");
+        }
     }
     ~AnnIteratorWrap() {
     }
 
     bool HasNext() {
-        return it_ && it_->HasNext();
+        return it_->HasNext();
     }
 
     std::pair<int64_t, float> Next() {
@@ -182,12 +185,12 @@ class IndexWrap {
     GetAnnIterator(knowhere::DataSetPtr dataset, const std::string& json, const knowhere::BitsetView& bitset, knowhere::Status& status) {
         GILReleaser rel;
         auto res = idx.AnnIterator(*dataset, knowhere::Json::parse(json), bitset);
+        std::vector<AnnIteratorWrap> result;
         if (!res.has_value()) {
             status = res.error();
-            return std::vector<AnnIteratorWrap>();
+            return result;
         }
         status = knowhere::Status::success;
-        std::vector<AnnIteratorWrap> result;
         for (auto it : res.value()) {
             result.emplace_back(it);
         }

--- a/python/setup.py
+++ b/python/setup.py
@@ -90,7 +90,7 @@ setup(
     description=(
         "A library for efficient similarity search and clustering of vectors."
     ),
-    url="https://github.com/milvus-io/knowhere",
+    url="https://github.com/zilliztech/knowhere",
     author="Milvus Team",
     author_email="milvus-team@zilliz.com",
     license='Apache License 2.0',

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -25,6 +25,7 @@ static const std::unordered_set<std::string> ext_legal_json_keys = {"metric_type
                                                                     "M",               // HNSW param
                                                                     "efConstruction",  // HNSW param
                                                                     "ef",              // HNSW param
+                                                                    "seed_ef",         // HNSW iterator param
                                                                     "level",
                                                                     "index_type",
                                                                     "index_mode",


### PR DESCRIPTION
Add GetAnnIterator method to the swigknowhere IndexWrap class to wrap the AnnIterator method, so iterator can also be used in pyknowhere.

/kind improvement
