### PR TITLE
Do not allow n_lists to exceed number of rows for RAFT IVF

### DIFF
--- a/src/common/raft/integration/raft_knowhere_index.cuh
+++ b/src/common/raft/integration/raft_knowhere_index.cuh
@@ -355,6 +355,10 @@ struct raft_knowhere_index<IndexKind>::impl {
           knowhere_indexing_type feature_count) {
         auto scoped_device = raft::device_setter{device_id};
         auto index_params = config_to_index_params<index_kind>(config);
+        if constexpr (index_kind == raft_proto::raft_index_kind::ivf_flat ||
+                      index_kind == raft_proto::raft_index_kind::ivf_pq) {
+            index_params.n_lists = std::min(knowhere_indexing_type(index_params.n_lists), row_count);
+        }
         auto const& res = raft::device_resources_manager::get_device_resources();
         auto host_data = raft::make_host_matrix_view(data, row_count, feature_count);
         device_dataset_storage =

--- a/src/index/gpu_raft/gpu_raft_ivf_pq_config.h
+++ b/src/index/gpu_raft/gpu_raft_ivf_pq_config.h
@@ -46,7 +46,7 @@ struct GpuRaftIvfPqConfig : public IvfPqConfig {
             .description("search for top k similar vector.")
             .set_range(1, 1024)  // Declared in base but limited to 1024
             .for_search();
-        KNOWHERE_CONFIG_DECLARE_FIELD(m).set_default(8).description("m").set_range(1, 65536).for_train();
+        KNOWHERE_CONFIG_DECLARE_FIELD(m).set_default(0).description("m").set_range(0, 65536).for_train();
         KNOWHERE_CONFIG_DECLARE_FIELD(nbits)
             .set_default(8)
             .description("nbits")


### PR DESCRIPTION
Cap the maximum value of n_lists in RAFT IVF and IVFPQ configurations at the number of rows used for training.

Revert change to default and range for "m" for RAFT indexes, since I believe that this change was due to a misidentification of the underlying issue.

/issue: #229