### PR TITLE
Accelerate range search for diskann

### DIFF
--- a/src/index/diskann/diskann_config.h
+++ b/src/index/diskann/diskann_config.h
@@ -139,7 +139,7 @@ class DiskANNConfig : public BaseConfig {
             .for_range_search();
         KNOWHERE_CONFIG_DECLARE_FIELD(search_list_and_k_ratio)
             .description("the ratio of search list size and k.")
-            .set_default(2.0)
+            .set_default(1.0)
             .set_range(1.0, 5.0)
             .for_range_search();
         KNOWHERE_CONFIG_DECLARE_FIELD(filter_threshold)


### PR DESCRIPTION
Set search list and k ratio to 1.0 This PR set the search list size to k ratio from 2.0 to 1.0 be default. 

DiskANN's range search is implemented by topK search with growing k. And this ratio decide how big the search list size should be in each round of topK search. 

When K grows bigger, this ratio doesn't need to be very big to get a high recall. And in range search scenario, K will always be relatively big, so making this ratio small can accelerate range search with a slight recall regression.

/kind improvement