### PR TITLE
Generate diskann cache asynchronously.

### DIFF
--- a/thirdparty/DiskANN/include/semaphore.h
+++ b/thirdparty/DiskANN/include/semaphore.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <mutex>
+#include <condition_variable>
+
+namespace diskann {
+class Semaphore {
+public:
+    Semaphore(long count = 0) : count(count) {}
+    void Signal()
+    {
+        std::unique_lock<std::mutex> unique(mt);
+        ++count;
+        if (count <= 0) {
+            cond.notify_one();
+        }
+    }
+    void Wait()
+    {
+        std::unique_lock<std::mutex> unique(mt);
+        --count;
+        if (count < 0) {
+            cond.wait(unique);
+        }
+    }
+    bool IsWaitting() {
+        std::unique_lock<std::mutex> unique(mt);
+        return count < 0;
+    }
+    
+private:
+    std::mutex mt;
+    std::condition_variable cond;
+    long count;
+};
+}  // namespace diskann


### PR DESCRIPTION
This PR will remove the previous sync cache generate function. 
The prepare phase takes a thread from the thread pool to do the following tasks in the background:
1. init search counter and node_visit_counter[nb];
2. if search counter < min(base row number, 100000), update these variables with samlping queries or input queries;
3.  load cached nodes into mem, insert cached vector and neighbors into diskann cache map;

If diskann calls the destructor, this background thread will : 
- search counter < min(base row number, 100000)，return immediately；
- return until all cached nodes are loaded.

I used sift1m(nb = 1M, nq = 10000, dim = 128) for experiments. 
Diskann parameters：
```
  "diskANN_build_config": {
      "data_path": data_path,
      "max_degree": 56,
      "search_list_size": 100,
      "pq_code_budget_gb":0.125 * nb * dim *4 / (1024*1024 *1024),
      "build_dram_budget_gb": 32.0,
      "num_threads": 16,
      "disk_pq_dims": 0,
      "accelerate_build": False
  },
  "diskANN_prepare_config": {
      "num_threads": 16,
      "search_cache_budget_gb": cache_gb,
      "warm_up": False,
      "use_bfs_cache": False
  },
  "diskANN_query_config": {
      "k": 10,
      "search_list_size": 36,
      "beamwidth": 4
  }
```
The experimental plan as follows:
1. Run 10 time nq = 10000, topk = 10 to generate cache;
2. Run random queries(nb = 10000) to eliminate the impact of lru cache；
3. Run last time search (nq = 10000, topk = 10)
previous version result : 
**sync cache generate: 22.35s
search VPS: 5119.53**
lastest version result : 
**aync cache generate: 33.23s
search VPS without cache: 3059
search VPS with cache:  6000.12**

The worst case is that there is no input query vector, and the background thread completes the task using the sampling queries alone. **And the worst case would take 108s to generate cache.**