### PR TITLE
Replace gettid() with syscall(SYS_gettid)

### DIFF
--- a/include/knowhere/comp/thread_pool.h
+++ b/include/knowhere/comp/thread_pool.h
@@ -12,7 +12,11 @@
 #pragma once
 
 #include <omp.h>
+
+#ifdef __linux__
 #include <sys/resource.h>
+#include <sys/syscall.h>
+#endif
 
 #include <cerrno>
 #include <cstring>
@@ -36,7 +40,7 @@ class ThreadPool {
         std::thread
         newThread(folly::Func&& func) override {
             return folly::NamedThreadFactory::newThread([&, func = std::move(func)]() mutable {
-                if (setpriority(PRIO_PROCESS, gettid(), 19) != 0) {
+                if (setpriority(PRIO_PROCESS, static_cast<pid_t>(syscall(SYS_gettid)), 19) != 0) {
                     LOG_KNOWHERE_ERROR_ << "Failed to set priority of knowhere thread. Error is: "
                                         << std::strerror(errno);
                 } else {


### PR DESCRIPTION
in some older glibc version gettid() wrapper does not exist.

issue: #394 
