### PR TITLE
update impl of sparse inverted index to use unorder_map 

### DIFF
--- a/include/knowhere/sparse_utils.h
+++ b/include/knowhere/sparse_utils.h
@@ -109,6 +109,7 @@ class SparseRow {
         return data_byte_size() + sizeof(*this);
     }
 
+    // return the number of bytes used by the underlying data array.
     size_t
     data_byte_size() const {
         return count_ * element_size();


### PR DESCRIPTION
issue: #412
/kind: enhancement

instead of vector as interted index, so that we can support arbitrary large dimension in the uint32 space.