### PR TITLE
Use search_pool to control iterator->Next()

### DIFF
--- a/include/knowhere/comp/brute_force.h
+++ b/include/knowhere/comp/brute_force.h
@@ -51,7 +51,7 @@ class BruteForce {
     template <typename DataType>
     static expected<std::vector<IndexNode::IteratorPtr>>
     AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
-                const BitsetView& bitset);
+                const BitsetView& bitset, bool use_knowhere_search_pool = true);
 };
 
 }  // namespace knowhere

--- a/include/knowhere/expected.h
+++ b/include/knowhere/expected.h
@@ -49,6 +49,7 @@ enum class Status {
     internal_error = 27,
     invalid_serialized_index_type = 28,
     sparse_inner_error = 29,
+    brute_force_inner_error = 30,
 };
 
 inline std::string
@@ -104,6 +105,8 @@ Status2String(knowhere::Status status) {
             return "the serialized index type is not recognized";
         case knowhere::Status::sparse_inner_error:
             return "sparse index inner error";
+        case knowhere::Status::brute_force_inner_error:
+            return "brute_force inner error";
         default:
             return "unexpected status";
     }

--- a/include/knowhere/index/index.h
+++ b/include/knowhere/index/index.h
@@ -161,7 +161,8 @@ class Index {
     Search(const DataSetPtr dataset, const Json& json, const BitsetView& bitset) const;
 
     expected<std::vector<IndexNode::IteratorPtr>>
-    AnnIterator(const DataSetPtr dataset, const Json& json, const BitsetView& bitset) const;
+    AnnIterator(const DataSetPtr dataset, const Json& json, const BitsetView& bitset,
+                bool use_knowhere_search_pool = true) const;
 
     expected<DataSetPtr>
     RangeSearch(const DataSetPtr dataset, const Json& json, const BitsetView& bitset) const;

--- a/include/knowhere/index/index_node_data_mock_wrapper.h
+++ b/include/knowhere/index/index_node_data_mock_wrapper.h
@@ -42,7 +42,8 @@ class IndexNodeDataMockWrapper : public IndexNode {
     RangeSearch(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset) const override;
 
     expected<std::vector<IteratorPtr>>
-    AnnIterator(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset) const override;
+    AnnIterator(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset,
+                bool use_knowhere_search_pool) const override;
 
     expected<DataSetPtr>
     GetVectorByIds(const DataSetPtr dataset) const override;

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -168,7 +168,8 @@ Index<T>::Search(const DataSetPtr dataset, const Json& json, const BitsetView& b
 
 template <typename T>
 inline expected<std::vector<std::shared_ptr<IndexNode::iterator>>>
-Index<T>::AnnIterator(const DataSetPtr dataset, const Json& json, const BitsetView& bitset_) const {
+Index<T>::AnnIterator(const DataSetPtr dataset, const Json& json, const BitsetView& bitset_,
+                      bool use_knowhere_search_pool) const {
     auto cfg = this->node->CreateConfig();
     std::string msg;
     Status status = LoadConfig(cfg.get(), json, knowhere::ITERATOR, "Iterator", &msg);
@@ -191,12 +192,12 @@ Index<T>::AnnIterator(const DataSetPtr dataset, const Json& json, const BitsetVi
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
     // note that this time includes only the initial search phase of iterator.
     TimeRecorder rc("AnnIterator");
-    auto res = this->node->AnnIterator(dataset, std::move(cfg), bitset);
+    auto res = this->node->AnnIterator(dataset, std::move(cfg), bitset, use_knowhere_search_pool);
     auto time = rc.ElapseFromBegin("done");
     time *= 0.001;  // convert to ms
     knowhere_search_latency.Observe(time);
 #else
-    auto res = this->node->AnnIterator(dataset, std::move(cfg), bitset);
+    auto res = this->node->AnnIterator(dataset, std::move(cfg), bitset, use_knowhere_search_pool);
 #endif
     return res;
 }

--- a/src/index/index_node_data_mock_wrapper.cc
+++ b/src/index/index_node_data_mock_wrapper.cc
@@ -60,9 +60,9 @@ IndexNodeDataMockWrapper<DataType>::RangeSearch(const DataSetPtr dataset, std::u
 template <typename DataType>
 expected<std::vector<IndexNode::IteratorPtr>>
 IndexNodeDataMockWrapper<DataType>::AnnIterator(const DataSetPtr dataset, std::unique_ptr<Config> cfg,
-                                                const BitsetView& bitset) const {
+                                                const BitsetView& bitset, bool use_knowhere_search_pool) const {
     auto ds_ptr = ConvertFromDataTypeIfNeeded<DataType>(dataset);
-    return index_node_->AnnIterator(ds_ptr, std::move(cfg), bitset);
+    return index_node_->AnnIterator(ds_ptr, std::move(cfg), bitset, use_knowhere_search_pool);
 }
 
 template <typename DataType>

--- a/tests/ut/test_index_node.cc
+++ b/tests/ut/test_index_node.cc
@@ -57,7 +57,8 @@ class BaseFlatIndexNode : public IndexNode {
     }
 
     expected<std::vector<IndexNode::IteratorPtr>>
-    AnnIterator(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset) const override {
+    AnnIterator(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset,
+                bool use_knowhere_search_pool) const override {
         LOG_KNOWHERE_INFO_ << "BaseFlatIndexNode::AnnIterator()";
         return expected<std::vector<IndexNode::IteratorPtr>>::Err(Status::not_implemented,
                                                                   "BaseFlatIndexNode::AnnIterator() not implemented");


### PR DESCRIPTION
issue: #997 

> The current AnnIterator function utilizes the search pool for concurrency control only when initializing the Iterator. Once the returned iterator is handed over to the upper layer, the ->next() calls are not subjected to any thread restrictions, which may lead to issues such as OMP conflicts.
> 
> To address this, we propose the following considerations:
> - All iterators will accept a use_knowhere_search_pool parameter during construction.
>   - When set to True (the default), the iterator->next() will be scheduled by the knowhere_search_thread_pool.
>   - When set to False, iterator->next() will not involve thread scheduling internally, so please take caution.
> - The initialization of iterator in the AnnIterator function will no longer be concurrent, which helps to avoid potential deadlocks.
>   - Furthermore, to enhance performance for large_nq, we will try to streamline the initialization process for all iterators by deferring heavier pre-computation tasks to the first call of ->next().