### PR TITLE
Move memory allocation out of elkan_L2_sse

### DIFF
--- a/thirdparty/faiss/faiss/IndexFlatElkan.cpp
+++ b/thirdparty/faiss/faiss/IndexFlatElkan.cpp
@@ -21,6 +21,8 @@ namespace faiss {
 IndexFlatElkan::IndexFlatElkan(idx_t d, MetricType metric, bool is_cosine, bool use_elkan)
         : IndexFlat(d, metric, is_cosine) {
     this->use_elkan = use_elkan;
+    if (this->use_elkan)
+        this->tmp_buffer_for_elkan = std::make_unique<float[]>(1024 * (1024 - 1) / 2);
 }
 
 void IndexFlatElkan::search(
@@ -54,7 +56,7 @@ void IndexFlatElkan::search(
             // ignore the metric_type, both use L2
             if (use_elkan) {
                 // use elkan
-                elkan_L2_sse(x, get_xb(), d, n, ntotal, labels, dis_inner);
+                elkan_L2_sse(x, get_xb(), d, n, ntotal, labels, dis_inner, tmp_buffer_for_elkan.get());
             }
             else {
                 // use L2 search. The same code as in IndexFlat::search() for L2.

--- a/thirdparty/faiss/faiss/IndexFlatElkan.cpp
+++ b/thirdparty/faiss/faiss/IndexFlatElkan.cpp
@@ -21,8 +21,10 @@ namespace faiss {
 IndexFlatElkan::IndexFlatElkan(idx_t d, MetricType metric, bool is_cosine, bool use_elkan)
         : IndexFlat(d, metric, is_cosine) {
     this->use_elkan = use_elkan;
-    if (this->use_elkan)
-        this->tmp_buffer_for_elkan = std::make_unique<float[]>(1024 * (1024 - 1) / 2);
+    if (this->use_elkan) {
+        this->sym_dim = 1024;
+        this->tmp_buffer_for_elkan = std::make_unique<float[]>(this->sym_dim * (this->sym_dim - 1) / 2);
+    }
 }
 
 void IndexFlatElkan::search(
@@ -56,7 +58,7 @@ void IndexFlatElkan::search(
             // ignore the metric_type, both use L2
             if (use_elkan) {
                 // use elkan
-                elkan_L2_sse(x, get_xb(), d, n, ntotal, labels, dis_inner, tmp_buffer_for_elkan.get());
+                elkan_L2_sse(x, get_xb(), d, n, ntotal, labels, dis_inner, tmp_buffer_for_elkan.get(), sym_dim);
             }
             else {
                 // use L2 search. The same code as in IndexFlat::search() for L2.

--- a/thirdparty/faiss/faiss/IndexFlatElkan.h
+++ b/thirdparty/faiss/faiss/IndexFlatElkan.h
@@ -36,8 +36,13 @@ namespace faiss {
 // 'IndexFlatElkan::search()' on the same instance should be avoided
 // to prevent data overwite corruption in the temporary buffer.
 //
+// The temporary buffer is used to store half size of symmetric matrix
+// data, excluding the diagnoal. IndexFlatElkan specifies the dimension
+// of the matrix.
+//
 struct IndexFlatElkan : IndexFlat {
     bool use_elkan = true;
+    size_t sym_dim = 0;
     std::unique_ptr<float[]> tmp_buffer_for_elkan = nullptr;
 
     explicit IndexFlatElkan(idx_t d, MetricType metric = METRIC_L2,

--- a/thirdparty/faiss/faiss/IndexFlatElkan.h
+++ b/thirdparty/faiss/faiss/IndexFlatElkan.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <faiss/IndexFlat.h>
+#include <memory>
 
 namespace faiss {
 
@@ -27,8 +28,17 @@ namespace faiss {
 // This index is intended to be used in Knowhere's ivf.cc file ONLY!!!
 //
 // Elkan algo was introduced into Knowhere in #2178, #2180 and #2258. 
+//
+// It pre-allocates a temporary buffer, to be used by elkan algorithm
+// to avoid the overhead caused by frequent memory allocation and
+// deallocation. Due to this strategy, the index is not thread-safe
+// on the search. Concurrent access by multiple threads to
+// 'IndexFlatElkan::search()' on the same instance should be avoided
+// to prevent data overwite corruption in the temporary buffer.
+//
 struct IndexFlatElkan : IndexFlat {
     bool use_elkan = true;
+    std::unique_ptr<float[]> tmp_buffer_for_elkan = nullptr;
 
     explicit IndexFlatElkan(idx_t d, MetricType metric = METRIC_L2,
                        bool is_cosine = false, bool use_elkan = true);

--- a/thirdparty/faiss/faiss/utils/distances.cpp
+++ b/thirdparty/faiss/faiss/utils/distances.cpp
@@ -1156,15 +1156,14 @@ void elkan_L2_sse(
         size_t ny,
         int64_t* ids,
         float* val,
-        float* tmp_buffer) {
+        float* tmp_buffer,
+        size_t sym_dim) {
     if (nx == 0 || ny == 0) {
         return;
     }
 
-    const size_t bs_y = 1024;
-
-    for (size_t j0 = 0; j0 < ny; j0 += bs_y) {
-        size_t j1 = j0 + bs_y;
+    for (size_t j0 = 0; j0 < ny; j0 += sym_dim) {
+        size_t j1 = j0 + sym_dim;
         if (j1 > ny)
             j1 = ny;
 

--- a/thirdparty/faiss/faiss/utils/distances.cpp
+++ b/thirdparty/faiss/faiss/utils/distances.cpp
@@ -1155,13 +1155,13 @@ void elkan_L2_sse(
         size_t nx,
         size_t ny,
         int64_t* ids,
-        float* val) {
+        float* val,
+        float* tmp_buffer) {
     if (nx == 0 || ny == 0) {
         return;
     }
 
     const size_t bs_y = 1024;
-    float* data = (float*)malloc((bs_y * (bs_y - 1) / 2) * sizeof(float));
 
     for (size_t j0 = 0; j0 < ny; j0 += bs_y) {
         size_t j1 = j0 + bs_y;
@@ -1171,8 +1171,8 @@ void elkan_L2_sse(
         auto Y = [&](size_t i, size_t j) -> float& {
             assert(i != j);
             i -= j0, j -= j0;
-            return (i > j) ? data[j + i * (i - 1) / 2]
-                           : data[i + j * (j - 1) / 2];
+            return (i > j) ? tmp_buffer[j + i * (i - 1) / 2]
+                           : tmp_buffer[i + j * (j - 1) / 2];
         };
 
 #pragma omp parallel
@@ -1219,7 +1219,6 @@ void elkan_L2_sse(
         }
     }
 
-    free(data);
 }
 
 } // namespace faiss

--- a/thirdparty/faiss/faiss/utils/distances.h
+++ b/thirdparty/faiss/faiss/utils/distances.h
@@ -418,11 +418,12 @@ void compute_PQ_dis_tables_dsub2(
 
 /** Return the nearest neighbors of each of the nx vectors x among the ny
  *
- * @param x    query vectors, size nx * d
- * @param y    database vectors, size ny * d
- * @param ids  result array ids
- * @param val  result array value
+ * @param x          query vectors, size nx * d
+ * @param y          database vectors, size ny * d
+ * @param ids        result array ids
+ * @param val        result array value
  * @param tmp_buffer tmporary memory for symmetric matrix data
+ * @param sym_dim    dimension of symmetric matrix
  */
 void elkan_L2_sse(
         const float* x,
@@ -432,7 +433,8 @@ void elkan_L2_sse(
         size_t ny,
         int64_t* ids,
         float* val,
-        float* tmp_buffer);
+        float* tmp_buffer,
+        size_t sym_dim);
 
 /***************************************************************************
  * Templatized versions of distance functions

--- a/thirdparty/faiss/faiss/utils/distances.h
+++ b/thirdparty/faiss/faiss/utils/distances.h
@@ -422,6 +422,7 @@ void compute_PQ_dis_tables_dsub2(
  * @param y    database vectors, size ny * d
  * @param ids  result array ids
  * @param val  result array value
+ * @param tmp_buffer tmporary memory for symmetric matrix data
  */
 void elkan_L2_sse(
         const float* x,
@@ -430,7 +431,8 @@ void elkan_L2_sse(
         size_t nx,
         size_t ny,
         int64_t* ids,
-        float* val);
+        float* val,
+        float* tmp_buffer);
 
 /***************************************************************************
  * Templatized versions of distance functions


### PR DESCRIPTION
elkan_L2_sse() does malloc/free each time when it's called by the loop in train_encoded() during data train for most of IVF index building. Memory allocation triggers the process of vma allocation, physical page allocation, page mapping setup and memory cgroup statistic update in kernel side, so more frequent allocation means more overhead. Move it out of the loop and do it only once when IndexFlatElkan is initialized to save CPU cycles.

issue #279 