### PR TITLE
Add support for GPU-accelerated brute force indexes

### DIFF
--- a/include/knowhere/comp/index_param.h
+++ b/include/knowhere/comp/index_param.h
@@ -37,6 +37,7 @@ constexpr const char* INDEX_FAISS_GPU_IVFFLAT = "GPU_FAISS_IVF_FLAT";
 constexpr const char* INDEX_FAISS_GPU_IVFPQ = "GPU_FAISS_IVF_PQ";
 constexpr const char* INDEX_FAISS_GPU_IVFSQ8 = "GPU_FAISS_IVF_SQ8";
 
+constexpr const char* INDEX_RAFT_BRUTEFORCE = "GPU_RAFT_BRUTE_FORCE";
 constexpr const char* INDEX_RAFT_IVFFLAT = "GPU_RAFT_IVF_FLAT";
 constexpr const char* INDEX_RAFT_IVFPQ = "GPU_RAFT_IVF_PQ";
 constexpr const char* INDEX_RAFT_CAGRA = "GPU_RAFT_CAGRA";

--- a/src/common/raft/integration/brute_force_index.cu
+++ b/src/common/raft/integration/brute_force_index.cu
@@ -14,8 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
+#undef RAFT_EXPLICIT_INSTANTIATE_ONLY
+#include "common/raft/integration/raft_knowhere_index.cuh"
+#include "common/raft/proto/filtered_search_instantiation.cuh"
+#include "common/raft/proto/raft_index_kind.hpp"
 
-namespace raft_proto {
-enum struct raft_index_kind { brute_force, ivf_flat, ivf_pq, cagra };
-}  // namespace raft_proto
+namespace raft_knowhere {
+template struct raft_knowhere_index<raft_proto::raft_index_kind::brute_force>;
+}  // namespace raft_knowhere

--- a/src/common/raft/integration/raft_knowhere_config.hpp
+++ b/src/common/raft/integration/raft_knowhere_config.hpp
@@ -75,6 +75,9 @@ struct raft_knowhere_config {
 // of RAFT index configurations.
 [[nodiscard]] inline auto
 validate_raft_knowhere_config(raft_knowhere_config config) {
+    if (config.index_type == raft_proto::raft_index_kind::brute_force) {
+        config.add_data_on_build = false;
+    }
     if (config.index_type == raft_proto::raft_index_kind::ivf_flat ||
         config.index_type == raft_proto::raft_index_kind::ivf_pq) {
         config.add_data_on_build = true;

--- a/src/common/raft/integration/raft_knowhere_index.cuh
+++ b/src/common/raft/integration/raft_knowhere_index.cuh
@@ -15,13 +15,17 @@
  * limitations under the License.
  */
 #pragma once
+#include <cmath>
 #include <cstdint>
 #include <istream>
+#include <limits>
 #include <ostream>
 #include <raft/core/bitset.cuh>
 #include <raft/core/copy.cuh>
 #include <raft/core/device_resources_manager.hpp>
 #include <raft/core/device_setter.hpp>
+#include <raft/core/resource/cuda_stream.hpp>
+#include <raft/core/resource/thrust_policy.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/neighbors/ivf_pq_types.hpp>
 #include <raft/neighbors/sample_filter.cuh>
@@ -40,6 +44,15 @@ namespace detail {
 template <bool B, raft_proto::raft_index_kind IndexKind>
 struct raft_index_type_mapper : std::false_type {};
 
+template <>
+struct raft_index_type_mapper<true, raft_proto::raft_index_kind::brute_force> : std::true_type {
+    using data_type = raft_data_t<raft_proto::raft_index_kind::brute_force>;
+    using indexing_type = raft_indexing_t<raft_proto::raft_index_kind::brute_force>;
+    using type = raft_proto::raft_index<raft::neighbors::brute_force::index, data_type>;
+    using underlying_index_type = typename type::vector_index_type;
+    using index_params_type = typename type::index_params_type;
+    using search_params_type = typename type::search_params_type;
+};
 template <>
 struct raft_index_type_mapper<true, raft_proto::raft_index_kind::ivf_flat> : std::true_type {
     using data_type = raft_data_t<raft_proto::raft_index_kind::ivf_flat>;
@@ -368,7 +381,11 @@ struct raft_knowhere_index<IndexKind>::impl {
     void
     add(data_type const* data, knowhere_indexing_type row_count, knowhere_indexing_type feature_count,
         knowhere_indexing_type const* new_ids) {
-        if constexpr (index_kind == raft_proto::raft_index_kind::cagra) {
+        if constexpr (index_kind == raft_proto::raft_index_kind::brute_force) {
+            if (index_) {
+                RAFT_FAIL("RAFT brute force does not support adding vectors after training");
+            }
+        } else if constexpr (index_kind == raft_proto::raft_index_kind::cagra) {
             if (index_) {
                 RAFT_FAIL("CAGRA does not support adding vectors after training");
             }
@@ -423,12 +440,22 @@ struct raft_knowhere_index<IndexKind>::impl {
 
         auto device_bitset =
             std::optional<raft::core::bitset<knowhere_bitset_data_type, knowhere_bitset_indexing_type>>{};
+        auto k_tmp = k;
 
         if (bitset_data != nullptr && bitset_byte_size != 0) {
             device_bitset =
                 raft::core::bitset<knowhere_bitset_data_type, knowhere_bitset_indexing_type>(res, bitset_size);
             raft::copy(res, device_bitset->to_mdspan(), raft::make_host_vector_view(bitset_data, bitset_byte_size));
-            device_bitset->flip(res);
+            if constexpr (index_kind == raft_proto::raft_index_kind::brute_force) {
+                k_tmp += device_bitset->count(res);
+                if (k_tmp == k) {
+                    device_bitset = std::nullopt;
+                }
+                k_tmp = std::min(k_tmp, size());
+            }
+            if (device_bitset) {
+                device_bitset->flip(res);
+            }
         }
 
         auto output_size = row_count * k;
@@ -438,8 +465,8 @@ struct raft_knowhere_index<IndexKind>::impl {
         auto host_ids = raft::make_host_matrix_view(ids.get(), row_count, k);
         auto host_distances = raft::make_host_matrix_view(distances.get(), row_count, k);
 
-        auto device_ids_storage = raft::make_device_matrix<indexing_type, input_indexing_type>(res, row_count, k);
-        auto device_distances_storage = raft::make_device_matrix<data_type, input_indexing_type>(res, row_count, k);
+        auto device_ids_storage = raft::make_device_matrix<indexing_type, input_indexing_type>(res, row_count, k_tmp);
+        auto device_distances_storage = raft::make_device_matrix<data_type, input_indexing_type>(res, row_count, k_tmp);
         auto device_ids = device_ids_storage.view();
         auto device_distances = device_distances_storage.view();
 
@@ -454,40 +481,42 @@ struct raft_knowhere_index<IndexKind>::impl {
                 device_distances, config.refine_ratio, input_indexing_type{}, dataset_view,
                 raft::neighbors::filtering::bitset_filter<knowhere_bitset_data_type, knowhere_bitset_indexing_type>{
                     device_bitset->view()});
-
         } else {
             raft_index_type::search(res, *index_, search_params, raft::make_const_mdspan(device_data_storage.view()),
                                     device_ids, device_distances, config.refine_ratio, input_indexing_type{},
                                     dataset_view);
         }
-        if constexpr (index_kind == raft_proto::raft_index_kind::ivf_pq) {
-            thrust::replace(res.get_thrust_policy(), thrust::device_ptr<indexing_type>(device_ids.data_handle()),
-                            thrust::device_ptr<indexing_type>(device_ids.data_handle() + output_size),
-                            std::numeric_limits<indexing_type>::max(), indexing_type{-1});
-        }
 
-        // For raft_ivf_flat, setting invalid IDs to 0 here will only
-        // slightly affect the recall(ground truth contain 0th vector). In order to
-        // maintain consistency in Knowhere's results and better serve the merging of results in the upper layers of
-        // Milvus, it is temporarily replaced with -1
-        if constexpr (index_kind == raft_proto::raft_index_kind::ivf_flat) {
-            thrust::replace(res.get_thrust_policy(), thrust::device_ptr<indexing_type>(device_ids.data_handle()),
-                            thrust::device_ptr<indexing_type>(device_ids.data_handle() + output_size), indexing_type{0},
-                            indexing_type{-1});
-        }
-
-        if constexpr (index_kind == raft_proto::raft_index_kind::cagra) {
-            auto tmp = raft::make_device_matrix<knowhere_indexing_type, input_indexing_type>(res, row_count, k);
-            raft::copy(res, tmp.view(), device_ids);
-            thrust::replace(res.get_thrust_policy(), thrust::device_ptr<knowhere_indexing_type>(tmp.data_handle()),
-                            thrust::device_ptr<knowhere_indexing_type>(tmp.data_handle() + output_size),
-                            knowhere_indexing_type{0x7fffffffu}, knowhere_indexing_type{-1});
-            raft::copy(res, host_ids, tmp.view());
-
+        if constexpr (index_kind == raft_proto::raft_index_kind::brute_force) {
+            if (k_tmp > k) {
+                for (auto i = 0; i < host_ids.extent(0); ++i) {
+                    raft::copy(res, raft::make_host_vector_view(host_ids.data_handle() + i * host_ids.extent(1), k),
+                               raft::make_device_vector_view(device_ids.data_handle() + i * device_ids.extent(1), k));
+                    raft::copy(
+                        res,
+                        raft::make_host_vector_view(host_distances.data_handle() + i * host_distances.extent(1), k),
+                        raft::make_device_vector_view(device_distances.data_handle() + i * device_distances.extent(1),
+                                                      k));
+                }
+            } else {
+                raft::copy(res, host_ids, device_ids);
+                raft::copy(res, host_distances, device_distances);
+            }
         } else {
             raft::copy(res, host_ids, device_ids);
+            raft::copy(res, host_distances, device_distances);
         }
-        raft::copy(res, host_distances, device_distances);
+        raft::resource::sync_stream(res);
+        auto static max_distance = std::nextafter(std::numeric_limits<data_type>::max(), 0.0f);
+        for (auto i = knowhere_indexing_type{}; i < row_count; ++i) {
+            for (auto j = knowhere_indexing_type{}; j < k; ++j) {
+                auto distance = host_distances(i, j);
+                if (distance >= max_distance || distance < 0 ||
+                    host_ids(i, j) == std::numeric_limits<indexing_type>::max()) {
+                    host_ids(i, j) = -1;
+                }
+            }
+        }
         return std::make_tuple(ids.release(), distances.release());
     }
     void

--- a/src/common/raft/integration/raft_knowhere_index.cuh
+++ b/src/common/raft/integration/raft_knowhere_index.cuh
@@ -509,12 +509,12 @@ struct raft_knowhere_index<IndexKind>::impl {
             std::optional<raft::device_matrix<knowhere_indexing_type, input_indexing_type>>{};
         auto device_knowhere_ids = [&device_knowhere_ids_storage, &res, row_count, k_tmp, device_ids]() {
             if constexpr (std::is_signed_v<indexing_type>) {
+                return device_ids;
+            } else {
                 device_knowhere_ids_storage =
                     raft::make_device_matrix<knowhere_indexing_type, input_indexing_type>(res, row_count, k_tmp);
                 raft::copy(res, device_knowhere_ids_storage->view(), device_ids);
                 return device_knowhere_ids_storage->view();
-            } else {
-                return device_ids;
             }
         }();
 

--- a/src/common/raft/integration/raft_knowhere_index.hpp
+++ b/src/common/raft/integration/raft_knowhere_index.hpp
@@ -76,6 +76,7 @@ struct raft_knowhere_index {
     }
 };
 
+extern template struct raft_knowhere_index<raft_proto::raft_index_kind::brute_force>;
 extern template struct raft_knowhere_index<raft_proto::raft_index_kind::ivf_flat>;
 extern template struct raft_knowhere_index<raft_proto::raft_index_kind::ivf_pq>;
 extern template struct raft_knowhere_index<raft_proto::raft_index_kind::cagra>;

--- a/src/common/raft/integration/type_mappers.hpp
+++ b/src/common/raft/integration/type_mappers.hpp
@@ -33,6 +33,13 @@ template <bool B, raft_proto::raft_index_kind IndexKind>
 struct raft_io_type_mapper : std::false_type {};
 
 template <>
+struct raft_io_type_mapper<true, raft_proto::raft_index_kind::brute_force> : std::true_type {
+    using data_type = float;
+    using indexing_type = std::int64_t;
+    using input_indexing_type = std::int64_t;
+};
+
+template <>
 struct raft_io_type_mapper<true, raft_proto::raft_index_kind::ivf_flat> : std::true_type {
     using data_type = float;
     using indexing_type = std::int64_t;

--- a/src/common/raft/proto/raft_index.cuh
+++ b/src/common/raft/proto/raft_index.cuh
@@ -15,12 +15,23 @@
  * limitations under the License.
  */
 #pragma once
+#include <thrust/device_ptr.h>
+#include <thrust/fill.h>
+#include <thrust/for_each.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/partition.h>
+#include <thrust/tuple.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <istream>
 #include <optional>
 #include <ostream>
 #include <raft/core/logger.hpp>
+#include <raft/neighbors/brute_force.cuh>
+#include <raft/neighbors/brute_force_serialize.cuh>
+#include <raft/neighbors/brute_force_types.hpp>
 #include <raft/neighbors/cagra.cuh>
 #include <raft/neighbors/cagra_serialize.cuh>
 #include <raft/neighbors/cagra_types.hpp>
@@ -43,6 +54,10 @@ template <raft_index_kind index_kind, template <typename...> typename index_temp
 struct template_matches_index_kind : std::false_type {};
 
 template <>
+struct template_matches_index_kind<raft_index_kind::brute_force, raft::neighbors::brute_force::index> : std::true_type {
+};
+
+template <>
 struct template_matches_index_kind<raft_index_kind::ivf_flat, raft::neighbors::ivf_flat::index> : std::true_type {};
 
 template <>
@@ -54,38 +69,107 @@ struct template_matches_index_kind<raft_index_kind::cagra, raft::neighbors::cagr
 template <raft_index_kind index_kind, template <typename...> typename index_template>
 auto static constexpr template_matches_index_kind_v = template_matches_index_kind<index_kind, index_template>::value;
 
+// Note: The following are not at all general or properly SFINAE-guarded. They
+// should be replaced if the post_filter proto is required for upstreaming.
+template <typename mdspan_t>
+auto
+mdspan_begin(mdspan_t data) {
+    return thrust::device_ptr<typename mdspan_t::value_type>(data.data_handle());
+}
+template <typename mdspan_t>
+auto
+mdspan_end(mdspan_t data) {
+    return thrust::device_ptr<typename mdspan_t::value_type>(data.data_handle() + data.size());
+}
+
+template <typename mdspan_t>
+auto
+mdspan_begin_row(mdspan_t data, std::size_t row) {
+    return thrust::device_ptr<typename mdspan_t::value_type>(data.data_handle() + row * data.extent(1));
+}
+template <typename mdspan_t>
+auto
+mdspan_end_row(mdspan_t data, std::size_t row) {
+    return thrust::device_ptr<typename mdspan_t::value_type>(data.data_handle() + (row + 1) * data.extent(1));
+}
+
+template <typename index_mdspan_t, typename distance_mdspan_t, typename filter_lambda_t>
+void
+post_filter(raft::resources const& res, filter_lambda_t const& sample_filter, index_mdspan_t index_mdspan,
+            distance_mdspan_t distance_mdspan) {
+    auto counter = thrust::counting_iterator<decltype(index_mdspan.extent(0))>(0);
+    // TODO (wphicks): This could be rolled into the stable_partition calls
+    // below, but I am not sure whether or not that would be a net benefit. This
+    // deserves some benchmarking unless pre-filtering gets in before we revisit
+    // this.
+    thrust::for_each(raft::resource::get_thrust_policy(res),
+                     thrust::make_zip_iterator(
+                         thrust::make_tuple(counter, mdspan_begin(index_mdspan), mdspan_begin(distance_mdspan))),
+                     thrust::make_zip_iterator(thrust::make_tuple(
+                         counter + index_mdspan.size(), mdspan_end(index_mdspan), mdspan_end(distance_mdspan))),
+                     [=] __device__(auto& index_id_distance) {
+                         auto index = thrust::get<0>(index_id_distance);
+                         auto& id = thrust::get<1>(index_id_distance);
+                         auto& distance = thrust::get<2>(index_id_distance);
+                         if (!sample_filter(index / index_mdspan.extent(1), id)) {
+                             id = std::numeric_limits<std::remove_reference_t<decltype(id)>>::max();
+                             distance = std::numeric_limits<std::remove_reference_t<decltype(distance)>>::max();
+                         }
+                     });
+    for (auto i = 0; i < index_mdspan.extent(0); ++i) {
+        auto id_row_begin = mdspan_begin_row(index_mdspan, i);
+        auto id_row_end = mdspan_end_row(index_mdspan, i);
+        auto distance_row_begin = mdspan_begin_row(distance_mdspan, i);
+        auto distance_row_end = mdspan_end_row(distance_mdspan, i);
+        thrust::stable_partition(
+            raft::resource::get_thrust_policy(res),
+            thrust::make_zip_iterator(thrust::make_tuple(id_row_begin, distance_row_begin)),
+            thrust::make_zip_iterator(thrust::make_tuple(id_row_end, distance_row_end)),
+            [=] __device__(auto& id_distance) {
+                return thrust::get<0>(id_distance) !=
+                       std::numeric_limits<std::remove_reference_t<decltype(thrust::get<0>(id_distance))>>::max();
+            });
+    }
+}
+
 }  // namespace detail
 
 template <template <typename...> typename underlying_index_type, typename... raft_index_args>
 struct raft_index {
     using vector_index_type = underlying_index_type<raft_index_args...>;
     auto static constexpr vector_index_kind = []() {
-        if constexpr (detail::template_matches_index_kind_v<raft_index_kind::ivf_flat, underlying_index_type>) {
+        if constexpr (detail::template_matches_index_kind_v<raft_index_kind::brute_force, underlying_index_type>) {
+            return raft_index_kind::brute_force;
+        } else if constexpr (detail::template_matches_index_kind_v<raft_index_kind::ivf_flat, underlying_index_type>) {
             return raft_index_kind::ivf_flat;
         } else if constexpr (detail::template_matches_index_kind_v<raft_index_kind::ivf_pq, underlying_index_type>) {
             return raft_index_kind::ivf_pq;
         } else if constexpr (detail::template_matches_index_kind_v<raft_index_kind::cagra, underlying_index_type>) {
             return raft_index_kind::cagra;
         } else {
-            static_assert(detail::template_matches_index_kind_v<raft_index_kind::ivf_flat, underlying_index_type>,
+            static_assert(detail::template_matches_index_kind_v<raft_index_kind::brute_force, underlying_index_type>,
                           "Unsupported index template passed to raft_index");
         }
     }();
 
     using index_params_type = std::conditional_t<
-        vector_index_kind == raft_index_kind::ivf_flat, raft::neighbors::ivf_flat::index_params,
+        vector_index_kind == raft_index_kind::brute_force, raft::neighbors::brute_force::index_params,
         std::conditional_t<
-            vector_index_kind == raft_index_kind::ivf_pq, raft::neighbors::ivf_pq::index_params,
-            std::conditional_t<vector_index_kind == raft_index_kind::cagra, raft::neighbors::cagra::index_params,
-                               // Should never get here; precluded by static assertion above
-                               raft::neighbors::ivf_flat::index_params>>>;
+            vector_index_kind == raft_index_kind::ivf_flat, raft::neighbors::ivf_flat::index_params,
+            std::conditional_t<
+                vector_index_kind == raft_index_kind::ivf_pq, raft::neighbors::ivf_pq::index_params,
+                std::conditional_t<vector_index_kind == raft_index_kind::cagra, raft::neighbors::cagra::index_params,
+                                   // Should never get here; precluded by static assertion above
+                                   raft::neighbors::brute_force::index_params>>>>;
     using search_params_type = std::conditional_t<
-        vector_index_kind == raft_index_kind::ivf_flat, raft::neighbors::ivf_flat::search_params,
+        vector_index_kind == raft_index_kind::brute_force, raft::neighbors::brute_force::search_params,
         std::conditional_t<
-            vector_index_kind == raft_index_kind::ivf_pq, raft::neighbors::ivf_pq::search_params,
-            std::conditional_t<vector_index_kind == raft_index_kind::cagra, raft::neighbors::cagra::search_params,
-                               // Should never get here; precluded by static assertion above
-                               raft::neighbors::ivf_flat::search_params>>>;
+            vector_index_kind == raft_index_kind::ivf_flat, raft::neighbors::ivf_flat::search_params,
+            std::conditional_t<
+                vector_index_kind == raft_index_kind::ivf_pq, raft::neighbors::ivf_pq::search_params,
+                std::conditional_t<vector_index_kind == raft_index_kind::cagra, raft::neighbors::cagra::search_params,
+                                   // Should never get here; precluded by static assertion above
+                                   raft::neighbors::brute_force::search_params>>>>;
 
     [[nodiscard]] auto&
     get_vector_index() {
@@ -107,7 +191,10 @@ struct raft_index {
     template <typename T, typename IdxT, typename InputIdxT>
     auto static build(raft::resources const& res, index_params_type const& index_params,
                       raft::device_matrix_view<T const, InputIdxT> data) {
-        if constexpr (vector_index_kind == raft_index_kind::ivf_flat) {
+        if constexpr (vector_index_kind == raft_index_kind::brute_force) {
+            return raft_index<underlying_index_type, raft_index_args...>{
+                raft::neighbors::brute_force::build<T>(res, index_params, data)};
+        } else if constexpr (vector_index_kind == raft_index_kind::ivf_flat) {
             return raft_index<underlying_index_type, raft_index_args...>{
                 raft::neighbors::ivf_flat::build<T, IdxT>(res, index_params, data)};
         } else if constexpr (vector_index_kind == raft_index_kind::ivf_pq) {
@@ -147,7 +234,15 @@ struct raft_index {
             distances_tmp = distances_storage->view();
         }
 
-        if constexpr (vector_index_kind == raft_index_kind::ivf_flat) {
+        if constexpr (vector_index_kind == raft_index_kind::brute_force) {
+            raft::neighbors::brute_force::search<T>(res, search_params, underlying_index, queries, neighbors_tmp,
+                                                    distances_tmp);
+            if constexpr (!std::is_same_v<FilterT, std::nullptr_t>) {
+                // TODO(wphicks): This can be replaced once prefiltering is
+                // implemented for brute force upstream
+                detail::post_filter(res, filter, neighbors_tmp, distances_tmp);
+            }
+        } else if constexpr (vector_index_kind == raft_index_kind::ivf_flat) {
             if constexpr (std::is_same_v<FilterT, std::nullptr_t>) {
                 raft::neighbors::ivf_flat::search<T, IdxT>(res, search_params, underlying_index, queries, neighbors_tmp,
                                                            distances_tmp);
@@ -205,7 +300,10 @@ struct raft_index {
                        raft_index<underlying_index_type, raft_index_args...>& index) {
         auto const& underlying_index = index.get_vector_index();
 
-        if constexpr (vector_index_kind == raft_index_kind::ivf_flat) {
+        if constexpr (vector_index_kind == raft_index_kind::brute_force) {
+            // TODO(wphicks): Implement brute force extend
+            RAFT_FAIL("Brute force implements no extend method");
+        } else if constexpr (vector_index_kind == raft_index_kind::ivf_flat) {
             return raft_index{raft::neighbors::ivf_flat::extend<T, IdxT>(res, new_vectors, new_ids, underlying_index)};
         } else if constexpr (vector_index_kind == raft_index_kind::ivf_pq) {
             return raft_index{raft::neighbors::ivf_pq::extend<T, IdxT>(res, new_vectors, new_ids, underlying_index)};
@@ -219,7 +317,9 @@ struct raft_index {
                           raft_index<underlying_index_type, raft_index_args...> const& index) {
         auto const& underlying_index = index.get_vector_index();
 
-        if constexpr (vector_index_kind == raft_index_kind::ivf_flat) {
+        if constexpr (vector_index_kind == raft_index_kind::brute_force) {
+            return raft::neighbors::brute_force::serialize<T>(res, os, underlying_index);
+        } else if constexpr (vector_index_kind == raft_index_kind::ivf_flat) {
             return raft::neighbors::ivf_flat::serialize<T, IdxT>(res, os, underlying_index);
         } else if constexpr (vector_index_kind == raft_index_kind::ivf_pq) {
             return raft::neighbors::ivf_pq::serialize<IdxT>(res, os, underlying_index);
@@ -230,7 +330,9 @@ struct raft_index {
 
     template <typename T, typename IdxT>
     auto static deserialize(raft::resources const& res, std::istream& is) {
-        if constexpr (vector_index_kind == raft_index_kind::ivf_flat) {
+        if constexpr (vector_index_kind == raft_index_kind::brute_force) {
+            return raft_index{raft::neighbors::brute_force::deserialize<T>(res, is)};
+        } else if constexpr (vector_index_kind == raft_index_kind::ivf_flat) {
             return raft_index{raft::neighbors::ivf_flat::deserialize<T, IdxT>(res, is)};
         } else if constexpr (vector_index_kind == raft_index_kind::ivf_pq) {
             return raft_index{raft::neighbors::ivf_pq::deserialize<IdxT>(res, is)};
@@ -245,192 +347,5 @@ struct raft_index {
     explicit raft_index(vector_index_type&& vector_index) : vector_index_{std::move(vector_index)} {
     }
 };
-
-/*template <typename T, typename IdxT, template <typename...> typename underlying_index, typename... raft_index_args>
-struct tiered_index {
-  using raft_index_type = raft_index<underlying_index, raft_index_args...>;
-  using data_type = T;
-  using index_type = IdxT;
-
-  tiered_index (
-    raft::device_resources const& res,
-    raft_index_type::index_params_type const& index_params,
-    raft::device_matrix_view<T const, IdxT> data,
-    IdxT max_staged_vectors = IdxT{}
-  ) : index_params_{index_params},
-      vector_index_{},
-      dataset_{
-        [&res, data]() {
-          auto result = raft::make_device_matrix<T, IdxT>(
-            res,
-            data.extent(0),
-            data.extent(1)
-          );
-          raft::copy(res, result.view(), data);
-          return result;
-        }()
-      },
-      staged_count{data.extent(0)},
-      max_staged_count{max_staged_vectors} {
-      if (staged_count >= max_staged_count) {
-        commit(res);
-      }
-    }
-
-  template <typename FilterT=std::nullptr_t>
-  auto search(
-    raft::device_resources const& res,
-    search_params_type const& search_params,
-    raft::device_matrix_view<T const, IdxT> queries,
-    raft::device_matrix_view<IdxT, IdxT> neighbors,
-    raft::device_matrix_view<float, IdxT> distances,
-    float refine_ratio = 1.0f,
-    FilterT filter = nullptr
-  ) const {
-    auto k = neighbors.extent(1);
-    auto k_committed = k;
-    if (refine_ratio > 1.0f) {
-      k_committed *= refine_ratio;
-    }
-    auto k_total = k_committed + staged_count;
-
-    auto neighbors_committed = neighbors;
-    auto distances_committed = distances;
-    auto neighbors_staged = neighbors;
-    auto distances_staged = distances;
-    auto neighbors_storage = std::optional<raft::device_matrix<IdxT, IdxT>>{};
-    auto distances_storage = std::optional<raft::device_matrix<float, IdxT>>{};
-    if (k_total > k) {
-      neighbors_storage = raft::make_device_matrix<IdxT, IdxT>(
-        res,
-        queries.extent(0),
-        k_total
-      );
-      neighbors_committed = raft::make_device_matrix_view(
-          new_dataset.data_handle(),
-          queries.extent(0),
-          dataset_.extent(1)
-        ),
-      distances_storage = raft::make_device_matrix<float, IdxT>(
-        res,
-        queries.extent(0),
-        k_total
-      );
-      distances_tmp = distances_storage.view();
-    }
-    raft::neighbors::refine(
-      res,
-      *dataset,
-      queries,
-      neighbors_tmp,
-      neighbors,
-      distances,
-      underlying_index.metric()
-    );
-    return raft_index_type::search(
-      res,
-      vector_index_,
-      search_params,
-      queries,
-      neighbors,
-      distances,
-      1.0f,
-      0,  // TODO (wphicks): Pass offset down when batching available
-      get_entire_dataset(),
-      filter
-    );
-  }
-
-  template <typename T, typename IdxT>
-  void extend(
-    raft::device_resources const& res,
-    raft::device_matrix_view<T const, IdxT> new_vectors,
-    std::optional<raft::device_matrix_view<IdxT const, IdxT>> new_ids
-  ) {
-    if (size() + new_vectors.extent(0) > capacity()) {
-      reserve(res, size() + std::max(size(), new_vectors.extent(0)));
-    }
-    staged_count += new_vectors.extent(0);
-    if (staged_count >= max_staged_vectors) {
-      commit(res);
-    }
-  }
-
-  auto size() const {
-    return committed_count + staged_count;
-  }
-
-  void reserve(raft::resources const& res, std::size_type new_capacity) {
-    if (new_capacity > capacity()) {
-      auto new_dataset = raft::make_device_matrix<T, IdxT>(
-        res,
-        new_capacity,
-        dataset_.extent(1)
-      );
-      raft::copy(
-        res,
-        raft::make_device_matrix_view(
-          new_dataset.data_handle(),
-          size(),
-          dataset_.extent(1)
-        ),
-        get_entire_dataset()
-      );
-    }
-  }
-
- private:
-  raft_index_type::index_params_type index_params_;
-  std::optional<raft_index_type> vector_index_;
-
-  raft::device_matrix<T, IdxT> dataset_;
-  IdxT committed_count;
-  IdxT max_staged_count;
-  IdxT build_size = IdxT{};
-  IdxT staged_count = IdxT{};
-
-  auto commit(raft::resources const& res) {
-    if (
-      (!vector_index_ && staged_count > max_staged_count) ||
-      build_size * 2 < size()
-    ) {
-      vector_index_ = raft_index_type::build(res, index_params_, dataset_.view());
-      committed_count = dataset_.extent(0);
-      build_size = committed_count;
-    } else {
-      raft_index_type::extend(res, vector_index_, get_staged_dataset());
-      committed_count += staged_count;
-    }
-    staged_count = IdxT{};
-  }
-
-  auto capacity() const {
-    return dataset_.extent(0);
-  }
-
-  auto get_committed_dataset() {
-    return raft::make_device_matrix_view(
-      dataset_.data_handle(),
-      committed_count,
-      dataset_.extent(1)
-    );
-  }
-
-  auto get_staged_dataset() {
-    return raft::make_device_matrix_view(
-      dataset_.data_handle() + committed_count * dataset_.extent(1),
-      staged_count,
-      dataset_.extent(1)
-    );
-  }
-
-  auto get_entire_dataset() {
-    return raft::make_device_matrix_view(
-      dataset_.data_handle(),
-      size(),
-      dataset_.extent(1)
-    );
-  }
-}; */
 
 }  // namespace raft_proto

--- a/src/index/gpu_raft/gpu_raft_brute_force.cc
+++ b/src/index/gpu_raft/gpu_raft_brute_force.cc
@@ -14,8 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
 
-namespace raft_proto {
-enum struct raft_index_kind { brute_force, ivf_flat, ivf_pq, cagra };
-}  // namespace raft_proto
+#include <vector>
+
+#include "common/raft/proto/raft_index_kind.hpp"
+#include "gpu_raft.h"
+#include "knowhere/factory.h"
+#include "knowhere/index_node_thread_pool_wrapper.h"
+
+namespace knowhere {
+template struct GpuRaftIndexNode<raft_proto::raft_index_kind::brute_force>;
+
+KNOWHERE_REGISTER_GLOBAL(GPU_RAFT_BRUTE_FORCE, [](const int32_t& version, const Object& object) {
+    return Index<IndexNodeThreadPoolWrapper>::Create(std::make_unique<GpuRaftBruteForceIndexNode>(version, object),
+                                                     cuda_concurrent_size);
+});
+
+}  // namespace knowhere

--- a/src/index/gpu_raft/gpu_raft_brute_force_config.h
+++ b/src/index/gpu_raft/gpu_raft_brute_force_config.h
@@ -14,8 +14,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
+#ifndef GPU_RAFT_BRUTE_FORCE_CONFIG_H
+#define GPU_RAFT_BRUTE_FORCE_CONFIG_H
 
-namespace raft_proto {
-enum struct raft_index_kind { brute_force, ivf_flat, ivf_pq, cagra };
-}  // namespace raft_proto
+#include "common/raft/integration/raft_knowhere_config.hpp"
+#include "common/raft/proto/raft_index_kind.hpp"
+#include "knowhere/config.h"
+
+namespace knowhere {
+
+struct GpuRaftBruteForceConfig : public BaseConfig {};
+
+[[nodiscard]] inline auto
+to_raft_knowhere_config(GpuRaftBruteForceConfig const& cfg) {
+    auto result = raft_knowhere::raft_knowhere_config{raft_proto::raft_index_kind::brute_force};
+
+    result.metric_type = cfg.metric_type.value();
+    result.k = cfg.k.value();
+
+    return result;
+}
+
+}  // namespace knowhere
+
+#endif /*GPU_RAFT_BRUTE_FORCE_CONFIG_H*/

--- a/tests/ut/test_gpu_search.cc
+++ b/tests/ut/test_gpu_search.cc
@@ -40,6 +40,8 @@ TEST_CASE("Test All GPU Index", "[search]") {
         return json;
     };
 
+    auto bruteforce_gen = base_gen;
+
     auto ivfflat_gen = [&base_gen]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::NLIST] = 16;
@@ -79,6 +81,7 @@ TEST_CASE("Test All GPU Index", "[search]") {
             // make_tuple(knowhere::IndexEnum::INDEX_FAISS_GPU_IVFFLAT, ivfflat_gen),
             // make_tuple(knowhere::IndexEnum::INDEX_FAISS_GPU_IVFPQ, ivfpq_gen),
             // make_tuple(knowhere::IndexEnum::INDEX_FAISS_GPU_IVFSQ8, ivfsq_gen),
+            make_tuple(knowhere::IndexEnum::INDEX_RAFT_BRUTEFORCE, bruteforce_gen),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFFLAT, ivfflat_gen),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFFLAT, refined_gen(ivfflat_gen)),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFPQ, ivfpq_gen),
@@ -105,6 +108,7 @@ TEST_CASE("Test All GPU Index", "[search]") {
     SECTION("Test Gpu Index Search With Bitset") {
         using std::make_tuple;
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
+            make_tuple(knowhere::IndexEnum::INDEX_RAFT_BRUTEFORCE, bruteforce_gen),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFFLAT, ivfflat_gen),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFFLAT, refined_gen(ivfflat_gen)),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFPQ, ivfpq_gen),
@@ -144,6 +148,7 @@ TEST_CASE("Test All GPU Index", "[search]") {
     SECTION("Test Gpu Index Search TopK") {
         using std::make_tuple;
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
+            make_tuple(knowhere::IndexEnum::INDEX_RAFT_BRUTEFORCE, bruteforce_gen),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFFLAT, ivfflat_gen),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFFLAT, refined_gen(ivfflat_gen)),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFPQ, ivfpq_gen),
@@ -175,6 +180,7 @@ TEST_CASE("Test All GPU Index", "[search]") {
     SECTION("Test Gpu Index Serialize/Deserialize") {
         using std::make_tuple;
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
+            make_tuple(knowhere::IndexEnum::INDEX_RAFT_BRUTEFORCE, bruteforce_gen),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFFLAT, ivfflat_gen),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFFLAT, refined_gen(ivfflat_gen)),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFPQ, ivfpq_gen),
@@ -205,13 +211,12 @@ TEST_CASE("Test All GPU Index", "[search]") {
 
     SECTION("Test Gpu Index Search Simple Bitset") {
         using std::make_tuple;
-        auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
-            make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFFLAT, ivfflat_gen),
-            make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFFLAT, refined_gen(ivfflat_gen)),
-            make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFPQ, ivfpq_gen),
-            make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFPQ, refined_gen(ivfpq_gen)),
-            make_tuple(knowhere::IndexEnum::INDEX_RAFT_CAGRA, cagra_gen),
-        }));
+        auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>(
+            {make_tuple(knowhere::IndexEnum::INDEX_RAFT_BRUTEFORCE, bruteforce_gen),
+             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFFLAT, refined_gen(ivfflat_gen)),
+             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFPQ, ivfpq_gen),
+             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFPQ, refined_gen(ivfpq_gen)),
+             make_tuple(knowhere::IndexEnum::INDEX_RAFT_CAGRA, cagra_gen)}));
         auto rows = 16;
         auto idx = knowhere::IndexFactory::Instance().Create(name, version);
         auto cfg_json = gen().dump();


### PR DESCRIPTION
This PR provides GPU-accelerated exact search using RAFT's brute force index. As part of the necessary work to implement post-filtering for brute force, I have also updated the logic for handling missing values. Rather than trying to handle the various missing values resulting from https://github.com/rapidsai/raft/issues/1822, we check both the distance and ID, replacing invalid IDs or IDs with associated infinite distance with `-1`. This may address #227, but if reviewers could double-check my logic, it would be much appreciated.

/issue: #288