### PR TITLE
[range search] iterator stops only if exceeds radius several times consecutively.

### DIFF
--- a/include/knowhere/config.h
+++ b/include/knowhere/config.h
@@ -634,6 +634,7 @@ class BaseConfig : public Config {
     // for similarity metrics, we search for vectors with similarity in (radius, range_filter].
     CFG_FLOAT radius;
     CFG_FLOAT range_filter;
+    CFG_FLOAT range_search_level;
     CFG_BOOL trace_visit;
     CFG_BOOL enable_mmap;
     CFG_BOOL enable_mmap_pop;
@@ -682,6 +683,11 @@ class BaseConfig : public Config {
         KNOWHERE_CONFIG_DECLARE_FIELD(range_filter)
             .set_default(defaultRangeFilter)
             .description("result filter for range search")
+            .for_range_search();
+        KNOWHERE_CONFIG_DECLARE_FIELD(range_search_level)
+            .set_default(0.01f)
+            .description("control the accurancy of range search, [0.0 - 0.5], the larger the more accurate")
+            .set_range(0, 0.5)
             .for_range_search();
         KNOWHERE_CONFIG_DECLARE_FIELD(trace_visit)
             .set_default(false)


### PR DESCRIPTION
A new param - range_search_level, default 0.01
- iterator stops only if it consecutively exceeds the `radius` more than `num_next() * range_search_level` times.