### PR TITLE
Add a common subclass for IndexNode::iterator

### DIFF
--- a/include/knowhere/config.h
+++ b/include/knowhere/config.h
@@ -635,6 +635,7 @@ class BaseConfig : public Config {
     CFG_INT trace_flags;
     CFG_MATERIALIZED_VIEW_SEARCH_INFO_TYPE materialized_view_search_info;
     CFG_STRING opt_fields_path;
+    CFG_FLOAT iterator_refine_ratio;
     KNOHWERE_DECLARE_CONFIG(BaseConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(metric_type)
             .set_default("L2")
@@ -717,6 +718,11 @@ class BaseConfig : public Config {
             .description("materialized view optional fields path")
             .allow_empty_without_default()
             .for_train();
+        KNOWHERE_CONFIG_DECLARE_FIELD(iterator_refine_ratio)
+            .set_default(0.5)
+            .description("refine ratio for iterator")
+            .for_iterator()
+            .for_range_search();
     }
 };
 }  // namespace knowhere

--- a/tests/ut/test_iterator.cc
+++ b/tests/ut/test_iterator.cc
@@ -129,7 +129,7 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
         return json;
     };
 
-    auto rand = GENERATE(1, 2, 3, 5);
+    auto rand = GENERATE(1, 2);
 
     const auto train_ds = GenDataSet(nb, dim, rand);
     const auto query_ds = GenDataSet(nq, dim, rand + 777);
@@ -138,6 +138,8 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
         using std::make_tuple;
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>(
             {make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),
+             make_tuple(knowhere::IndexEnum::INDEX_HNSW_SQ8, hnsw_gen),
+             make_tuple(knowhere::IndexEnum::INDEX_HNSW_SQ8_REFINE, hnsw_gen),
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, ivfflat_gen),
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, ivfflatcc_gen)}));
         auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version).value();
@@ -169,6 +171,8 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
         using std::make_tuple;
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>(
             {make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),
+             make_tuple(knowhere::IndexEnum::INDEX_HNSW_SQ8, hnsw_gen),
+             make_tuple(knowhere::IndexEnum::INDEX_HNSW_SQ8_REFINE, hnsw_gen),
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, ivfflat_gen),
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, ivfflatcc_gen)}));
         auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version).value();
@@ -203,6 +207,8 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
         using std::make_tuple;
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>(
             {make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),
+             make_tuple(knowhere::IndexEnum::INDEX_HNSW_SQ8, hnsw_gen),
+             make_tuple(knowhere::IndexEnum::INDEX_HNSW_SQ8_REFINE, hnsw_gen),
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, ivfflat_gen),
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, ivfflatcc_gen)}));
         auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version).value();

--- a/thirdparty/faiss/faiss/IndexIVF.cpp
+++ b/thirdparty/faiss/faiss/IndexIVF.cpp
@@ -18,6 +18,7 @@
 #include <cstdio>
 #include <limits>
 #include <memory>
+#include <vector>
 
 #include <faiss/utils/hamming.h>
 #include <faiss/utils/utils.h>
@@ -27,6 +28,8 @@
 #include <faiss/impl/CodePacker.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/IDSelector.h>
+
+#include "knowhere/object.h"
 
 namespace faiss {
 
@@ -581,7 +584,7 @@ void IndexIVF::search_preassigned(
                                 idxi,
                                 k,
                                 scan_cnt);
-                    }                
+                    }
 
                     return scan_cnt;
                 }
@@ -786,7 +789,7 @@ void IndexIVF::range_search_preassigned(
         const IVFSearchParameters* params,
         IndexIVFStats* stats) const {
 
-    // Knowhere-specific code: 
+    // Knowhere-specific code:
     //   only "parallel_mode == 0" branch is supported.
 
     idx_t nprobe = params ? params->nprobe : this->nprobe;
@@ -899,7 +902,7 @@ void IndexIVF::range_search_preassigned(
                 // ====================================================
                 // The following piece of the code is Knowhere-specific.
                 //
-                // cbe86cf716dc1969fc716c29ccf8ea63e82a2b4c: 
+                // cbe86cf716dc1969fc716c29ccf8ea63e82a2b4c:
                 //   Adopt new strategy for faiss IVF range search
 
                 size_t prev_nres = qres.nres;
@@ -921,7 +924,7 @@ void IndexIVF::range_search_preassigned(
                     prev_nres = qres.nres;
                 }
 
-                // The end of Knowhere-specific code. 
+                // The end of Knowhere-specific code.
                 // ====================================================
             }
         } else {
@@ -1373,14 +1376,12 @@ size_t InvertedListScanner::scan_codes(
     return nup;
 }
 
-size_t InvertedListScanner::scan_codes_and_push_back(
-        size_t list_size,
-        const uint8_t* codes,
-        const float* code_norms,
-        const idx_t* ids,
-        float* distances,
-        idx_t* labels,
-        size_t& counter_back) const {
+void InvertedListScanner::scan_codes_and_return(
+                size_t list_size,
+                const uint8_t* codes,
+                const float* code_norms,
+                const idx_t* ids,
+                std::vector<knowhere::DistId>& out) const {
     FAISS_THROW_MSG("Not implemented.");
 }
 

--- a/thirdparty/faiss/faiss/IndexIVF.h
+++ b/thirdparty/faiss/faiss/IndexIVF.h
@@ -23,6 +23,8 @@
 #include <faiss/invlists/InvertedLists.h>
 #include <faiss/utils/Heap.h>
 
+#include "knowhere/object.h"
+
 namespace faiss {
 
 /** Encapsulates a quantizer object for the IndexIVF
@@ -512,26 +514,20 @@ struct InvertedListScanner {
             size_t& scan_cnt) const;
 
     /** scan a set of codes, compute distances to current query and
-     * push all to heap. Default implemetation
-     * calls distance_to_code.
+     * return in a vector.
      *
      * @param list_size     number of codes to scan
      * @param codes         codes to scan (list_size * code_size)
      * @param code_norms    norms of code (for cosine)
      * @param ids           corresponding ids (ignored if store_pairs)
-     * @param distances     heap distances (size counter_back)
-     * @param labels        heap labels (size counter_back)
-     * @param counter_back  heap size (will increase)
-     * @return number of heap pushes performed
+     * @param out           output distances and ids
      */
-    virtual size_t scan_codes_and_push_back(
+    virtual void scan_codes_and_return(
             size_t list_size,
             const uint8_t* codes,
             const float* code_norms,
             const idx_t* ids,
-            float* distances,
-            idx_t* labels,
-            size_t& counter_back) const;
+            std::vector<knowhere::DistId>& out) const;
 
     // same as scan_codes, using an iterator
     virtual size_t iterate_codes(

--- a/thirdparty/faiss/faiss/IndexIVFFlat.cpp
+++ b/thirdparty/faiss/faiss/IndexIVFFlat.cpp
@@ -15,6 +15,7 @@
 #include <cinttypes>
 #include <cstdio>
 
+#include "knowhere/object.h"
 #include "knowhere/utils.h"
 #include "knowhere/bitsetview_idselector.h"
 
@@ -295,13 +296,13 @@ struct IVFFlatScanner : InvertedListScanner {
         size_t nup = 0;
 
         // the lambda that filters acceptable elements.
-        auto filter = 
+        auto filter =
             [&](const size_t j) { return (!use_sel || sel->is_member(ids[j])); };
 
         // the lambda that applies a valid element.
-        auto apply = 
+        auto apply =
             [&](const float dis_in, const size_t j) {
-                const float dis = (code_norms == nullptr) ? dis_in : (dis_in / code_norms[j]); 
+                const float dis = (code_norms == nullptr) ? dis_in : (dis_in / code_norms[j]);
                 scan_cnt++;
                 if (C::cmp(simi[0], dis)) {
                     const int64_t id = store_pairs ? lo_build(list_no, j) : ids[j];
@@ -322,37 +323,23 @@ struct IVFFlatScanner : InvertedListScanner {
         return nup;
     }
 
-    size_t scan_codes_and_push_back(
+    void scan_codes_and_return(
             size_t list_size,
             const uint8_t* codes,
             const float* code_norms,
             const idx_t* ids,
-            float* distances,
-            idx_t* labels,
-            size_t& counter_back) const override {
+            std::vector<knowhere::DistId>& out) const override {
         const float* list_vecs = (const float*)codes;
 
         // the lambda that filters acceptable elements.
         auto filter = [&](const size_t j) {
             return (!use_sel || sel->is_member(ids[j]));
         };
-
-        size_t n_heap = 0;
-
         // the lambda that applies a valid element.
         auto apply = [&](const float dis_in, const size_t j) {
             const float dis =
                     (code_norms == nullptr) ? dis_in : (dis_in / code_norms[j]);
-
-            counter_back++;
-            if constexpr (metric == METRIC_INNER_PRODUCT) {
-                heap_push<CMax<float, int64_t>>(
-                        counter_back, distances, labels, dis, ids[j]);
-            } else {
-                heap_push<CMin<float, int64_t>>(
-                        counter_back, distances, labels, dis, ids[j]);
-            }
-            n_heap++;
+            out.emplace_back(ids[j], dis);
         };
         if constexpr (metric == METRIC_INNER_PRODUCT) {
             fvec_inner_products_ny_if(
@@ -360,7 +347,6 @@ struct IVFFlatScanner : InvertedListScanner {
         } else {
             fvec_L2sqr_ny_if(xi, list_vecs, d, list_size, filter, apply);
         }
-        return n_heap;
     }
 
     void scan_codes_range(
@@ -373,13 +359,13 @@ struct IVFFlatScanner : InvertedListScanner {
         const float* list_vecs = (const float*)codes;
 
         // the lambda that filters acceptable elements.
-        auto filter = 
+        auto filter =
             [&](const size_t j) { return (!use_sel || sel->is_member(ids[j])); };
 
         // the lambda that applies a filtered element.
-        auto apply = 
+        auto apply =
             [&](const float dis_in, const size_t j) {
-                const float dis = (code_norms == nullptr) ? dis_in : (dis_in / code_norms[j]); 
+                const float dis = (code_norms == nullptr) ? dis_in : (dis_in / code_norms[j]);
                 if (C::cmp(radius, dis)) {
                     int64_t id = store_pairs ? lo_build(list_no, j) : ids[j];
                     res.add(dis, id);
@@ -441,13 +427,13 @@ struct IVFFlatBitsetViewScanner : InvertedListScanner {
         size_t nup = 0;
 
         // the lambda that filters acceptable elements.
-        auto filter = 
+        auto filter =
             [&](const size_t j) { return (!use_sel || !bitset.test(ids[j])); };
 
         // the lambda that applies a valid element.
-        auto apply = 
+        auto apply =
             [&](const float dis_in, const size_t j) {
-                const float dis = (code_norms == nullptr) ? dis_in : (dis_in / code_norms[j]); 
+                const float dis = (code_norms == nullptr) ? dis_in : (dis_in / code_norms[j]);
                 scan_cnt++;
                 if (C::cmp(simi[0], dis)) {
                     const int64_t id = store_pairs ? lo_build(list_no, j) : ids[j];
@@ -468,37 +454,23 @@ struct IVFFlatBitsetViewScanner : InvertedListScanner {
         return nup;
     }
 
-    size_t scan_codes_and_push_back(
+    void scan_codes_and_return(
             size_t list_size,
             const uint8_t* codes,
             const float* code_norms,
             const idx_t* ids,
-            float* distances,
-            idx_t* labels,
-            size_t& counter_back) const override {
+            std::vector<knowhere::DistId>& out) const override {
         const float* list_vecs = (const float*)codes;
 
         // the lambda that filters acceptable elements.
         auto filter = [&](const size_t j) {
             return (!use_sel || !bitset.test(ids[j]));
         };
-
-        size_t n_heap = 0;
-
         // the lambda that applies a valid element.
         auto apply = [&](const float dis_in, const size_t j) {
             const float dis =
                     (code_norms == nullptr) ? dis_in : (dis_in / code_norms[j]);
-
-            counter_back++;
-            if constexpr (metric == METRIC_INNER_PRODUCT) {
-                heap_push<CMax<float, int64_t>>(
-                        counter_back, distances, labels, dis, ids[j]);
-            } else {
-                heap_push<CMin<float, int64_t>>(
-                        counter_back, distances, labels, dis, ids[j]);
-            }
-            n_heap++;
+            out.emplace_back(ids[j], dis);
         };
         if constexpr (metric == METRIC_INNER_PRODUCT) {
             fvec_inner_products_ny_if(
@@ -506,7 +478,6 @@ struct IVFFlatBitsetViewScanner : InvertedListScanner {
         } else {
             fvec_L2sqr_ny_if(xi, list_vecs, d, list_size, filter, apply);
         }
-        return n_heap;
     }
 
     void scan_codes_range(
@@ -519,13 +490,13 @@ struct IVFFlatBitsetViewScanner : InvertedListScanner {
         const float* list_vecs = (const float*)codes;
 
         // the lambda that filters acceptable elements.
-        auto filter = 
+        auto filter =
             [&](const size_t j) { return (!use_sel || !bitset.test(ids[j])); };
 
         // the lambda that applies a filtered element.
-        auto apply = 
+        auto apply =
             [&](const float dis_in, const size_t j) {
-                const float dis = (code_norms == nullptr) ? dis_in : (dis_in / code_norms[j]); 
+                const float dis = (code_norms == nullptr) ? dis_in : (dis_in / code_norms[j]);
                 if (C::cmp(radius, dis)) {
                     int64_t id = store_pairs ? lo_build(list_no, j) : ids[j];
                     res.add(dis, id);
@@ -548,8 +519,8 @@ InvertedListScanner* get_InvertedListScanner1(
         const IndexIVFFlat* ivf,
         bool store_pairs,
         const IDSelector* sel) {
-    // A specialized version for Knowhere. 
-    //   It is needed to get rid of virtual function calls, because sel 
+    // A specialized version for Knowhere.
+    //   It is needed to get rid of virtual function calls, because sel
     //   can filter out 99% of samples, so the cost of virtual function calls
     //   becomes noticeable compared to distance computations.
     if (const auto* bitsetview_sel = dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel)) {
@@ -602,180 +573,127 @@ void IndexIVFFlat::reconstruct_from_offset(
 std::unique_ptr<IVFFlatIteratorWorkspace> IndexIVFFlat::getIteratorWorkspace(
         const float* query_data,
         const IVFSearchParameters* ivfsearchParams) const {
-    return std::make_unique<IVFFlatIteratorWorkspace>(
+    auto workspace = std::make_unique<IVFFlatIteratorWorkspace>(
             query_data, ivfsearchParams);
+
+    // snapshot of list_sizes;
+    auto coarse_list_sizes = std::make_unique<size_t[]>(nlist);
+    // total size of all lists
+    size_t count = 0;
+    auto max_coarse_list_size = 0;
+    for (size_t list_no = 0; list_no < nlist; ++list_no) {
+        auto list_size = invlists->list_size(list_no);
+        coarse_list_sizes[list_no] = list_size;
+        count += list_size;
+        if (list_size > max_coarse_list_size) {
+            max_coarse_list_size = list_size;
+        }
+    }
+    // compute backup_count_threshold - (nprobe / nlist) * count
+    size_t nprobe = workspace->search_params->nprobe
+            ? workspace->search_params->nprobe
+            : this->nprobe;
+    nprobe = std::min(nlist, nprobe);
+    workspace->backup_count_threshold = count * nprobe / nlist;
+    auto max_backup_count =
+            max_coarse_list_size + workspace->backup_count_threshold;
+
+    // compute distances of all centroids
+    auto coarse_idx = std::make_unique<idx_t[]>(nlist);
+    auto coarse_dis = std::make_unique<float[]>(nlist);
+    quantizer->search(
+            1,
+            workspace->query_data,
+            nlist,
+            coarse_dis.get(),
+            coarse_idx.get(),
+            workspace->search_params
+                    ? workspace->search_params->quantizer_params
+                    : nullptr);
+
+    workspace->coarse_idx = std::move(coarse_idx);
+    workspace->coarse_dis = std::move(coarse_dis);
+    workspace->coarse_list_sizes = std::move(coarse_list_sizes);
+    workspace->nprobe = nprobe;
+    workspace->dists.reserve(max_backup_count);
+
+    return workspace;
 }
 
-std::optional<std::pair<float, idx_t>> IndexIVFFlat::getIteratorNext(
-        IVFFlatIteratorWorkspace* workspace) const {
-    auto scan_one_list_then_add_to_backup =
-            [&](idx_t list_no,
-                float coarse_list_centroid_dist, // no use, dist for residual.
-                float* distances,
-                idx_t* labels,
-                size_t& counter_back,
-                size_t max_codes) {
-                if (list_no < 0) {
-                    // not enough centroids for multiprobe
-                    return (size_t)0;
-                }
-                FAISS_THROW_IF_NOT_FMT(
-                        list_no < (idx_t)nlist,
-                        "Invalid list_no=%" PRId64 " nlist=%zd\n",
-                        list_no,
-                        nlist);
+void IndexIVFFlat::getIteratorNextBatch(
+        IVFFlatIteratorWorkspace* workspace,
+        size_t current_backup_count) const {
+    workspace->dists.clear();
 
-                // don't waste time on empty lists
-                void* inverted_list_context =
-                        workspace->search_params 
-                        ? workspace->search_params->inverted_list_context 
-                        : nullptr;
-
-                if (invlists->is_empty(list_no, inverted_list_context)) {
-                    return (size_t)0;
-                }
-
-                // get scanner
-                IDSelector* sel = workspace->search_params
-                        ? workspace->search_params->sel
-                        : nullptr;
-                std::unique_ptr<InvertedListScanner> scanner(
-                    get_InvertedListScanner(false, sel));
-                scanner->set_query(workspace->query_data);
-
-                size_t segment_num = invlists->get_segment_num(list_no);
-                size_t scan_cnt = 0;
-                for (size_t segment_idx = 0; segment_idx < segment_num;
-                     segment_idx++) {
-                    size_t segment_size =
-                            invlists->get_segment_size(list_no, segment_idx);
-                    size_t should_scan_size =
-                            std::min(segment_size, max_codes - scan_cnt);
-                    scan_cnt += should_scan_size;
-                    if (should_scan_size <= 0) {
-                        break;
-                    }
-                    size_t segment_offset =
-                            invlists->get_segment_offset(list_no, segment_idx);
-                    InvertedLists::ScopedCodes scodes(
-                            invlists, list_no, segment_offset);
-                    InvertedLists::ScopedCodeNorms scode_norms(
-                            invlists, list_no, segment_offset);
-                    InvertedLists::ScopedIds sids(
-                            invlists, list_no, segment_offset);
-
-                    size_t n_heap = scanner->scan_codes_and_push_back(
-                            should_scan_size,
-                            scodes.get(),
-                            scode_norms.get(),
-                            sids.get(),
-                            distances,
-                            labels,
-                            counter_back);
-                }
-
-                return max_codes;
-            };
-
-    if (!workspace->initial_search_done) {
-        // snapshot of list_sizes;
-        auto coarse_list_sizes = std::make_unique<size_t[]>(nlist);
-        size_t count = 0;
-        for (size_t list_no = 0; list_no < nlist; ++list_no) {
-            auto list_size = invlists->list_size(list_no);
-            coarse_list_sizes[list_no] = list_size;
-            count += list_size;
-            if (list_size > workspace->max_coarse_list_size) {
-                workspace->max_coarse_list_size = list_size;
-            }
-        }
-
-        // compute backup_count_threshold - (nprobe / nlist) * count
-        size_t nprobe = workspace->search_params->nprobe
-                ? workspace->search_params->nprobe
-                : this->nprobe;
-        nprobe = std::min(nlist, nprobe);
-        workspace->backup_count_threshold = count * nprobe / nlist;
-        workspace->max_backup_count = workspace->max_coarse_list_size +
-                workspace->backup_count_threshold;
-
-        // compute distances of all centroids
-        auto coarse_idx = std::make_unique<idx_t[]>(nlist);
-        auto coarse_dis = std::make_unique<float[]>(nlist);
-        quantizer->search(
-                1,
-                workspace->query_data,
-                nlist,
-                coarse_dis.get(),
-                coarse_idx.get(),
-                workspace->search_params
-                        ? workspace->search_params->quantizer_params
-                        : nullptr);
-
-        // init backup_nodes until more than threshold
-        invlists->prefetch_lists(coarse_idx.get(), nprobe);
-        auto labels = std::make_unique<idx_t[]>(workspace->max_backup_count);
-        auto distances = std::make_unique<float[]>(workspace->max_backup_count);
-        size_t backup_count = 0;
-        size_t next_visit_coarse_list_idx = 0;
-        while (next_visit_coarse_list_idx < nlist &&
-               backup_count < workspace->backup_count_threshold) {
-            scan_one_list_then_add_to_backup(
-                    coarse_idx[next_visit_coarse_list_idx],
-                    coarse_dis[next_visit_coarse_list_idx], // no use
-                    distances.get(),
-                    labels.get(),
-                    backup_count,
-                    coarse_list_sizes[coarse_idx[next_visit_coarse_list_idx]]);
-            next_visit_coarse_list_idx++;
-        }
-        workspace->backup_count = backup_count;
-        workspace->next_visit_coarse_list_idx = next_visit_coarse_list_idx;
-
-        workspace->labels = std::move(labels);
-        workspace->distances = std::move(distances);
-        workspace->coarse_idx = std::move(coarse_idx);
-        workspace->coarse_dis = std::move(coarse_dis);
-        workspace->coarse_list_sizes = std::move(coarse_list_sizes);
-
-        workspace->initial_search_done = true;
-    }
-
-    // terminate when no backup nodes.
-    if (workspace->backup_count == 0 &&
-        workspace->next_visit_coarse_list_idx >= nlist) {
-        return std::nullopt;
-    }
-    while (workspace->backup_count < workspace->backup_count_threshold &&
+    while (current_backup_count + workspace->dists.size() <
+                   workspace->backup_count_threshold &&
            workspace->next_visit_coarse_list_idx < nlist) {
         auto next_list_idx = workspace->next_visit_coarse_list_idx;
-        scan_one_list_then_add_to_backup(
-                workspace->coarse_idx[next_list_idx],
-                workspace->coarse_dis[next_list_idx], // no use
-                workspace->distances.get(),
-                workspace->labels.get(),
-                workspace->backup_count,
-                workspace->coarse_list_sizes
-                        [workspace->coarse_idx[next_list_idx]]);
         workspace->next_visit_coarse_list_idx++;
-    }
 
-    auto next_dis = workspace->distances[0];
-    auto next_id = workspace->labels[0];
-    if (metric_type == METRIC_INNER_PRODUCT) {
-        heap_pop<CMax<float, int64_t>>(
-                workspace->backup_count,
-                workspace->distances.get(),
-                workspace->labels.get());
-    } else {
-        heap_pop<CMin<float, int64_t>>(
-                workspace->backup_count,
-                workspace->distances.get(),
-                workspace->labels.get());
-    }
-    workspace->backup_count--;
+        invlists->prefetch_lists(
+                workspace->coarse_idx.get() + next_list_idx, 1);
+        const auto list_no = workspace->coarse_idx[next_list_idx];
 
-    return std::make_optional(std::make_pair(next_dis, next_id));
+        // max_codes is the size of the list when we started the
+        // iteration so that we won't search vectors added during the
+        // iteration(for IVFCC).
+        const auto max_codes = workspace->coarse_list_sizes
+                                       [workspace->coarse_idx[next_list_idx]];
+        if (list_no < 0) {
+            // not enough centroids for multiprobe
+            continue;
+        }
+        FAISS_THROW_IF_NOT_FMT(
+                list_no < (idx_t)nlist,
+                "Invalid list_no=%" PRId64 " nlist=%zd\n",
+                list_no,
+                nlist);
+
+        // don't waste time on empty lists
+        void* inverted_list_context = workspace->search_params
+                ? workspace->search_params->inverted_list_context
+                : nullptr;
+
+        if (invlists->is_empty(list_no, inverted_list_context)) {
+            continue;
+        }
+
+        // get scanner
+        IDSelector* sel = workspace->search_params
+                ? workspace->search_params->sel
+                : nullptr;
+        std::unique_ptr<InvertedListScanner> scanner(
+                get_InvertedListScanner(false, sel));
+        scanner->set_query(workspace->query_data);
+
+        size_t segment_num = invlists->get_segment_num(list_no);
+        size_t scan_cnt = 0;
+        for (size_t segment_idx = 0; segment_idx < segment_num; segment_idx++) {
+            size_t segment_size =
+                    invlists->get_segment_size(list_no, segment_idx);
+            size_t should_scan_size =
+                    std::min(segment_size, max_codes - scan_cnt);
+            scan_cnt += should_scan_size;
+            if (should_scan_size <= 0) {
+                break;
+            }
+            size_t segment_offset =
+                    invlists->get_segment_offset(list_no, segment_idx);
+            InvertedLists::ScopedCodes scodes(
+                    invlists, list_no, segment_offset);
+            InvertedLists::ScopedCodeNorms scode_norms(
+                    invlists, list_no, segment_offset);
+            InvertedLists::ScopedIds sids(invlists, list_no, segment_offset);
+
+            scanner->scan_codes_and_return(
+                    should_scan_size,
+                    scodes.get(),
+                    scode_norms.get(),
+                    sids.get(),
+                    workspace->dists);
+        }
+    }
 }
 
 IndexIVFFlatCC::IndexIVFFlatCC(

--- a/thirdparty/faiss/faiss/IndexIVFFlat.h
+++ b/thirdparty/faiss/faiss/IndexIVFFlat.h
@@ -16,6 +16,8 @@
 
 #include <faiss/IndexIVF.h>
 
+#include "knowhere/object.h"
+
 namespace faiss {
 struct IVFFlatIteratorWorkspace {
     IVFFlatIteratorWorkspace(
@@ -25,17 +27,13 @@ struct IVFFlatIteratorWorkspace {
 
     const float* query_data = nullptr; // single query
     const IVFSearchParameters* search_params = nullptr;
-    bool initial_search_done = false;
-    std::unique_ptr<float[]> distances = nullptr; // backup distances (heap)
-    std::unique_ptr<idx_t[]> labels = nullptr;    // backup ids (heap)
-    size_t backup_count = 0;            // scan a new coarse-list when less than backup_count_threshold
-    size_t max_backup_count = 0;        
+    size_t nprobe = 0;
     size_t backup_count_threshold = 0;  // count * nprobe / nlist
+    std::vector<knowhere::DistId> dists;    // should be cleared after each use
     size_t next_visit_coarse_list_idx = 0;
     std::unique_ptr<float[]> coarse_dis = nullptr;   // backup coarse centroids distances (heap)
     std::unique_ptr<idx_t[]> coarse_idx = nullptr;   // backup coarse centroids ids (heap)
     std::unique_ptr<size_t[]> coarse_list_sizes = nullptr;  // snapshot of the list_size
-    size_t max_coarse_list_size = 0;
 };
 
 /** Inverted file with stored vectors. Here the inverted file
@@ -91,12 +89,13 @@ struct IndexIVFFlat : IndexIVF {
 
     // Unlike regular knn-search, the iterator does not know the size `k` of the
     // returned result.
-    //   The workspace will maintain a heap of at least (nprobe/nlist) nodes for
+    //   The iterator will maintain a heap of at least (nprobe/nlist) nodes for
     //   iterator `Next()` operation.
     //   When there are not enough nodes in the heap, iterator will scan the
     //   next coarse list.
-    std::optional<std::pair<float, idx_t>> getIteratorNext(
-            IVFFlatIteratorWorkspace* workspace) const;
+    void getIteratorNextBatch(
+            IVFFlatIteratorWorkspace* workspace,
+            size_t current_backup_count) const;
 };
 
 struct IndexIVFFlatCC : IndexIVFFlat {


### PR DESCRIPTION
so that different indexes only need to implement next_batch. Any index that gradually adds new points as the `iterator::Next()` is called should implement their iterator by inheriting this new class.

Updated the impl for supported ivf and hnsw index.

issue: https://github.com/zilliztech/knowhere/issues/500
/kind: enhancement
