### PR TITLE
use new double_pop_list to replace neighborset; 

### DIFF
--- a/include/knowhere/bitsetview.h
+++ b/include/knowhere/bitsetview.h
@@ -23,7 +23,8 @@ class BitsetView {
     BitsetView() = default;
     ~BitsetView() = default;
 
-    BitsetView(const uint8_t* data, size_t num_bits) : bits_(data), num_bits_(num_bits) {
+    BitsetView(const uint8_t* data, size_t num_bits, size_t filtered_out_num = 0)
+        : bits_(data), num_bits_(num_bits), filtered_out_num_(filtered_out_num) {
     }
 
     BitsetView(const std::nullptr_t) : BitsetView() {
@@ -57,6 +58,16 @@ class BitsetView {
 
     size_t
     count() const {
+        return filtered_out_num_;
+    }
+
+    float
+    filter_ratio() const {
+        return empty() ? 0.0f : ((float)filtered_out_num_ / num_bits_);
+    }
+
+    size_t
+    get_filtered_out_num_() const {
         size_t ret = 0;
         auto len_uint8 = byte_size();
         auto len_uint64 = len_uint8 >> 3;
@@ -100,6 +111,7 @@ class BitsetView {
  private:
     const uint8_t* bits_ = nullptr;
     size_t num_bits_ = 0;
+    size_t filtered_out_num_ = 0;
 };
 }  // namespace knowhere
 

--- a/src/common/index.cc
+++ b/src/common/index.cc
@@ -68,13 +68,14 @@ Index<T>::Add(const DataSet& dataset, const Json& json) {
 
 template <typename T>
 inline expected<DataSetPtr>
-Index<T>::Search(const DataSet& dataset, const Json& json, const BitsetView& bitset) const {
+Index<T>::Search(const DataSet& dataset, const Json& json, const BitsetView& bitset_) const {
     auto cfg = this->node->CreateConfig();
     std::string msg;
     const Status load_status = LoadConfig(cfg.get(), json, knowhere::SEARCH, "Search", &msg);
     if (load_status != Status::success) {
         return expected<DataSetPtr>::Err(load_status, msg);
     }
+    const auto bitset = BitsetView(bitset_.data(), bitset_.size(), bitset_.get_filtered_out_num_());
 
 #ifdef NOT_COMPILE_FOR_SWIG
     TimeRecorder rc("Search");
@@ -91,13 +92,14 @@ Index<T>::Search(const DataSet& dataset, const Json& json, const BitsetView& bit
 
 template <typename T>
 inline expected<std::vector<std::shared_ptr<IndexNode::iterator>>>
-Index<T>::AnnIterator(const DataSet& dataset, const Json& json, const BitsetView& bitset) const {
+Index<T>::AnnIterator(const DataSet& dataset, const Json& json, const BitsetView& bitset_) const {
     auto cfg = this->node->CreateConfig();
     std::string msg;
     Status status = LoadConfig(cfg.get(), json, knowhere::ITERATOR, "Iterator", &msg);
     if (status != Status::success) {
         return expected<std::vector<std::shared_ptr<IndexNode::iterator>>>::Err(status, msg);
     }
+    const auto bitset = BitsetView(bitset_.data(), bitset_.size(), bitset_.get_filtered_out_num_());
 
 #ifdef NOT_COMPILE_FOR_SWIG
     // note that this time includes only the initial search phase of iterator.
@@ -114,13 +116,14 @@ Index<T>::AnnIterator(const DataSet& dataset, const Json& json, const BitsetView
 
 template <typename T>
 inline expected<DataSetPtr>
-Index<T>::RangeSearch(const DataSet& dataset, const Json& json, const BitsetView& bitset) const {
+Index<T>::RangeSearch(const DataSet& dataset, const Json& json, const BitsetView& bitset_) const {
     auto cfg = this->node->CreateConfig();
     std::string msg;
     auto status = LoadConfig(cfg.get(), json, knowhere::RANGE_SEARCH, "RangeSearch", &msg);
     if (status != Status::success) {
         return expected<DataSetPtr>::Err(status, std::move(msg));
     }
+    const auto bitset = BitsetView(bitset_.data(), bitset_.size(), bitset_.get_filtered_out_num_());
 
 #ifdef NOT_COMPILE_FOR_SWIG
     TimeRecorder rc("Range Search");

--- a/thirdparty/hnswlib/hnswlib/neighbor.h
+++ b/thirdparty/hnswlib/hnswlib/neighbor.h
@@ -28,18 +28,30 @@ struct Neighbor {
     }
 };
 typedef std::priority_queue<Neighbor, std::vector<Neighbor>, std::greater<Neighbor>> IteratorMinHeap;
-class NeighborSet {
- public:
-    explicit NeighborSet(size_t capacity = 0) : capacity_(capacity), data_(capacity_ + 1) {
+
+template <bool need_save>
+class NeighborSetPopList {
+ private:
+    inline void
+    insert_helper(const Neighbor& nbr, size_t pos) {
+        // move
+        std::memmove(&data_[pos + 1], &data_[pos], (size_ - pos) * sizeof(Neighbor));
+        if (size_ < capacity_) {
+            size_++;
+        }
+
+        // insert
+        data_[pos] = nbr;
     }
 
-    // will push any neighbor that does not fit into NeighborSet to disqualified.
-    // When searching for iterator, those points removed from NeighborSet may be
-    // qualified candidates as the iterator iterates, thus we need to retain
-    // instead of disposing them.
-    bool
-    insert(Neighbor nbr, IteratorMinHeap* disqualified = nullptr) {
-        if (size_ == capacity_ && nbr.distance >= data_[size_ - 1].distance) {
+ public:
+    explicit NeighborSetPopList(size_t capacity) : capacity_(capacity), data_(capacity + 1) {
+    }
+
+    inline bool
+    insert(const Neighbor nbr, IteratorMinHeap* disqualified = nullptr) {
+        auto pos = std::upper_bound(&data_[0], &data_[0] + size_, nbr) - &data_[0];
+        if (pos >= capacity_) {
             if (disqualified) {
                 disqualified->push(nbr);
             }
@@ -48,63 +60,62 @@ class NeighborSet {
         if (size_ == capacity_ && disqualified) {
             disqualified->push(data_[size_ - 1]);
         }
-        int lo = 0, hi = size_;
-        while (lo < hi) {
-            int mid = (lo + hi) >> 1;
-            if (data_[mid].distance > nbr.distance) {
-                hi = mid;
-            } else {
-                lo = mid + 1;
+        insert_helper(nbr, pos);
+        if constexpr (need_save) {
+            if (pos < cur_) {
+                cur_ = pos;
             }
-        }
-        std::memmove(&data_[lo + 1], &data_[lo], (size_ - lo) * sizeof(Neighbor));
-        data_[lo] = nbr;
-        if (size_ < capacity_) {
-            size_++;
-        }
-        if (lo < cur_) {
-            cur_ = lo;
         }
         return true;
     }
 
-    Neighbor
-    pop() {
+    inline auto
+    pop() -> Neighbor {
         auto ret = data_[cur_];
-        if (data_[cur_].status == Neighbor::kValid) {
+        if constexpr (need_save) {
             data_[cur_].status = Neighbor::kChecked;
-        } else if (data_[cur_].status == Neighbor::kInvalid) {
-            std::memmove(&data_[cur_], &data_[cur_ + 1], (size_ - cur_ - 1) * sizeof(Neighbor));
-            size_--;
-        }
-        while (cur_ < size_ && data_[cur_].status == Neighbor::kChecked) {
             cur_++;
+            while (cur_ < size_ && data_[cur_].status == Neighbor::kChecked) {
+                cur_++;
+            }
+        } else {
+            if (size_ > 1) {
+                std::memmove(&data_[0], &data_[1], (size_ - 1) * sizeof(Neighbor));
+            }
+            size_--;
         }
         return ret;
     }
 
-    bool
-    has_next() const {
-        return cur_ < size_;
+    inline auto
+    has_next() const -> bool {
+        if constexpr (need_save) {
+            return cur_ < size_;
+        } else {
+            return size_ > 0;
+        }
     }
 
-    size_t
-    size() const {
+    inline auto
+    size() const -> size_t {
         return size_;
     }
-    size_t
-    capacity() const {
-        return capacity_;
+
+    inline auto
+    cur() const -> const Neighbor& {
+        if constexpr (need_save) {
+            return data_[cur_];
+        } else {
+            return data_[0];
+        }
     }
 
-    Neighbor&
-    operator[](size_t i) {
-        return data_[i];
-    }
-
-    const Neighbor&
-    operator[](size_t i) const {
-        return data_[i];
+    inline auto
+    at_search_back_dist() const -> float {
+        if (size_ < capacity_) {
+            return std::numeric_limits<float>::max();
+        }
+        return data_[capacity_ - 1].distance;
     }
 
     void
@@ -113,11 +124,78 @@ class NeighborSet {
         cur_ = 0;
     }
 
+    inline const Neighbor&
+    operator[](size_t i) {
+        return data_[i];
+    }
+
  private:
-    size_t size_ = 0;
-    size_t capacity_;
-    size_t cur_ = 0;
+    size_t capacity_ = 0, size_ = 0, cur_ = 0;
     std::vector<Neighbor> data_;
+};
+
+class NeighborSetDoublePopList {
+ public:
+    explicit NeighborSetDoublePopList(size_t capacity = 0) {
+        valid_ns_ = std::make_unique<NeighborSetPopList<true>>(capacity);
+        invalid_ns_ = std::make_unique<NeighborSetPopList<false>>(capacity);
+    }
+
+    // will push any neighbor that does not fit into NeighborSet to disqualified.
+    // When searching for iterator, those points removed from NeighborSet may be
+    // qualified candidates as the iterator iterates, thus we need to retain
+    // instead of disposing them.
+    bool
+    insert(const Neighbor& nbr, IteratorMinHeap* disqualified = nullptr) {
+        if (nbr.status == Neighbor::kValid) {
+            return valid_ns_->insert(nbr, disqualified);
+        } else {
+            if (nbr.distance < valid_ns_->at_search_back_dist()) {
+                return invalid_ns_->insert(nbr, disqualified);
+            } else if (disqualified) {
+                disqualified->push(nbr);
+            }
+        }
+        return false;
+    }
+    auto
+    pop() -> Neighbor {
+        return pop_based_on_distance();
+    }
+
+    auto
+    has_next() const -> bool {
+        return valid_ns_->has_next() ||
+               (invalid_ns_->has_next() && invalid_ns_->cur().distance < valid_ns_->at_search_back_dist());
+    }
+
+    inline const Neighbor&
+    operator[](size_t i) {
+        return (*valid_ns_)[i];
+    }
+
+    inline size_t
+    size() const {
+        return valid_ns_->size();
+    }
+
+ private:
+    auto
+    pop_based_on_distance() -> Neighbor {
+        bool hasCandNext = invalid_ns_->has_next();
+        bool hasResNext = valid_ns_->has_next();
+
+        if (hasCandNext && hasResNext) {
+            return invalid_ns_->cur().distance < valid_ns_->cur().distance ? invalid_ns_->pop() : valid_ns_->pop();
+        }
+        if (hasCandNext != hasResNext) {
+            return hasCandNext ? invalid_ns_->pop() : valid_ns_->pop();
+        }
+        return {0, 0, Neighbor::kValid};
+    }
+
+    std::unique_ptr<NeighborSetPopList<true>> valid_ns_ = nullptr;
+    std::unique_ptr<NeighborSetPopList<false>> invalid_ns_ = nullptr;
 };
 
 static inline int


### PR DESCRIPTION
issue: #343 

- Use double_pop_list(`NeighborSetDoublePopList`) to replace single_pop_list(`NeighborSet`); 
- Update alpha-candidates strategy, alpha = filte_ratio / 2; 
- BitsetView's count only calculated once.

Results:
Tested directly via pyknowhere, cohere 1M * 768dim, cosine, single segment.
- recall remains stable with different filter_ratio.
- low filtering - qps improved. qps gap between filter 0 and 0.01 is smoothed out. 
- high filtering - qps is sacrificed to keep recall stable.
![image](https://github.com/zilliztech/knowhere/assets/22510720/ed6d4509-7012-480b-b506-6dd57fe3fc80)
