### PR TITLE
make sure we rethrow exceptions in async tasks

### DIFF
--- a/include/knowhere/comp/thread_pool.h
+++ b/include/knowhere/comp/thread_pool.h
@@ -22,6 +22,7 @@
 
 #include "folly/executors/CPUThreadPoolExecutor.h"
 #include "folly/futures/Future.h"
+#include "knowhere/expected.h"
 #include "knowhere/log.h"
 
 namespace knowhere {
@@ -211,4 +212,23 @@ class ThreadPool {
 
     constexpr static size_t kTaskQueueFactor = 16;
 };
+
+// T is either folly::Unit or Status
+template <typename T>
+inline Status
+WaitAllSuccess(std::vector<folly::Future<T>>& futures) {
+    static_assert(std::is_same<T, folly::Unit>::value || std::is_same<T, Status>::value,
+                  "WaitAllSuccess can only be used with folly::Unit or knowhere::Status");
+    auto allFuts = folly::collectAll(futures.begin(), futures.end()).get();
+    for (const auto& result : allFuts) {
+        result.throwUnlessValue();
+        if constexpr (!std::is_same_v<T, folly::Unit>) {
+            if (result.value() != Status::success) {
+                return result.value();
+            }
+        }
+    }
+    return Status::success;
+}
+
 }  // namespace knowhere

--- a/src/common/comp/brute_force.cc
+++ b/src/common/comp/brute_force.cc
@@ -128,12 +128,9 @@ BruteForce::Search(const DataSetPtr base_dataset, const DataSetPtr query_dataset
             return Status::success;
         }));
     }
-    for (auto& fut : futs) {
-        fut.wait();
-        auto ret = fut.result().value();
-        if (ret != Status::success) {
-            return expected<DataSetPtr>::Err(ret, "failed to brute force search");
-        }
+    auto ret = WaitAllSuccess(futs);
+    if (ret != Status::success) {
+        return expected<DataSetPtr>::Err(ret, "failed to brute force search");
     }
     return GenResultDataSet(nq, cfg.k.value(), labels, distances);
 }
@@ -233,11 +230,7 @@ BruteForce::SearchWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_
             return Status::success;
         }));
     }
-    for (auto& fut : futs) {
-        fut.wait();
-        auto ret = fut.result().value();
-        RETURN_IF_ERROR(ret);
-    }
+    RETURN_IF_ERROR(WaitAllSuccess(futs));
     return Status::success;
 }
 
@@ -348,12 +341,9 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
             return Status::success;
         }));
     }
-    for (auto& fut : futs) {
-        fut.wait();
-        auto ret = fut.result().value();
-        if (ret != Status::success) {
-            return expected<DataSetPtr>::Err(ret, "failed to brute force search");
-        }
+    auto ret = WaitAllSuccess(futs);
+    if (ret != Status::success) {
+        return expected<DataSetPtr>::Err(ret, "failed to brute force search");
     }
 
     int64_t* ids = nullptr;

--- a/src/common/comp/brute_force.cc
+++ b/src/common/comp/brute_force.cc
@@ -62,17 +62,17 @@ BruteForce::Search(const DataSetPtr base_dataset, const DataSetPtr query_dataset
     bool is_cosine = IsMetricType(metric_str, metric::COSINE);
 
     int topk = cfg.k.value();
-    auto labels = new int64_t[nq * topk];
-    auto distances = new float[nq * topk];
+    auto labels = std::make_unique<int64_t[]>(nq * topk);
+    auto distances = std::make_unique<float[]>(nq * topk);
 
     auto pool = ThreadPool::GetGlobalSearchThreadPool();
     std::vector<folly::Future<Status>> futs;
     futs.reserve(nq);
     for (int i = 0; i < nq; ++i) {
-        futs.emplace_back(pool->push([&, index = i] {
+        futs.emplace_back(pool->push([&, index = i, labels_ptr = labels.get(), distances_ptr = distances.get()] {
             ThreadPool::ScopedOmpSetter setter(1);
-            auto cur_labels = labels + topk * index;
-            auto cur_distances = distances + topk * index;
+            auto cur_labels = labels_ptr + topk * index;
+            auto cur_distances = distances_ptr + topk * index;
 
             BitsetViewIDSelector bw_idselector(bitset);
             faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
@@ -132,7 +132,7 @@ BruteForce::Search(const DataSetPtr base_dataset, const DataSetPtr query_dataset
     if (ret != Status::success) {
         return expected<DataSetPtr>::Err(ret, "failed to brute force search");
     }
-    return GenResultDataSet(nq, cfg.k.value(), labels, distances);
+    return GenResultDataSet(nq, cfg.k.value(), labels.release(), distances.release());
 }
 
 template <typename DataType>

--- a/src/common/thread/thread.cc
+++ b/src/common/thread/thread.cc
@@ -19,6 +19,7 @@
 #include <utility>
 
 #include "knowhere/comp/thread_pool.h"
+
 namespace knowhere {
 
 void
@@ -33,14 +34,7 @@ ExecOverSearchThreadPool(std::vector<std::function<void()>>& tasks) {
         }));
     }
     std::this_thread::yield();
-    // check for exceptions. value() is {}, so either
-    //   a call does nothing, or it throws an inner exception.
-    for (auto& f : futures) {
-        f.wait();
-    }
-    for (auto& f : futures) {
-        f.result().value();
-    }
+    WaitAllSuccess(futures);
 }
 
 void
@@ -55,14 +49,7 @@ ExecOverBuildThreadPool(std::vector<std::function<void()>>& tasks) {
         }));
     }
     std::this_thread::yield();
-    // check for exceptions. value() is {}, so either
-    //   a call does nothing, or it throws an inner exception.
-    for (auto& f : futures) {
-        f.wait();
-    }
-    for (auto& f : futures) {
-        f.result().value();
-    }
+    WaitAllSuccess(futures);
 }
 
 void

--- a/src/index/flat/flat.cc
+++ b/src/index/flat/flat.cc
@@ -127,14 +127,7 @@ class FlatIndexNode : public IndexNode {
                 }));
             }
             // wait for the completion
-            for (auto& fut : futs) {
-                fut.wait();
-            }
-            // check for exceptions. value() is {}, so either
-            //   a call does nothing, or it throws an inner exception.
-            for (auto& fut : futs) {
-                fut.result().value();
-            }
+            WaitAllSuccess(futs);
         } catch (const std::exception& e) {
             std::unique_ptr<int64_t[]> auto_delete_ids(ids);
             std::unique_ptr<float[]> auto_delete_dis(distances);
@@ -216,14 +209,7 @@ class FlatIndexNode : public IndexNode {
                 }));
             }
             // wait for the completion
-            for (auto& fut : futs) {
-                fut.wait();
-            }
-            // check for exceptions. value() is {}, so either
-            //   a call does nothing, or it throws an inner exception.
-            for (auto& fut : futs) {
-                fut.result().value();
-            }
+            WaitAllSuccess(futs);
             GetRangeSearchResult(result_dist_array, result_id_array, is_ip, nq, radius, range_filter, distances, ids,
                                  lims);
         } catch (const std::exception& e) {

--- a/src/index/hnsw/hnsw.cc
+++ b/src/index/hnsw/hnsw.cc
@@ -126,13 +126,7 @@ class HnswIndexNode : public IndexNode {
                         }
                     }));
                 }
-                for (auto& future : futures) {
-                    future.wait();
-                }
-                // check for exceptions
-                for (auto& future : futures) {
-                    future.result().value();
-                }
+                WaitAllSuccess(futures);
                 futures.clear();
             }
 
@@ -146,13 +140,7 @@ class HnswIndexNode : public IndexNode {
                     futures.emplace_back(
                         build_pool->push([&, idx = i]() { index_->repairGraphConnectivity(unreached[idx]); }));
                 }
-                for (auto& future : futures) {
-                    future.wait();
-                }
-                // check for exceptions
-                for (auto& future : futures) {
-                    future.result().value();
-                }
+                WaitAllSuccess(futures);
             }
             build_time.RecordSection("graph repair");
             LOG_KNOWHERE_INFO_ << "HNSW built with #points num:" << index_->max_elements_ << " #M:" << index_->M_
@@ -213,9 +201,7 @@ class HnswIndexNode : public IndexNode {
                 }
             }));
         }
-        for (auto& fut : futs) {
-            fut.wait();
-        }
+        WaitAllSuccess(futs);
 
         auto res = GenResultDataSet(nq, k, p_id, p_dist);
 
@@ -300,9 +286,7 @@ class HnswIndexNode : public IndexNode {
             }));
         }
         // wait for initial search(in top layers and search for seed_ef in base layer) to finish
-        for (auto& fut : futs) {
-            fut.wait();
-        }
+        WaitAllSuccess(futs);
 
         return vec;
     }
@@ -365,9 +349,7 @@ class HnswIndexNode : public IndexNode {
                 }
             }));
         }
-        for (auto& fut : futs) {
-            fut.wait();
-        }
+        WaitAllSuccess(futs);
 
         // filter range search result
         GetRangeSearchResult(result_dist_array, result_id_array, is_ip, nq, radius_for_filter, range_filter, dis, ids,

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -589,14 +589,7 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSet& dataset, const Config& 
             }));
         }
         // wait for the completion
-        for (auto& fut : futs) {
-            fut.wait();
-        }
-        // check for exceptions. value() is {}, so either
-        //   a call does nothing, or it throws an inner exception.
-        for (auto& fut : futs) {
-            fut.result().value();
-        }
+        WaitAllSuccess(futs);
     } catch (const std::exception& e) {
         delete[] ids;
         delete[] distances;
@@ -718,14 +711,7 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSet& dataset, const Con
             }));
         }
         // wait for the completion
-        for (auto& fut : futs) {
-            fut.wait();
-        }
-        // check for exceptions. value() is {}, so either
-        //   a call does nothing, or it throws an inner exception.
-        for (auto& fut : futs) {
-            fut.result().value();
-        }
+        WaitAllSuccess(futs);
         GetRangeSearchResult(result_dist_array, result_id_array, is_ip, nq, radius, range_filter, distances, ids, lims);
     } catch (const std::exception& e) {
         LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();

--- a/tests/ut/test_utils.cc
+++ b/tests/ut/test_utils.cc
@@ -9,11 +9,15 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
+#include <chrono>
+#include <thread>
 #include <vector>
 
 #include "catch2/catch_approx.hpp"
 #include "catch2/catch_test_macros.hpp"
+#include "knowhere/comp/thread_pool.h"
 #include "knowhere/comp/time_recorder.h"
+#include "knowhere/expected.h"
 #include "knowhere/heap.h"
 #include "knowhere/utils.h"
 #include "knowhere/version.h"
@@ -121,4 +125,84 @@ TEST_CASE("Test DiskLoad") {
                                   knowhere::Version::GetCurrentVersion().VersionNumber()));
     REQUIRE(!knowhere::UseDiskLoad(knowhere::IndexEnum::INDEX_HNSW,
                                    knowhere::Version::GetCurrentVersion().VersionNumber()));
+}
+
+TEST_CASE("Test WaitAllSuccess with folly::Unit futures") {
+    auto pool = knowhere::ThreadPool::GetGlobalSearchThreadPool();
+    std::vector<folly::Future<folly::Unit>> futures;
+
+    SECTION("All futures succeed") {
+        for (size_t i = 0; i < 10; ++i) {
+            futures.emplace_back(pool->push([]() { return folly::Unit(); }));
+        }
+        REQUIRE(knowhere::WaitAllSuccess(futures) == knowhere::Status::success);
+    }
+
+    SECTION("One future throws an exception") {
+        for (size_t i = 0; i < 10; ++i) {
+            futures.emplace_back(pool->push([i]() {
+                if (i == 5) {
+                    throw std::runtime_error("Task failed");
+                }
+                return folly::Unit();
+            }));
+        }
+        REQUIRE_THROWS_AS(knowhere::WaitAllSuccess(futures), std::runtime_error);
+    }
+
+    SECTION("WaitAllSuccess should wait until all tasks finish even if any throws exception") {
+        std::atomic<int> externalValue{0};
+
+        futures.emplace_back(pool->push([&]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+            REQUIRE(externalValue.load() == 1);
+            externalValue.store(2);
+            return folly::Unit();
+        }));
+
+        futures.emplace_back(pool->push([&]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            externalValue.store(1);
+            throw std::runtime_error("Task failed");
+        }));
+
+        REQUIRE_THROWS_AS(knowhere::WaitAllSuccess(futures), std::runtime_error);
+        REQUIRE(externalValue.load() == 2);
+    }
+}
+
+TEST_CASE("Test WaitAllSuccess with knowhere::Status futures") {
+    auto pool = knowhere::ThreadPool::GetGlobalSearchThreadPool();
+    std::vector<folly::Future<knowhere::Status>> futures;
+
+    SECTION("All futures succeed with Status::success") {
+        for (size_t i = 0; i < 10; ++i) {
+            futures.emplace_back(pool->push([]() { return knowhere::Status::success; }));
+        }
+        REQUIRE(knowhere::WaitAllSuccess(futures) == knowhere::Status::success);
+    }
+
+    SECTION("One future returns Status::invalid_args") {
+        for (size_t i = 0; i < 10; ++i) {
+            futures.emplace_back(pool->push([i]() {
+                if (i == 5) {
+                    return knowhere::Status::invalid_args;
+                }
+                return knowhere::Status::success;
+            }));
+        }
+        REQUIRE(knowhere::WaitAllSuccess(futures) == knowhere::Status::invalid_args);
+    }
+
+    SECTION("One future throws an exception") {
+        for (size_t i = 0; i < 10; ++i) {
+            futures.emplace_back(pool->push([i]() {
+                if (i == 5) {
+                    throw std::runtime_error("Task failed");
+                }
+                return knowhere::Status::success;
+            }));
+        }
+        REQUIRE_THROWS_AS(knowhere::WaitAllSuccess(futures), std::runtime_error);
+    }
 }

--- a/thirdparty/DiskANN/src/aux_utils.cpp
+++ b/thirdparty/DiskANN/src/aux_utils.cpp
@@ -24,6 +24,7 @@
 #include "diskann/partition_and_pq.h"
 #include "diskann/percentile_stats.h"
 #include "diskann/pq_flash_index.h"
+#include "knowhere/comp/thread_pool.h"
 #include "tsl/robin_set.h"
 
 #include "diskann/utils.h"
@@ -496,7 +497,7 @@ namespace diskann {
       paras.Set<bool>("saturate_graph", 1);
       paras.Set<std::string>("save_path", mem_index_path);
       paras.Set<bool>("accelerate_build", accelerate_build);
-      paras.Set<bool>("shuffle_build", shuffle_build); 
+      paras.Set<bool>("shuffle_build", shuffle_build);
 
       std::unique_ptr<diskann::Index<T>> _pvamanaIndex =
           std::unique_ptr<diskann::Index<T>>(new diskann::Index<T>(
@@ -745,9 +746,7 @@ namespace diskann {
       }));
     }
 
-    for (auto &future : futures) {
-      future.wait();
-    }
+    knowhere::WaitAllSuccess(futures);
 
     std::sort(node_count_list.begin(), node_count_list.end(),
               [](std::pair<_u32, _u32> &a, std::pair<_u32, _u32> &b) {
@@ -800,9 +799,7 @@ namespace diskann {
               stats + index);
         }));
       }
-      for (auto &future : futures) {
-        future.wait();
-      }
+      knowhere::WaitAllSuccess(futures);
       auto e = std::chrono::high_resolution_clock::now();
       std::chrono::duration<double> diff = e - s;
       double                        qps =

--- a/thirdparty/DiskANN/src/index.cpp
+++ b/thirdparty/DiskANN/src/index.cpp
@@ -14,6 +14,7 @@
 #include <sstream>
 #include <string>
 #include "knowhere/log.h"
+#include "knowhere/comp/thread_pool.h"
 #include "tsl/robin_set.h"
 #include "tsl/robin_map.h"
 #include <unordered_map>
@@ -816,9 +817,7 @@ namespace diskann {
             }
           }));
     }
-    for (auto &future : futures) {
-      future.wait();
-    }
+    knowhere::WaitAllSuccess(futures);
     // find imin
     unsigned min_idx = 0;
     float    min_dist = distances[0];
@@ -1343,7 +1342,7 @@ namespace diskann {
     _indexingRange = parameters.Get<unsigned>("R");
     _indexingMaxC = parameters.Get<unsigned>("C");
     const bool  accelerate_build = parameters.Get<bool>("accelerate_build");
-    const bool  shuffle_build    = parameters.Get<bool>("shuffle_build"); 
+    const bool  shuffle_build    = parameters.Get<bool>("shuffle_build");
     const float last_round_alpha = parameters.Get<float>("alpha");
     unsigned    L = _indexingQueueSize;
 
@@ -1483,9 +1482,7 @@ namespace diskann {
             prune_neighbors(node, pool, pruned_list);
           }));
         }
-        for (auto &future : futures) {
-          future.wait();
-        }
+        knowhere::WaitAllSuccess(futures);
         diff = std::chrono::high_resolution_clock::now() - s;
         sync_time += diff.count();
 
@@ -1509,9 +1506,7 @@ namespace diskann {
                 }
               }));
         }
-        for (auto &future : futures) {
-          future.wait();
-        }
+        knowhere::WaitAllSuccess(futures);
         s = std::chrono::high_resolution_clock::now();
 
         futures.clear();
@@ -1532,9 +1527,7 @@ namespace diskann {
                 }
               }));
         }
-        for (auto &future : futures) {
-          future.wait();
-        }
+        knowhere::WaitAllSuccess(futures);
 
         futures.clear();
         for (_s64 node_ctr = 0; node_ctr < (_s64) (visit_order.size());
@@ -1567,9 +1560,7 @@ namespace diskann {
             }));
           }
         }
-        for (auto &future : futures) {
-          future.wait();
-        }
+        knowhere::WaitAllSuccess(futures);
 
         diff = std::chrono::high_resolution_clock::now() - s;
         inter_time += diff.count();
@@ -1638,9 +1629,7 @@ namespace diskann {
         }));
       }
     }
-    for (auto &future : futures) {
-      future.wait();
-    }
+    knowhere::WaitAllSuccess(futures);
     if (_nd > 0) {
       LOG_KNOWHERE_DEBUG_ << "final cleanup done. Link time: "
                           << ((double) link_timer.elapsed() / (double) 1000000)
@@ -1683,9 +1672,7 @@ namespace diskann {
         }
       }
     }
-    for (auto &future : futures) {
-      future.wait();
-    }
+    knowhere::WaitAllSuccess(futures);
 
     diskann::cout << "Prune time : " << timer.elapsed() / 1000 << "ms"
                   << std::endl;
@@ -2385,9 +2372,7 @@ namespace diskann {
       }));
     }
 
-    for (auto &future : futures) {
-      future.wait();
-    }
+    knowhere::WaitAllSuccess(futures);
 
     if (_support_eager_delete)
       update_in_graph();

--- a/thirdparty/DiskANN/src/partition_and_pq.cpp
+++ b/thirdparty/DiskANN/src/partition_and_pq.cpp
@@ -32,6 +32,7 @@
 #include "diskann/parameters.h"
 #include "tsl/robin_set.h"
 #include "diskann/utils.h"
+#include "knowhere/comp/thread_pool.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -355,9 +356,7 @@ int generate_pq_pivots(const float *passed_train_data, size_t num_train,
       }
     }));
   }
-  for (auto &future : futures) {
-    future.wait();
-  }
+  knowhere::WaitAllSuccess(futures);
 
   diskann::save_bin<float>(pq_pivots_path.c_str(), full_pivot_data.get(),
                            (size_t) num_centers, dim);
@@ -574,9 +573,7 @@ int generate_pq_data_from_pivots(const std::string data_file,
         }
       }));
     }
-    for (auto &future : futures) {
-      future.wait();
-    }
+    knowhere::WaitAllSuccess(futures);
 
     if (num_centers > 256) {
       compressed_file_writer.write(

--- a/thirdparty/DiskANN/src/utils.cpp
+++ b/thirdparty/DiskANN/src/utils.cpp
@@ -1,4 +1,6 @@
 #include "diskann/utils.h"
+#include "knowhere/comp/thread_pool.h"
+
 #include <stdio.h>
 
 namespace diskann {
@@ -23,9 +25,7 @@ namespace diskann {
         }
       }));
     }
-    for (auto& future : futures) {
-      future.wait();
-    }
+    knowhere::WaitAllSuccess(futures);
     writr.write((char*) read_buf, npts * ndims * sizeof(float));
   }
 


### PR DESCRIPTION
in many places where folly::Future is used, we only wait but not try to get the value. if the async task thrown an exception wait() will unblock but not rethrow it, causing the async thread to crash. 

now using folly::collect().get() to make sure we always wait for all futures and rethrow exceptions so callers may catch and handle them.

/kind improvement