### PR TITLE
Fix LAPACK not found

### DIFF
--- a/cmake/libs/libfaiss.cmake
+++ b/cmake/libs/libfaiss.cmake
@@ -59,6 +59,8 @@ if(__PPC64)
   target_link_libraries(knowhere_utils PUBLIC glog::glog)
 endif()
 
+find_package(LAPACK REQUIRED)
+
 if(LINUX)
   set(BLA_VENDOR OpenBLAS)
 endif()
@@ -68,8 +70,6 @@ if(APPLE)
 endif()
 
 find_package(BLAS REQUIRED)
-
-find_package(LAPACK REQUIRED)
 
 if(__X86_64)
   list(REMOVE_ITEM FAISS_SRCS ${FAISS_AVX2_SRCS})


### PR DESCRIPTION
after #448 , LAPACK dependency is limited to 'openblas' vendor and will not be found in some enviroments, and also find_package(LAPACK) will overwrite BLAS_LIBRARIES, move find_package(LAPACK) above and limit BLAS_LIBRARIES to openblas

/kind improvement