### PR TITLE
Nit: fix variable types

### DIFF
--- a/thirdparty/faiss/faiss/impl/pq4_fast_scan_search_1.cpp
+++ b/thirdparty/faiss/faiss/impl/pq4_fast_scan_search_1.cpp
@@ -125,7 +125,7 @@ void accumulate_fixed_blocks(
         ResultHandler& res,
         const Scaler& scaler) {
     constexpr int bbs = 32 * BB;
-    for (int64_t j0 = 0; j0 < nb; j0 += bbs) {
+    for (size_t j0 = 0; j0 < nb; j0 += bbs) {
         FixedStorageHandler<NQ, 2 * BB> res2;
         kernel_accumulate_block<NQ, BB>(nsq, codes, LUT, res2, scaler);
         res.set_block_origin(0, j0);

--- a/thirdparty/faiss/faiss/impl/pq4_fast_scan_search_qbs.cpp
+++ b/thirdparty/faiss/faiss/impl/pq4_fast_scan_search_qbs.cpp
@@ -123,13 +123,13 @@ void accumulate_q_4step(
     constexpr int Q4 = (QBS >> 12) & 15;
     constexpr int SQ = Q1 + Q2 + Q3 + Q4;
 
-    for (int64_t j0 = 0; j0 < ntotal2; j0 += 32, codes += 32 * nsq / 2) {
+    for (size_t j0 = 0; j0 < ntotal2; j0 += 32, codes += 32 * nsq / 2) {
         res.set_block_origin(0, j0);
 
         // skip computing distances if all vectors inside a block are filtered out
         if (res.sel != nullptr) {  // we have filter here
             bool skip_flag = true;
-            for (int64_t jj = 0; jj < std::min<int64_t>(32, ntotal2 - j0);
+            for (size_t jj = 0; jj < std::min<size_t>(32, ntotal2 - j0);
                  jj++) {
                 auto real_idx = res.adjust_id(0, jj);
                 if (res.sel->is_member(real_idx)) {  // id is not filtered out, can not skip computing
@@ -173,7 +173,7 @@ void kernel_accumulate_block_loop(
         const uint8_t* LUT,
         ResultHandler& res,
         const Scaler& scaler) {
-    for (int64_t j0 = 0; j0 < ntotal2; j0 += 32) {
+    for (size_t j0 = 0; j0 < ntotal2; j0 += 32) {
         res.set_block_origin(0, j0);
         kernel_accumulate_block<NQ, ResultHandler>(
                 nsq, codes + j0 * nsq / 2, LUT, res, scaler);
@@ -260,7 +260,7 @@ void pq4_accumulate_loop_qbs(
 
     // default implementation where qbs is not known at compile time
 
-    for (int64_t j0 = 0; j0 < ntotal2; j0 += 32) {
+    for (size_t j0 = 0; j0 < ntotal2; j0 += 32) {
         const uint8_t* LUT = LUT0;
         int qi = qbs;
         int i0 = 0;

--- a/thirdparty/faiss/faiss/utils/partitioning_avx2.cpp
+++ b/thirdparty/faiss/faiss/utils/partitioning_avx2.cpp
@@ -84,7 +84,7 @@ void count_lt_and_eq(
         n_lt += 16 - i_ge;
     }
 
-    for (size_t i = n1 * 16; i < n; i++) {
+    for (size_t i = n1 * 16; i < (size_t)n; i++) {
         uint16_t v = *vals++;
         if (C::cmp(thresh, v)) {
             n_lt++;
@@ -162,7 +162,7 @@ int simd_compress_array(
     }
 
     // end with scalar
-    for (int i = (n & ~15); i < n; i++) {
+    for (size_t i = (n & ~15); i < n; i++) {
         if (C::cmp(thresh, vals[i])) {
             vals[wp] = vals[i];
             ids[wp] = ids[i];


### PR DESCRIPTION
The inconsistency in variable types would generate waaaaaaay too many warnings `comparison of integer expressions of different signedness` during the compilation if all the warnings are made reported

Corresponsing baseline FAISS PR is https://github.com/facebookresearch/faiss/pull/3147 

/Issue #228 
/kind improvement 