### PR TITLE
fix: fail to load ivf_flat(metric = cosine) with DeserializeFromFile

### DIFF
--- a/thirdparty/faiss/faiss/invlists/OnDiskInvertedLists.h
+++ b/thirdparty/faiss/faiss/invlists/OnDiskInvertedLists.h
@@ -77,6 +77,7 @@ struct OnDiskInvertedLists : InvertedLists {
     size_t totsize;
     uint8_t* ptr;   // mmap base pointer
     bool read_only; /// are inverted lists mapped read-only
+    bool with_norm = false;
 
     OnDiskInvertedLists(size_t nlist, size_t code_size, const char* filename);
 
@@ -138,6 +139,8 @@ struct OnDiskInvertedLists : InvertedLists {
 
     // empty constructor for the I/O functions
     OnDiskInvertedLists();
+
+    const float* get_code_norms(size_t list_no, size_t offset) const override;
 };
 
 struct OnDiskInvertedListsIOHook : InvertedListsIOHook {


### PR DESCRIPTION
issue:https://github.com/milvus-io/milvus/issues/36052

When we set IO_FLAG_WITH_NORM = true to read a faiss index,  ArrayInvertedLists will read into a read-only OnDiskInvertedLists. 
OnDiskInvertedLists will mmap all ids and vectors with the index file,  and record the ids and vectors offset in memory. If we use cosine, l1-norms will save in index file and all offsets are wrong.
