### PR TITLE
Move read/writeBinaryPOD from hnswlib to knowhere utils.

### DIFF
--- a/include/knowhere/utils.h
+++ b/include/knowhere/utils.h
@@ -80,4 +80,16 @@ ConvertIVFFlat(const BinarySet& binset, const MetricType metric_type, const uint
 bool
 UseDiskLoad(const std::string& index_type, const int32_t& /*version*/);
 
+template <typename T, typename W>
+static void
+writeBinaryPOD(W& out, const T& podRef) {
+    out.write((char*)&podRef, sizeof(T));
+}
+
+template <typename T, typename R>
+static void
+readBinaryPOD(R& in, T& podRef) {
+    in.read((char*)&podRef, sizeof(T));
+}
+
 }  // namespace knowhere

--- a/thirdparty/hnswlib/hnswlib/hnswalg.h
+++ b/thirdparty/hnswlib/hnswlib/hnswalg.h
@@ -27,6 +27,7 @@
 #include "hnswlib.h"
 #include "io/memory_io.h"
 #include "knowhere/config.h"
+#include "knowhere/utils.h"
 #include "knowhere/heap.h"
 #include "neighbor.h"
 #include "visited_list_pool.h"
@@ -661,6 +662,7 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
 
     void
     loadIndex(const std::string& location, const knowhere::Config& config, size_t max_elements_i = 0) {
+        using knowhere::readBinaryPOD;
         auto cfg = static_cast<const knowhere::BaseConfig&>(config);
 
         auto input = knowhere::FileReader(location);
@@ -770,6 +772,7 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
 
     void
     saveIndex(knowhere::MemoryIOWriter& output) {
+        using knowhere::writeBinaryPOD;
         // write l2/ip calculator
         writeBinaryPOD(output, metric_type_);
         writeBinaryPOD(output, data_size_);
@@ -807,6 +810,7 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
 
     void
     loadIndex(knowhere::MemoryIOReader& input, size_t max_elements_i = 0) {
+        using knowhere::readBinaryPOD;
         // linxj: init with metrictype
         size_t dim;
         readBinaryPOD(input, metric_type_);

--- a/thirdparty/hnswlib/hnswlib/hnswlib.h
+++ b/thirdparty/hnswlib/hnswlib/hnswlib.h
@@ -148,30 +148,6 @@ class pairGreater {
     }
 };
 
-template <typename T>
-static void
-writeBinaryPOD(std::ostream& out, const T& podRef) {
-    out.write((char*)&podRef, sizeof(T));
-}
-
-template <typename T>
-static void
-readBinaryPOD(std::istream& in, T& podRef) {
-    in.read((char*)&podRef, sizeof(T));
-}
-
-template <typename T, typename W>
-static void
-writeBinaryPOD(W& out, const T& podRef) {
-    out.write((char*)&podRef, sizeof(T));
-}
-
-template <typename T, typename R>
-static void
-readBinaryPOD(R& in, T& podRef) {
-    in.read((char*)&podRef, sizeof(T));
-}
-
 template <typename MTYPE>
 using DISTFUNC = MTYPE (*)(const void*, const void*, const void*);
 


### PR DESCRIPTION
/kind improvement

serialize/deserialize of sparse vector #193 can also make use of read/writeBinaryPOD methods, thus moving it from hnswlib to knowhere.