### PR TITLE
enhance: BF functions support real fp16/bf16 calculate

### DIFF
--- a/include/knowhere/operands.h
+++ b/include/knowhere/operands.h
@@ -170,6 +170,8 @@ template <typename InType>
 using KnowhereDataTypeCheck = TypeMatch<InType, bin1, fp16, fp32, bf16>;
 template <typename InType>
 using KnowhereFloatTypeCheck = TypeMatch<InType, fp16, fp32, bf16>;
+template <typename InType>
+using KnowhereHalfPrecisionFloatPointTypeCheck = TypeMatch<InType, fp16, bf16>;
 
 template <typename T>
 struct MockData {

--- a/src/simd/distances_avx.cc
+++ b/src/simd/distances_avx.cc
@@ -58,19 +58,22 @@ FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 float
 fp16_vec_inner_product_avx(const knowhere::fp16* x, const knowhere::fp16* y, size_t d) {
     __m256 msum_0 = _mm256_setzero_ps();
-    __m256 msum_1 = _mm256_setzero_ps();
     while (d >= 16) {
-        auto mx_0 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)x));
-        auto my_0 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y));
-        auto mx_1 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)(x + 8)));
-        auto my_1 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)(y + 8)));
+        auto mx = _mm256_loadu_si256((__m256i*)x);
+        auto mx_0 = _mm256_cvtph_ps(_mm256_extracti128_si256(mx, 0));
+        auto mx_1 = _mm256_cvtph_ps(_mm256_extracti128_si256(mx, 1));
+
+        auto my = _mm256_loadu_si256((__m256i*)y);
+        auto my_0 = _mm256_cvtph_ps(_mm256_extracti128_si256(my, 0));
+        auto my_1 = _mm256_cvtph_ps(_mm256_extracti128_si256(my, 1));
+
         msum_0 = _mm256_fmadd_ps(mx_0, my_0, msum_0);
-        msum_1 = _mm256_fmadd_ps(mx_1, my_1, msum_1);
+        auto msum_1 = _mm256_mul_ps(mx_1, my_1);
+        msum_0 = msum_0 + msum_1;
         x += 16;
         y += 16;
         d -= 16;
     }
-    msum_0 = msum_0 + msum_1;
     while (d >= 8) {
         auto mx = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)x));
         auto my = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y));
@@ -91,19 +94,22 @@ fp16_vec_inner_product_avx(const knowhere::fp16* x, const knowhere::fp16* y, siz
 float
 bf16_vec_inner_product_avx(const knowhere::bf16* x, const knowhere::bf16* y, size_t d) {
     __m256 msum_0 = _mm256_setzero_ps();
-    __m256 msum_1 = _mm256_setzero_ps();
     while (d >= 16) {
-        auto mx_0 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)x));
-        auto my_0 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y));
-        auto mx_1 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)(x + 8)));
-        auto my_1 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)(y + 8)));
+        auto mx = _mm256_loadu_si256((__m256i*)x);
+        auto mx_0 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(mx, 0));
+        auto mx_1 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(mx, 1));
+
+        auto my = _mm256_loadu_si256((__m256i*)y);
+        auto my_0 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(my, 0));
+        auto my_1 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(my, 1));
+
         msum_0 = _mm256_fmadd_ps(mx_0, my_0, msum_0);
-        msum_1 = _mm256_fmadd_ps(mx_1, my_1, msum_1);
+        auto msum_1 = _mm256_mul_ps(mx_1, my_1);
+        msum_0 = msum_0 + msum_1;
         x += 16;
         y += 16;
         d -= 16;
     }
-    msum_0 = msum_0 + msum_1;
     while (d >= 8) {
         auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)x));
         auto my = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y));
@@ -153,21 +159,24 @@ FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 float
 fp16_vec_L2sqr_avx(const knowhere::fp16* x, const knowhere::fp16* y, size_t d) {
     __m256 msum_0 = _mm256_setzero_ps();
-    __m256 msum_1 = _mm256_setzero_ps();
     while (d >= 16) {
-        auto mx_0 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)x));
-        auto my_0 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y));
-        auto mx_1 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)(x + 8)));
-        auto my_1 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)(y + 8)));
+        auto mx = _mm256_loadu_si256((__m256i*)x);
+        auto mx_0 = _mm256_cvtph_ps(_mm256_extracti128_si256(mx, 0));
+        auto mx_1 = _mm256_cvtph_ps(_mm256_extracti128_si256(mx, 1));
+
+        auto my = _mm256_loadu_si256((__m256i*)y);
+        auto my_0 = _mm256_cvtph_ps(_mm256_extracti128_si256(my, 0));
+        auto my_1 = _mm256_cvtph_ps(_mm256_extracti128_si256(my, 1));
+
         mx_0 = _mm256_sub_ps(mx_0, my_0);
         mx_1 = _mm256_sub_ps(mx_1, my_1);
         msum_0 = _mm256_fmadd_ps(mx_0, mx_0, msum_0);
-        msum_1 = _mm256_fmadd_ps(mx_1, mx_1, msum_1);
+        msum_0 = _mm256_fmadd_ps(mx_1, mx_1, msum_0);
+
         x += 16;
         y += 16;
         d -= 16;
     }
-    msum_0 = msum_0 + msum_1;
     while (d >= 8) {
         auto mx = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)x));
         auto my = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y));
@@ -190,21 +199,22 @@ fp16_vec_L2sqr_avx(const knowhere::fp16* x, const knowhere::fp16* y, size_t d) {
 float
 bf16_vec_L2sqr_avx(const knowhere::bf16* x, const knowhere::bf16* y, size_t d) {
     __m256 msum_0 = _mm256_setzero_ps();
-    __m256 msum_1 = _mm256_setzero_ps();
     while (d >= 16) {
-        auto mx_0 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)x));
-        auto my_0 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y));
-        auto mx_1 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)(x + 8)));
-        auto my_1 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)(y + 8)));
+        auto mx = _mm256_loadu_si256((__m256i*)x);
+        auto mx_0 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(mx, 0));
+        auto mx_1 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(mx, 1));
+
+        auto my = _mm256_loadu_si256((__m256i*)y);
+        auto my_0 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(my, 0));
+        auto my_1 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(my, 1));
         mx_0 = _mm256_sub_ps(mx_0, my_0);
         mx_1 = _mm256_sub_ps(mx_1, my_1);
         msum_0 = _mm256_fmadd_ps(mx_0, mx_0, msum_0);
-        msum_1 = _mm256_fmadd_ps(mx_1, mx_1, msum_1);
+        msum_0 = _mm256_fmadd_ps(mx_1, mx_1, msum_0);
         x += 16;
         y += 16;
         d -= 16;
     }
-    msum_0 = msum_0 + msum_1;
     while (d >= 8) {
         auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)x));
         auto my = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y));
@@ -438,6 +448,200 @@ fvec_L2sqr_batch_4_avx_bf16_patch(const float* x, const float* y0, const float* 
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
+void
+fp16_vec_inner_product_batch_4_avx(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                                   const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3) {
+    __m256 msum_0 = _mm256_setzero_ps();
+    __m256 msum_1 = _mm256_setzero_ps();
+    __m256 msum_2 = _mm256_setzero_ps();
+    __m256 msum_3 = _mm256_setzero_ps();
+
+    size_t cur_d = d;
+    while (cur_d >= 8) {
+        auto mx = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)x));
+        auto my0 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y0));
+        auto my1 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y1));
+        auto my2 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y2));
+        auto my3 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y3));
+        msum_0 = _mm256_fmadd_ps(mx, my0, msum_0);
+        msum_1 = _mm256_fmadd_ps(mx, my1, msum_1);
+        msum_2 = _mm256_fmadd_ps(mx, my2, msum_2);
+        msum_3 = _mm256_fmadd_ps(mx, my3, msum_3);
+        x += 8;
+        y0 += 8;
+        y1 += 8;
+        y2 += 8;
+        y3 += 8;
+        cur_d -= 8;
+    }
+    if (cur_d > 0) {
+        auto mx = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)x));
+        auto my0 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y0));
+        auto my1 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y1));
+        auto my2 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y2));
+        auto my3 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y3));
+        msum_0 = _mm256_fmadd_ps(mx, my0, msum_0);
+        msum_1 = _mm256_fmadd_ps(mx, my1, msum_1);
+        msum_2 = _mm256_fmadd_ps(mx, my2, msum_2);
+        msum_3 = _mm256_fmadd_ps(mx, my3, msum_3);
+    }
+    dis0 = _mm256_reduce_add_ps(msum_0);
+    dis1 = _mm256_reduce_add_ps(msum_1);
+    dis2 = _mm256_reduce_add_ps(msum_2);
+    dis3 = _mm256_reduce_add_ps(msum_3);
+    return;
+}
+
+void
+bf16_vec_inner_product_batch_4_avx(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                                   const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3) {
+    __m256 msum_0 = _mm256_setzero_ps();
+    __m256 msum_1 = _mm256_setzero_ps();
+    __m256 msum_2 = _mm256_setzero_ps();
+    __m256 msum_3 = _mm256_setzero_ps();
+    size_t cur_d = d;
+    while (cur_d >= 8) {
+        auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)x));
+        auto my0 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y0));
+        auto my1 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y1));
+        auto my2 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y2));
+        auto my3 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y3));
+        msum_0 = _mm256_fmadd_ps(mx, my0, msum_0);
+        msum_1 = _mm256_fmadd_ps(mx, my1, msum_1);
+        msum_2 = _mm256_fmadd_ps(mx, my2, msum_2);
+        msum_3 = _mm256_fmadd_ps(mx, my3, msum_3);
+        x += 8;
+        y0 += 8;
+        y1 += 8;
+        y2 += 8;
+        y3 += 8;
+        cur_d -= 8;
+    }
+    if (cur_d > 0) {
+        auto mx = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)x));
+        auto my0 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y0));
+        auto my1 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y1));
+        auto my2 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y2));
+        auto my3 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y3));
+        msum_0 = _mm256_fmadd_ps(mx, my0, msum_0);
+        msum_1 = _mm256_fmadd_ps(mx, my1, msum_1);
+        msum_2 = _mm256_fmadd_ps(mx, my2, msum_2);
+        msum_3 = _mm256_fmadd_ps(mx, my3, msum_3);
+    }
+    dis0 = _mm256_reduce_add_ps(msum_0);
+    dis1 = _mm256_reduce_add_ps(msum_1);
+    dis2 = _mm256_reduce_add_ps(msum_2);
+    dis3 = _mm256_reduce_add_ps(msum_3);
+
+    return;
+}
+
+void
+fp16_vec_L2sqr_batch_4_avx(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                           const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3) {
+    __m256 msum_0 = _mm256_setzero_ps();
+    __m256 msum_1 = _mm256_setzero_ps();
+    __m256 msum_2 = _mm256_setzero_ps();
+    __m256 msum_3 = _mm256_setzero_ps();
+    auto cur_d = d;
+    while (cur_d >= 8) {
+        auto mx = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)x));
+        auto my0 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y0));
+        auto my1 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y1));
+        auto my2 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y2));
+        auto my3 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y3));
+        my0 = _mm256_sub_ps(mx, my0);
+        msum_0 = _mm256_fmadd_ps(my0, my0, msum_0);
+        my1 = _mm256_sub_ps(mx, my1);
+        msum_1 = _mm256_fmadd_ps(my1, my1, msum_1);
+        my2 = _mm256_sub_ps(mx, my2);
+        msum_2 = _mm256_fmadd_ps(my2, my2, msum_2);
+        my3 = _mm256_sub_ps(mx, my3);
+        msum_3 = _mm256_fmadd_ps(my3, my3, msum_3);
+        x += 8;
+        y0 += 8;
+        y1 += 8;
+        y2 += 8;
+        y3 += 8;
+        cur_d -= 8;
+    }
+    if (cur_d > 0) {
+        auto mx = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)x));
+        auto my0 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y0));
+        auto my1 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y1));
+        auto my2 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y2));
+        auto my3 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y3));
+        my0 = _mm256_sub_ps(mx, my0);
+        my1 = _mm256_sub_ps(mx, my1);
+        my2 = _mm256_sub_ps(mx, my2);
+        my3 = _mm256_sub_ps(mx, my3);
+        msum_0 = _mm256_fmadd_ps(my0, my0, msum_0);
+        msum_1 = _mm256_fmadd_ps(my1, my1, msum_1);
+        msum_2 = _mm256_fmadd_ps(my2, my2, msum_2);
+        msum_3 = _mm256_fmadd_ps(my3, my3, msum_3);
+    }
+    dis0 = _mm256_reduce_add_ps(msum_0);
+    dis1 = _mm256_reduce_add_ps(msum_1);
+    dis2 = _mm256_reduce_add_ps(msum_2);
+    dis3 = _mm256_reduce_add_ps(msum_3);
+    return;
+}
+
+void
+bf16_vec_L2sqr_batch_4_avx(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                           const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3) {
+    __m256 msum_0 = _mm256_setzero_ps();
+    __m256 msum_1 = _mm256_setzero_ps();
+    __m256 msum_2 = _mm256_setzero_ps();
+    __m256 msum_3 = _mm256_setzero_ps();
+    size_t cur_d = d;
+    while (cur_d >= 8) {
+        auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)x));
+        auto my0 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y0));
+        auto my1 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y1));
+        auto my2 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y2));
+        auto my3 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y3));
+        my0 = _mm256_sub_ps(mx, my0);
+        my1 = _mm256_sub_ps(mx, my1);
+        my2 = _mm256_sub_ps(mx, my2);
+        my3 = _mm256_sub_ps(mx, my3);
+        msum_0 = _mm256_fmadd_ps(my0, my0, msum_0);
+        msum_1 = _mm256_fmadd_ps(my1, my1, msum_1);
+        msum_2 = _mm256_fmadd_ps(my2, my2, msum_2);
+        msum_3 = _mm256_fmadd_ps(my3, my3, msum_3);
+        x += 8;
+        y0 += 8;
+        y1 += 8;
+        y2 += 8;
+        y3 += 8;
+        cur_d -= 8;
+    }
+    if (cur_d > 0) {
+        auto mx = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)x));
+        auto my0 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y0));
+        auto my1 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y1));
+        auto my2 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y2));
+        auto my3 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y3));
+        my0 = _mm256_sub_ps(mx, my0);
+        my1 = _mm256_sub_ps(mx, my1);
+        my2 = _mm256_sub_ps(mx, my2);
+        my3 = _mm256_sub_ps(mx, my3);
+        msum_0 = _mm256_fmadd_ps(my0, my0, msum_0);
+        msum_1 = _mm256_fmadd_ps(my1, my1, msum_1);
+        msum_2 = _mm256_fmadd_ps(my2, my2, msum_2);
+        msum_3 = _mm256_fmadd_ps(my3, my3, msum_3);
+    }
+    dis0 = _mm256_reduce_add_ps(msum_0);
+    dis1 = _mm256_reduce_add_ps(msum_1);
+    dis2 = _mm256_reduce_add_ps(msum_2);
+    dis3 = _mm256_reduce_add_ps(msum_3);
+    return;
+}
+
 // trust the compiler to unroll this properly
 int32_t
 ivec_inner_product_avx(const int8_t* x, const int8_t* y, size_t d) {
@@ -464,16 +668,15 @@ ivec_L2sqr_avx(const int8_t* x, const int8_t* y, size_t d) {
 float
 fvec_norm_L2sqr_avx(const float* x, size_t d) {
     __m256 msum_0 = _mm256_setzero_ps();
-    __m256 msum_1 = _mm256_setzero_ps();
     while (d >= 16) {
         auto mx_0 = _mm256_loadu_ps(x);
         auto mx_1 = _mm256_loadu_ps(x + 8);
         msum_0 = _mm256_fmadd_ps(mx_0, mx_0, msum_0);
-        msum_1 = _mm256_fmadd_ps(mx_1, mx_1, msum_1);
+        auto msum_1 = _mm256_mul_ps(mx_1, mx_1);
+        msum_0 = msum_0 + msum_1;
         x += 16;
         d -= 16;
     }
-    msum_0 = msum_0 + msum_1;
     if (d >= 8) {
         auto mx = _mm256_loadu_ps(x);
         msum_0 = _mm256_fmadd_ps(mx, mx, msum_0);
@@ -501,16 +704,16 @@ fvec_norm_L2sqr_avx(const float* x, size_t d) {
 float
 fp16_vec_norm_L2sqr_avx(const knowhere::fp16* x, size_t d) {
     __m256 msum_0 = _mm256_setzero_ps();
-    __m256 msum_1 = _mm256_setzero_ps();
     while (d >= 16) {
-        auto mx_0 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)x));
-        auto mx_1 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)(x + 8)));
+        auto mx = _mm256_loadu_si256((__m256i*)x);
+        auto mx_0 = _mm256_cvtph_ps(_mm256_extracti128_si256(mx, 0));
+        auto mx_1 = _mm256_cvtph_ps(_mm256_extracti128_si256(mx, 1));
         msum_0 = _mm256_fmadd_ps(mx_0, mx_0, msum_0);
-        msum_1 = _mm256_fmadd_ps(mx_1, mx_1, msum_1);
+        auto msum_1 = _mm256_mul_ps(mx_1, mx_1);
+        msum_0 = msum_0 + msum_1;
         x += 16;
         d -= 16;
     }
-    msum_0 = msum_0 + msum_1;
     while (d >= 8) {
         auto mx = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)x));
         msum_0 = _mm256_fmadd_ps(mx, mx, msum_0);
@@ -528,16 +731,16 @@ fp16_vec_norm_L2sqr_avx(const knowhere::fp16* x, size_t d) {
 float
 bf16_vec_norm_L2sqr_avx(const knowhere::bf16* x, size_t d) {
     __m256 msum_0 = _mm256_setzero_ps();
-    __m256 msum_1 = _mm256_setzero_ps();
     while (d >= 16) {
-        auto mx_0 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)x));
-        auto mx_1 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)(x + 8)));
+        auto mx = _mm256_loadu_si256((__m256i*)x);
+        auto mx_0 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(mx, 0));
+        auto mx_1 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(mx, 1));
         msum_0 = _mm256_fmadd_ps(mx_0, mx_0, msum_0);
-        msum_1 = _mm256_fmadd_ps(mx_1, mx_1, msum_1);
+        auto msum_1 = _mm256_mul_ps(mx_1, mx_1);
+        msum_0 = msum_0 + msum_1;
         x += 16;
         d -= 16;
     }
-    msum_0 = msum_0 + msum_1;
     while (d >= 8) {
         auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)x));
         msum_0 = _mm256_fmadd_ps(mx, mx, msum_0);

--- a/src/simd/distances_avx.h
+++ b/src/simd/distances_avx.h
@@ -66,12 +66,32 @@ fvec_inner_product_batch_4_avx_bf16_patch(const float* x, const float* y0, const
                                           float& dis3);
 
 void
+fp16_vec_inner_product_batch_4_avx(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                                   const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3);
+
+void
+bf16_vec_inner_product_batch_4_avx(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                                   const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3);
+
+void
 fvec_L2sqr_batch_4_avx(const float* x, const float* y0, const float* y1, const float* y2, const float* y3,
                        const size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
 
 void
 fvec_L2sqr_batch_4_avx_bf16_patch(const float* x, const float* y0, const float* y1, const float* y2, const float* y3,
                                   const size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
+
+void
+fp16_vec_L2sqr_batch_4_avx(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                           const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3);
+
+void
+bf16_vec_L2sqr_batch_4_avx(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                           const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3);
 
 int32_t
 ivec_inner_product_avx(const int8_t* x, const int8_t* y, size_t d);

--- a/src/simd/distances_avx512.h
+++ b/src/simd/distances_avx512.h
@@ -65,12 +65,32 @@ fvec_inner_product_batch_4_avx512_bf16_patch(const float* x, const float* y0, co
                                              float& dis3);
 
 void
+fp16_vec_inner_product_batch_4_avx512(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                                      const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0,
+                                      float& dis1, float& dis2, float& dis3);
+
+void
+bf16_vec_inner_product_batch_4_avx512(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                                      const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0,
+                                      float& dis1, float& dis2, float& dis3);
+
+void
 fvec_L2sqr_batch_4_avx512(const float* x, const float* y0, const float* y1, const float* y2, const float* y3,
                           const size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
 
 void
 fvec_L2sqr_batch_4_avx512_bf16_patch(const float* x, const float* y0, const float* y1, const float* y2, const float* y3,
                                      const size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
+
+void
+fp16_vec_L2sqr_batch_4_avx512(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                              const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0,
+                              float& dis1, float& dis2, float& dis3);
+
+void
+bf16_vec_L2sqr_batch_4_avx512(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                              const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0,
+                              float& dis1, float& dis2, float& dis3);
 
 int32_t
 ivec_inner_product_avx512(const int8_t* x, const int8_t* y, size_t d);

--- a/src/simd/distances_neon.cc
+++ b/src/simd/distances_neon.cc
@@ -2090,5 +2090,633 @@ fvec_L2sqr_batch_4_neon_bf16_patch(const float* x, const float* y0, const float*
     dis3 = vaddvq_f32(sum_.val[3]);
 }
 
+void
+fp16_vec_inner_product_batch_4_neon(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                                    const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0,
+                                    float& dis1, float& dis2, float& dis3) {
+    // res store sub result of {4*dis0, 4*dis1, d4*is2, 4*dis3}
+    float32x4x4_t res = {vdupq_n_f32(0.0f), vdupq_n_f32(0.0f), vdupq_n_f32(0.0f), vdupq_n_f32(0.0f)};
+    auto cur_d = d;
+    while (cur_d >= 16) {
+        float32x4x4_t a = vcvt4_f32_f16(vld4_f16((const __fp16*)x));
+        float32x4x4_t b0 = vcvt4_f32_f16(vld4_f16((const __fp16*)y0));
+        float32x4x4_t b1 = vcvt4_f32_f16(vld4_f16((const __fp16*)y1));
+        float32x4x4_t b2 = vcvt4_f32_f16(vld4_f16((const __fp16*)y2));
+        float32x4x4_t b3 = vcvt4_f32_f16(vld4_f16((const __fp16*)y3));
+
+        res.val[0] = vmlaq_f32(res.val[0], a.val[0], b0.val[0]);
+        res.val[1] = vmlaq_f32(res.val[1], a.val[0], b1.val[0]);
+        res.val[2] = vmlaq_f32(res.val[2], a.val[0], b2.val[0]);
+        res.val[3] = vmlaq_f32(res.val[3], a.val[0], b3.val[0]);
+
+        res.val[0] = vmlaq_f32(res.val[0], a.val[1], b0.val[1]);
+        res.val[1] = vmlaq_f32(res.val[1], a.val[1], b1.val[1]);
+        res.val[2] = vmlaq_f32(res.val[2], a.val[1], b2.val[1]);
+        res.val[3] = vmlaq_f32(res.val[3], a.val[1], b3.val[1]);
+
+        res.val[0] = vmlaq_f32(res.val[0], a.val[2], b0.val[2]);
+        res.val[1] = vmlaq_f32(res.val[1], a.val[2], b1.val[2]);
+        res.val[2] = vmlaq_f32(res.val[2], a.val[2], b2.val[2]);
+        res.val[3] = vmlaq_f32(res.val[3], a.val[2], b3.val[2]);
+
+        res.val[0] = vmlaq_f32(res.val[0], a.val[3], b0.val[3]);
+        res.val[1] = vmlaq_f32(res.val[1], a.val[3], b1.val[3]);
+        res.val[2] = vmlaq_f32(res.val[2], a.val[3], b2.val[3]);
+        res.val[3] = vmlaq_f32(res.val[3], a.val[3], b3.val[3]);
+
+        cur_d -= 16;
+        x += 16;
+        y0 += 16;
+        y1 += 16;
+        y2 += 16;
+        y3 += 16;
+    }
+    if (cur_d >= 8) {
+        float32x4x2_t a = vcvt2_f32_f16(vld2_f16((const __fp16*)x));
+        float32x4x2_t b0 = vcvt2_f32_f16(vld2_f16((const __fp16*)y0));
+        float32x4x2_t b1 = vcvt2_f32_f16(vld2_f16((const __fp16*)y1));
+        float32x4x2_t b2 = vcvt2_f32_f16(vld2_f16((const __fp16*)y2));
+        float32x4x2_t b3 = vcvt2_f32_f16(vld2_f16((const __fp16*)y3));
+        res.val[0] = vmlaq_f32(res.val[0], a.val[0], b0.val[0]);
+        res.val[1] = vmlaq_f32(res.val[1], a.val[0], b1.val[0]);
+        res.val[2] = vmlaq_f32(res.val[2], a.val[0], b2.val[0]);
+        res.val[3] = vmlaq_f32(res.val[3], a.val[0], b3.val[0]);
+
+        res.val[0] = vmlaq_f32(res.val[0], a.val[1], b0.val[1]);
+        res.val[1] = vmlaq_f32(res.val[1], a.val[1], b1.val[1]);
+        res.val[2] = vmlaq_f32(res.val[2], a.val[1], b2.val[1]);
+        res.val[3] = vmlaq_f32(res.val[3], a.val[1], b3.val[1]);
+
+        cur_d -= 8;
+        x += 8;
+        y0 += 8;
+        y1 += 8;
+        y2 += 8;
+        y3 += 8;
+    }
+    if (cur_d >= 4) {
+        float32x4_t a = vcvt_f32_f16(vld1_f16((const __fp16*)x));
+        float32x4_t b0 = vcvt_f32_f16(vld1_f16((const __fp16*)y0));
+        float32x4_t b1 = vcvt_f32_f16(vld1_f16((const __fp16*)y1));
+        float32x4_t b2 = vcvt_f32_f16(vld1_f16((const __fp16*)y2));
+        float32x4_t b3 = vcvt_f32_f16(vld1_f16((const __fp16*)y3));
+        res.val[0] = vmlaq_f32(res.val[0], a, b0);
+        res.val[1] = vmlaq_f32(res.val[1], a, b1);
+        res.val[2] = vmlaq_f32(res.val[2], a, b2);
+        res.val[3] = vmlaq_f32(res.val[3], a, b3);
+        cur_d -= 4;
+        x += 4;
+        y0 += 4;
+        y1 += 4;
+        y2 += 4;
+        y3 += 4;
+    }
+    if (cur_d >= 0) {
+        float16x4_t res_x = {0.0f, 0.0f, 0.0f, 0.0f};
+        float16x4_t res_y0 = {0.0f, 0.0f, 0.0f, 0.0f};
+        float16x4_t res_y1 = {0.0f, 0.0f, 0.0f, 0.0f};
+        float16x4_t res_y2 = {0.0f, 0.0f, 0.0f, 0.0f};
+        float16x4_t res_y3 = {0.0f, 0.0f, 0.0f, 0.0f};
+        switch (cur_d) {
+            case 3:
+                res_x = vld1_lane_f16((const __fp16*)x, res_x, 2);
+                res_y0 = vld1_lane_f16((const __fp16*)y0, res_y0, 2);
+                res_y1 = vld1_lane_f16((const __fp16*)y1, res_y1, 2);
+                res_y2 = vld1_lane_f16((const __fp16*)y2, res_y2, 2);
+                res_y3 = vld1_lane_f16((const __fp16*)y3, res_y3, 2);
+                x++;
+                y0++;
+                y1++;
+                y2++;
+                y3++;
+                cur_d--;
+            case 2:
+                res_x = vld1_lane_f16((const __fp16*)x, res_x, 1);
+                res_y0 = vld1_lane_f16((const __fp16*)y0, res_y0, 1);
+                res_y1 = vld1_lane_f16((const __fp16*)y1, res_y1, 1);
+                res_y2 = vld1_lane_f16((const __fp16*)y2, res_y2, 1);
+                res_y3 = vld1_lane_f16((const __fp16*)y3, res_y3, 1);
+                x++;
+                y0++;
+                y1++;
+                y2++;
+                y3++;
+                cur_d--;
+            case 1:
+                res_x = vld1_lane_f16((const __fp16*)x, res_x, 0);
+                res_y0 = vld1_lane_f16((const __fp16*)y0, res_y0, 0);
+                res_y1 = vld1_lane_f16((const __fp16*)y1, res_y1, 0);
+                res_y2 = vld1_lane_f16((const __fp16*)y2, res_y2, 0);
+                res_y3 = vld1_lane_f16((const __fp16*)y3, res_y3, 0);
+                x++;
+                y0++;
+                y1++;
+                y2++;
+                y3++;
+                cur_d--;
+        }
+        res.val[0] = vmlaq_f32(res.val[0], vcvt_f32_f16(res_x), vcvt_f32_f16(res_y0));
+        res.val[1] = vmlaq_f32(res.val[1], vcvt_f32_f16(res_x), vcvt_f32_f16(res_y1));
+        res.val[2] = vmlaq_f32(res.val[2], vcvt_f32_f16(res_x), vcvt_f32_f16(res_y2));
+        res.val[3] = vmlaq_f32(res.val[3], vcvt_f32_f16(res_x), vcvt_f32_f16(res_y3));
+    }
+    dis0 = vaddvq_f32(res.val[0]);
+    dis1 = vaddvq_f32(res.val[1]);
+    dis2 = vaddvq_f32(res.val[2]);
+    dis3 = vaddvq_f32(res.val[3]);
+    return;
+}
+
+void
+bf16_vec_inner_product_batch_4_neon(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                                    const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0,
+                                    float& dis1, float& dis2, float& dis3) {
+    float32x4x4_t res = {vdupq_n_f32(0.0f), vdupq_n_f32(0.0f), vdupq_n_f32(0.0f), vdupq_n_f32(0.0f)};
+    auto cur_d = d;
+    while (cur_d >= 16) {
+        float32x4x4_t a = vcvt4_f32_half(vld4_u16((const uint16_t*)x));
+        float32x4x4_t b0 = vcvt4_f32_half(vld4_u16((const uint16_t*)y0));
+        float32x4x4_t b1 = vcvt4_f32_half(vld4_u16((const uint16_t*)y1));
+        float32x4x4_t b2 = vcvt4_f32_half(vld4_u16((const uint16_t*)y2));
+        float32x4x4_t b3 = vcvt4_f32_half(vld4_u16((const uint16_t*)y3));
+
+        res.val[0] = vmlaq_f32(res.val[0], a.val[0], b0.val[0]);
+        res.val[1] = vmlaq_f32(res.val[1], a.val[0], b1.val[0]);
+        res.val[2] = vmlaq_f32(res.val[2], a.val[0], b2.val[0]);
+        res.val[3] = vmlaq_f32(res.val[3], a.val[0], b3.val[0]);
+
+        res.val[0] = vmlaq_f32(res.val[0], a.val[1], b0.val[1]);
+        res.val[1] = vmlaq_f32(res.val[1], a.val[1], b1.val[1]);
+        res.val[2] = vmlaq_f32(res.val[2], a.val[1], b2.val[1]);
+        res.val[3] = vmlaq_f32(res.val[3], a.val[1], b3.val[1]);
+
+        res.val[0] = vmlaq_f32(res.val[0], a.val[2], b0.val[2]);
+        res.val[1] = vmlaq_f32(res.val[1], a.val[2], b1.val[2]);
+        res.val[2] = vmlaq_f32(res.val[2], a.val[2], b2.val[2]);
+        res.val[3] = vmlaq_f32(res.val[3], a.val[2], b3.val[2]);
+
+        res.val[0] = vmlaq_f32(res.val[0], a.val[3], b0.val[3]);
+        res.val[1] = vmlaq_f32(res.val[1], a.val[3], b1.val[3]);
+        res.val[2] = vmlaq_f32(res.val[2], a.val[3], b2.val[3]);
+        res.val[3] = vmlaq_f32(res.val[3], a.val[3], b3.val[3]);
+
+        cur_d -= 16;
+        x += 16;
+        y0 += 16;
+        y1 += 16;
+        y2 += 16;
+        y3 += 16;
+    }
+    if (cur_d >= 8) {
+        float32x4x2_t a = vcvt2_f32_half(vld2_u16((const uint16_t*)x));
+        float32x4x2_t b0 = vcvt2_f32_half(vld2_u16((const uint16_t*)y0));
+        float32x4x2_t b1 = vcvt2_f32_half(vld2_u16((const uint16_t*)y1));
+        float32x4x2_t b2 = vcvt2_f32_half(vld2_u16((const uint16_t*)y2));
+        float32x4x2_t b3 = vcvt2_f32_half(vld2_u16((const uint16_t*)y3));
+        res.val[0] = vmlaq_f32(res.val[0], a.val[0], b0.val[0]);
+        res.val[1] = vmlaq_f32(res.val[1], a.val[0], b1.val[0]);
+        res.val[2] = vmlaq_f32(res.val[2], a.val[0], b2.val[0]);
+        res.val[3] = vmlaq_f32(res.val[3], a.val[0], b3.val[0]);
+
+        res.val[0] = vmlaq_f32(res.val[0], a.val[1], b0.val[1]);
+        res.val[1] = vmlaq_f32(res.val[1], a.val[1], b1.val[1]);
+        res.val[2] = vmlaq_f32(res.val[2], a.val[1], b2.val[1]);
+        res.val[3] = vmlaq_f32(res.val[3], a.val[1], b3.val[1]);
+
+        cur_d -= 8;
+        x += 8;
+        y0 += 8;
+        y1 += 8;
+        y2 += 8;
+        y3 += 8;
+    }
+    if (cur_d >= 4) {
+        float32x4_t a = vcvt_f32_half(vld1_u16((const uint16_t*)x));
+        float32x4_t b0 = vcvt_f32_half(vld1_u16((const uint16_t*)y0));
+        float32x4_t b1 = vcvt_f32_half(vld1_u16((const uint16_t*)y1));
+        float32x4_t b2 = vcvt_f32_half(vld1_u16((const uint16_t*)y2));
+        float32x4_t b3 = vcvt_f32_half(vld1_u16((const uint16_t*)y3));
+        res.val[0] = vmlaq_f32(res.val[0], a, b0);
+        res.val[1] = vmlaq_f32(res.val[1], a, b1);
+        res.val[2] = vmlaq_f32(res.val[2], a, b2);
+        res.val[3] = vmlaq_f32(res.val[3], a, b3);
+        cur_d -= 4;
+        x += 4;
+        y0 += 4;
+        y1 += 4;
+        y2 += 4;
+        y3 += 4;
+    }
+    if (cur_d >= 0) {
+        uint16x4_t res_x = vdup_n_u16(0);
+        uint16x4_t res_y0 = vdup_n_u16(0);
+        uint16x4_t res_y1 = vdup_n_u16(0);
+        uint16x4_t res_y2 = vdup_n_u16(0);
+        uint16x4_t res_y3 = vdup_n_u16(0);
+        switch (cur_d) {
+            case 3:
+                res_x = vld1_lane_u16((const uint16_t*)x, res_x, 2);
+                res_y0 = vld1_lane_u16((const uint16_t*)y0, res_y0, 2);
+                res_y1 = vld1_lane_u16((const uint16_t*)y1, res_y1, 2);
+                res_y2 = vld1_lane_u16((const uint16_t*)y2, res_y2, 2);
+                res_y3 = vld1_lane_u16((const uint16_t*)y3, res_y3, 2);
+                x++;
+                y0++;
+                y1++;
+                y2++;
+                y3++;
+                cur_d--;
+            case 2:
+                res_x = vld1_lane_u16((const uint16_t*)x, res_x, 1);
+                res_y0 = vld1_lane_u16((const uint16_t*)y0, res_y0, 1);
+                res_y1 = vld1_lane_u16((const uint16_t*)y1, res_y1, 1);
+                res_y2 = vld1_lane_u16((const uint16_t*)y2, res_y2, 1);
+                res_y3 = vld1_lane_u16((const uint16_t*)y3, res_y3, 1);
+                x++;
+                y0++;
+                y1++;
+                y2++;
+                y3++;
+                cur_d--;
+            case 1:
+                res_x = vld1_lane_u16((const uint16_t*)x, res_x, 0);
+                res_y0 = vld1_lane_u16((const uint16_t*)y0, res_y0, 0);
+                res_y1 = vld1_lane_u16((const uint16_t*)y1, res_y1, 0);
+                res_y2 = vld1_lane_u16((const uint16_t*)y2, res_y2, 0);
+                res_y3 = vld1_lane_u16((const uint16_t*)y3, res_y3, 0);
+                x++;
+                y0++;
+                y1++;
+                y2++;
+                y3++;
+                cur_d--;
+        }
+        res.val[0] = vmlaq_f32(res.val[0], vcvt_f32_half(res_x), vcvt_f32_half(res_y0));
+        res.val[1] = vmlaq_f32(res.val[1], vcvt_f32_half(res_x), vcvt_f32_half(res_y1));
+        res.val[2] = vmlaq_f32(res.val[2], vcvt_f32_half(res_x), vcvt_f32_half(res_y2));
+        res.val[3] = vmlaq_f32(res.val[3], vcvt_f32_half(res_x), vcvt_f32_half(res_y3));
+    }
+    dis0 = vaddvq_f32(res.val[0]);
+    dis1 = vaddvq_f32(res.val[1]);
+    dis2 = vaddvq_f32(res.val[2]);
+    dis3 = vaddvq_f32(res.val[3]);
+    return;
+}
+
+void
+fp16_vec_L2sqr_batch_4_neon(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                            const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0,
+                            float& dis1, float& dis2, float& dis3) {
+    float32x4x4_t res = {vdupq_n_f32(0.0f), vdupq_n_f32(0.0f), vdupq_n_f32(0.0f), vdupq_n_f32(0.0f)};
+    auto cur_d = d;
+    while (cur_d >= 16) {
+        float32x4x4_t a = vcvt4_f32_f16(vld4_f16((const __fp16*)x));
+        float32x4x4_t b0 = vcvt4_f32_f16(vld4_f16((const __fp16*)y0));
+        float32x4x4_t b1 = vcvt4_f32_f16(vld4_f16((const __fp16*)y1));
+        float32x4x4_t b2 = vcvt4_f32_f16(vld4_f16((const __fp16*)y2));
+        float32x4x4_t b3 = vcvt4_f32_f16(vld4_f16((const __fp16*)y3));
+
+        b0.val[0] = vsubq_f32(a.val[0], b0.val[0]);
+        b0.val[1] = vsubq_f32(a.val[1], b0.val[1]);
+        b0.val[2] = vsubq_f32(a.val[2], b0.val[2]);
+        b0.val[3] = vsubq_f32(a.val[3], b0.val[3]);
+
+        b1.val[0] = vsubq_f32(a.val[0], b1.val[0]);
+        b1.val[1] = vsubq_f32(a.val[1], b1.val[1]);
+        b1.val[2] = vsubq_f32(a.val[2], b1.val[2]);
+        b1.val[3] = vsubq_f32(a.val[3], b1.val[3]);
+
+        b2.val[0] = vsubq_f32(a.val[0], b2.val[0]);
+        b2.val[1] = vsubq_f32(a.val[1], b2.val[1]);
+        b2.val[2] = vsubq_f32(a.val[2], b2.val[2]);
+        b2.val[3] = vsubq_f32(a.val[3], b2.val[3]);
+
+        b3.val[0] = vsubq_f32(a.val[0], b3.val[0]);
+        b3.val[1] = vsubq_f32(a.val[1], b3.val[1]);
+        b3.val[2] = vsubq_f32(a.val[2], b3.val[2]);
+        b3.val[3] = vsubq_f32(a.val[3], b3.val[3]);
+
+        res.val[0] = vaddq_f32(vmulq_f32(b0.val[0], b0.val[0]), res.val[0]);
+        res.val[1] = vaddq_f32(vmulq_f32(b1.val[0], b1.val[0]), res.val[1]);
+        res.val[2] = vaddq_f32(vmulq_f32(b2.val[0], b2.val[0]), res.val[2]);
+        res.val[3] = vaddq_f32(vmulq_f32(b3.val[0], b3.val[0]), res.val[3]);
+
+        res.val[0] = vaddq_f32(vmulq_f32(b0.val[1], b0.val[1]), res.val[0]);
+        res.val[1] = vaddq_f32(vmulq_f32(b1.val[1], b1.val[1]), res.val[1]);
+        res.val[2] = vaddq_f32(vmulq_f32(b2.val[1], b2.val[1]), res.val[2]);
+        res.val[3] = vaddq_f32(vmulq_f32(b3.val[1], b3.val[1]), res.val[3]);
+
+        res.val[0] = vaddq_f32(vmulq_f32(b0.val[2], b0.val[2]), res.val[0]);
+        res.val[1] = vaddq_f32(vmulq_f32(b1.val[2], b1.val[2]), res.val[1]);
+        res.val[2] = vaddq_f32(vmulq_f32(b2.val[2], b2.val[2]), res.val[2]);
+        res.val[3] = vaddq_f32(vmulq_f32(b3.val[2], b3.val[2]), res.val[3]);
+
+        res.val[0] = vaddq_f32(vmulq_f32(b0.val[3], b0.val[3]), res.val[0]);
+        res.val[1] = vaddq_f32(vmulq_f32(b1.val[3], b1.val[3]), res.val[1]);
+        res.val[2] = vaddq_f32(vmulq_f32(b2.val[3], b2.val[3]), res.val[2]);
+        res.val[3] = vaddq_f32(vmulq_f32(b3.val[3], b3.val[3]), res.val[3]);
+
+        cur_d -= 16;
+        x += 16;
+        y0 += 16;
+        y1 += 16;
+        y2 += 16;
+        y3 += 16;
+    }
+    if (cur_d >= 8) {
+        float32x4x2_t a = vcvt2_f32_f16(vld2_f16((const __fp16*)x));
+        float32x4x2_t b0 = vcvt2_f32_f16(vld2_f16((const __fp16*)y0));
+        float32x4x2_t b1 = vcvt2_f32_f16(vld2_f16((const __fp16*)y1));
+        float32x4x2_t b2 = vcvt2_f32_f16(vld2_f16((const __fp16*)y2));
+        float32x4x2_t b3 = vcvt2_f32_f16(vld2_f16((const __fp16*)y3));
+        b0.val[0] = vsubq_f32(a.val[0], b0.val[0]);
+        b0.val[1] = vsubq_f32(a.val[1], b0.val[1]);
+
+        b1.val[0] = vsubq_f32(a.val[0], b1.val[0]);
+        b1.val[1] = vsubq_f32(a.val[1], b1.val[1]);
+
+        b2.val[0] = vsubq_f32(a.val[0], b2.val[0]);
+        b2.val[1] = vsubq_f32(a.val[1], b2.val[1]);
+
+        b3.val[0] = vsubq_f32(a.val[0], b3.val[0]);
+        b3.val[1] = vsubq_f32(a.val[1], b3.val[1]);
+
+        res.val[0] = vaddq_f32(vmulq_f32(b0.val[0], b0.val[0]), res.val[0]);
+        res.val[1] = vaddq_f32(vmulq_f32(b1.val[0], b1.val[0]), res.val[1]);
+        res.val[2] = vaddq_f32(vmulq_f32(b2.val[0], b2.val[0]), res.val[2]);
+        res.val[3] = vaddq_f32(vmulq_f32(b3.val[0], b3.val[0]), res.val[3]);
+
+        res.val[0] = vaddq_f32(vmulq_f32(b0.val[1], b0.val[1]), res.val[0]);
+        res.val[1] = vaddq_f32(vmulq_f32(b1.val[1], b1.val[1]), res.val[1]);
+        res.val[2] = vaddq_f32(vmulq_f32(b2.val[1], b2.val[1]), res.val[2]);
+        res.val[3] = vaddq_f32(vmulq_f32(b3.val[1], b3.val[1]), res.val[3]);
+
+        cur_d -= 8;
+        x += 8;
+        y0 += 8;
+        y1 += 8;
+        y2 += 8;
+        y3 += 8;
+    }
+    if (cur_d >= 4) {
+        float32x4_t a = vcvt_f32_f16(vld1_f16((const __fp16*)x));
+        float32x4_t b0 = vcvt_f32_f16(vld1_f16((const __fp16*)y0));
+        float32x4_t b1 = vcvt_f32_f16(vld1_f16((const __fp16*)y1));
+        float32x4_t b2 = vcvt_f32_f16(vld1_f16((const __fp16*)y2));
+        float32x4_t b3 = vcvt_f32_f16(vld1_f16((const __fp16*)y3));
+
+        b0 = vsubq_f32(a, b0);
+        b1 = vsubq_f32(a, b1);
+        b2 = vsubq_f32(a, b2);
+        b3 = vsubq_f32(a, b3);
+
+        res.val[0] = vaddq_f32(vmulq_f32(b0, b0), res.val[0]);
+        res.val[1] = vaddq_f32(vmulq_f32(b1, b1), res.val[1]);
+        res.val[2] = vaddq_f32(vmulq_f32(b2, b2), res.val[2]);
+        res.val[3] = vaddq_f32(vmulq_f32(b3, b3), res.val[3]);
+        cur_d -= 4;
+        x += 4;
+        y0 += 4;
+        y1 += 4;
+        y2 += 4;
+        y3 += 4;
+    }
+    if (cur_d >= 0) {
+        float16x4_t res_x = {0.0f, 0.0f, 0.0f, 0.0f};
+        float16x4_t res_y0 = {0.0f, 0.0f, 0.0f, 0.0f};
+        float16x4_t res_y1 = {0.0f, 0.0f, 0.0f, 0.0f};
+        float16x4_t res_y2 = {0.0f, 0.0f, 0.0f, 0.0f};
+        float16x4_t res_y3 = {0.0f, 0.0f, 0.0f, 0.0f};
+        switch (cur_d) {
+            case 3:
+                res_x = vld1_lane_f16((const __fp16*)x, res_x, 2);
+                res_y0 = vld1_lane_f16((const __fp16*)y0, res_y0, 2);
+                res_y1 = vld1_lane_f16((const __fp16*)y1, res_y1, 2);
+                res_y2 = vld1_lane_f16((const __fp16*)y2, res_y2, 2);
+                res_y3 = vld1_lane_f16((const __fp16*)y3, res_y3, 2);
+                x++;
+                y0++;
+                y1++;
+                y2++;
+                y3++;
+                cur_d--;
+            case 2:
+                res_x = vld1_lane_f16((const __fp16*)x, res_x, 1);
+                res_y0 = vld1_lane_f16((const __fp16*)y0, res_y0, 1);
+                res_y1 = vld1_lane_f16((const __fp16*)y1, res_y1, 1);
+                res_y2 = vld1_lane_f16((const __fp16*)y2, res_y2, 1);
+                res_y3 = vld1_lane_f16((const __fp16*)y3, res_y3, 1);
+                x++;
+                y0++;
+                y1++;
+                y2++;
+                y3++;
+                cur_d--;
+            case 1:
+                res_x = vld1_lane_f16((const __fp16*)x, res_x, 0);
+                res_y0 = vld1_lane_f16((const __fp16*)y0, res_y0, 0);
+                res_y1 = vld1_lane_f16((const __fp16*)y1, res_y1, 0);
+                res_y2 = vld1_lane_f16((const __fp16*)y2, res_y2, 0);
+                res_y3 = vld1_lane_f16((const __fp16*)y3, res_y3, 0);
+                x++;
+                y0++;
+                y1++;
+                y2++;
+                y3++;
+                cur_d--;
+        }
+        float32x4_t diff0 = vsubq_f32(vcvt_f32_f16(res_x), vcvt_f32_f16(res_y0));
+        float32x4_t diff1 = vsubq_f32(vcvt_f32_f16(res_x), vcvt_f32_f16(res_y1));
+        float32x4_t diff2 = vsubq_f32(vcvt_f32_f16(res_x), vcvt_f32_f16(res_y2));
+        float32x4_t diff3 = vsubq_f32(vcvt_f32_f16(res_x), vcvt_f32_f16(res_y3));
+        res.val[0] = vaddq_f32(vmulq_f32(diff0, diff0), res.val[0]);
+        res.val[1] = vaddq_f32(vmulq_f32(diff1, diff1), res.val[1]);
+        res.val[2] = vaddq_f32(vmulq_f32(diff2, diff2), res.val[2]);
+        res.val[3] = vaddq_f32(vmulq_f32(diff3, diff3), res.val[3]);
+    }
+    dis0 = vaddvq_f32(res.val[0]);
+    dis1 = vaddvq_f32(res.val[1]);
+    dis2 = vaddvq_f32(res.val[2]);
+    dis3 = vaddvq_f32(res.val[3]);
+    return;
+}
+
+void
+bf16_vec_L2sqr_batch_4_neon(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                            const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0,
+                            float& dis1, float& dis2, float& dis3) {
+    float32x4x4_t res = {vdupq_n_f32(0.0f), vdupq_n_f32(0.0f), vdupq_n_f32(0.0f), vdupq_n_f32(0.0f)};
+    auto cur_d = d;
+    while (cur_d >= 16) {
+        float32x4x4_t a = vcvt4_f32_half(vld4_u16((const uint16_t*)x));
+        float32x4x4_t b0 = vcvt4_f32_half(vld4_u16((const uint16_t*)y0));
+        float32x4x4_t b1 = vcvt4_f32_half(vld4_u16((const uint16_t*)y1));
+        float32x4x4_t b2 = vcvt4_f32_half(vld4_u16((const uint16_t*)y2));
+        float32x4x4_t b3 = vcvt4_f32_half(vld4_u16((const uint16_t*)y3));
+
+        b0.val[0] = vsubq_f32(a.val[0], b0.val[0]);
+        b0.val[1] = vsubq_f32(a.val[1], b0.val[1]);
+        b0.val[2] = vsubq_f32(a.val[2], b0.val[2]);
+        b0.val[3] = vsubq_f32(a.val[3], b0.val[3]);
+
+        b1.val[0] = vsubq_f32(a.val[0], b1.val[0]);
+        b1.val[1] = vsubq_f32(a.val[1], b1.val[1]);
+        b1.val[2] = vsubq_f32(a.val[2], b1.val[2]);
+        b1.val[3] = vsubq_f32(a.val[3], b1.val[3]);
+
+        b2.val[0] = vsubq_f32(a.val[0], b2.val[0]);
+        b2.val[1] = vsubq_f32(a.val[1], b2.val[1]);
+        b2.val[2] = vsubq_f32(a.val[2], b2.val[2]);
+        b2.val[3] = vsubq_f32(a.val[3], b2.val[3]);
+
+        b3.val[0] = vsubq_f32(a.val[0], b3.val[0]);
+        b3.val[1] = vsubq_f32(a.val[1], b3.val[1]);
+        b3.val[2] = vsubq_f32(a.val[2], b3.val[2]);
+        b3.val[3] = vsubq_f32(a.val[3], b3.val[3]);
+
+        res.val[0] = vmlaq_f32(res.val[0], b0.val[0], b0.val[0]);
+        res.val[1] = vmlaq_f32(res.val[1], b1.val[0], b1.val[0]);
+        res.val[2] = vmlaq_f32(res.val[2], b2.val[0], b2.val[0]);
+        res.val[3] = vmlaq_f32(res.val[3], b3.val[0], b3.val[0]);
+
+        res.val[0] = vmlaq_f32(res.val[0], b0.val[1], b0.val[1]);
+        res.val[1] = vmlaq_f32(res.val[1], b1.val[1], b1.val[1]);
+        res.val[2] = vmlaq_f32(res.val[2], b2.val[1], b2.val[1]);
+        res.val[3] = vmlaq_f32(res.val[3], b3.val[1], b3.val[1]);
+
+        res.val[0] = vmlaq_f32(res.val[0], b0.val[2], b0.val[2]);
+        res.val[1] = vmlaq_f32(res.val[1], b1.val[2], b1.val[2]);
+        res.val[2] = vmlaq_f32(res.val[2], b2.val[2], b2.val[2]);
+        res.val[3] = vmlaq_f32(res.val[3], b3.val[2], b3.val[2]);
+
+        res.val[0] = vmlaq_f32(res.val[0], b0.val[3], b0.val[3]);
+        res.val[1] = vmlaq_f32(res.val[1], b1.val[3], b1.val[3]);
+        res.val[2] = vmlaq_f32(res.val[2], b2.val[3], b2.val[3]);
+        res.val[3] = vmlaq_f32(res.val[3], b3.val[3], b3.val[3]);
+
+        cur_d -= 16;
+        x += 16;
+        y0 += 16;
+        y1 += 16;
+        y2 += 16;
+        y3 += 16;
+    }
+    if (cur_d >= 8) {
+        float32x4x2_t a = vcvt2_f32_half(vld2_u16((const uint16_t*)x));
+        float32x4x2_t b0 = vcvt2_f32_half(vld2_u16((const uint16_t*)y0));
+        float32x4x2_t b1 = vcvt2_f32_half(vld2_u16((const uint16_t*)y1));
+        float32x4x2_t b2 = vcvt2_f32_half(vld2_u16((const uint16_t*)y2));
+        float32x4x2_t b3 = vcvt2_f32_half(vld2_u16((const uint16_t*)y3));
+
+        b0.val[0] = vsubq_f32(a.val[0], b0.val[0]);
+        b0.val[1] = vsubq_f32(a.val[1], b0.val[1]);
+
+        b1.val[0] = vsubq_f32(a.val[0], b1.val[0]);
+        b1.val[1] = vsubq_f32(a.val[1], b1.val[1]);
+
+        b2.val[0] = vsubq_f32(a.val[0], b2.val[0]);
+        b2.val[1] = vsubq_f32(a.val[1], b2.val[1]);
+
+        b3.val[0] = vsubq_f32(a.val[0], b3.val[0]);
+        b3.val[1] = vsubq_f32(a.val[1], b3.val[1]);
+
+        res.val[0] = vmlaq_f32(res.val[0], b0.val[0], b0.val[0]);
+        res.val[1] = vmlaq_f32(res.val[1], b1.val[0], b1.val[0]);
+        res.val[2] = vmlaq_f32(res.val[2], b2.val[0], b2.val[0]);
+        res.val[3] = vmlaq_f32(res.val[3], b3.val[0], b3.val[0]);
+
+        res.val[0] = vmlaq_f32(res.val[0], b0.val[1], b0.val[1]);
+        res.val[1] = vmlaq_f32(res.val[1], b1.val[1], b1.val[1]);
+        res.val[2] = vmlaq_f32(res.val[2], b2.val[1], b2.val[1]);
+        res.val[3] = vmlaq_f32(res.val[3], b3.val[1], b3.val[1]);
+
+        cur_d -= 8;
+        x += 8;
+        y0 += 8;
+        y1 += 8;
+        y2 += 8;
+        y3 += 8;
+    }
+    if (cur_d >= 4) {
+        float32x4_t a = vcvt_f32_half(vld1_u16((const uint16_t*)x));
+        float32x4_t b0 = vcvt_f32_half(vld1_u16((const uint16_t*)y0));
+        float32x4_t b1 = vcvt_f32_half(vld1_u16((const uint16_t*)y1));
+        float32x4_t b2 = vcvt_f32_half(vld1_u16((const uint16_t*)y2));
+        float32x4_t b3 = vcvt_f32_half(vld1_u16((const uint16_t*)y3));
+        b0 = vsubq_f32(a, b0);
+        b1 = vsubq_f32(a, b1);
+        b2 = vsubq_f32(a, b2);
+        b3 = vsubq_f32(a, b3);
+
+        res.val[0] = vmlaq_f32(res.val[0], b0, b0);
+        res.val[1] = vmlaq_f32(res.val[1], b1, b1);
+        res.val[2] = vmlaq_f32(res.val[2], b2, b2);
+        res.val[3] = vmlaq_f32(res.val[3], b3, b3);
+        cur_d -= 4;
+        x += 4;
+        y0 += 4;
+        y1 += 4;
+        y2 += 4;
+        y3 += 4;
+    }
+    if (cur_d >= 0) {
+        uint16x4_t res_x = vdup_n_u16(0);
+        uint16x4_t res_y0 = vdup_n_u16(0);
+        uint16x4_t res_y1 = vdup_n_u16(0);
+        uint16x4_t res_y2 = vdup_n_u16(0);
+        uint16x4_t res_y3 = vdup_n_u16(0);
+        switch (cur_d) {
+            case 3:
+                res_x = vld1_lane_u16((const uint16_t*)x, res_x, 2);
+                res_y0 = vld1_lane_u16((const uint16_t*)y0, res_y0, 2);
+                res_y1 = vld1_lane_u16((const uint16_t*)y1, res_y1, 2);
+                res_y2 = vld1_lane_u16((const uint16_t*)y2, res_y2, 2);
+                res_y3 = vld1_lane_u16((const uint16_t*)y3, res_y3, 2);
+                x++;
+                y0++;
+                y1++;
+                y2++;
+                y3++;
+                cur_d--;
+            case 2:
+                res_x = vld1_lane_u16((const uint16_t*)x, res_x, 1);
+                res_y0 = vld1_lane_u16((const uint16_t*)y0, res_y0, 1);
+                res_y1 = vld1_lane_u16((const uint16_t*)y1, res_y1, 1);
+                res_y2 = vld1_lane_u16((const uint16_t*)y2, res_y2, 1);
+                res_y3 = vld1_lane_u16((const uint16_t*)y3, res_y3, 1);
+                x++;
+                y0++;
+                y1++;
+                y2++;
+                y3++;
+                cur_d--;
+            case 1:
+                res_x = vld1_lane_u16((const uint16_t*)x, res_x, 0);
+                res_y0 = vld1_lane_u16((const uint16_t*)y0, res_y0, 0);
+                res_y1 = vld1_lane_u16((const uint16_t*)y1, res_y1, 0);
+                res_y2 = vld1_lane_u16((const uint16_t*)y2, res_y2, 0);
+                res_y3 = vld1_lane_u16((const uint16_t*)y3, res_y3, 0);
+                x++;
+                y0++;
+                y1++;
+                y2++;
+                y3++;
+                cur_d--;
+        }
+        float32x4_t diff0 = vsubq_f32(vcvt_f32_half(res_x), vcvt_f32_half(res_y0));
+        float32x4_t diff1 = vsubq_f32(vcvt_f32_half(res_x), vcvt_f32_half(res_y1));
+        float32x4_t diff2 = vsubq_f32(vcvt_f32_half(res_x), vcvt_f32_half(res_y2));
+        float32x4_t diff3 = vsubq_f32(vcvt_f32_half(res_x), vcvt_f32_half(res_y3));
+        res.val[0] = vmlaq_f32(res.val[0], diff0, diff0);
+        res.val[1] = vmlaq_f32(res.val[1], diff1, diff1);
+        res.val[2] = vmlaq_f32(res.val[2], diff2, diff2);
+        res.val[3] = vmlaq_f32(res.val[3], diff3, diff3);
+    }
+    dis0 = vaddvq_f32(res.val[0]);
+    dis1 = vaddvq_f32(res.val[1]);
+    dis2 = vaddvq_f32(res.val[2]);
+    dis3 = vaddvq_f32(res.val[3]);
+    return;
+}
 }  // namespace faiss
 #endif

--- a/src/simd/distances_neon.h
+++ b/src/simd/distances_neon.h
@@ -92,6 +92,16 @@ fvec_inner_product_batch_4_neon_bf16_patch(const float* x, const float* y0, cons
                                            const float* y3, const size_t dim, float& dis0, float& dis1, float& dis2,
                                            float& dis3);
 
+void
+fp16_vec_inner_product_batch_4_neon(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                                    const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0,
+                                    float& dis1, float& dis2, float& dis3);
+
+void
+bf16_vec_inner_product_batch_4_neon(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                                    const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0,
+                                    float& dis1, float& dis2, float& dis3);
+
 /// Special version of L2sqr that computes 4 distances
 /// between x and yi, which is performance oriented.
 void
@@ -101,6 +111,16 @@ fvec_L2sqr_batch_4_neon(const float* x, const float* y0, const float* y1, const 
 void
 fvec_L2sqr_batch_4_neon_bf16_patch(const float* x, const float* y0, const float* y1, const float* y2, const float* y3,
                                    const size_t dim, float& dis0, float& dis1, float& dis2, float& dis3);
+
+void
+fp16_vec_L2sqr_batch_4_neon(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                            const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0,
+                            float& dis1, float& dis2, float& dis3);
+
+void
+bf16_vec_L2sqr_batch_4_neon(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                            const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0,
+                            float& dis1, float& dis2, float& dis3);
 
 }  // namespace faiss
 

--- a/src/simd/distances_ref.cc
+++ b/src/simd/distances_ref.cc
@@ -343,6 +343,102 @@ fvec_L2sqr_batch_4_ref_bf16_patch(const float* x, const float* y0, const float* 
     dis3 = d3;
 }
 
+void
+fp16_vec_inner_product_batch_4_ref(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                                   const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3) {
+    float d0 = 0;
+    float d1 = 0;
+    float d2 = 0;
+    float d3 = 0;
+    for (size_t i = 0; i < d; ++i) {
+        auto x_i = (float)x[i];
+        d0 += x_i * (float)y0[i];
+        d1 += x_i * (float)y1[i];
+        d2 += x_i * (float)y2[i];
+        d3 += x_i * (float)y3[i];
+    }
+
+    dis0 = d0;
+    dis1 = d1;
+    dis2 = d2;
+    dis3 = d3;
+}
+
+void
+bf16_vec_inner_product_batch_4_ref(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                                   const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3) {
+    float d0 = 0;
+    float d1 = 0;
+    float d2 = 0;
+    float d3 = 0;
+    for (size_t i = 0; i < d; ++i) {
+        auto x_i = (float)x[i];
+        d0 += x_i * (float)y0[i];
+        d1 += x_i * (float)y1[i];
+        d2 += x_i * (float)y2[i];
+        d3 += x_i * (float)y3[i];
+    }
+
+    dis0 = d0;
+    dis1 = d1;
+    dis2 = d2;
+    dis3 = d3;
+}
+
+void
+fp16_vec_L2sqr_batch_4_ref(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                           const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3) {
+    float d0 = 0;
+    float d1 = 0;
+    float d2 = 0;
+    float d3 = 0;
+    for (size_t i = 0; i < d; ++i) {
+        auto x_i = (float)x[i];
+        const float q0 = x_i - (float)y0[i];
+        const float q1 = x_i - (float)y1[i];
+        const float q2 = x_i - (float)y2[i];
+        const float q3 = x_i - (float)y3[i];
+        d0 += q0 * q0;
+        d1 += q1 * q1;
+        d2 += q2 * q2;
+        d3 += q3 * q3;
+    }
+
+    dis0 = d0;
+    dis1 = d1;
+    dis2 = d2;
+    dis3 = d3;
+}
+
+void
+bf16_vec_L2sqr_batch_4_ref(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                           const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3) {
+    float d0 = 0;
+    float d1 = 0;
+    float d2 = 0;
+    float d3 = 0;
+    for (size_t i = 0; i < d; ++i) {
+        auto x_i = (float)x[i];
+        const float q0 = x_i - (float)y0[i];
+        const float q1 = x_i - (float)y1[i];
+        const float q2 = x_i - (float)y2[i];
+        const float q3 = x_i - (float)y3[i];
+        d0 += q0 * q0;
+        d1 += q1 * q1;
+        d2 += q2 * q2;
+        d3 += q3 * q3;
+    }
+
+    dis0 = d0;
+    dis1 = d1;
+    dis2 = d2;
+    dis3 = d3;
+}
+
 int32_t
 ivec_inner_product_ref(const int8_t* x, const int8_t* y, size_t d) {
     size_t i;

--- a/src/simd/distances_ref.h
+++ b/src/simd/distances_ref.h
@@ -97,6 +97,16 @@ fvec_inner_product_batch_4_ref_bf16_patch(const float* x, const float* y0, const
                                           const float* y3, const size_t d, float& dis0, float& dis1, float& dis2,
                                           float& dis3);
 
+void
+fp16_vec_inner_product_batch_4_ref(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                                   const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3);
+
+void
+bf16_vec_inner_product_batch_4_ref(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                                   const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3);
+
 /// Special version of L2sqr that computes 4 distances
 /// between x and yi, which is performance oriented.
 void
@@ -106,6 +116,16 @@ fvec_L2sqr_batch_4_ref(const float* x, const float* y0, const float* y1, const f
 void
 fvec_L2sqr_batch_4_ref_bf16_patch(const float* x, const float* y0, const float* y1, const float* y2, const float* y3,
                                   const size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
+
+void
+fp16_vec_L2sqr_batch_4_ref(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                           const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3);
+
+void
+bf16_vec_L2sqr_batch_4_ref(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                           const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3);
 
 int32_t
 ivec_inner_product_ref(const int8_t* x, const int8_t* y, size_t d);

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -75,6 +75,11 @@ decltype(bf16_vec_inner_product) bf16_vec_inner_product = bf16_vec_inner_product
 decltype(fp16_vec_norm_L2sqr) fp16_vec_norm_L2sqr = fp16_vec_norm_L2sqr_ref;
 decltype(bf16_vec_norm_L2sqr) bf16_vec_norm_L2sqr = bf16_vec_norm_L2sqr_ref;
 
+decltype(fp16_vec_inner_product_batch_4) fp16_vec_inner_product_batch_4 = fp16_vec_inner_product_batch_4_ref;
+decltype(bf16_vec_inner_product_batch_4) bf16_vec_inner_product_batch_4 = bf16_vec_inner_product_batch_4_ref;
+decltype(fp16_vec_L2sqr_batch_4) fp16_vec_L2sqr_batch_4 = fp16_vec_L2sqr_batch_4_ref;
+decltype(bf16_vec_L2sqr_batch_4) bf16_vec_L2sqr_batch_4 = bf16_vec_L2sqr_batch_4_ref;
+
 #if defined(__x86_64__)
 bool
 cpu_support_avx512() {
@@ -205,6 +210,11 @@ fvec_hook(std::string& simd_type) {
         bf16_vec_L2sqr = bf16_vec_L2sqr_avx512;
         bf16_vec_norm_L2sqr = bf16_vec_norm_L2sqr_avx512;
 
+        fp16_vec_inner_product_batch_4 = fp16_vec_inner_product_batch_4_avx512;
+        bf16_vec_inner_product_batch_4 = bf16_vec_inner_product_batch_4_avx512;
+        fp16_vec_L2sqr_batch_4 = fp16_vec_L2sqr_batch_4_avx512;
+        bf16_vec_L2sqr_batch_4 = bf16_vec_L2sqr_batch_4_avx512;
+
         simd_type = "AVX512";
         support_pq_fast_scan = true;
     } else if (use_avx2 && cpu_support_avx2()) {
@@ -232,6 +242,11 @@ fvec_hook(std::string& simd_type) {
         bf16_vec_inner_product = bf16_vec_inner_product_avx;
         bf16_vec_L2sqr = bf16_vec_L2sqr_avx;
         bf16_vec_norm_L2sqr = bf16_vec_norm_L2sqr_avx;
+
+        fp16_vec_inner_product_batch_4 = fp16_vec_inner_product_batch_4_avx;
+        bf16_vec_inner_product_batch_4 = bf16_vec_inner_product_batch_4_avx;
+        fp16_vec_L2sqr_batch_4 = fp16_vec_L2sqr_batch_4_avx;
+        bf16_vec_L2sqr_batch_4 = bf16_vec_L2sqr_batch_4_avx;
 
         simd_type = "AVX2";
         support_pq_fast_scan = true;
@@ -261,6 +276,11 @@ fvec_hook(std::string& simd_type) {
         bf16_vec_L2sqr = bf16_vec_L2sqr_sse;
         bf16_vec_norm_L2sqr = bf16_vec_norm_L2sqr_sse;
 
+        fp16_vec_inner_product_batch_4 = fp16_vec_inner_product_batch_4_ref;
+        bf16_vec_inner_product_batch_4 = bf16_vec_inner_product_batch_4_ref;
+        fp16_vec_L2sqr_batch_4 = fp16_vec_L2sqr_batch_4_ref;
+        bf16_vec_L2sqr_batch_4 = bf16_vec_L2sqr_batch_4_ref;
+
         simd_type = "SSE4_2";
         support_pq_fast_scan = false;
     } else {
@@ -288,6 +308,11 @@ fvec_hook(std::string& simd_type) {
         bf16_vec_inner_product = bf16_vec_inner_product_ref;
         bf16_vec_L2sqr = bf16_vec_L2sqr_ref;
         bf16_vec_norm_L2sqr = bf16_vec_norm_L2sqr_ref;
+
+        fp16_vec_inner_product_batch_4 = fp16_vec_inner_product_batch_4_ref;
+        bf16_vec_inner_product_batch_4 = bf16_vec_inner_product_batch_4_ref;
+        fp16_vec_L2sqr_batch_4 = fp16_vec_L2sqr_batch_4_ref;
+        bf16_vec_L2sqr_batch_4 = bf16_vec_L2sqr_batch_4_ref;
 
         simd_type = "GENERIC";
         support_pq_fast_scan = false;
@@ -319,6 +344,11 @@ fvec_hook(std::string& simd_type) {
 
     fvec_inner_product_batch_4 = fvec_inner_product_batch_4_neon;
     fvec_L2sqr_batch_4 = fvec_L2sqr_batch_4_neon;
+
+    fp16_vec_inner_product_batch_4 = fp16_vec_inner_product_batch_4_neon;
+    bf16_vec_inner_product_batch_4 = bf16_vec_inner_product_batch_4_neon;
+    fp16_vec_L2sqr_batch_4 = fp16_vec_L2sqr_batch_4_neon;
+    bf16_vec_L2sqr_batch_4 = bf16_vec_L2sqr_batch_4_neon;
 
     simd_type = "NEON";
     support_pq_fast_scan = true;

--- a/src/simd/hook.h
+++ b/src/simd/hook.h
@@ -78,11 +78,27 @@ extern int (*fvec_madd_and_argmin)(size_t, const float*, float, const float*, fl
 extern void (*fvec_inner_product_batch_4)(const float*, const float*, const float*, const float*, const float*,
                                           const size_t, float&, float&, float&, float&);
 
+extern void (*fp16_vec_inner_product_batch_4)(const knowhere::fp16*, const knowhere::fp16*, const knowhere::fp16*,
+                                              const knowhere::fp16*, const knowhere::fp16*, const size_t, float&,
+                                              float&, float&, float&);
+
+extern void (*bf16_vec_inner_product_batch_4)(const knowhere::bf16*, const knowhere::bf16*, const knowhere::bf16*,
+                                              const knowhere::bf16*, const knowhere::bf16*, const size_t, float&,
+                                              float&, float&, float&);
+
 /// Special version of L2sqr that computes 4 distances
 /// between x and yi, which is performance oriented.
 /// todo aguzhva: bring non-ref versions
 extern void (*fvec_L2sqr_batch_4)(const float*, const float*, const float*, const float*, const float*, const size_t,
                                   float&, float&, float&, float&);
+
+extern void (*fp16_vec_L2sqr_batch_4)(const knowhere::fp16*, const knowhere::fp16*, const knowhere::fp16*,
+                                      const knowhere::fp16*, const knowhere::fp16*, const size_t, float&, float&,
+                                      float&, float&);
+
+extern void (*bf16_vec_L2sqr_batch_4)(const knowhere::bf16*, const knowhere::bf16*, const knowhere::bf16*,
+                                      const knowhere::bf16*, const knowhere::bf16*, const size_t, float&, float&,
+                                      float&, float&);
 
 extern int32_t (*ivec_inner_product)(const int8_t*, const int8_t*, size_t);
 

--- a/tests/ut/utils.h
+++ b/tests/ut/utils.h
@@ -239,6 +239,14 @@ GetRangeSearchRecall(const knowhere::DataSet& gt, const knowhere::DataSet& resul
     return (1 + precision) * recall / 2;
 }
 
+inline float
+GetRelativeLoss(float gt_res, float res) {
+    if (gt_res == 0.0 || std::abs(gt_res) < 0.000001) {
+        return gt_res;
+    }
+    return std::abs((gt_res - res) / gt_res);
+}
+
 inline bool
 CheckDistanceInScope(const knowhere::DataSet& result, int topk, float low_bound, float high_bound) {
     auto ids = result.GetDistance();

--- a/thirdparty/faiss/faiss/utils/half_precision_floating_point_distances.cpp
+++ b/thirdparty/faiss/faiss/utils/half_precision_floating_point_distances.cpp
@@ -1,0 +1,692 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License
+
+#include <algorithm>
+
+#include <faiss/impl/IDSelector.h>
+#include <faiss/impl/ResultHandler.h>
+#include <faiss/utils/distances.h>
+#include <faiss/utils/distances_if.h>
+#include <faiss/utils/half_precision_floating_point_distances.h>
+#include "knowhere/bitsetview_idselector.h"
+#include "knowhere/operands.h"
+#include "simd/hook.h"
+namespace faiss {
+namespace {
+template <typename DataType, class BlockResultHandler, class IDSelector>
+void half_precision_floating_point_exhaustive_inner_product_impl(
+        const DataType* __restrict x,
+        const DataType* __restrict y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        BlockResultHandler& res,
+        const IDSelector& selector) {
+    using SingleResultHandler =
+            typename BlockResultHandler::SingleResultHandler;
+
+    SingleResultHandler resi(res);
+    for (int64_t i = 0; i < nx; i++) {
+        const DataType* x_i = x + i * d;
+        resi.begin(i);
+
+        // the lambda that applies a filtered element.
+        auto apply = [&resi](const float ip, const idx_t j) {
+            resi.add_result(ip, j);
+        };
+        if constexpr (std::is_same_v<IDSelector, IDSelectorArray>) {
+            // todo: need more tests about this branch
+            auto filter = [](const size_t j) { return true; };
+            if constexpr (std::is_same_v<DataType, knowhere::fp16>) {
+                fp16_vec_inner_products_ny_by_idx_if(
+                        x_i, y, selector.ids, d, selector.n, filter, apply);
+            } else {
+                bf16_vec_inner_products_ny_by_idx_if(
+                        x_i, y, selector.ids, d, selector.n, filter, apply);
+            }
+        } else {
+            // the lambda that filters acceptable elements.
+            auto filter = [&selector](const size_t j) {
+                return selector.is_member(j);
+            };
+            if constexpr (std::is_same_v<DataType, knowhere::fp16>) {
+                fp16_vec_inner_products_ny_if(x_i, y, d, ny, filter, apply);
+            } else {
+                bf16_vec_inner_products_ny_if(x_i, y, d, ny, filter, apply);
+            }
+        }
+        resi.end();
+    }
+}
+
+template <typename DataType, class BlockResultHandler, class IDSelector>
+void half_precision_floating_point_exhaustive_L2sqr_seq_impl(
+        const DataType* __restrict x,
+        const DataType* __restrict y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        BlockResultHandler& res,
+        const IDSelector& selector) {
+    using SingleResultHandler =
+            typename BlockResultHandler::SingleResultHandler;
+
+    SingleResultHandler resi(res);
+    for (int64_t i = 0; i < nx; i++) {
+        const DataType* x_i = x + i * d;
+        resi.begin(i);
+
+        // the lambda that applies a filtered element.
+        auto apply = [&resi](const float ip, const idx_t j) {
+            resi.add_result(ip, j);
+        };
+        if constexpr (std::is_same_v<IDSelector, IDSelectorArray>) {
+            // todo: need more tests about this branch
+            auto filter = [](const size_t j) { return true; };
+            if constexpr (std::is_same_v<DataType, knowhere::fp16>) {
+                fp16_vec_L2sqr_ny_by_idx_if(
+                        x_i, y, selector.ids, d, selector->n, filter, apply);
+            } else {
+                bf16_vec_L2sqr_ny_by_idx_if(
+                        x_i, y, selector.ids, d, selector->n, filter, apply);
+            }
+        } else {
+            // the lambda that filters acceptable elements.
+            auto filter = [&selector](const size_t j) {
+                return selector.is_member(j);
+            };
+            if constexpr (std::is_same_v<DataType, knowhere::fp16>) {
+                fp16_vec_L2sqr_ny_if(x_i, y, d, ny, filter, apply);
+            } else {
+                bf16_vec_L2sqr_ny_if(x_i, y, d, ny, filter, apply);
+            }
+        }
+        resi.end();
+    }
+}
+
+template <typename DataType, class BlockResultHandler, class IDSelector>
+void half_precision_floating_point_exhaustive_cosine_seq_impl(
+        const DataType* __restrict x,
+        const DataType* __restrict y,
+        const float* __restrict y_norms,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        BlockResultHandler& res,
+        const IDSelector& selector) {
+    using SingleResultHandler =
+            typename BlockResultHandler::SingleResultHandler;
+    typedef float (*NormComputer)(const DataType*, size_t);
+    NormComputer norm_computer;
+    if constexpr (std::is_same_v<DataType, knowhere::fp16>) {
+        norm_computer = fp16_vec_norm_L2sqr;
+    } else {
+        norm_computer = bf16_vec_norm_L2sqr;
+    }
+    SingleResultHandler resi(res);
+    for (int64_t i = 0; i < nx; i++) {
+        const DataType* x_i = x + i * d;
+        // distance div x_norm before pushing into the heap
+        auto x_norm = sqrtf(norm_computer(x_i, d));
+        x_norm = (x_norm == 0.0 ? 1.0 : x_norm);
+        auto apply = [&resi, x_norm, y, y_norms, d, norm_computer](
+                             const float ip, const idx_t j) {
+            float y_norm = (y_norms != nullptr)
+                    ? y_norms[j]
+                    : sqrtf(norm_computer(y + j * d, d));
+
+            y_norm = (y_norm == 0.0 ? 1.0 : y_norm);
+            resi.add_result(ip / (x_norm * y_norm), j);
+        };
+        resi.begin(i);
+        // the lambda that applies a filtered element
+        if constexpr (std::is_same_v<IDSelector, IDSelectorArray>) {
+            // todo: need more tests about this branch
+            auto filter = [](const size_t j) { return true; };
+            if constexpr (std::is_same_v<DataType, knowhere::fp16>) {
+                fp16_vec_inner_products_ny_by_idx_if(
+                        x_i, y, selector.ids, d, selector->n, filter, apply);
+            } else {
+                bf16_vec_inner_products_ny_by_idx_if(
+                        x_i, y, selector.ids, d, selector->n, filter, apply);
+            }
+        } else {
+            // the lambda that filters acceptable elements.
+            auto filter = [&selector](const size_t j) {
+                return selector.is_member(j);
+            };
+            if constexpr (std::is_same_v<DataType, knowhere::fp16>) {
+                fp16_vec_inner_products_ny_if(x_i, y, d, ny, filter, apply);
+            } else {
+                bf16_vec_inner_products_ny_if(x_i, y, d, ny, filter, apply);
+            }
+        }
+        resi.end();
+    }
+}
+} // namespace
+
+template <typename DataType>
+void half_precision_floating_point_knn_inner_product(
+        const DataType* x,
+        const DataType* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        size_t k,
+        float* vals,
+        int64_t* ids,
+        const IDSelector* sel) {
+    int64_t imin = 0;
+    if (auto selr = dynamic_cast<const IDSelectorRange*>(sel)) {
+        imin = std::max(selr->imin, int64_t(0));
+        int64_t imax = std::min(selr->imax, int64_t(ny));
+        ny = imax - imin;
+        y += d * imin;
+        sel = nullptr;
+    }
+    if (k < distance_compute_min_k_reservoir) {
+        HeapBlockResultHandler<CMin<float, int64_t>> res(nx, vals, ids, k);
+        if (const auto* sel_bs =
+                    dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel)) {
+            half_precision_floating_point_exhaustive_inner_product_impl(
+                    x, y, d, nx, ny, res, *sel_bs);
+        } else if (sel == nullptr) {
+            half_precision_floating_point_exhaustive_inner_product_impl(
+                    x, y, d, nx, ny, res, IDSelectorAll());
+        } else {
+            half_precision_floating_point_exhaustive_inner_product_impl(
+                    x, y, d, nx, ny, res, *sel);
+        }
+    } else {
+        ReservoirBlockResultHandler<CMin<float, int64_t>> res(nx, vals, ids, k);
+        if (const auto* sel_bs =
+                    dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel)) {
+            half_precision_floating_point_exhaustive_inner_product_impl(
+                    x, y, d, nx, ny, res, *sel_bs);
+        } else if (sel == nullptr) {
+            half_precision_floating_point_exhaustive_inner_product_impl(
+                    x, y, d, nx, ny, res, IDSelectorAll());
+        } else {
+            half_precision_floating_point_exhaustive_inner_product_impl(
+                    x, y, d, nx, ny, res, *sel);
+        }
+    }
+
+    if (imin != 0) {
+        for (size_t i = 0; i < nx * k; i++) {
+            if (ids[i] >= 0) {
+                ids[i] += imin;
+            }
+        }
+    }
+    return;
+}
+
+template <typename DataType>
+void half_precision_floating_point_all_inner_product(
+        const DataType* x,
+        const DataType* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        std::vector<knowhere::DistId>& output,
+        const IDSelector* sel) {
+    CollectAllResultHandler<CMax<float, int64_t>> res(nx, ny, output);
+    if (const auto* sel_bs =
+                dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel)) {
+        half_precision_floating_point_exhaustive_inner_product_impl(
+                x, y, d, nx, ny, res, *sel_bs);
+    } else if (sel == nullptr) {
+        half_precision_floating_point_exhaustive_inner_product_impl(
+                x, y, d, nx, ny, res, IDSelectorAll());
+    } else {
+        half_precision_floating_point_exhaustive_inner_product_impl(
+                x, y, d, nx, ny, res, *sel);
+    }
+    return;
+}
+
+template <typename DataType>
+void half_precision_floating_point_knn_L2sqr(
+        const DataType* x,
+        const DataType* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        size_t k,
+        float* vals,
+        int64_t* ids,
+        const float* y_norm2,
+        const IDSelector* sel) {
+    int64_t imin = 0;
+    if (auto selr = dynamic_cast<const IDSelectorRange*>(sel)) {
+        imin = std::max(selr->imin, int64_t(0));
+        int64_t imax = std::min(selr->imax, int64_t(ny));
+        ny = imax - imin;
+        y += d * imin;
+        sel = nullptr;
+    }
+    if (k < distance_compute_min_k_reservoir) {
+        HeapBlockResultHandler<CMax<float, int64_t>> res(nx, vals, ids, k);
+        if (const auto* sel_bs =
+                    dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel)) {
+            half_precision_floating_point_exhaustive_L2sqr_seq_impl(
+                    x, y, d, nx, ny, res, *sel_bs);
+        } else if (sel == nullptr) {
+            half_precision_floating_point_exhaustive_L2sqr_seq_impl(
+                    x, y, d, nx, ny, res, IDSelectorAll());
+        } else {
+            half_precision_floating_point_exhaustive_L2sqr_seq_impl(
+                    x, y, d, nx, ny, res, *sel);
+        }
+    } else {
+        ReservoirBlockResultHandler<CMax<float, int64_t>> res(nx, vals, ids, k);
+        if (const auto* sel_bs =
+                    dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel)) {
+            half_precision_floating_point_exhaustive_L2sqr_seq_impl(
+                    x, y, d, nx, ny, res, *sel_bs);
+        } else if (sel == nullptr) {
+            half_precision_floating_point_exhaustive_L2sqr_seq_impl(
+                    x, y, d, nx, ny, res, IDSelectorAll());
+        } else {
+            half_precision_floating_point_exhaustive_L2sqr_seq_impl(
+                    x, y, d, nx, ny, res, *sel);
+        }
+    }
+    if (imin != 0) {
+        for (size_t i = 0; i < nx * k; i++) {
+            if (ids[i] >= 0) {
+                ids[i] += imin;
+            }
+        }
+    }
+    return;
+}
+
+template <typename DataType>
+void half_precision_floating_point_all_L2sqr(
+        const DataType* x,
+        const DataType* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        std::vector<knowhere::DistId>& output,
+        const float* y_norms,
+        const IDSelector* sel) {
+    CollectAllResultHandler<CMax<float, int64_t>> res(nx, ny, output);
+    if (const auto* sel_bs =
+                dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel)) {
+        half_precision_floating_point_exhaustive_L2sqr_seq_impl(
+                x, y, d, nx, ny, res, *sel_bs);
+    } else if (sel == nullptr) {
+        half_precision_floating_point_exhaustive_L2sqr_seq_impl(
+                x, y, d, nx, ny, res, IDSelectorAll());
+    } else {
+        half_precision_floating_point_exhaustive_L2sqr_seq_impl(
+                x, y, d, nx, ny, res, *sel);
+    }
+    return;
+}
+
+template <typename DataType>
+void half_precision_floating_point_knn_cosine(
+        const DataType* x,
+        const DataType* y,
+        const float* y_norm2,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        size_t k,
+        float* vals,
+        int64_t* ids,
+        const IDSelector* sel) {
+    int64_t imin = 0;
+    if (auto selr = dynamic_cast<const IDSelectorRange*>(sel)) {
+        imin = std::max(selr->imin, int64_t(0));
+        int64_t imax = std::min(selr->imax, int64_t(ny));
+        ny = imax - imin;
+        y += d * imin;
+        sel = nullptr;
+    }
+    if (k < distance_compute_min_k_reservoir) {
+        HeapBlockResultHandler<CMin<float, int64_t>> res(nx, vals, ids, k);
+        if (const auto* sel_bs =
+                    dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel)) {
+            half_precision_floating_point_exhaustive_cosine_seq_impl(
+                    x, y, y_norm2, d, nx, ny, res, *sel_bs);
+        } else if (sel == nullptr) {
+            half_precision_floating_point_exhaustive_cosine_seq_impl(
+                    x, y, y_norm2, d, nx, ny, res, IDSelectorAll());
+        } else {
+            half_precision_floating_point_exhaustive_cosine_seq_impl(
+                    x, y, y_norm2, d, nx, ny, res, *sel);
+        }
+    } else {
+        ReservoirBlockResultHandler<CMin<float, int64_t>> res(nx, vals, ids, k);
+        if (const auto* sel_bs =
+                    dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel)) {
+            half_precision_floating_point_exhaustive_cosine_seq_impl(
+                    x, y, y_norm2, d, nx, ny, res, *sel_bs);
+        } else if (sel == nullptr) {
+            half_precision_floating_point_exhaustive_cosine_seq_impl(
+                    x, y, y_norm2, d, nx, ny, res, IDSelectorAll());
+        } else {
+            half_precision_floating_point_exhaustive_cosine_seq_impl(
+                    x, y, y_norm2, d, nx, ny, res, *sel);
+        }
+    }
+    if (imin != 0) {
+        for (size_t i = 0; i < nx * k; i++) {
+            if (ids[i] >= 0) {
+                ids[i] += imin;
+            }
+        }
+    }
+    return;
+}
+
+template <typename DataType>
+void half_precision_floating_point_all_cosine(
+        const DataType* x,
+        const DataType* y,
+        const float* y_norms,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        std::vector<knowhere::DistId>& output,
+        const IDSelector* sel) {
+    CollectAllResultHandler<CMax<float, int64_t>> res(nx, ny, output);
+    if (const auto* sel_bs =
+                dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel)) {
+        half_precision_floating_point_exhaustive_cosine_seq_impl(
+                x, y, y_norms, d, nx, ny, res, *sel_bs);
+    } else if (sel == nullptr) {
+        half_precision_floating_point_exhaustive_cosine_seq_impl(
+                x, y, y_norms, d, nx, ny, res, IDSelectorAll());
+    } else {
+        half_precision_floating_point_exhaustive_cosine_seq_impl(
+                x, y, y_norms, d, nx, ny, res, *sel);
+    }
+    return;
+}
+
+/***************************************************************************
+ * Range search
+ ***************************************************************************/
+struct RangeSearchResult;
+
+template <typename DataType>
+void half_precision_floating_point_range_search_L2sqr(
+        const DataType* x,
+        const DataType* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        float radius,
+        RangeSearchResult* res,
+        const IDSelector* sel) {
+    RangeSearchBlockResultHandler<CMax<float, int64_t>> resh(res, radius);
+    if (const auto* sel_bs =
+                dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel)) {
+        half_precision_floating_point_exhaustive_L2sqr_seq_impl(
+                x, y, d, nx, ny, resh, *sel_bs);
+    } else if (sel == nullptr) {
+        half_precision_floating_point_exhaustive_L2sqr_seq_impl(
+                x, y, d, nx, ny, resh, IDSelectorAll());
+    } else {
+        half_precision_floating_point_exhaustive_L2sqr_seq_impl(
+                x, y, d, nx, ny, resh, *sel);
+    }
+    return;
+}
+
+template <typename DataType>
+void half_precision_floating_point_range_search_inner_product(
+        const DataType* x,
+        const DataType* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        float radius,
+        RangeSearchResult* res,
+        const IDSelector* sel) {
+    RangeSearchBlockResultHandler<CMin<float, int64_t>> resh(res, radius);
+    if (const auto* sel_bs =
+                dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel)) {
+        half_precision_floating_point_exhaustive_inner_product_impl(
+                x, y, d, nx, ny, resh, *sel_bs);
+    } else if (sel == nullptr) {
+        half_precision_floating_point_exhaustive_inner_product_impl(
+                x, y, d, nx, ny, resh, IDSelectorAll());
+    } else {
+        half_precision_floating_point_exhaustive_inner_product_impl(
+                x, y, d, nx, ny, resh, *sel);
+    }
+    return;
+}
+
+// Knowhere-specific function
+template <typename DataType>
+void half_precision_floating_point_range_search_cosine(
+        const DataType* x,
+        const DataType* y,
+        const float* y_norms,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        float radius,
+        RangeSearchResult* res,
+        const IDSelector* sel) {
+    RangeSearchBlockResultHandler<CMin<float, int64_t>> resh(res, radius);
+    if (const auto* sel_bs =
+                dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel)) {
+        half_precision_floating_point_exhaustive_cosine_seq_impl(
+                x, y, y_norms, d, nx, ny, resh, *sel_bs);
+    } else if (sel == nullptr) {
+        half_precision_floating_point_exhaustive_cosine_seq_impl(
+                x, y, y_norms, d, nx, ny, resh, IDSelectorAll());
+    } else {
+        half_precision_floating_point_exhaustive_cosine_seq_impl(
+                x, y, y_norms, d, nx, ny, resh, *sel);
+    }
+    return;
+}
+
+// knn functions
+template void faiss::half_precision_floating_point_knn_inner_product<
+        knowhere::fp16>(
+        const knowhere::fp16*,
+        const knowhere::fp16*,
+        size_t,
+        size_t,
+        size_t,
+        size_t,
+        float*,
+        int64_t*,
+        const IDSelector*);
+template void faiss::half_precision_floating_point_knn_inner_product<
+        knowhere::bf16>(
+        const knowhere::bf16*,
+        const knowhere::bf16*,
+        size_t,
+        size_t,
+        size_t,
+        size_t,
+        float*,
+        int64_t*,
+        const IDSelector*);
+template void faiss::half_precision_floating_point_all_inner_product<
+        knowhere::fp16>(
+        const knowhere::fp16*,
+        const knowhere::fp16*,
+        size_t,
+        size_t,
+        size_t,
+        std::vector<knowhere::DistId>&,
+        const IDSelector*);
+template void faiss::half_precision_floating_point_all_inner_product<
+        knowhere::bf16>(
+        const knowhere::bf16*,
+        const knowhere::bf16*,
+        size_t,
+        size_t,
+        size_t,
+        std::vector<knowhere::DistId>&,
+        const IDSelector*);
+template void faiss::half_precision_floating_point_knn_L2sqr<knowhere::fp16>(
+        const knowhere::fp16*,
+        const knowhere::fp16*,
+        size_t,
+        size_t,
+        size_t,
+        size_t,
+        float*,
+        int64_t*,
+        const float*,
+        const IDSelector*);
+template void faiss::half_precision_floating_point_knn_L2sqr<knowhere::bf16>(
+        const knowhere::bf16*,
+        const knowhere::bf16*,
+        size_t,
+        size_t,
+        size_t,
+        size_t,
+        float*,
+        int64_t*,
+        const float*,
+        const IDSelector*);
+template void faiss::half_precision_floating_point_all_L2sqr<knowhere::fp16>(
+        const knowhere::fp16*,
+        const knowhere::fp16*,
+        size_t,
+        size_t,
+        size_t,
+        std::vector<knowhere::DistId>&,
+        const float*,
+        const IDSelector*);
+template void faiss::half_precision_floating_point_all_L2sqr<knowhere::bf16>(
+        const knowhere::bf16*,
+        const knowhere::bf16*,
+        size_t,
+        size_t,
+        size_t,
+        std::vector<knowhere::DistId>&,
+        const float*,
+        const IDSelector*);
+template void faiss::half_precision_floating_point_knn_cosine<knowhere::fp16>(
+        const knowhere::fp16*,
+        const knowhere::fp16*,
+        const float*,
+        size_t,
+        size_t,
+        size_t,
+        size_t,
+        float*,
+        int64_t*,
+        const IDSelector*);
+template void faiss::half_precision_floating_point_knn_cosine<knowhere::bf16>(
+        const knowhere::bf16*,
+        const knowhere::bf16*,
+        const float*,
+        size_t,
+        size_t,
+        size_t,
+        size_t,
+        float*,
+        int64_t*,
+        const IDSelector*);
+template void faiss::half_precision_floating_point_all_cosine<knowhere::fp16>(
+        const knowhere::fp16*,
+        const knowhere::fp16*,
+        const float*,
+        size_t,
+        size_t,
+        size_t,
+        std::vector<knowhere::DistId>&,
+        const IDSelector*);
+template void faiss::half_precision_floating_point_all_cosine<knowhere::bf16>(
+        const knowhere::bf16*,
+        const knowhere::bf16*,
+        const float*,
+        size_t,
+        size_t,
+        size_t,
+        std::vector<knowhere::DistId>&,
+        const IDSelector*);
+// range search functions
+template void faiss::half_precision_floating_point_range_search_L2sqr<
+        knowhere::fp16>(
+        const knowhere::fp16*,
+        const knowhere::fp16*,
+        size_t,
+        size_t,
+        size_t,
+        float,
+        faiss::RangeSearchResult*,
+        const faiss::IDSelector*);
+template void faiss::half_precision_floating_point_range_search_L2sqr<
+        knowhere::bf16>(
+        const knowhere::bf16*,
+        const knowhere::bf16*,
+        size_t,
+        size_t,
+        size_t,
+        float,
+        faiss::RangeSearchResult*,
+        const faiss::IDSelector*);
+template void faiss::half_precision_floating_point_range_search_inner_product<
+        knowhere::fp16>(
+        const knowhere::fp16*,
+        const knowhere::fp16*,
+        size_t,
+        size_t,
+        size_t,
+        float,
+        faiss::RangeSearchResult*,
+        const faiss::IDSelector*);
+template void faiss::half_precision_floating_point_range_search_inner_product<
+        knowhere::bf16>(
+        const knowhere::bf16*,
+        const knowhere::bf16*,
+        size_t,
+        size_t,
+        size_t,
+        float,
+        faiss::RangeSearchResult*,
+        const faiss::IDSelector*);
+template void faiss::half_precision_floating_point_range_search_cosine<
+        knowhere::fp16>(
+        const knowhere::fp16*,
+        const knowhere::fp16*,
+        const float*,
+        size_t,
+        size_t,
+        size_t,
+        float,
+        faiss::RangeSearchResult*,
+        const faiss::IDSelector*);
+template void faiss::half_precision_floating_point_range_search_cosine<
+        knowhere::bf16>(
+        const knowhere::bf16*,
+        const knowhere::bf16*,
+        const float*,
+        size_t,
+        size_t,
+        size_t,
+        float,
+        faiss::RangeSearchResult*,
+        const faiss::IDSelector*);
+} // namespace faiss

--- a/thirdparty/faiss/faiss/utils/half_precision_floating_point_distances.h
+++ b/thirdparty/faiss/faiss/utils/half_precision_floating_point_distances.h
@@ -1,0 +1,138 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License
+
+#ifndef FAISS_HALF_PRECISION_FLOATING_POINT_DISTANCES_H
+#define FAISS_HALF_PRECISION_FLOATING_POINT_DISTANCES_H
+#pragma once
+#include <faiss/utils/Heap.h>
+#include <stdint.h>
+#include <vector>
+#include "knowhere/object.h"
+namespace faiss {
+struct IDSelector;
+/***************************************************************************
+ * KNN functions
+ ***************************************************************************/
+// Knowhere-specific function
+template <typename DataType>
+void half_precision_floating_point_knn_inner_product(
+        const DataType* x,
+        const DataType* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        size_t k,
+        float* distances,
+        int64_t* indexes,
+        const IDSelector* sel = nullptr);
+
+template <typename DataType>
+void half_precision_floating_point_all_inner_product(
+        const DataType* x,
+        const DataType* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        std::vector<knowhere::DistId>& output,
+        const IDSelector* sel = nullptr);
+
+template <typename DataType>
+void half_precision_floating_point_knn_L2sqr(
+        const DataType* x,
+        const DataType* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        size_t k,
+        float* distances,
+        int64_t* indexes,
+        const float* y_norm2 = nullptr,
+        const IDSelector* sel = nullptr);
+
+template <typename DataType>
+void half_precision_floating_point_all_L2sqr(
+        const DataType* x,
+        const DataType* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        std::vector<knowhere::DistId>& output,
+        const float* y_norms = nullptr,
+        const IDSelector* sel = nullptr);
+
+template <typename DataType>
+void half_precision_floating_point_knn_cosine(
+        const DataType* x,
+        const DataType* y,
+        const float* y_norms,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        size_t k,
+        float* distances,
+        int64_t* indexes,
+        const IDSelector* sel = nullptr);
+
+template <typename DataType>
+void half_precision_floating_point_all_cosine(
+        const DataType* x,
+        const DataType* y,
+        const float* y_norms,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        std::vector<knowhere::DistId>& output,
+        const IDSelector* sel = nullptr);
+
+/***************************************************************************
+ * Range search
+ ***************************************************************************/
+struct RangeSearchResult;
+template <typename DataType>
+void half_precision_floating_point_range_search_L2sqr(
+        const DataType* x,
+        const DataType* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        float radius,
+        RangeSearchResult* result,
+        const IDSelector* sel = nullptr);
+
+/// same as range_search_L2sqr for the inner product similarity
+template <typename DataType>
+void half_precision_floating_point_range_search_inner_product(
+        const DataType* x,
+        const DataType* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        float radius,
+        RangeSearchResult* result,
+        const IDSelector* sel = nullptr);
+
+// Knowhere-specific function
+template <typename DataType>
+void half_precision_floating_point_range_search_cosine(
+        const DataType* x,
+        const DataType* y,
+        const float* y_norms,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        float radius,
+        RangeSearchResult* result,
+        const IDSelector* sel = nullptr);
+} // namespace faiss
+#endif // FAISS_HALF_PRECISION_FLOATING_POINT_DISTANCES_H


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/909
This purpose of this pr is to remove memory copy of input data and prepare for NM index search.

simple test with cohere-768d-cosine:
8cpu, avx512
fp16/bf16: rowcount = 174762,  total size = 128MB 
QPS of float16: 170.49 --> before: 75.5
QPS of bfloat16: 158.87 --> before: 73.95

fp32: rowcount = 174762,  total size = 256MB 
QPS of float32: 132.029

Use VecTool to test with gist1M-960d-L2:
bf vs. flat(convert to fp32)
bf16:
I1216 02:53:15.839870 69100 metric.cpp:141] case = gist_query_FLAT_k_100_0.00 | repeat = 1 | nq = 1000 | k = 100 | time = 66.1252s | qps = 15.1228 | avg_recall = 1 | min_recall = 1 | avg_ncdg = -nan | min_ncdg = 3.40282e+38 | avg_disterr = 0 | max_disterr = 1.17549e-38
fp16:
I1216 02:59:14.644295 70049 metric.cpp:141] case = gist_query_FLAT_k_100_0.00 | repeat = 1 | nq = 1000 | k = 100 | time = 67.0043s | qps = 14.9244 | avg_recall = 1 | min_recall = 1 | avg_ncdg = -nan | min_ncdg = 3.40282e+38 | avg_disterr = 0 | max_disterr = 1.17549e-38


