### PR TITLE
Allow brute force fallback for large k on GPU

### DIFF
--- a/src/common/raft/proto/raft_index.cuh
+++ b/src/common/raft/proto/raft_index.cuh
@@ -220,6 +220,10 @@ struct raft_index {
         }
     }
 
+    auto static get_metric(raft_index<underlying_index_type, raft_index_args...> const& index) {
+        return index.get_vector_index().metric();
+    }
+
     template <typename T, typename IdxT, typename InputIdxT, typename FilterT = std::nullptr_t>
     auto static search(raft::resources const& res, raft_index<underlying_index_type, raft_index_args...> const& index,
                        search_params_type const& search_params, raft::device_matrix_view<T const, InputIdxT> queries,

--- a/src/index/gpu_raft/gpu_raft_ivf_flat_config.h
+++ b/src/index/gpu_raft/gpu_raft_ivf_flat_config.h
@@ -39,11 +39,6 @@ struct GpuRaftIvfFlatConfig : public IvfFlatConfig {
             .set_default(1.0f)
             .description("search refine_ratio * k results then refine")
             .for_search();
-        KNOWHERE_CONFIG_DECLARE_FIELD(k)
-            .set_default(10)
-            .description("search for top k similar vector.")
-            .set_range(1, 256)  // Declared in base but limited to 256
-            .for_search();
         KNOWHERE_CONFIG_DECLARE_FIELD(kmeans_n_iters)
             .description("iterations to search for kmeans centers")
             .set_default(20)

--- a/src/index/gpu_raft/gpu_raft_ivf_pq_config.h
+++ b/src/index/gpu_raft/gpu_raft_ivf_pq_config.h
@@ -46,11 +46,6 @@ struct GpuRaftIvfPqConfig : public IvfPqConfig {
             .set_default(1.0f)
             .description("search refine_ratio * k results then refine")
             .for_search();
-        KNOWHERE_CONFIG_DECLARE_FIELD(k)
-            .set_default(10)
-            .description("search for top k similar vector.")
-            .set_range(1, 1024)  // Declared in base but limited to 1024
-            .for_search();
         KNOWHERE_CONFIG_DECLARE_FIELD(m).set_default(0).description("m").set_range(0, 65536).for_train();
         KNOWHERE_CONFIG_DECLARE_FIELD(nbits)
             .set_default(8)

--- a/tests/ut/test_gpu_search.cc
+++ b/tests/ut/test_gpu_search.cc
@@ -76,12 +76,6 @@ TEST_CASE("Test All GPU Index", "[search]") {
     SECTION("Test Gpu Index Search") {
         using std::make_tuple;
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
-            // GPU_FLAT cannot run this test is because its Train() and Add() actually run in CPU,
-            // "res_" in gpu_index_ is not set correctly
-            // make_tuple(knowhere::IndexEnum::INDEX_FAISS_GPU_IDMAP, gpu_flat_gen),
-            // make_tuple(knowhere::IndexEnum::INDEX_FAISS_GPU_IVFFLAT, ivfflat_gen),
-            // make_tuple(knowhere::IndexEnum::INDEX_FAISS_GPU_IVFPQ, ivfpq_gen),
-            // make_tuple(knowhere::IndexEnum::INDEX_FAISS_GPU_IVFSQ8, ivfsq_gen),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_BRUTEFORCE, bruteforce_gen),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFFLAT, ivfflat_gen),
             make_tuple(knowhere::IndexEnum::INDEX_RAFT_IVFFLAT, refined_gen(ivfflat_gen)),
@@ -166,8 +160,9 @@ TEST_CASE("Test All GPU Index", "[search]") {
         REQUIRE(idx.Type() == name);
         auto res = idx.Build(*train_ds, json);
         REQUIRE(res == knowhere::Status::success);
-        const auto topk_values = {// Tuple with [TopKValue, Threshold]
-                                  make_tuple(5, 0.85f), make_tuple(25, 0.85f), make_tuple(100, 0.85f)};
+        const auto topk_values = {
+            // Tuple with [TopKValue, Threshold]
+            make_tuple(5, 0.85f), make_tuple(25, 0.85f), make_tuple(100, 0.85f), make_tuple(1025, 0.85f)};
 
         for (const auto& topKTuple : topk_values) {
             json[knowhere::meta::TOPK] = std::get<0>(topKTuple);


### PR DESCRIPTION
issue:  #290
This PR allows RAFT indexes to fall back to brute force if the requested k exceeds the value currently supported by the ANN implementation.