### PR TITLE
Iterator for IVFFlat and IVFFlatCC

### DIFF
--- a/include/knowhere/config.h
+++ b/include/knowhere/config.h
@@ -528,6 +528,7 @@ class BaseConfig : public Config {
             .set_default("L2")
             .description("metric type")
             .for_train_and_search()
+            .for_iterator()
             .for_deserialize();
         KNOWHERE_CONFIG_DECLARE_FIELD(retrieve_friendly)
             .description("whether the index holds raw data for fast retrieval")

--- a/src/index/ivf/ivf_config.h
+++ b/src/index/ivf/ivf_config.h
@@ -32,6 +32,7 @@ class IvfConfig : public BaseConfig {
             .set_default(8)
             .description("number of probes at query time.")
             .for_search()
+            .for_iterator()
             .set_range(1, 65536);
         KNOWHERE_CONFIG_DECLARE_FIELD(use_elkan)
             .set_default(true)

--- a/tests/ut/test_iterator.cc
+++ b/tests/ut/test_iterator.cc
@@ -23,24 +23,26 @@
 #include "utils.h"
 
 namespace {
-constexpr float kKnnRecallThreshold = 0.6f;
-constexpr float kBruteForceRecallThreshold = 0.99f;
+constexpr float kKnnRecallThreshold = 0.8f;
 
 knowhere::DataSetPtr
-GetKNNResult(const std::vector<std::shared_ptr<knowhere::IndexNode::iterator>>& iterators, int k,
-             const knowhere::BitsetView* bitset = nullptr) {
+GetIteratorKNNResult(const std::vector<std::shared_ptr<knowhere::IndexNode::iterator>>& iterators, int k,
+                     const knowhere::BitsetView* bitset = nullptr) {
     int nq = iterators.size();
     auto p_id = new int64_t[nq * k];
     auto p_dist = new float[nq * k];
     for (int i = 0; i < nq; ++i) {
         auto& iter = iterators[i];
         for (int j = 0; j < k; ++j) {
-            REQUIRE(iter->HasNext());
-            auto [id, dist] = iter->Next();
-            // if bitset is provided, verify we don't return filtered out points.
-            REQUIRE((!bitset || !bitset->test(id)));
-            p_id[i * k + j] = id;
-            p_dist[i * k + j] = dist;
+            if (iter->HasNext()) {
+                auto [id, dist] = iter->Next();
+                // if bitset is provided, verify we don't return filtered out points.
+                REQUIRE((!bitset || !bitset->test(id)));
+                p_id[i * k + j] = id;
+                p_dist[i * k + j] = dist;
+            } else {
+                break;
+            }
         }
     }
     return knowhere::GenResultDataSet(nq, k, p_id, p_dist);
@@ -55,7 +57,7 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
     const int64_t dim = 128;
     auto topk = GENERATE(5, 10, 20);
 
-    auto metric = GENERATE(as<std::string>{}, knowhere::metric::L2, knowhere::metric::COSINE);
+    auto metric = GENERATE(as<std::string>{}, knowhere::metric::L2, knowhere::metric::COSINE, knowhere::metric::IP);
     auto version = GenTestVersionList();
 
     auto base_gen = [&]() {
@@ -71,6 +73,22 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
         json[knowhere::indexparam::HNSW_M] = 128;
         json[knowhere::indexparam::EFCONSTRUCTION] = 200;
         json[knowhere::indexparam::SEED_EF] = 64;
+        json[knowhere::indexparam::EF] = 64;
+        return json;
+    };
+
+    auto ivfflat_gen = [&base_gen]() {
+        knowhere::Json json = base_gen();
+        json[knowhere::indexparam::NPROBE] = 16;
+        json[knowhere::indexparam::NLIST] = 24;
+        return json;
+    };
+
+    auto ivfflatcc_gen = [&base_gen]() {
+        knowhere::Json json = base_gen();
+        json[knowhere::indexparam::NPROBE] = 16;
+        json[knowhere::indexparam::NLIST] = 24;
+        json[knowhere::indexparam::SSIZE] = 32;
         return json;
     };
 
@@ -79,17 +97,12 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
     const auto train_ds = GenDataSet(nb, dim, rand);
     const auto query_ds = GenDataSet(nq, dim, rand + 777);
 
-    const knowhere::Json conf = {
-        {knowhere::meta::METRIC_TYPE, metric},
-        {knowhere::meta::TOPK, topk},
-    };
-    auto gt = knowhere::BruteForce::Search<knowhere::fp32>(train_ds, query_ds, conf, nullptr);
-
     SECTION("Test Search using iterator") {
         using std::make_tuple;
-        auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
-            make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),
-        }));
+        auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>(
+            {make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),
+             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, ivfflat_gen),
+             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, ivfflatcc_gen)}));
         auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version);
         auto cfg_json = gen().dump();
         CAPTURE(name, cfg_json);
@@ -104,16 +117,23 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
         REQUIRE(idx.Deserialize(bs) == knowhere::Status::success);
         auto its = idx.AnnIterator(*query_ds, json, nullptr);
         REQUIRE(its.has_value());
-        auto results = GetKNNResult(its.value(), topk);
-        float recall = GetKNNRecall(*gt.value(), *results);
+
+        // compare iterator_search results with normal ann search results
+        // the iterator resutls should not be too bad.
+        auto iterator_results = GetIteratorKNNResult(its.value(), topk);
+        auto search_results = idx.Search(*query_ds, json, nullptr);
+        REQUIRE(search_results.has_value());
+        bool dist_less_better = knowhere::IsMetricType(metric, knowhere::metric::L2);
+        float recall = GetKNNRelativeRecall(*search_results.value(), *iterator_results, dist_less_better);
         REQUIRE(recall > kKnnRecallThreshold);
     }
 
     SECTION("Test Search with Bitset using iterator") {
         using std::make_tuple;
-        auto [name, gen, threshold] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>, float>({
-            make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen, hnswlib::kHnswSearchKnnBFFilterThreshold),
-        }));
+        auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>(
+            {make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),
+             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, ivfflat_gen),
+             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, ivfflatcc_gen)}));
         auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version);
         auto cfg_json = gen().dump();
         CAPTURE(name, cfg_json);
@@ -131,9 +151,12 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
                 // Iterator doesn't have a fallback to bruteforce mechanism at high filter rate.
                 auto its = idx.AnnIterator(*query_ds, json, bitset);
                 REQUIRE(its.has_value());
-                auto results = GetKNNResult(its.value(), topk, &bitset);
-                auto gt = knowhere::BruteForce::Search<knowhere::fp32>(train_ds, query_ds, json, bitset);
-                float recall = GetKNNRecall(*gt.value(), *results);
+
+                auto iterator_results = GetIteratorKNNResult(its.value(), topk);
+                auto search_results = idx.Search(*query_ds, json, bitset);
+                REQUIRE(search_results.has_value());
+                bool dist_less_better = knowhere::IsMetricType(metric, knowhere::metric::L2);
+                float recall = GetKNNRelativeRecall(*search_results.value(), *iterator_results, dist_less_better);
                 REQUIRE(recall > kKnnRecallThreshold);
             }
         }
@@ -141,9 +164,10 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
 
     SECTION("Test Search with Bitset using iterator insufficient results") {
         using std::make_tuple;
-        auto [name, gen, threshold] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>, float>({
-            make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen, hnswlib::kHnswSearchKnnBFFilterThreshold),
-        }));
+        auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>(
+            {make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),
+             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, ivfflat_gen),
+             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, ivfflatcc_gen)}));
         auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version);
         auto cfg_json = gen().dump();
         CAPTURE(name, cfg_json);
@@ -160,19 +184,103 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
             knowhere::BitsetView bitset(bitset_data.data(), nb);
             auto its = idx.AnnIterator(*query_ds, json, bitset);
             REQUIRE(its.has_value());
-            auto results = GetKNNResult(its.value(), filter_remaining, &bitset);
+            auto iterator_results = GetIteratorKNNResult(its.value(), topk);
             // after get those remaining points, iterator should return false for HasNext.
             for (const auto& it : its.value()) {
                 REQUIRE(!it->HasNext());
             }
-            auto gt = knowhere::BruteForce::Search<knowhere::fp32>(train_ds, query_ds, json, bitset);
-            float recall = GetKNNRecall(*gt.value(), *results);
+            auto search_results = idx.Search(*query_ds, json, bitset);
+            REQUIRE(search_results.has_value());
+            bool dist_less_better = knowhere::IsMetricType(metric, knowhere::metric::L2);
+            float recall = GetKNNRelativeRecall(*search_results.value(), *iterator_results, dist_less_better);
             REQUIRE(recall > kKnnRecallThreshold);
         }
     }
 }
 
-TEST_CASE("Test Iterator Mem Index With Binary Vector", "[float metrics]") {
+// ivfflatcc iterator should not scan newly added vectors.
+TEST_CASE("Test Iterator IVFFlatCC With Newly Insert Vectors", "[float metrics] ") {
+    using Catch::Approx;
+
+    const int64_t nb = 1000, nq = 10;
+    const int64_t dim = 128;
+    const int64_t topk = nb;
+    auto nb_new = GENERATE(100, 1000, 4000);
+
+    auto metric = GENERATE(as<std::string>{}, knowhere::metric::L2, knowhere::metric::COSINE, knowhere::metric::IP);
+    auto version = GenTestVersionList();
+
+    auto base_gen = [&]() {
+        knowhere::Json json;
+        json[knowhere::meta::DIM] = dim;
+        json[knowhere::meta::METRIC_TYPE] = metric;
+        json[knowhere::meta::TOPK] = topk;
+        return json;
+    };
+
+    auto ivfflatcc_gen = [&base_gen]() {
+        knowhere::Json json = base_gen();
+        json[knowhere::indexparam::NPROBE] = 16;
+        json[knowhere::indexparam::NLIST] = 24;
+        json[knowhere::indexparam::SSIZE] = 32;
+        return json;
+    };
+
+    auto rand = GENERATE(1, 3, 5);
+
+    const auto train_ds = GenDataSet(nb, dim, rand);
+    const auto train_ds_new = GenDataSet(nb_new, dim, rand);
+    const auto query_ds = GenDataSet(nq, dim, rand + 777);
+
+    SECTION("Test Search using iterator with newly inserted vectors") {
+        using std::make_tuple;
+        auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>(
+            {make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, ivfflatcc_gen)}));
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version);
+        auto cfg_json = gen().dump();
+        CAPTURE(name, cfg_json, nb_new);
+
+        knowhere::Json json = knowhere::Json::parse(cfg_json);
+        REQUIRE(idx.Type() == name);
+        REQUIRE(idx.Build(*train_ds, json) == knowhere::Status::success);
+        REQUIRE(idx.Size() > 0);
+
+        REQUIRE(idx.Count() == nb);
+        auto its_old = idx.AnnIterator(*query_ds, json, nullptr);
+        REQUIRE(its_old.has_value());
+        auto& iters_old = its_old.value();
+
+        REQUIRE(idx.Add(*train_ds_new, json) == knowhere::Status::success);
+        REQUIRE(idx.Count() == nb + nb_new);
+        auto its_new = idx.AnnIterator(*query_ds, json, nullptr);
+        REQUIRE(its_new.has_value());
+        auto& iters_new = its_new.value();
+
+        // make sure old_iterator will not return newly inserted vectors
+        for (int i = 0; i < iters_old.size(); ++i) {
+            auto& iter = iters_old[i];
+            for (int j = 0; j < nb; ++j) {
+                REQUIRE(iter->HasNext());
+                auto [id, dist] = iter->Next();
+                REQUIRE(id < nb);
+            }
+        }
+
+        // make sure new_iterator will get sufficient results (nb + nb_new)
+        for (int i = 0; i < iters_new.size(); ++i) {
+            auto& iter = iters_new[i];
+            bool id_larger_than_nb = false;
+            for (int j = 0; j < nb + nb_new; ++j) {
+                REQUIRE(iter->HasNext());
+                auto [id, dist] = iter->Next();
+                id_larger_than_nb |= id >= nb;
+            }
+            REQUIRE(id_larger_than_nb);
+        }
+    }
+}
+
+TEST_CASE("Test Iterator Mem Index With Binary Metrics", "[float metrics]") {
     using Catch::Approx;
 
     const int64_t nb = 1000, nq = 10;
@@ -222,8 +330,12 @@ TEST_CASE("Test Iterator Mem Index With Binary Vector", "[float metrics]") {
 
         auto its = idx.AnnIterator(*query_ds, json, nullptr);
         REQUIRE(its.has_value());
-        auto results = GetKNNResult(its.value(), topk);
-        float recall = GetKNNRecall(*gt.value(), *results);
+
+        auto iterator_results = GetIteratorKNNResult(its.value(), topk);
+        auto search_results = idx.Search(*query_ds, json, nullptr);
+        REQUIRE(search_results.has_value());
+        bool dist_less_better = knowhere::IsMetricType(metric, knowhere::metric::L2);
+        float recall = GetKNNRelativeRecall(*search_results.value(), *iterator_results, dist_less_better);
         REQUIRE(recall > kKnnRecallThreshold);
     }
 }

--- a/thirdparty/faiss/faiss/IndexIVF.cpp
+++ b/thirdparty/faiss/faiss/IndexIVF.cpp
@@ -1351,6 +1351,17 @@ size_t InvertedListScanner::scan_codes(
     return nup;
 }
 
+size_t InvertedListScanner::scan_codes_and_push_back(
+        size_t list_size,
+        const uint8_t* codes,
+        const float* code_norms,
+        const idx_t* ids,
+        float* distances,
+        idx_t* labels,
+        size_t& counter_back) const {
+    FAISS_THROW_MSG("Not implemented.");
+}
+
 size_t InvertedListScanner::iterate_codes(
         InvertedListsIterator* it,
         float* simi,

--- a/thirdparty/faiss/faiss/IndexIVF.h
+++ b/thirdparty/faiss/faiss/IndexIVF.h
@@ -503,6 +503,28 @@ struct InvertedListScanner {
             size_t k,
             size_t& scan_cnt) const;
 
+    /** scan a set of codes, compute distances to current query and
+     * push all to heap. Default implemetation
+     * calls distance_to_code.
+     *
+     * @param list_size     number of codes to scan
+     * @param codes         codes to scan (list_size * code_size)
+     * @param code_norms    norms of code (for cosine)
+     * @param ids           corresponding ids (ignored if store_pairs)
+     * @param distances     heap distances (size counter_back)
+     * @param labels        heap labels (size counter_back)
+     * @param counter_back  heap size (will increase)
+     * @return number of heap pushes performed
+     */
+    virtual size_t scan_codes_and_push_back(
+            size_t list_size,
+            const uint8_t* codes,
+            const float* code_norms,
+            const idx_t* ids,
+            float* distances,
+            idx_t* labels,
+            size_t& counter_back) const;
+
     // same as scan_codes, using an iterator
     virtual size_t iterate_codes(
             InvertedListsIterator* iterator,

--- a/thirdparty/faiss/faiss/IndexIVFFlat.cpp
+++ b/thirdparty/faiss/faiss/IndexIVFFlat.cpp
@@ -319,6 +319,47 @@ struct IVFFlatScanner : InvertedListScanner {
         return nup;
     }
 
+    size_t scan_codes_and_push_back(
+            size_t list_size,
+            const uint8_t* codes,
+            const float* code_norms,
+            const idx_t* ids,
+            float* distances,
+            idx_t* labels,
+            size_t& counter_back) const override {
+        const float* list_vecs = (const float*)codes;
+
+        // the lambda that filters acceptable elements.
+        auto filter = [&](const size_t j) {
+            return (!use_sel || sel->is_member(ids[j]));
+        };
+
+        size_t n_heap = 0;
+
+        // the lambda that applies a valid element.
+        auto apply = [&](const float dis_in, const size_t j) {
+            const float dis =
+                    (code_norms == nullptr) ? dis_in : (dis_in / code_norms[j]);
+
+            counter_back++;
+            if constexpr (metric == METRIC_INNER_PRODUCT) {
+                heap_push<CMax<float, int64_t>>(
+                        counter_back, distances, labels, dis, ids[j]);
+            } else {
+                heap_push<CMin<float, int64_t>>(
+                        counter_back, distances, labels, dis, ids[j]);
+            }
+            n_heap++;
+        };
+        if constexpr (metric == METRIC_INNER_PRODUCT) {
+            fvec_inner_products_ny_if(
+                    xi, list_vecs, d, list_size, filter, apply);
+        } else {
+            fvec_L2sqr_ny_if(xi, list_vecs, d, list_size, filter, apply);
+        }
+        return n_heap;
+    }
+
     void scan_codes_range(
             size_t list_size,
             const uint8_t* codes,
@@ -424,6 +465,47 @@ struct IVFFlatBitsetViewScanner : InvertedListScanner {
         return nup;
     }
 
+    size_t scan_codes_and_push_back(
+            size_t list_size,
+            const uint8_t* codes,
+            const float* code_norms,
+            const idx_t* ids,
+            float* distances,
+            idx_t* labels,
+            size_t& counter_back) const override {
+        const float* list_vecs = (const float*)codes;
+
+        // the lambda that filters acceptable elements.
+        auto filter = [&](const size_t j) {
+            return (!use_sel || !bitset.test(ids[j]));
+        };
+
+        size_t n_heap = 0;
+
+        // the lambda that applies a valid element.
+        auto apply = [&](const float dis_in, const size_t j) {
+            const float dis =
+                    (code_norms == nullptr) ? dis_in : (dis_in / code_norms[j]);
+
+            counter_back++;
+            if constexpr (metric == METRIC_INNER_PRODUCT) {
+                heap_push<CMax<float, int64_t>>(
+                        counter_back, distances, labels, dis, ids[j]);
+            } else {
+                heap_push<CMin<float, int64_t>>(
+                        counter_back, distances, labels, dis, ids[j]);
+            }
+            n_heap++;
+        };
+        if constexpr (metric == METRIC_INNER_PRODUCT) {
+            fvec_inner_products_ny_if(
+                    xi, list_vecs, d, list_size, filter, apply);
+        } else {
+            fvec_L2sqr_ny_if(xi, list_vecs, d, list_size, filter, apply);
+        }
+        return n_heap;
+    }
+
     void scan_codes_range(
             size_t list_size,
             const uint8_t* __restrict codes,
@@ -512,6 +594,180 @@ void IndexIVFFlat::reconstruct_from_offset(
         int64_t offset,
         float* recons) const {
     memcpy(recons, invlists->get_single_code(list_no, offset), code_size);
+}
+
+std::unique_ptr<IVFFlatIteratorWorkspace> IndexIVFFlat::getIteratorWorkspace(
+        const float* query_data,
+        const IVFSearchParameters* ivfsearchParams) const {
+    return std::make_unique<IVFFlatIteratorWorkspace>(
+            query_data, ivfsearchParams);
+}
+
+std::optional<std::pair<float, idx_t>> IndexIVFFlat::getIteratorNext(
+        IVFFlatIteratorWorkspace* workspace) const {
+    auto scan_one_list_then_add_to_backup =
+            [&](idx_t list_no,
+                float coarse_list_centroid_dist, // no use, dist for residual.
+                float* distances,
+                idx_t* labels,
+                size_t& counter_back,
+                size_t max_codes) {
+                if (list_no < 0) {
+                    // not enough centroids for multiprobe
+                    return (size_t)0;
+                }
+                FAISS_THROW_IF_NOT_FMT(
+                        list_no < (idx_t)nlist,
+                        "Invalid list_no=%" PRId64 " nlist=%zd\n",
+                        list_no,
+                        nlist);
+
+                // don't waste time on empty lists
+                if (invlists->is_empty(list_no)) {
+                    return (size_t)0;
+                }
+
+                // get scanner
+                IDSelector* sel = workspace->search_params
+                        ? workspace->search_params->sel
+                        : nullptr;
+                InvertedListScanner* scanner = get_InvertedListScanner(false, sel);
+                scanner->set_query(workspace->query_data);
+                ScopeDeleter1<InvertedListScanner> del(scanner);
+
+                size_t segment_num = invlists->get_segment_num(list_no);
+                size_t scan_cnt = 0;
+                for (size_t segment_idx = 0; segment_idx < segment_num;
+                     segment_idx++) {
+                    size_t segment_size =
+                            invlists->get_segment_size(list_no, segment_idx);
+                    size_t should_scan_size =
+                            std::min(segment_size, max_codes - scan_cnt);
+                    scan_cnt += should_scan_size;
+                    if (should_scan_size <= 0) {
+                        break;
+                    }
+                    size_t segment_offset =
+                            invlists->get_segment_offset(list_no, segment_idx);
+                    InvertedLists::ScopedCodes scodes(
+                            invlists, list_no, segment_offset);
+                    InvertedLists::ScopedCodeNorms scode_norms(
+                            invlists, list_no, segment_offset);
+                    InvertedLists::ScopedIds sids(
+                            invlists, list_no, segment_offset);
+
+                    size_t n_heap = scanner->scan_codes_and_push_back(
+                            should_scan_size,
+                            scodes.get(),
+                            scode_norms.get(),
+                            sids.get(),
+                            distances,
+                            labels,
+                            counter_back);
+                }
+
+                return max_codes;
+            };
+
+    if (!workspace->initial_search_done) {
+        // snapshot of list_sizes;
+        auto coarse_list_sizes = std::make_unique<size_t[]>(nlist);
+        size_t count = 0;
+        for (size_t list_no = 0; list_no < nlist; ++list_no) {
+            auto list_size = invlists->list_size(list_no);
+            coarse_list_sizes[list_no] = list_size;
+            count += list_size;
+            if (list_size > workspace->max_coarse_list_size) {
+                workspace->max_coarse_list_size = list_size;
+            }
+        }
+
+        // compute backup_count_threshold - (nprobe / nlist) * count
+        size_t nprobe = workspace->search_params->nprobe
+                ? workspace->search_params->nprobe
+                : this->nprobe;
+        nprobe = std::min(nlist, nprobe);
+        workspace->backup_count_threshold = count * nprobe / nlist;
+        workspace->max_backup_count = workspace->max_coarse_list_size +
+                workspace->backup_count_threshold;
+
+        // compute distances of all centroids
+        auto coarse_idx = std::make_unique<idx_t[]>(nlist);
+        auto coarse_dis = std::make_unique<float[]>(nlist);
+        quantizer->search(
+                1,
+                workspace->query_data,
+                nlist,
+                coarse_dis.get(),
+                coarse_idx.get(),
+                workspace->search_params
+                        ? workspace->search_params->quantizer_params
+                        : nullptr);
+
+        // init backup_nodes until more than threshold
+        invlists->prefetch_lists(coarse_idx.get(), nprobe);
+        auto labels = std::make_unique<idx_t[]>(workspace->max_backup_count);
+        auto distances = std::make_unique<float[]>(workspace->max_backup_count);
+        size_t backup_count = 0;
+        size_t next_visit_coarse_list_idx = 0;
+        while (next_visit_coarse_list_idx < nlist &&
+               backup_count < workspace->backup_count_threshold) {
+            scan_one_list_then_add_to_backup(
+                    coarse_idx[next_visit_coarse_list_idx],
+                    coarse_dis[next_visit_coarse_list_idx], // no use
+                    distances.get(),
+                    labels.get(),
+                    backup_count,
+                    coarse_list_sizes[coarse_idx[next_visit_coarse_list_idx]]);
+            next_visit_coarse_list_idx++;
+        }
+        workspace->backup_count = backup_count;
+        workspace->next_visit_coarse_list_idx = next_visit_coarse_list_idx;
+
+        workspace->labels = std::move(labels);
+        workspace->distances = std::move(distances);
+        workspace->coarse_idx = std::move(coarse_idx);
+        workspace->coarse_dis = std::move(coarse_dis);
+        workspace->coarse_list_sizes = std::move(coarse_list_sizes);
+
+        workspace->initial_search_done = true;
+    }
+
+    // terminate when no backup nodes.
+    if (workspace->backup_count == 0 &&
+        workspace->next_visit_coarse_list_idx >= nlist) {
+        return std::nullopt;
+    }
+    while (workspace->backup_count < workspace->backup_count_threshold &&
+           workspace->next_visit_coarse_list_idx < nlist) {
+        auto next_list_idx = workspace->next_visit_coarse_list_idx;
+        scan_one_list_then_add_to_backup(
+                workspace->coarse_idx[next_list_idx],
+                workspace->coarse_dis[next_list_idx], // no use
+                workspace->distances.get(),
+                workspace->labels.get(),
+                workspace->backup_count,
+                workspace->coarse_list_sizes
+                        [workspace->coarse_idx[next_list_idx]]);
+        workspace->next_visit_coarse_list_idx++;
+    }
+
+    auto next_dis = workspace->distances[0];
+    auto next_id = workspace->labels[0];
+    if (metric_type == METRIC_INNER_PRODUCT) {
+        heap_pop<CMax<float, int64_t>>(
+                workspace->backup_count,
+                workspace->distances.get(),
+                workspace->labels.get());
+    } else {
+        heap_pop<CMin<float, int64_t>>(
+                workspace->backup_count,
+                workspace->distances.get(),
+                workspace->labels.get());
+    }
+    workspace->backup_count--;
+
+    return std::make_optional(std::make_pair(next_dis, next_id));
 }
 
 IndexIVFFlatCC::IndexIVFFlatCC(

--- a/thirdparty/faiss/faiss/IndexIVFFlat.h
+++ b/thirdparty/faiss/faiss/IndexIVFFlat.h
@@ -11,11 +11,32 @@
 #define FAISS_INDEX_IVF_FLAT_H
 
 #include <stdint.h>
+#include <optional>
 #include <unordered_map>
 
 #include <faiss/IndexIVF.h>
 
 namespace faiss {
+struct IVFFlatIteratorWorkspace {
+    IVFFlatIteratorWorkspace(
+            const float* query_data,
+            const IVFSearchParameters* search_params)
+            : query_data(query_data), search_params(search_params) {}
+
+    const float* query_data = nullptr; // single query
+    const IVFSearchParameters* search_params = nullptr;
+    bool initial_search_done = false;
+    std::unique_ptr<float[]> distances = nullptr; // backup distances (heap)
+    std::unique_ptr<idx_t[]> labels = nullptr;    // backup ids (heap)
+    size_t backup_count = 0;            // scan a new coarse-list when less than backup_count_threshold
+    size_t max_backup_count = 0;        
+    size_t backup_count_threshold = 0;  // count * nprobe / nlist
+    size_t next_visit_coarse_list_idx = 0;
+    std::unique_ptr<float[]> coarse_dis = nullptr;   // backup coarse centroids distances (heap)
+    std::unique_ptr<idx_t[]> coarse_idx = nullptr;   // backup coarse centroids ids (heap)
+    std::unique_ptr<size_t[]> coarse_list_sizes = nullptr;  // snapshot of the list_size
+    size_t max_coarse_list_size = 0;
+};
 
 /** Inverted file with stored vectors. Here the inverted file
  * pre-selects the vectors to be searched, but they are not otherwise
@@ -32,7 +53,7 @@ struct IndexIVFFlat : IndexIVF {
     void restore_codes(const uint8_t* raw_data, const size_t raw_size);
 
     // Be careful with overriding this function, because
-    //   renormalized x may be used inside. 
+    //   renormalized x may be used inside.
     // Overridden by IndexIVFFlatDedup.
     void train(idx_t n, const float* x) override;
 
@@ -62,6 +83,19 @@ struct IndexIVFFlat : IndexIVF {
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
 
     IndexIVFFlat();
+
+    std::unique_ptr<IVFFlatIteratorWorkspace> getIteratorWorkspace(
+            const float* query_data,
+            const IVFSearchParameters* ivfsearchParams) const;
+
+    // Unlike regular knn-search, the iterator does not know the size `k` of the
+    // returned result.
+    //   The workspace will maintain a heap of at least (nprobe/nlist) nodes for
+    //   iterator `Next()` operation.
+    //   When there are not enough nodes in the heap, iterator will scan the
+    //   next coarse list.
+    std::optional<std::pair<float, idx_t>> getIteratorNext(
+            IVFFlatIteratorWorkspace* workspace) const;
 };
 
 struct IndexIVFFlatCC : IndexIVFFlat {


### PR DESCRIPTION
issue: #367 
- Iterator Search for IVFFlat and IVFFlatCC.
  - Each iterator `Next()` will return the optimal result from within at least (nprobe/nlist)% rows.
  - For `IVFFlatCC`, the iterator will not scan any newly inserted vectors after it is created.
- Add test for ivfflat and ivfflatcc iterator.

/kind feature