### PR TITLE
Iterator for diskann

### DIFF
--- a/include/knowhere/config.h
+++ b/include/knowhere/config.h
@@ -517,7 +517,6 @@ class BaseConfig : public Config {
     CFG_BOOL trace_visit;
     CFG_BOOL enable_mmap;
     CFG_BOOL enable_mmap_pop;
-    CFG_BOOL for_tuning;
     CFG_BOOL shuffle_build;
     CFG_STRING trace_id;
     CFG_STRING span_id;
@@ -602,7 +601,6 @@ class BaseConfig : public Config {
             .description("enable map_populate option for mmap")
             .for_deserialize()
             .for_deserialize_from_file();
-        KNOWHERE_CONFIG_DECLARE_FIELD(for_tuning).set_default(false).description("for tuning").for_search();
         KNOWHERE_CONFIG_DECLARE_FIELD(shuffle_build)
             .set_default(true)
             .description("shuffle ids before index building")

--- a/tests/ut/test_diskann.cc
+++ b/tests/ut/test_diskann.cc
@@ -135,15 +135,6 @@ TEST_CASE("Invalid diskann params test", "[diskann]") {
             REQUIRE_FALSE(res.has_value());
             REQUIRE(res.error() == knowhere::Status::out_of_range_in_json);
         }
-        // min_k > max_k
-        {
-            test_json = test_gen();
-            test_json["min_k"] = 10000;
-            test_json["max_k"] = 100;
-            auto res = diskann.RangeSearch(query_ds, test_json, nullptr);
-            REQUIRE_FALSE(res.has_value());
-            REQUIRE(res.error() == knowhere::Status::out_of_range_in_json);
-        }
 #endif
     }
     fs::remove_all(kDir);
@@ -223,8 +214,6 @@ base_search() {
         knowhere::Json json = base_gen();
         json["index_prefix"] = metric_dir_map[metric_str];
         json["beamwidth"] = 8;
-        json["min_k"] = 10;
-        json["max_k"] = 8000;
         return json;
     };
 

--- a/thirdparty/DiskANN/include/diskann/pq_flash_index.h
+++ b/thirdparty/DiskANN/include/diskann/pq_flash_index.h
@@ -142,6 +142,7 @@ namespace diskann {
     tsl::robin_set<_u64>      *visited = nullptr;
     float                      query_norm = 0.0f;
     float                      max_base_norm = 0.0f;
+    bool                       not_l2_but_zero = false; // (cosine or ip) and query_norm == 0.
     std::vector<unsigned>      frontier;
     std::vector<AlignedRead>   frontier_read_reqs;
     const knowhere::BitsetView bitset;

--- a/thirdparty/DiskANN/include/diskann/pq_flash_index.h
+++ b/thirdparty/DiskANN/include/diskann/pq_flash_index.h
@@ -106,7 +106,7 @@ namespace diskann {
                       const uint64_t aligned_dim, const uint64_t data_dim,
                       const float alpha, const uint64_t lsearch,
                       const uint64_t beam_width, const float filter_ratio,
-                      const bool for_tuning, const float max_base_norm,
+                      const float                 max_base_norm,
                       const knowhere::BitsetView &bitset);
 
     ~IteratorWorkspace();
@@ -134,15 +134,14 @@ namespace diskann {
     Metric   metric = Metric::L2;
     float    alpha = 0;
     float    acc_alpha = 0;
-    bool     for_tuning = false;
     bool     initialized = false;
 
-    T                         *aligned_query_T = nullptr;
-    float                     *aligned_query_float = nullptr;
-    tsl::robin_set<_u64>      *visited = nullptr;
-    float                      query_norm = 0.0f;
-    float                      max_base_norm = 0.0f;
-    bool                       not_l2_but_zero = false; // (cosine or ip) and query_norm == 0.
+    T                    *aligned_query_T = nullptr;
+    float                *aligned_query_float = nullptr;
+    tsl::robin_set<_u64> *visited = nullptr;
+    float                 query_norm = 0.0f;
+    float                 max_base_norm = 0.0f;
+    bool not_l2_but_zero = false;  // (cosine or ip) and query_norm == 0.
     std::vector<unsigned>      frontier;
     std::vector<AlignedRead>   frontier_read_reqs;
     const knowhere::BitsetView bitset;
@@ -222,8 +221,7 @@ namespace diskann {
 
     std::unique_ptr<IteratorWorkspace<T>> getIteratorWorkspace(
         const T *query_data, const uint64_t lsearch, const uint64_t beam_width,
-        const bool use_reorder_data, const float filter_ratio,
-        const bool for_tuning, const knowhere::BitsetView &bitset);
+        const float filter_ratio, const knowhere::BitsetView &bitset);
 
     _u64 cal_size();
 

--- a/thirdparty/DiskANN/include/diskann/pq_flash_index.h
+++ b/thirdparty/DiskANN/include/diskann/pq_flash_index.h
@@ -76,6 +76,101 @@ namespace diskann {
     QueryScratch<T> scratch;
   };
 
+  /** Algorithm Introduction for diskann-iterator
+   * First, two unbounded min-heaps are maintained: `retset` and `candidates`,
+   * sorted by *pq_dist*. (Similar to the navigation search path of hnswlib-hnsw
+   * with ef=1.)
+   *
+   * When visiting candidates, another unbounded minimum heap, `full_retset`, is
+   * maintained to collect all *full_dist* along the paths.
+   * Each `iterator->next` is called, `candidates` are continually visited until
+   * the optimal candidates are farther than the optimal retset.
+   * "candidates.top.pq_dist < retset.top.pq_dist"
+   *
+   * Once the condition is met, we consider the `retset` to have reached its
+   * current optimal state, and we stop visiting new candidates. The top element
+   * of `full_retset` is returned as the final result. At this point, the top of
+   * `retset` has also completed its task and will be directly popped.
+   *
+   * It is important to note that "ef=1" is clearly insufficient in terms of
+   * accuracy. To address this, the `lsearch` parameter is provided, which
+   * allows the `workspace` to effectively make an *additional* `lsearch`
+   * iterations each time `iterator->next` is called. Specifically, this means
+   * "good_pq_res_count - next_count >= lsearch".
+   * The additional results will be sorted and saved by the upper-level
+   * `iterator.res_` through `next_batch` func with `backup_res`.
+   */
+  template<typename T>
+  struct IteratorWorkspace {
+    IteratorWorkspace(const T *query_data, const diskann::Metric metric,
+                      const uint64_t aligned_dim, const uint64_t data_dim,
+                      const float alpha, const uint64_t lsearch,
+                      const uint64_t beam_width, const float filter_ratio,
+                      const bool for_tuning, const float max_base_norm,
+                      const knowhere::BitsetView &bitset);
+
+    ~IteratorWorkspace();
+
+    bool is_good_pq_enough();
+
+    bool has_candidates();
+
+    bool should_visit_next_candidate();
+
+    void insert_to_pq(unsigned id, float dist, bool valid);
+
+    void insert_to_full(unsigned id, float dist);
+
+    void pop_pq_retset();
+
+    void move_full_retset_to_backup();
+
+    void move_last_full_retset_to_backup();
+
+    uint64_t q_dim = 0;
+    uint64_t lsearch = 0;
+    uint64_t beam_width = 0;
+    float    filter_ratio = 0;
+    Metric   metric = Metric::L2;
+    float    alpha = 0;
+    float    acc_alpha = 0;
+    bool     for_tuning = false;
+    bool     initialized = false;
+
+    T                         *aligned_query_T = nullptr;
+    float                     *aligned_query_float = nullptr;
+    tsl::robin_set<_u64>      *visited = nullptr;
+    float                      query_norm = 0.0f;
+    float                      max_base_norm = 0.0f;
+    std::vector<unsigned>      frontier;
+    std::vector<AlignedRead>   frontier_read_reqs;
+    const knowhere::BitsetView bitset;
+
+    std::vector<std::pair<unsigned, char *>> frontier_nhoods;
+    std::vector<std::pair<unsigned, std::pair<unsigned, unsigned *>>>
+        cached_nhoods;
+
+    struct MinHeapCompareForSimpleNeighbor {
+      bool operator()(const SimpleNeighbor &a, const SimpleNeighbor &b) {
+        return a.distance > b.distance;
+      }
+    };
+    std::priority_queue<SimpleNeighbor, std::vector<SimpleNeighbor>,
+                        MinHeapCompareForSimpleNeighbor>
+        full_retset;
+    std::priority_queue<SimpleNeighbor, std::vector<SimpleNeighbor>,
+                        MinHeapCompareForSimpleNeighbor>
+        retset;
+    std::priority_queue<SimpleNeighbor, std::vector<SimpleNeighbor>,
+                        MinHeapCompareForSimpleNeighbor>
+        candidates;
+
+    size_t good_pq_res_count = 0;
+    size_t next_count = 0;
+
+    std::vector<knowhere::DistId> backup_res;
+  };
+
   template<typename T>
   class PQFlashIndex {
    public:
@@ -105,13 +200,6 @@ namespace diskann {
         knowhere::BitsetView                             bitset_view = nullptr,
         const float                                      filter_ratio = -1.0f);
 
-    _u32 range_search(const T *query1, const double range,
-                      const _u64 min_l_search, const _u64 max_l_search,
-                      std::vector<_s64> &indices, std::vector<float> &distances,
-                      const _u64           beam_width,
-                      knowhere::BitsetView bitset_view = nullptr,
-                      QueryStats          *stats = nullptr);
-
     void get_vector_by_ids(const int64_t *ids, const int64_t n,
                            T *const output_data);
 
@@ -128,6 +216,13 @@ namespace diskann {
     size_t get_num_medoids() const noexcept;
 
     diskann::Metric get_metric() const noexcept;
+
+    void getIteratorNextBatch(IteratorWorkspace<T> *workspace);
+
+    std::unique_ptr<IteratorWorkspace<T>> getIteratorWorkspace(
+        const T *query_data, const uint64_t lsearch, const uint64_t beam_width,
+        const bool use_reorder_data, const float filter_ratio,
+        const bool for_tuning, const knowhere::BitsetView &bitset);
 
     _u64 cal_size();
 

--- a/thirdparty/DiskANN/src/pq_flash_index.cpp
+++ b/thirdparty/DiskANN/src/pq_flash_index.cpp
@@ -63,11 +63,11 @@ namespace diskann {
       const T *query_data, const diskann::Metric metric,
       const uint64_t aligned_dim, const uint64_t data_dim, const float alpha,
       const uint64_t lsearch, const uint64_t beam_width,
-      const float filter_ratio, const bool for_tuning,
-      const float max_base_norm, const knowhere::BitsetView &bitset)
+      const float filter_ratio, const float max_base_norm,
+      const knowhere::BitsetView &bitset)
       : lsearch(lsearch), beam_width(beam_width), filter_ratio(filter_ratio),
-        metric(metric), alpha(alpha), for_tuning(for_tuning),
-        max_base_norm(max_base_norm), bitset(bitset) {
+        metric(metric), alpha(alpha), max_base_norm(max_base_norm),
+        bitset(bitset) {
     frontier.reserve(2 * beam_width);
     frontier_nhoods.reserve(2 * beam_width);
     frontier_read_reqs.reserve(2 * beam_width);
@@ -1699,21 +1699,17 @@ namespace diskann {
 
     if (!workspace->initialized) {
       uint32_t best_medoid = 0;
-      if (workspace->for_tuning) {
-        float best_dist = (std::numeric_limits<float>::max)();
-        std::vector<SimpleNeighbor> medoid_dists;
-        for (_u64 cur_m = 0; cur_m < num_medoids; cur_m++) {
-          float cur_expanded_dist =
-              dist_cmp_float_wrap(workspace->aligned_query_float,
-                                  centroid_data + aligned_dim * cur_m,
-                                  (size_t) aligned_dim, medoids[cur_m]);
-          if (cur_expanded_dist < best_dist) {
-            best_medoid = medoids[cur_m];
-            best_dist = cur_expanded_dist;
-          }
+      float    best_dist = (std::numeric_limits<float>::max)();
+      std::vector<SimpleNeighbor> medoid_dists;
+      for (size_t cur_m = 0; cur_m < num_medoids; cur_m++) {
+        float cur_expanded_dist = dist_cmp_float_wrap(
+            workspace->aligned_query_float, centroid_data + aligned_dim * cur_m,
+            (size_t) aligned_dim, medoids[cur_m]);
+        if (cur_expanded_dist < best_dist) {
+          best_medoid = medoids[cur_m];
+          best_dist = cur_expanded_dist;
         }
       }
-
       compute_dists(&best_medoid, 1, dist_scratch);
       bool valid =
           workspace->bitset.empty() || !workspace->bitset.test(best_medoid);
@@ -1883,12 +1879,11 @@ namespace diskann {
   template<typename T>
   std::unique_ptr<IteratorWorkspace<T>> PQFlashIndex<T>::getIteratorWorkspace(
       const T *query_data, const uint64_t lsearch, const uint64_t beam_width,
-      const bool use_reorder_data, const float filter_ratio,
-      const bool for_tuning, const knowhere::BitsetView &bitset) {
+      const float filter_ratio, const knowhere::BitsetView &bitset) {
     float alpha = kAlpha;
     return std::make_unique<IteratorWorkspace<T>>(
         query_data, metric, this->aligned_dim, this->data_dim, alpha, lsearch,
-        beam_width, filter_ratio, for_tuning, this->max_base_norm, bitset);
+        beam_width, filter_ratio, this->max_base_norm, bitset);
   }
 
   template<typename T>


### PR DESCRIPTION
- add iterator support for knowhere diskann
- remove diskann-range_search, use index_node-range_search instead. (implemented by diskann-iterator)

issue: https://github.com/milvus-io/milvus/issues/34816
co-author: @xxxlzhxxx 