### PR TITLE
a theoretical fix for binary data type

### DIFF
--- a/src/index/flat/flat.cc
+++ b/src/index/flat/flat.cc
@@ -117,7 +117,8 @@ class FlatIndexNode : public IndexNode {
                         faiss::SearchParameters search_params;
                         search_params.sel = id_selector;
 
-                        index_->search(1, (const uint8_t*)x + index * dim / 8, k, cur_i_dis, cur_ids, &search_params);
+                        index_->search(1, (const uint8_t*)x + index * ((dim + 7) / 8), k, cur_i_dis, cur_ids,
+                                       &search_params);
 
                         if (index_->metric_type == faiss::METRIC_Hamming) {
                             for (int64_t j = 0; j < k; j++) {
@@ -189,7 +190,8 @@ class FlatIndexNode : public IndexNode {
                         faiss::SearchParameters search_params;
                         search_params.sel = id_selector;
 
-                        index_->range_search(1, (const uint8_t*)xq + index * dim / 8, radius, &res, &search_params);
+                        index_->range_search(1, (const uint8_t*)xq + index * ((dim + 7) / 8), radius, &res,
+                                             &search_params);
                     }
                     auto elem_cnt = res.lims[1];
                     result_dist_array[index].resize(elem_cnt);
@@ -238,9 +240,9 @@ class FlatIndexNode : public IndexNode {
         if constexpr (std::is_same<IndexType, faiss::IndexBinaryFlat>::value) {
             uint8_t* data = nullptr;
             try {
-                data = new uint8_t[rows * dim / 8];
+                data = new uint8_t[rows * ((dim + 7) / 8)];
                 for (int64_t i = 0; i < rows; i++) {
-                    index_->reconstruct(ids[i], data + i * dim / 8);
+                    index_->reconstruct(ids[i], data + i * ((dim + 7) / 8));
                 }
                 return GenResultDataSet(rows, dim, data);
             } catch (const std::exception& e) {

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -656,7 +656,7 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, const Config
                 faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
 
                 if constexpr (std::is_same<IndexType, faiss::IndexBinaryIVF>::value) {
-                    auto cur_data = (const uint8_t*)data + index * dim / 8;
+                    auto cur_data = (const uint8_t*)data + index * ((dim + 7) / 8);
 
                     int32_t* i_distances = reinterpret_cast<int32_t*>(distances.get());
 
@@ -781,7 +781,7 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, const C
                 faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
 
                 if constexpr (std::is_same<IndexType, faiss::IndexBinaryIVF>::value) {
-                    auto cur_data = (const uint8_t*)xq + index * dim / 8;
+                    auto cur_data = (const uint8_t*)xq + index * ((dim + 7) / 8);
 
                     faiss::IVFSearchParameters ivf_search_params;
                     ivf_search_params.nprobe = index_->nlist;
@@ -931,11 +931,11 @@ IvfIndexNode<DataType, IndexType>::GetVectorByIds(const DataSetPtr dataset) cons
         auto ids = dataset->GetIds();
 
         try {
-            auto data = std::make_unique<uint8_t[]>(dim * rows / 8);
+            auto data = std::make_unique<uint8_t[]>(rows * ((dim + 7) / 8));
             for (int64_t i = 0; i < rows; i++) {
                 int64_t id = ids[i];
                 assert(id >= 0 && id < index_->ntotal);
-                index_->reconstruct(id, data.get() + i * dim / 8);
+                index_->reconstruct(id, data.get() + i * ((dim + 7) / 8));
             }
             return GenResultDataSet(rows, dim, std::move(data));
         } catch (const std::exception& e) {


### PR DESCRIPTION
Faiss `IndexBinary`-derived indices prohibit `dim % 8 != 0` use cases. Still, it is needed to correctly handle non-standard `dim` values inside Knowhere, just in hope that a Faiss might lift its restriction one day.

/kind improvement

  