### PR TITLE
fix: diskann memory leak after failure

### DIFF
--- a/src/index/diskann/diskann.cc
+++ b/src/index/diskann/diskann.cc
@@ -417,12 +417,9 @@ DiskANNIndexNode<DataType>::Deserialize(const BinarySet& binset, const Config& c
     if (file_exists(cached_nodes_file)) {
         LOG_KNOWHERE_INFO_ << "Reading cached nodes from file.";
         size_t num_nodes, nodes_id_dim;
-        uint32_t* cached_nodes_ids = nullptr;
+        std::unique_ptr<uint32_t[]> cached_nodes_ids = nullptr;
         diskann::load_bin<uint32_t>(cached_nodes_file, cached_nodes_ids, num_nodes, nodes_id_dim);
-        node_list.assign(cached_nodes_ids, cached_nodes_ids + num_nodes);
-        if (cached_nodes_ids != nullptr) {
-            delete[] cached_nodes_ids;
-        }
+        node_list.assign(cached_nodes_ids.get(), cached_nodes_ids.get() + num_nodes);
     } else {
         auto num_nodes_to_cache = GetCachedNodeNum(prep_conf.search_cache_budget_gb.value(),
                                                    pq_flash_index_->get_data_dim(), pq_flash_index_->get_max_degree());

--- a/thirdparty/DiskANN/include/diskann/logger_impl.h
+++ b/thirdparty/DiskANN/include/diskann/logger_impl.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <memory>
 #include <sstream>
 #include <mutex>
 
@@ -36,7 +37,7 @@ namespace diskann {
 
    private:
     FILE*              _fp;
-    char*              _buf;
+    std::unique_ptr<char[]> _buf;
     int                _bufIndex;
     std::mutex         _mutex;
     ANNIndex::LogLevel _logLevel;

--- a/thirdparty/DiskANN/include/diskann/math_utils.h
+++ b/thirdparty/DiskANN/include/diskann/math_utils.h
@@ -16,7 +16,7 @@ namespace math_utils {
   // compute l2-squared norms of data stored in row major num_points * dim,
   // needs
   // to be pre-allocated
-  void compute_vecs_l2sq(float* vecs_l2sq, float* data, const size_t num_points,
+  void compute_vecs_l2sq(float* vecs_l2sq, const float* data, const size_t num_points,
                          const size_t dim);
 
   void rotate_data_randomly(float* data, size_t num_points, size_t dim,
@@ -48,9 +48,9 @@ namespace math_utils {
   // those
   // values
 
-  void compute_closest_centers(float* data, size_t num_points, size_t dim,
-                               float* pivot_data, size_t num_centers, size_t k,
-                               uint32_t*            closest_centers_ivf,
+  void compute_closest_centers(const float* data, size_t num_points, size_t dim,
+                               const float* pivot_data, size_t num_centers,
+                               size_t k, uint32_t* closest_centers_ivf,
                                std::vector<size_t>* inverted_index = NULL,
                                float*               pts_norms_squared = NULL);
 
@@ -74,9 +74,10 @@ namespace kmeans {
   // If closest_centers == NULL, will allocate memory and return.
   // Similarly, if closest_docs == NULL, will allocate memory and return.
 
-  float lloyds_iter(float* data, size_t num_points, size_t dim, float* centers,
-                    size_t num_centers, std::vector<size_t>* closest_docs,
-                    uint32_t*& closest_center);
+  float lloyds_iter(const float* data, size_t num_points, size_t dim,
+                    float* centers, size_t num_centers,
+                    std::unique_ptr<std::vector<size_t>[]>& closest_docs,
+                    std::unique_ptr<uint32_t[]>&            closest_center);
 
   // Run Lloyds until max_reps or stopping criterion
   // If you pass NULL for closest_docs and closest_center, it will NOT return
@@ -84,15 +85,16 @@ namespace kmeans {
   // vector<size_t> [num_centers], and closest_center = new size_t[num_points]
   // Final centers are output in centers as row major num_centers * dim
   //
-  float run_lloyds(float* data, size_t num_points, size_t dim, float* centers,
-                   const size_t num_centers, const size_t max_reps,
-                   std::vector<size_t>* closest_docs, uint32_t* closest_center);
+  float run_lloyds(const float* data, size_t num_points, size_t dim,
+                   float* centers, const size_t num_centers,
+                   const size_t max_reps, std::vector<size_t>* closest_docs,
+                   uint32_t* closest_center);
 
   // assumes already memory allocated for pivot_data as new
   // float[num_centers*dim] and select randomly num_centers points as pivots
   void selecting_pivots(float* data, size_t num_points, size_t dim,
                         float* pivot_data, size_t num_centers);
 
-  void kmeanspp_selecting_pivots(float* data, size_t num_points, size_t dim,
+  void kmeanspp_selecting_pivots(const float* data, size_t num_points, size_t dim,
                                  float* pivot_data, size_t num_centers);
 }  // namespace kmeans

--- a/thirdparty/DiskANN/include/diskann/partition_and_pq.h
+++ b/thirdparty/DiskANN/include/diskann/partition_and_pq.h
@@ -19,14 +19,16 @@ void gen_random_slice(const std::string base_file,
 
 template<typename T>
 void gen_random_slice(const std::string data_file, double p_val,
-                      float *&sampled_data, size_t &slice_size, size_t &ndims);
+                      std::unique_ptr<float[]> &sampled_data,
+                      size_t &slice_size, size_t &ndims);
 
 template<typename T>
 void gen_random_slice(const T *inputdata, size_t npts, size_t ndims,
-                      double p_val, float *&sampled_data, size_t &slice_size);
+                      double p_val, std::unique_ptr<float[]> &sampled_data,
+                      size_t &slice_size);
 
 int estimate_cluster_sizes(float *test_data_float, size_t num_test,
-                           float *pivots, const size_t num_centers,
+                           const float *pivots, const size_t num_centers,
                            const size_t dim, const size_t k_base,
                            std::vector<size_t> &cluster_sizes);
 

--- a/thirdparty/DiskANN/include/diskann/pq_flash_index.h
+++ b/thirdparty/DiskANN/include/diskann/pq_flash_index.h
@@ -196,7 +196,7 @@ namespace diskann {
     float max_base_norm = 0.0f;
 
     // used only for cosine search to re-scale the caculated distance.
-    float *base_norms = nullptr;
+    std::unique_ptr<float[]> base_norms = nullptr;
 
     // data info
     bool long_node = false;
@@ -225,7 +225,7 @@ namespace diskann {
     // data: _u8 * n_chunks
     // chunk_size = chunk size of each dimension chunk
     // pq_tables = float* [[2^8 * [chunk_size]] * n_chunks]
-    _u8              *data = nullptr;
+    std::unique_ptr<_u8[]> data = nullptr;
     _u64              n_chunks;
     FixedChunkPQTable pq_table;
 
@@ -259,7 +259,7 @@ namespace diskann {
 
     // graph has one entry point by default,
     // we can optionally have multiple starting points
-    uint32_t *medoids = nullptr;
+    std::unique_ptr<uint32_t[]> medoids = nullptr;
     // defaults to 1
     size_t num_medoids;
     // by default, it is empty. If there are multiple
@@ -271,7 +271,7 @@ namespace diskann {
     std::shared_mutex cache_mtx;
 
     // nhood_cache
-    unsigned *nhood_cache_buf = nullptr;
+    std::unique_ptr<unsigned[]> nhood_cache_buf = nullptr;
     tsl::robin_map<_u32, std::pair<_u32, _u32 *>>
         nhood_cache;  // <id, <neihbors_num, neihbors>>
 

--- a/thirdparty/DiskANN/src/logger.cpp
+++ b/thirdparty/DiskANN/src/logger.cpp
@@ -26,16 +26,15 @@ namespace diskann {
     _fp = fp;
     _logLevel = (_fp == stdout) ? ANNIndex::LogLevel::LL_Info
                                 : ANNIndex::LogLevel::LL_Error;
-    _buf = new char[BUFFER_SIZE];  // See comment in the header
+    _buf = std::make_unique<char[]>(BUFFER_SIZE);
 
-    std::memset(_buf, 0, (BUFFER_SIZE) * sizeof(char));
-    setp(_buf, _buf + BUFFER_SIZE);
+    std::memset(_buf.get(), 0, (BUFFER_SIZE) * sizeof(char));
+    setp(_buf.get(), _buf.get() + BUFFER_SIZE);
   }
 
   ANNStreamBuf::~ANNStreamBuf() {
     sync();
     _fp = nullptr;  // we'll not close because we can't.
-    delete[] _buf;
   }
 
   int ANNStreamBuf::overflow(int c) {

--- a/thirdparty/DiskANN/src/math_utils.cpp
+++ b/thirdparty/DiskANN/src/math_utils.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #include <limits>
+#include <memory>
 #include <unordered_set>
 #include <malloc.h>
 #include <diskann/math_utils.h>
@@ -38,7 +39,7 @@ namespace math_utils {
   // compute l2-squared norms of data stored in row major num_points * dim,
   // needs
   // to be pre-allocated
-  void compute_vecs_l2sq(float* vecs_l2sq, float* data, const size_t num_points,
+  void compute_vecs_l2sq(float* vecs_l2sq, const float* data, const size_t num_points,
                          const size_t dim) {
     for (int64_t n_iter = 0; n_iter < (_s64) num_points; n_iter++) {
       vecs_l2sq[n_iter] =
@@ -146,8 +147,8 @@ namespace math_utils {
       return;
     }
 
-    float* ones_a = new float[num_centers];
-    float* ones_b = new float[num_points];
+    auto ones_a = std::make_unique<float[]>(num_centers);
+    auto ones_b = std::make_unique<float[]>(num_points);
 
     for (size_t i = 0; i < num_centers; i++) {
       ones_a[i] = 1.0;
@@ -160,9 +161,9 @@ namespace math_utils {
     FINTEGER m = num_points, n = num_centers, finteger_one = 1,
              finteger_dim = dim;
     sgemm_(kNoTranspose, kTranspose, &m, &n, &finteger_one, &one, docs_l2sq,
-           &finteger_one, ones_a, &finteger_one, &zero, dist_matrix, &n);
+           &finteger_one, ones_a.get(), &finteger_one, &zero, dist_matrix, &n);
 
-    sgemm_(kNoTranspose, kTranspose, &m, &n, &finteger_one, &one, ones_b,
+    sgemm_(kNoTranspose, kTranspose, &m, &n, &finteger_one, &one, ones_b.get(),
            &finteger_one, centers_l2sq, &finteger_one, &one, dist_matrix, &n);
 
     sgemm_(kNoTranspose, kTranspose, &m, &n, &finteger_dim, &minus_two, data,
@@ -194,8 +195,6 @@ namespace math_utils {
         }
       }
     }
-    delete[] ones_a;
-    delete[] ones_b;
   }
 
   // Given data in num_points * new_dim row major
@@ -208,11 +207,11 @@ namespace math_utils {
   // indices is an empty vector. Additionally, if pts_norms_squared is not null,
   // then it will assume that point norms are pre-computed and use those values
 
-  void compute_closest_centers(float* data, size_t num_points, size_t dim,
-                               float* pivot_data, size_t num_centers, size_t k,
-                               uint32_t*            closest_centers_ivf,
-                               std::vector<size_t>* inverted_index,
-                               float*               pts_norms_squared) {
+  void compute_closest_centers(const float* data, size_t num_points, size_t dim,
+                               const float* pivot_data, size_t num_centers,
+                               size_t k, uint32_t* closest_centers_ivf,
+                               std::vector<size_t>*      inverted_index,
+                               float* pts_norms_squared) {
     if (k > num_centers) {
       diskann::cout << "ERROR: k (" << k << ") > num_center(" << num_centers
                     << ")" << std::endl;
@@ -221,9 +220,12 @@ namespace math_utils {
 
     bool is_norm_given_for_pts = (pts_norms_squared != NULL);
 
-    float* pivs_norms_squared = new float[num_centers];
-    if (!is_norm_given_for_pts)
-      pts_norms_squared = new float[num_points];
+    auto pivs_norms_squared = std::make_unique<float>(num_centers);
+    std::unique_ptr<float[]> pts_norms_squared_deleter = nullptr;
+    if (!is_norm_given_for_pts) {
+      pts_norms_squared_deleter = std::make_unique<float[]>(num_points);
+      pts_norms_squared = pts_norms_squared_deleter.get();
+    }
 
     size_t PAR_BLOCK_SIZE = num_points;
     size_t N_BLOCKS = (num_points % PAR_BLOCK_SIZE) == 0
@@ -232,21 +234,21 @@ namespace math_utils {
 
     if (!is_norm_given_for_pts)
       math_utils::compute_vecs_l2sq(pts_norms_squared, data, num_points, dim);
-    math_utils::compute_vecs_l2sq(pivs_norms_squared, pivot_data, num_centers,
+    math_utils::compute_vecs_l2sq(pivs_norms_squared.get(), pivot_data, num_centers,
                                   dim);
-    uint32_t* closest_centers = new uint32_t[PAR_BLOCK_SIZE * k];
-    float*    distance_matrix = new float[num_centers * PAR_BLOCK_SIZE];
+    auto closest_centers = std::make_unique<uint32_t[]>(PAR_BLOCK_SIZE * k);
+    auto distance_matrix = std::make_unique<float[]>(num_centers * PAR_BLOCK_SIZE);
 
     for (size_t cur_blk = 0; cur_blk < N_BLOCKS; cur_blk++) {
-      float* data_cur_blk = data + cur_blk * PAR_BLOCK_SIZE * dim;
+      const float* data_cur_blk = data + cur_blk * PAR_BLOCK_SIZE * dim;
       size_t num_pts_blk =
           std::min(PAR_BLOCK_SIZE, num_points - cur_blk * PAR_BLOCK_SIZE);
       float* pts_norms_blk = pts_norms_squared + cur_blk * PAR_BLOCK_SIZE;
 
       math_utils::compute_closest_centers_in_block(
           data_cur_blk, num_pts_blk, dim, pivot_data, num_centers,
-          pts_norms_blk, pivs_norms_squared, closest_centers, distance_matrix,
-          k);
+          pts_norms_blk, pivs_norms_squared.get(), closest_centers.get(),
+          distance_matrix.get(), k);
 
       int64_t blk_st = cur_blk * PAR_BLOCK_SIZE;
       int64_t blk_ed =
@@ -264,11 +266,6 @@ namespace math_utils {
         }
       }
     }
-    delete[] closest_centers;
-    delete[] distance_matrix;
-    delete[] pivs_norms_squared;
-    if (!is_norm_given_for_pts)
-      delete[] pts_norms_squared;
   }
 
   // if to_subtract is 1, will subtract nearest center from each row. Else will
@@ -306,20 +303,21 @@ namespace kmeans {
   // closest_centers == NULL, will allocate memory and return. Similarly, if
   // closest_docs == NULL, will allocate memory and return.
 
-  float lloyds_iter(float* data, size_t num_points, size_t dim, float* centers,
-                    size_t num_centers, std::vector<size_t>* closest_docs,
-                    uint32_t*& closest_center) {
+  float lloyds_iter(const float* data, size_t num_points, size_t dim,
+                    float* centers, size_t num_centers,
+                    std::unique_ptr<std::vector<size_t>[]>& closest_docs,
+                    std::unique_ptr<uint32_t[]>&          closest_center) {
     bool compute_residual = true;
     // Timer timer;
 
     bool ret_closest_center = true;
     bool ret_closest_docs = true;
-    if (closest_center == NULL) {
-      closest_center = new uint32_t[num_points];
+    if (closest_center == nullptr) {
+      closest_center = std::make_unique<uint32_t[]>(num_points);
       ret_closest_center = false;
     }
-    if (closest_docs == NULL) {
-      closest_docs = new std::vector<size_t>[num_centers];
+    if (closest_docs == nullptr) {
+      closest_docs = std::make_unique<std::vector<size_t>[]>(num_centers);
       ret_closest_docs = false;
     } else {
       for (size_t c = 0; c < num_centers; ++c)
@@ -327,18 +325,18 @@ namespace kmeans {
     }
 
     math_utils::elkan_L2(data, centers, dim, num_points, num_centers,
-                         closest_center);
+                         closest_center.get());
     for (size_t i = 0; i < num_points; ++i) {
       closest_docs[closest_center[i]].push_back(i);
     }
 
     for (int64_t c = 0; c < (_s64) num_centers; ++c) {
       float*  center = centers + (size_t) c * (size_t) dim;
-      double* cluster_sum = new double[dim];
+      auto cluster_sum = std::make_unique<double[]>(dim);
       for (size_t i = 0; i < dim; i++)
         cluster_sum[i] = 0.0;
       for (size_t i = 0; i < closest_docs[c].size(); i++) {
-        float* current = data + ((closest_docs[c][i]) * dim);
+        const float* current = data + ((closest_docs[c][i]) * dim);
         for (size_t j = 0; j < dim; j++) {
           cluster_sum[j] += (double) current[j];
         }
@@ -348,7 +346,6 @@ namespace kmeans {
           center[i] =
               (float) (cluster_sum[i] / ((double) closest_docs[c].size()));
       }
-      delete[] cluster_sum;
     }
 
     float residual = 0.0;
@@ -371,10 +368,10 @@ namespace kmeans {
     }
 
     if (!ret_closest_docs) {
-      delete[] closest_docs;
+      closest_docs.reset();
     }
     if (!ret_closest_center) {
-      delete[] closest_center;
+      closest_center.reset();
     }
     return residual;
   }
@@ -386,20 +383,21 @@ namespace kmeans {
   // vector<size_t> [num_centers], and closest_center = new size_t[num_points]
   // Final centers are output in centers as row major num_centers * dim
   //
-  float run_lloyds(float* data, size_t num_points, size_t dim, float* centers,
-                   const size_t num_centers, const size_t max_reps,
-                   std::vector<size_t>* closest_docs,
-                   uint32_t*            closest_center) {
+  float run_lloyds(const float* data, size_t num_points, size_t dim,
+                   float* centers, const size_t num_centers,
+                   const size_t max_reps, std::vector<size_t>* closest_docs,
+                   uint32_t* closest_center) {
     float residual = std::numeric_limits<float>::max();
-    bool  ret_closest_docs = true;
-    bool  ret_closest_center = true;
-    if (closest_docs == NULL) {
-      closest_docs = new std::vector<size_t>[num_centers];
-      ret_closest_docs = false;
+
+    std::unique_ptr<std::vector<size_t>[]> closest_docs_deleter = nullptr;
+    std::unique_ptr<uint32_t[]> closest_center_deleter = nullptr;
+    if (closest_docs == nullptr) {
+      closest_docs_deleter = std::make_unique<std::vector<size_t>[]>(num_centers);
+      closest_docs = closest_docs_deleter.get();
     }
-    if (closest_center == NULL) {
-      closest_center = new uint32_t[num_points];
-      ret_closest_center = false;
+    if (closest_center == nullptr) {
+      closest_center_deleter  = std::make_unique<uint32_t[]>(num_points);
+      closest_center = closest_center_deleter.get();
     }
 
     float old_residual;
@@ -408,7 +406,7 @@ namespace kmeans {
       old_residual = residual;
 
       residual = lloyds_iter(data, num_points, dim, centers, num_centers,
-                             closest_docs, closest_center);
+                             closest_docs_deleter, closest_center_deleter);
 
       LOG_KNOWHERE_DEBUG_ << "Lloyd's iter " << i
                           << "  dist_sq residual: " << residual;
@@ -421,20 +419,14 @@ namespace kmeans {
         break;
       }
     }
-    if (!ret_closest_docs)
-      delete[] closest_docs;
-    if (!ret_closest_center)
-      delete[] closest_center;
     return residual;
   }
 
   // assumes memory allocated for pivot_data as new
   // float[num_centers*dim]
   // and select randomly num_centers points as pivots
-  void selecting_pivots(float* data, size_t num_points, size_t dim,
+  void selecting_pivots(const float* data, size_t num_points, size_t dim,
                         float* pivot_data, size_t num_centers) {
-    //	pivot_data = new float[num_centers * dim];
-
     std::unordered_set<size_t> picked;
     std::random_device         rd;
     auto                       x = rd();
@@ -456,7 +448,7 @@ namespace kmeans {
     }
   }
 
-  void kmeanspp_selecting_pivots(float* data, size_t num_points, size_t dim,
+  void kmeanspp_selecting_pivots(const float* data, size_t num_points, size_t dim,
                                  float* pivot_data, size_t num_centers) {
     if (num_points > 1 << 23) {
       diskann::cout << "ERROR: n_pts " << num_points
@@ -486,7 +478,7 @@ namespace kmeans {
     picked.push_back(init_id);
     std::memcpy(pivot_data, data + init_id * dim, dim * sizeof(float));
 
-    float* dist = new float[num_points];
+    auto dist = std::make_unique<float[]>(num_points);
 
     for (int64_t i = 0; i < (_s64) num_points; i++) {
       dist[i] =
@@ -537,7 +529,6 @@ namespace kmeans {
     }
     stream << "done.";
     LOG_KNOWHERE_DEBUG_ << stream.str();
-    delete[] dist;
   }
 
 }  // namespace kmeans

--- a/thirdparty/DiskANN/src/partition_and_pq.cpp
+++ b/thirdparty/DiskANN/src/partition_and_pq.cpp
@@ -16,6 +16,7 @@
 #include <iomanip>
 #include <iterator>
 #include <map>
+#include <memory>
 #include <set>
 #include <sstream>
 #include <string>
@@ -104,7 +105,7 @@ void gen_random_slice(const std::string base_file,
 
 template<typename T>
 void gen_random_slice(const std::string data_file, double p_val,
-                      float *&sampled_data, size_t &slice_size, size_t &ndims) {
+                      std::unique_ptr<float[]>& sampled_data, size_t &slice_size, size_t &ndims) {
   size_t                          npts;
   uint32_t                        npts32, ndims32;
   std::vector<std::vector<float>> sampled_vectors;
@@ -139,7 +140,7 @@ void gen_random_slice(const std::string data_file, double p_val,
     }
   }
   slice_size = sampled_vectors.size();
-  sampled_data = new float[slice_size * ndims];
+  sampled_data = std::make_unique<float[]>(slice_size * ndims);
   for (size_t i = 0; i < slice_size; i++) {
     for (size_t j = 0; j < ndims; j++) {
       sampled_data[i * ndims + j] = sampled_vectors[i][j];
@@ -151,7 +152,7 @@ void gen_random_slice(const std::string data_file, double p_val,
 // npts*ndims to return sampled_data of size slice_size*ndims.
 template<typename T>
 void gen_random_slice(const T *inputdata, size_t npts, size_t ndims,
-                      double p_val, float *&sampled_data, size_t &slice_size) {
+                      double p_val, std::unique_ptr<float[]> &sampled_data, size_t &slice_size) {
   std::vector<std::vector<float>> sampled_vectors;
   const T                        *cur_vector_T;
 
@@ -175,7 +176,7 @@ void gen_random_slice(const T *inputdata, size_t npts, size_t ndims,
     }
   }
   slice_size = sampled_vectors.size();
-  sampled_data = new float[slice_size * ndims];
+  sampled_data = std::make_unique<float[]>(slice_size * ndims);
   for (size_t i = 0; i < slice_size; i++) {
     for (size_t j = 0; j < ndims; j++) {
       sampled_data[i * ndims + j] = sampled_vectors[i][j];
@@ -611,19 +612,19 @@ int generate_pq_data_from_pivots(const std::string data_file,
 }
 
 int estimate_cluster_sizes(float *test_data_float, size_t num_test,
-                           float *pivots, const size_t num_centers,
+                           const float *pivots, const size_t num_centers,
                            const size_t test_dim, const size_t k_base,
                            std::vector<size_t> &cluster_sizes) {
   cluster_sizes.clear();
 
-  size_t *shard_counts = new size_t[num_centers];
+  auto shard_counts = std::make_unique<size_t[]>(num_centers);
 
   for (size_t i = 0; i < num_centers; i++) {
     shard_counts[i] = 0;
   }
 
   size_t block_size = num_test <= BLOCK_SIZE ? num_test : BLOCK_SIZE;
-  _u32  *block_closest_centers = new _u32[block_size * k_base];
+  auto block_closest_centers = std::make_unique<_u32[]>(block_size * k_base);
   float *block_data_float;
 
   size_t num_blocks = DIV_ROUND_UP(num_test, block_size);
@@ -637,7 +638,7 @@ int estimate_cluster_sizes(float *test_data_float, size_t num_test,
 
     math_utils::compute_closest_centers(block_data_float, cur_blk_size,
                                         test_dim, pivots, num_centers, k_base,
-                                        block_closest_centers);
+                                        block_closest_centers.get());
 
     for (size_t p = 0; p < cur_blk_size; p++) {
       for (size_t p1 = 0; p1 < k_base; p1++) {
@@ -654,8 +655,6 @@ int estimate_cluster_sizes(float *test_data_float, size_t num_test,
     cluster_size_stream << cur_shard_count << " ";
   }
   LOG_KNOWHERE_DEBUG_ << cluster_size_stream.str();
-  delete[] shard_counts;
-  delete[] block_closest_centers;
   return 0;
 }
 
@@ -870,7 +869,7 @@ int retrieve_shard_data_from_ids(const std::string data_file,
   shard_data_writer.write((char *) &dummy_size, sizeof(uint32_t));
   shard_data_writer.write((char *) &basedim32, sizeof(uint32_t));
 
-  _u32 *shard_ids;
+  std::unique_ptr<_u32[]> shard_ids = nullptr;
   _u64  shard_size, tmp;
   diskann::load_bin<_u32>(idmap_filename, shard_ids, shard_size, tmp);
 
@@ -911,7 +910,6 @@ int retrieve_shard_data_from_ids(const std::string data_file,
   shard_data_writer.seekp(0);
   shard_data_writer.write((char *) &num_written, sizeof(uint32_t));
   shard_data_writer.close();
-  delete[] shard_ids;
   return 0;
 }
 
@@ -927,12 +925,10 @@ int partition(const std::string data_file, const float sampling_rate,
               const std::string prefix_path, size_t k_base) {
   size_t train_dim;
   size_t num_train;
-  float *train_data_float;
+  std::unique_ptr<float[]> train_data_float = nullptr;
 
   gen_random_slice<T>(data_file, sampling_rate, train_data_float, num_train,
                       train_dim);
-
-  float *pivot_data;
 
   std::string cur_file = std::string(prefix_path);
   std::string output_file;
@@ -942,27 +938,25 @@ int partition(const std::string data_file, const float sampling_rate,
   //  cur_file = cur_file + "_kmeans_partitioning-" + std::to_string(num_parts);
   output_file = cur_file + "_centroids.bin";
 
-  pivot_data = new float[num_parts * train_dim];
+  auto pivot_data = std::make_unique<float[]>(num_parts * train_dim);
 
   // Process Global k-means for kmeans_partitioning Step
   LOG_KNOWHERE_DEBUG_ << "Processing global k-means (kmeans_partitioning Step)";
-  kmeans::kmeanspp_selecting_pivots(train_data_float, num_train, train_dim,
-                                    pivot_data, num_parts);
+  kmeans::kmeanspp_selecting_pivots(train_data_float.get(), num_train, train_dim,
+                                    pivot_data.get(), num_parts);
 
-  kmeans::run_lloyds(train_data_float, num_train, train_dim, pivot_data,
+  kmeans::run_lloyds(train_data_float.get(), num_train, train_dim, pivot_data.get(),
                      num_parts, max_k_means_reps, NULL, NULL);
 
   LOG_KNOWHERE_DEBUG_ << "Saving global k-center pivots";
-  diskann::save_bin<float>(output_file.c_str(), pivot_data, (size_t) num_parts,
+  diskann::save_bin<float>(output_file.c_str(), pivot_data.get(), (size_t) num_parts,
                            train_dim);
 
   // now pivots are ready. need to stream base points and assign them to
   // closest clusters.
 
-  shard_data_into_clusters<T>(data_file, pivot_data, num_parts, train_dim,
+  shard_data_into_clusters<T>(data_file, pivot_data.get(), num_parts, train_dim,
                               k_base, prefix_path);
-  delete[] pivot_data;
-  delete[] train_data_float;
   return 0;
 }
 
@@ -973,7 +967,7 @@ int partition_with_ram_budget(const std::string data_file,
                               const std::string prefix_path, size_t k_base) {
   size_t train_dim;
   size_t num_train;
-  float *train_data_float;
+  std::unique_ptr<float[]> train_data_float = nullptr;
   size_t max_k_means_reps = 10;
 
   int  num_parts = 3;
@@ -984,12 +978,11 @@ int partition_with_ram_budget(const std::string data_file,
 
   size_t test_dim;
   size_t num_test;
-  float *test_data_float;
+  std::unique_ptr<float[]> test_data_float = nullptr;
   gen_random_slice<T>(data_file, sampling_rate, test_data_float, num_test,
                       test_dim);
-
-  float *pivot_data = nullptr;
-
+  
+  std::unique_ptr<float[]> pivot_data = nullptr;
   std::string cur_file = std::string(prefix_path);
   std::string output_file;
 
@@ -1002,24 +995,21 @@ int partition_with_ram_budget(const std::string data_file,
     fit_in_ram = true;
 
     double max_ram_usage = 0;
-    if (pivot_data != nullptr)
-      delete[] pivot_data;
-
-    pivot_data = new float[num_parts * train_dim];
+    pivot_data = std::make_unique<float[]>(num_parts * train_dim);
     // Process Global k-means for kmeans_partitioning Step
     LOG_KNOWHERE_INFO_
         << "Processing global k-means (kmeans_partitioning Step)";
-    kmeans::kmeanspp_selecting_pivots(train_data_float, num_train, train_dim,
-                                      pivot_data, num_parts);
+    kmeans::kmeanspp_selecting_pivots(train_data_float.get(), num_train, train_dim,
+                                      pivot_data.get(), num_parts);
 
-    kmeans::run_lloyds(train_data_float, num_train, train_dim, pivot_data,
+    kmeans::run_lloyds(train_data_float.get(), num_train, train_dim, pivot_data.get(),
                        num_parts, max_k_means_reps, NULL, NULL);
 
     // now pivots are ready. need to stream base points and assign them to
     // closest clusters.
 
     std::vector<size_t> cluster_sizes;
-    estimate_cluster_sizes(test_data_float, num_test, pivot_data, num_parts,
+    estimate_cluster_sizes(test_data_float.get(), num_test, pivot_data.get(), num_parts,
                            train_dim, k_base, cluster_sizes);
 
     for (auto &p : cluster_sizes) {
@@ -1043,14 +1033,11 @@ int partition_with_ram_budget(const std::string data_file,
   }
 
   LOG_KNOWHERE_DEBUG_ << "Saving global k-center pivots";
-  diskann::save_bin<float>(output_file.c_str(), pivot_data, (size_t) num_parts,
+  diskann::save_bin<float>(output_file.c_str(), pivot_data.get(), (size_t) num_parts,
                            train_dim);
 
-  shard_data_into_clusters_only_ids<T>(data_file, pivot_data, num_parts,
+  shard_data_into_clusters_only_ids<T>(data_file, pivot_data.get(), num_parts,
                                        train_dim, k_base, prefix_path);
-  delete[] pivot_data;
-  delete[] train_data_float;
-  delete[] test_data_float;
   return num_parts;
 }
 
@@ -1068,24 +1055,25 @@ template void gen_random_slice<float>(const std::string base_file,
 
 template void gen_random_slice<float>(const float *inputdata, size_t npts,
                                       size_t ndims, double p_val,
-                                      float *&sampled_data, size_t &slice_size);
+                                      std::unique_ptr<float[]> &sampled_data,
+                                      size_t                 &slice_size);
 template void gen_random_slice<uint8_t>(const uint8_t *inputdata, size_t npts,
                                         size_t ndims, double p_val,
-                                        float *&sampled_data,
-                                        size_t &slice_size);
+                                        std::unique_ptr<float[]> &sampled_data,
+                                        size_t                 &slice_size);
 template void gen_random_slice<int8_t>(const int8_t *inputdata, size_t npts,
                                        size_t ndims, double p_val,
-                                       float *&sampled_data,
-                                       size_t &slice_size);
+                                       std::unique_ptr<float[]> &sampled_data,
+                                       size_t                 &slice_size);
 
 template void gen_random_slice<float>(const std::string data_file, double p_val,
-                                      float *&sampled_data, size_t &slice_size,
+                                      std::unique_ptr<float[]> &sampled_data, size_t &slice_size,
                                       size_t &ndims);
 template void gen_random_slice<uint8_t>(const std::string data_file,
-                                        double p_val, float *&sampled_data,
+                                        double p_val, std::unique_ptr<float[]> &sampled_data,
                                         size_t &slice_size, size_t &ndims);
 template void gen_random_slice<int8_t>(const std::string data_file,
-                                       double p_val, float *&sampled_data,
+                                       double p_val, std::unique_ptr<float[]> &sampled_data,
                                        size_t &slice_size, size_t &ndims);
 
 template int partition<int8_t>(const std::string data_file,

--- a/thirdparty/DiskANN/src/utils.cpp
+++ b/thirdparty/DiskANN/src/utils.cpp
@@ -2,6 +2,7 @@
 #include "knowhere/comp/thread_pool.h"
 
 #include <stdio.h>
+#include <memory>
 
 namespace diskann {
   void block_convert(std::ofstream& writr, std::ifstream& readr,
@@ -49,12 +50,11 @@ namespace diskann {
     _u64 nblks = ROUND_UP(npts, blk_size) / blk_size;
     LOG_KNOWHERE_DEBUG_ << "# blks: " << nblks;
 
-    float* read_buf = new float[npts * ndims];
+    auto read_buf = std::make_unique<float[]>(npts * ndims);
     for (_u64 i = 0; i < nblks; i++) {
       _u64 cblk_size = std::min(npts - i * blk_size, blk_size);
-      block_convert(writr, readr, read_buf, cblk_size, ndims);
+      block_convert(writr, readr, read_buf.get(), cblk_size, ndims);
     }
-    delete[] read_buf;
 
     LOG_KNOWHERE_DEBUG_ << "Wrote normalized points to file: " << outFileName;
   }


### PR DESCRIPTION
issue: #407 

Fixes some memory leaks in DiskANN caused by allocating memory without ownership. It could happen when
1. Memory allocate with `new` keyword
2. Exception throws during execution
3. Instructions freeing memory do not have a chance to execute because of the exception

This PR fixes most of them related to `new`. There are still some `new` and `alloc_aligned`, but they are enclosed in the destructors so rely on RAII they should be fine.