### PR TITLE
fix: conan: make glog shared

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -44,6 +44,7 @@ class KnowhereConan(ConanFile):
         "with_cardinal": False,
         "with_profiler": False,
         "with_ut": False,
+        "glog:shared": True,
         "glog:with_gflags": True,
         "gtest:build_gmock": False,
         "prometheus-cpp:with_pull": False,


### PR DESCRIPTION
This change is aimed to fix knowhere_tests running error after latest modification.