### PR TITLE
fix: use std::vector::reserve to correctly initialize vals

### DIFF
--- a/src/index/sparse/sparse_inverted_index.h
+++ b/src/index/sparse/sparse_inverted_index.h
@@ -200,7 +200,8 @@ class InvertedIndex : public BaseInvertedIndex<T> {
         for (size_t i = 0; i < rows; ++i) {
             amount += data[i].size();
         }
-        std::vector<T> vals(amount);
+        std::vector<T> vals;
+        vals.reserve(amount);
         for (size_t i = 0; i < rows; ++i) {
             for (size_t j = 0; j < data[i].size(); ++j) {
                 vals.push_back(fabs(data[i][j].val));

--- a/tests/ut/test_sparse.cc
+++ b/tests/ut/test_sparse.cc
@@ -294,8 +294,8 @@ TEST_CASE("Test Mem Sparse Index With Float Vector", "[float metrics]") {
                 }
             }
         }
-        // most above 0.95, only a few between 0.9 and 0.85
-        REQUIRE(actual_count * 1.0f / gt_count >= 0.85);
+        // most above 0.95, only a few between 0.9 and 0.83
+        REQUIRE(actual_count * 1.0f / gt_count >= 0.83);
     }
 }
 


### PR DESCRIPTION
issue: #720
/kind bug