### PR TITLE
improve SQ6 code for AVX512

### DIFF
--- a/cmake/libs/libfaiss.cmake
+++ b/cmake/libs/libfaiss.cmake
@@ -96,6 +96,7 @@ if(__X86_64)
             -mavx512f
             -mavx512dq
             -mavx512bw
+            -mavx512vl
             -mpopcnt>)
 
   add_library(faiss STATIC ${FAISS_SRCS})


### PR DESCRIPTION
Significantly improves SQ6 performance for AVX512.

Also, the new code contains two commented out version candidates which are even faster, but require a proper platform (`-mbmi2` for Intel or AMD Zen4+ CPU families). TODO.

issue: #743 
/kind improvement
 
