### PR TITLE
Remove search_list_and_k_ratio param

### DIFF
--- a/src/index/diskann/diskann.cc
+++ b/src/index/diskann/diskann.cc
@@ -594,7 +594,6 @@ DiskANNIndexNode<T>::RangeSearch(const DataSet& dataset, const Config& cfg, cons
     auto beamwidth = static_cast<uint64_t>(search_conf.beamwidth.value());
     auto min_k = static_cast<uint64_t>(search_conf.min_k.value());
     auto max_k = static_cast<uint64_t>(search_conf.max_k.value());
-    auto search_list_and_k_ratio = search_conf.search_list_and_k_ratio.value();
 
     auto radius = search_conf.radius.value();
     auto range_filter = search_conf.range_filter.value();
@@ -620,7 +619,7 @@ DiskANNIndexNode<T>::RangeSearch(const DataSet& dataset, const Config& cfg, cons
             std::vector<int64_t> indices;
             std::vector<float> distances;
             pq_flash_index_->range_search(xq + (index * dim), radius, min_k, max_k, result_id_array[index],
-                                          result_dist_array[index], beamwidth, search_list_and_k_ratio, bitset);
+                                          result_dist_array[index], beamwidth, bitset);
             // filter range search result
             if (search_conf.range_filter.value() != defaultRangeFilter) {
                 FilterRangeSearchResultForOneNq(result_dist_array[index], result_id_array[index], is_ip, radius,

--- a/src/index/diskann/diskann_config.h
+++ b/src/index/diskann/diskann_config.h
@@ -67,9 +67,6 @@ class DiskANNConfig : public BaseConfig {
     CFG_INT min_k;
     // DiskANN uses TopK search to simulate range search by double the K in every round. This is the largest K.
     CFG_INT max_k;
-    // DiskANN uses TopK search to simulate range search, this is the ratio of search list size and k. With larger
-    // ratio, the accuracy will get higher but throughput will get affected.
-    CFG_FLOAT search_list_and_k_ratio;
     // The threshold which determines when to switch to PQ + Refine strategy based on the number of bits set. The
     // value should be in range of [0.0, 1.0] which means when greater or equal to x% of the bits are set,
     // use PQ + Refine. Default to -1.0f, negative vlaues will use dynamic threshold calculator given topk.
@@ -136,11 +133,6 @@ class DiskANNConfig : public BaseConfig {
             .description("the max l_search size used in range search.")
             .set_default(std::numeric_limits<CFG_INT::value_type>::max())
             .set_range(1, std::numeric_limits<CFG_INT::value_type>::max())
-            .for_range_search();
-        KNOWHERE_CONFIG_DECLARE_FIELD(search_list_and_k_ratio)
-            .description("the ratio of search list size and k.")
-            .set_default(2.0)
-            .set_range(1.0, 5.0)
             .for_range_search();
         KNOWHERE_CONFIG_DECLARE_FIELD(filter_threshold)
             .description("the threshold of filter ratio to use PQ + Refine.")

--- a/tests/ut/test_diskann.cc
+++ b/tests/ut/test_diskann.cc
@@ -86,7 +86,6 @@ TEST_CASE("Invalid diskann params test", "[diskann]") {
         json["beamwidth"] = 8;
         json["min_k"] = 10;
         json["max_k"] = 8000;
-        json["search_list_and_k_ratio"] = 2.0;
         return json;
     };
     std::shared_ptr<knowhere::FileManager> file_manager = std::make_shared<knowhere::LocalFileManager>();
@@ -218,7 +217,6 @@ TEST_CASE("Test DiskANNIndexNode.", "[diskann]") {
         json["beamwidth"] = 8;
         json["min_k"] = 10;
         json["max_k"] = 8000;
-        json["search_list_and_k_ratio"] = 2.0;
         return json;
     };
 

--- a/thirdparty/DiskANN/include/diskann/pq_flash_index.h
+++ b/thirdparty/DiskANN/include/diskann/pq_flash_index.h
@@ -91,7 +91,7 @@ namespace diskann {
     _u32 range_search(const T *query1, const double range,
                       const _u64 min_l_search, const _u64 max_l_search,
                       std::vector<_s64> &indices, std::vector<float> &distances,
-                      const _u64 beam_width, const float l_k_ratio,
+                      const _u64 beam_width,
                       knowhere::BitsetView bitset_view = nullptr,
                       QueryStats          *stats = nullptr);
 

--- a/thirdparty/DiskANN/src/pq_flash_index.cpp
+++ b/thirdparty/DiskANN/src/pq_flash_index.cpp
@@ -1284,8 +1284,7 @@ namespace diskann {
       const T *query1, const double range, const _u64 min_l_search,
       const _u64 max_l_search, std::vector<_s64> &indices,
       std::vector<float> &distances, const _u64 beam_width,
-      const float l_k_ratio, knowhere::BitsetView bitset_view,
-      QueryStats *stats) {
+      knowhere::BitsetView bitset_view, QueryStats *stats) {
     _u32 res_count = 0;
 
     bool stop_flag = false;
@@ -1296,7 +1295,7 @@ namespace diskann {
       distances.resize(l_search);
       for (auto &x : distances)
         x = std::numeric_limits<float>::max();
-      this->cached_beam_search(query1, l_search, l_k_ratio * l_search,
+      this->cached_beam_search(query1, l_search, l_search,
                                indices.data(), distances.data(), beam_width,
                                false, stats, nullptr, bitset_view);
       for (_u32 i = 0; i < l_search; i++) {


### PR DESCRIPTION
`search_list_and_k_ratio` is useless, since in range search we will perform iterative search each time we will enlarge topk. We don't need `search_list_and_k_ratio` to make search_list larger than topk, once we search by search_list in an iteration, we could get all results to verify, not just choosing topk of them.  Therefore we only need min_k and max_k to control the range search.

/kind improvement