### PR TITLE
add DAAT MaxScore support for sparse vector

### DIFF
--- a/include/knowhere/comp/index_param.h
+++ b/include/knowhere/comp/index_param.h
@@ -173,7 +173,8 @@ constexpr const char* HNSW_REFINE_TYPE = "refine_type";
 constexpr const char* SQ_TYPE = "sq_type";  // for IVF_SQ and HNSW_SQ
 constexpr const char* PRQ_NUM = "nrq";      // for PRQ, number of redisual quantizers
 
-// Sparse Params
+// Sparse Inverted Index Params
+constexpr const char* INVERTED_INDEX_ALGO = "inverted_index_algo";
 constexpr const char* DROP_RATIO_BUILD = "drop_ratio_build";
 constexpr const char* DROP_RATIO_SEARCH = "drop_ratio_search";
 }  // namespace indexparam

--- a/src/index/sparse/sparse_index_node.cc
+++ b/src/index/sparse/sparse_index_node.cc
@@ -27,7 +27,7 @@
 
 namespace knowhere {
 
-// Inverted Index impl for sparse vectors. May optionally use WAND algorithm to speed up search.
+// Inverted Index impl for sparse vectors.
 //
 // Not overriding RangeSearch, will use the default implementation in IndexNode.
 //
@@ -348,8 +348,6 @@ class SparseInvertedIndexNode : public IndexNode {
     expected<sparse::BaseInvertedIndex<T>*>
     CreateIndex(const SparseInvertedIndexConfig& cfg) const {
         if (IsMetricType(cfg.metric_type.value(), metric::BM25)) {
-            // quantize float to uint16_t when BM25 metric type is used.
-            auto idx = new sparse::InvertedIndex<T, uint16_t, use_wand, true, mmapped>();
             if (!cfg.bm25_k1.has_value() || !cfg.bm25_b.has_value() || !cfg.bm25_avgdl.has_value()) {
                 return expected<sparse::BaseInvertedIndex<T>*>::Err(
                     Status::invalid_args, "BM25 parameters k1, b, and avgdl must be set when building/loading");
@@ -358,10 +356,40 @@ class SparseInvertedIndexNode : public IndexNode {
             auto b = cfg.bm25_b.value();
             auto avgdl = cfg.bm25_avgdl.value();
             auto max_score_ratio = cfg.wand_bm25_max_score_ratio.value();
-            idx->SetBM25Params(k1, b, avgdl, max_score_ratio);
-            return idx;
+            if (use_wand || cfg.inverted_index_algo.value() == "DAAT_WAND") {
+                auto index =
+                    new sparse::InvertedIndex<T, uint16_t, sparse::InvertedIndexAlgo::DAAT_WAND, true, mmapped>();
+                index->SetBM25Params(k1, b, avgdl, max_score_ratio);
+                return index;
+            } else if (cfg.inverted_index_algo.value() == "DAAT_MAXSCORE") {
+                auto index =
+                    new sparse::InvertedIndex<T, uint16_t, sparse::InvertedIndexAlgo::DAAT_MAXSCORE, true, mmapped>();
+                index->SetBM25Params(k1, b, avgdl, max_score_ratio);
+                return index;
+            } else if (cfg.inverted_index_algo.value() == "TAAT_NAIVE") {
+                auto index =
+                    new sparse::InvertedIndex<T, uint16_t, sparse::InvertedIndexAlgo::TAAT_NAIVE, true, mmapped>();
+                index->SetBM25Params(k1, b, avgdl, max_score_ratio);
+                return index;
+            } else {
+                return expected<sparse::BaseInvertedIndex<T>*>::Err(Status::invalid_args,
+                                                                    "Invalid search algorithm for SparseInvertedIndex");
+            }
         } else {
-            return new sparse::InvertedIndex<T, T, use_wand, false, mmapped>();
+            if (use_wand || cfg.inverted_index_algo.value() == "DAAT_WAND") {
+                auto index = new sparse::InvertedIndex<T, T, sparse::InvertedIndexAlgo::DAAT_WAND, false, mmapped>();
+                return index;
+            } else if (cfg.inverted_index_algo.value() == "DAAT_MAXSCORE") {
+                auto index =
+                    new sparse::InvertedIndex<T, T, sparse::InvertedIndexAlgo::DAAT_MAXSCORE, false, mmapped>();
+                return index;
+            } else if (cfg.inverted_index_algo.value() == "TAAT_NAIVE") {
+                auto index = new sparse::InvertedIndex<T, T, sparse::InvertedIndexAlgo::TAAT_NAIVE, false, mmapped>();
+                return index;
+            } else {
+                return expected<sparse::BaseInvertedIndex<T>*>::Err(Status::invalid_args,
+                                                                    "Invalid search algorithm for SparseInvertedIndex");
+            }
         }
     }
 

--- a/src/index/sparse/sparse_inverted_index.h
+++ b/src/index/sparse/sparse_inverted_index.h
@@ -189,8 +189,8 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
         }
 
         auto dim_map_reverse = std::unordered_map<uint32_t, table_t>();
-        for (const auto& [dim, idx] : dim_map_) {
-            dim_map_reverse[idx] = dim;
+        for (const auto& [dim, dim_id] : dim_map_) {
+            dim_map_reverse[dim_id] = dim;
         }
 
         std::vector<size_t> row_sizes(n_rows_internal_, 0);
@@ -439,14 +439,20 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
         if (drop_ratio_search == 0) {
             refine_factor = 1;
         }
+
+        auto q_vec = parse_query(query, q_threshold);
+        if (q_vec.empty()) {
+            return;
+        }
+
         MaxMinHeap<float> heap(k * refine_factor);
         // DAAT_WAND and DAAT_MAXSCORE are based on the implementation in PISA.
         if constexpr (algo == InvertedIndexAlgo::DAAT_WAND) {
-            search_daat_wand(query, q_threshold, heap, bitset, computer);
+            search_daat_wand(q_vec, heap, bitset, computer);
         } else if constexpr (algo == InvertedIndexAlgo::DAAT_MAXSCORE) {
-            search_daat_maxscore(query, q_threshold, heap, bitset, computer);
+            search_daat_maxscore(q_vec, heap, bitset, computer);
         } else {
-            search_taat_naive(query, q_threshold, heap, bitset, computer);
+            search_taat_naive(q_vec, heap, bitset, computer);
         }
 
         if (refine_factor == 1) {
@@ -468,7 +474,9 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
             values[i] = std::abs(query[i].val);
         }
         auto q_threshold = get_threshold(values, drop_ratio_search);
-        auto distances = compute_all_distances(query, q_threshold, computer);
+        auto q_vec = parse_query(query, q_threshold);
+
+        auto distances = compute_all_distances(q_vec, computer);
         if (!bitset.empty()) {
             for (size_t i = 0; i < distances.size(); ++i) {
                 if (bitset.test(i)) {
@@ -485,16 +493,16 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
         float distance = 0.0f;
 
         for (size_t i = 0; i < query.size(); ++i) {
-            auto [idx, val] = query[i];
-            auto dim_id = dim_map_.find(idx);
-            if (dim_id == dim_map_.end()) {
+            auto [dim, val] = query[i];
+            auto dim_it = dim_map_.find(dim);
+            if (dim_it == dim_map_.cend()) {
                 continue;
             }
-            auto& plist_ids = inverted_index_ids_[dim_id->second];
+            auto& plist_ids = inverted_index_ids_[dim_it->second];
             auto it = std::lower_bound(plist_ids.begin(), plist_ids.end(), vec_id,
                                        [](const auto& x, table_t y) { return x < y; });
             if (it != plist_ids.end() && *it == vec_id) {
-                distance += val * computer(inverted_index_vals_[dim_id->second][it - plist_ids.begin()],
+                distance += val * computer(inverted_index_vals_[dim_it->second][it - plist_ids.begin()],
                                            bm25 ? bm25_params_->row_sums.at(vec_id) : 0);
             }
         }
@@ -556,26 +564,17 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
     }
 
     std::vector<float>
-    compute_all_distances(const SparseRow<DType>& q_vec, DType q_threshold,
+    compute_all_distances(const std::vector<std::pair<size_t, DType>>& q_vec,
                           const DocValueComputer<float>& computer) const {
         std::vector<float> scores(n_rows_internal_, 0.0f);
-        for (size_t idx = 0; idx < q_vec.size(); ++idx) {
-            auto [i, v] = q_vec[idx];
-            if (v < q_threshold || i >= max_dim_) {
-                continue;
-            }
-            auto dim_id = dim_map_.find(i);
-            if (dim_id == dim_map_.end()) {
-                continue;
-            }
-            auto& plist_ids = inverted_index_ids_[dim_id->second];
-            auto& plist_vals = inverted_index_vals_[dim_id->second];
+        for (size_t i = 0; i < q_vec.size(); ++i) {
+            auto& plist_ids = inverted_index_ids_[q_vec[i].first];
+            auto& plist_vals = inverted_index_vals_[q_vec[i].first];
             // TODO: improve with SIMD
             for (size_t j = 0; j < plist_ids.size(); ++j) {
                 auto doc_id = plist_ids[j];
-                auto val = plist_vals[j];
                 float val_sum = bm25 ? bm25_params_->row_sums.at(doc_id) : 0;
-                scores[doc_id] += v * computer(val, val_sum);
+                scores[doc_id] += q_vec[i].second * computer(plist_vals[j], val_sum);
             }
         }
         return scores;
@@ -644,14 +643,43 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
         }
     };  // struct Cursor
 
+    std::vector<std::pair<size_t, DType>>
+    parse_query(const SparseRow<DType>& query, DType q_threshold) const {
+        std::vector<std::pair<size_t, DType>> filtered_query;
+        for (size_t i = 0; i < query.size(); ++i) {
+            auto [dim, val] = query[i];
+            auto dim_it = dim_map_.find(dim);
+            if (dim_it == dim_map_.cend() || std::abs(val) < q_threshold) {
+                continue;
+            }
+            filtered_query.emplace_back(dim_it->second, val);
+        }
+        return filtered_query;
+    }
+
+    template <typename DocIdFilter>
+    std::vector<Cursor<DocIdFilter>>
+    make_cursors(const std::vector<std::pair<size_t, DType>>& q_vec, const DocValueComputer<float>& computer,
+                 DocIdFilter& filter) const {
+        std::vector<Cursor<DocIdFilter>> cursors;
+        cursors.reserve(q_vec.size());
+        for (auto q_dim : q_vec) {
+            auto& plist_ids = inverted_index_ids_[q_dim.first];
+            auto& plist_vals = inverted_index_vals_[q_dim.first];
+            cursors.emplace_back(plist_ids, plist_vals, n_rows_internal_, max_score_in_dim_[q_dim.first] * q_dim.second,
+                                 q_dim.second, filter);
+        }
+        return cursors;
+    }
+
     // find the top-k candidates using brute force search, k as specified by the capacity of the heap.
     // any value in q_vec that is smaller than q_threshold and any value with dimension >= n_cols() will be ignored.
     // TODO: may switch to row-wise brute force if filter rate is high. Benchmark needed.
     template <typename DocIdFilter>
     void
-    search_taat_naive(const SparseRow<DType>& q_vec, DType q_threshold, MaxMinHeap<float>& heap, DocIdFilter& filter,
+    search_taat_naive(const std::vector<std::pair<size_t, DType>>& q_vec, MaxMinHeap<float>& heap, DocIdFilter& filter,
                       const DocValueComputer<float>& computer) const {
-        auto scores = compute_all_distances(q_vec, q_threshold, computer);
+        auto scores = compute_all_distances(q_vec, computer);
         for (size_t i = 0; i < n_rows_internal_; ++i) {
             if ((filter.empty() || !filter.test(i)) && scores[i] != 0) {
                 heap.push(i, scores[i]);
@@ -659,43 +687,33 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
         }
     }
 
-    // any value in q_vec that is smaller than q_threshold will be ignored.
     template <typename DocIdFilter>
     void
-    search_daat_wand(const SparseRow<DType>& q_vec, DType q_threshold, MaxMinHeap<float>& heap, DocIdFilter& filter,
+    search_daat_wand(const std::vector<std::pair<size_t, DType>>& q_vec, MaxMinHeap<float>& heap, DocIdFilter& filter,
                      const DocValueComputer<float>& computer) const {
-        auto q_dim = q_vec.size();
-        std::vector<std::shared_ptr<Cursor<DocIdFilter>>> cursors(q_dim);
-        size_t valid_q_dim = 0;
-        for (size_t i = 0; i < q_dim; ++i) {
-            auto [idx, val] = q_vec[i];
-            auto dim_id = dim_map_.find(idx);
-            if (dim_id == dim_map_.end() || std::abs(val) < q_threshold) {
-                continue;
-            }
-            auto& plist_ids = inverted_index_ids_[dim_id->second];
-            auto& plist_vals = inverted_index_vals_[dim_id->second];
-            cursors[valid_q_dim++] = std::make_shared<Cursor<DocIdFilter>>(
-                plist_ids, plist_vals, n_rows_internal_, max_score_in_dim_[dim_id->second] * val, val, filter);
+        std::vector<Cursor<DocIdFilter>> cursors = make_cursors(q_vec, computer, filter);
+        std::vector<Cursor<DocIdFilter>*> cursor_ptrs(cursors.size());
+        for (size_t i = 0; i < cursors.size(); ++i) {
+            cursor_ptrs[i] = &cursors[i];
         }
-        if (valid_q_dim == 0) {
-            return;
-        }
-        cursors.resize(valid_q_dim);
-        auto sort_cursors = [&cursors] {
-            std::sort(cursors.begin(), cursors.end(), [](auto& x, auto& y) { return x->cur_vec_id_ < y->cur_vec_id_; });
+
+        auto sort_cursors = [&cursor_ptrs] {
+            std::sort(cursor_ptrs.begin(), cursor_ptrs.end(),
+                      [](auto& x, auto& y) { return x->cur_vec_id_ < y->cur_vec_id_; });
         };
         sort_cursors();
+
         while (true) {
             float threshold = heap.full() ? heap.top().val : 0;
             float upper_bound = 0;
             size_t pivot;
+
             bool found_pivot = false;
-            for (pivot = 0; pivot < valid_q_dim; ++pivot) {
-                if (cursors[pivot]->loc_ >= cursors[pivot]->plist_size_) {
+            for (pivot = 0; pivot < q_vec.size(); ++pivot) {
+                if (cursor_ptrs[pivot]->cur_vec_id_ >= n_rows_internal_) {
                     break;
                 }
-                upper_bound += cursors[pivot]->max_score_;
+                upper_bound += cursor_ptrs[pivot]->max_score_;
                 if (upper_bound > threshold) {
                     found_pivot = true;
                     break;
@@ -704,29 +722,30 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
             if (!found_pivot) {
                 break;
             }
-            table_t pivot_id = cursors[pivot]->cur_vec_id_;
-            if (pivot_id == cursors[0]->cur_vec_id_) {
+
+            table_t pivot_id = cursor_ptrs[pivot]->cur_vec_id_;
+            if (pivot_id == cursor_ptrs[0]->cur_vec_id_) {
                 float score = 0;
-                for (auto& cursor : cursors) {
-                    if (cursor->cur_vec_id_ != pivot_id) {
+                float cur_vec_sum = bm25 ? bm25_params_->row_sums.at(pivot_id) : 0;
+                for (auto& cursor_ptr : cursor_ptrs) {
+                    if (cursor_ptr->cur_vec_id_ != pivot_id) {
                         break;
                     }
-                    float cur_vec_sum = bm25 ? bm25_params_->row_sums.at(cursor->cur_vec_id_) : 0;
-                    score += cursor->q_value_ * computer(cursor->cur_vec_val(), cur_vec_sum);
-                    cursor->next();
+                    score += cursor_ptr->q_value_ * computer(cursor_ptr->cur_vec_val(), cur_vec_sum);
+                    cursor_ptr->next();
                 }
                 heap.push(pivot_id, score);
                 sort_cursors();
             } else {
                 size_t next_list = pivot;
-                for (; cursors[next_list]->cur_vec_id_ == pivot_id; --next_list) {
+                for (; cursor_ptrs[next_list]->cur_vec_id_ == pivot_id; --next_list) {
                 }
-                cursors[next_list]->seek(pivot_id);
-                for (size_t i = next_list + 1; i < valid_q_dim; ++i) {
-                    if (cursors[i]->cur_vec_id_ >= cursors[i - 1]->cur_vec_id_) {
+                cursor_ptrs[next_list]->seek(pivot_id);
+                for (size_t i = next_list + 1; i < q_vec.size(); ++i) {
+                    if (cursor_ptrs[i]->cur_vec_id_ >= cursor_ptrs[i - 1]->cur_vec_id_) {
                         break;
                     }
-                    std::swap(cursors[i], cursors[i - 1]);
+                    std::swap(cursor_ptrs[i], cursor_ptrs[i - 1]);
                 }
             }
         }
@@ -734,42 +753,27 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
 
     template <typename DocIdFilter>
     void
-    search_daat_maxscore(const SparseRow<DType>& q_vec, DType q_threshold, MaxMinHeap<float>& heap,
-                         const DocIdFilter& filter, const DocValueComputer<float>& computer) const {
-        auto q_dim = q_vec.size();
-        std::vector<std::shared_ptr<Cursor<DocIdFilter>>> cursors(q_dim);
-        size_t valid_q_dim = 0;
-        for (size_t i = 0; i < q_dim; ++i) {
-            auto [idx, val] = q_vec[i];
-            auto dim_id = dim_map_.find(idx);
-            if (dim_id == dim_map_.end() || std::abs(val) < q_threshold) {
-                continue;
-            }
-            auto& plist_ids = inverted_index_ids_[dim_id->second];
-            auto& plist_vals = inverted_index_vals_[dim_id->second];
-            cursors[valid_q_dim++] = std::make_shared<Cursor<DocIdFilter>>(
-                plist_ids, plist_vals, n_rows_internal_, max_score_in_dim_[dim_id->second] * val, val, filter);
-        }
-        if (valid_q_dim == 0) {
-            return;
-        }
-        cursors.resize(valid_q_dim);
+    search_daat_maxscore(std::vector<std::pair<size_t, DType>>& q_vec, MaxMinHeap<float>& heap, DocIdFilter& filter,
+                         const DocValueComputer<float>& computer) const {
+        std::sort(q_vec.begin(), q_vec.end(), [this](auto& a, auto& b) {
+            return a.second * max_score_in_dim_[a.first] > b.second * max_score_in_dim_[b.first];
+        });
 
-        std::sort(cursors.begin(), cursors.end(), [](auto& x, auto& y) { return x->max_score_ > y->max_score_; });
+        std::vector<Cursor<DocIdFilter>> cursors = make_cursors(q_vec, computer, filter);
 
         float threshold = heap.full() ? heap.top().val : 0;
 
         std::vector<float> upper_bounds(cursors.size());
         float bound_sum = 0.0;
         for (size_t i = cursors.size() - 1; i + 1 > 0; --i) {
-            bound_sum += cursors[i]->max_score_;
+            bound_sum += cursors[i].max_score_;
             upper_bounds[i] = bound_sum;
         }
 
-        uint32_t next_cand_vec_id = n_rows_internal_;
+        table_t next_cand_vec_id = n_rows_internal_;
         for (size_t i = 0; i < cursors.size(); ++i) {
-            if (cursors[i]->cur_vec_id_ < next_cand_vec_id) {
-                next_cand_vec_id = cursors[i]->cur_vec_id_;
+            if (cursors[i].cur_vec_id_ < next_cand_vec_id) {
+                next_cand_vec_id = cursors[i].cur_vec_id_;
             }
         }
 
@@ -784,7 +788,7 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
         }
 
         float curr_cand_score = 0.0f;
-        uint32_t curr_cand_vec_id = 0;
+        table_t curr_cand_vec_id = 0;
 
         while (curr_cand_vec_id < n_rows_internal_) {
             auto found_cand = false;
@@ -798,15 +802,15 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
                 curr_cand_score = 0.0f;
                 // update next_cand_vec_id
                 next_cand_vec_id = n_rows_internal_;
+                float cur_vec_sum = bm25 ? bm25_params_->row_sums.at(curr_cand_vec_id) : 0;
 
                 for (size_t i = 0; i < first_ne_idx; ++i) {
-                    if (cursors[i]->cur_vec_id_ == curr_cand_vec_id) {
-                        float cur_vec_sum = bm25 ? bm25_params_->row_sums.at(cursors[i]->cur_vec_id_) : 0;
-                        curr_cand_score += cursors[i]->q_value_ * computer(cursors[i]->cur_vec_val(), cur_vec_sum);
-                        cursors[i]->next();
+                    if (cursors[i].cur_vec_id_ == curr_cand_vec_id) {
+                        curr_cand_score += cursors[i].q_value_ * computer(cursors[i].cur_vec_val(), cur_vec_sum);
+                        cursors[i].next();
                     }
-                    if (cursors[i]->cur_vec_id_ < next_cand_vec_id) {
-                        next_cand_vec_id = cursors[i]->cur_vec_id_;
+                    if (cursors[i].cur_vec_id_ < next_cand_vec_id) {
+                        next_cand_vec_id = cursors[i].cur_vec_id_;
                     }
                 }
 
@@ -816,10 +820,9 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
                         found_cand = false;
                         break;
                     }
-                    cursors[i]->seek(curr_cand_vec_id);
-                    if (cursors[i]->cur_vec_id_ == curr_cand_vec_id) {
-                        float cur_vec_sum = bm25 ? bm25_params_->row_sums.at(cursors[i]->cur_vec_id_) : 0;
-                        curr_cand_score += cursors[i]->q_value_ * computer(cursors[i]->cur_vec_val(), cur_vec_sum);
+                    cursors[i].seek(curr_cand_vec_id);
+                    if (cursors[i].cur_vec_id_ == curr_cand_vec_id) {
+                        curr_cand_score += cursors[i].q_value_ * computer(cursors[i].cur_vec_val(), cur_vec_sum);
                     }
                 }
             }
@@ -838,7 +841,7 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
     }
 
     void
-    refine_and_collect(const SparseRow<DType>& q_vec, MaxMinHeap<float>& inacc_heap, size_t k, float* distances,
+    refine_and_collect(const SparseRow<DType>& query, MaxMinHeap<float>& inacc_heap, size_t k, float* distances,
                        label_t* labels, const DocValueComputer<float>& computer) const {
         std::vector<table_t> docids;
         MaxMinHeap<float> heap(k);
@@ -849,13 +852,18 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
             docids.emplace_back(u);
         }
 
+        auto q_vec = parse_query(query, 0);
+        if (q_vec.empty()) {
+            return;
+        }
+
         DocIdFilterByVector filter(std::move(docids));
         if constexpr (algo == InvertedIndexAlgo::DAAT_WAND) {
-            search_daat_wand(q_vec, 0, heap, filter, computer);
+            search_daat_wand(q_vec, heap, filter, computer);
         } else if constexpr (algo == InvertedIndexAlgo::DAAT_MAXSCORE) {
-            search_daat_maxscore(q_vec, 0, heap, filter, computer);
+            search_daat_maxscore(q_vec, heap, filter, computer);
         } else {
-            search_taat_naive(q_vec, 0, heap, filter, computer);
+            search_taat_naive(q_vec, heap, filter, computer);
         }
         collect_result(heap, distances, labels);
     }
@@ -875,7 +883,7 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
     add_row_to_index(const SparseRow<DType>& row, table_t vec_id) {
         [[maybe_unused]] float row_sum = 0;
         for (size_t j = 0; j < row.size(); ++j) {
-            auto [idx, val] = row[j];
+            auto [dim, val] = row[j];
             if constexpr (bm25) {
                 row_sum += val;
             }
@@ -884,12 +892,12 @@ class InvertedIndex : public BaseInvertedIndex<DType> {
             if (val == 0) {
                 continue;
             }
-            auto dim_it = dim_map_.find(idx);
-            if (dim_it == dim_map_.end()) {
+            auto dim_it = dim_map_.find(dim);
+            if (dim_it == dim_map_.cend()) {
                 if constexpr (mmapped) {
                     throw std::runtime_error("unexpected vector dimension in mmaped InvertedIndex");
                 }
-                dim_it = dim_map_.insert({idx, next_dim_id_++}).first;
+                dim_it = dim_map_.insert({dim, next_dim_id_++}).first;
                 inverted_index_ids_.emplace_back();
                 inverted_index_vals_.emplace_back();
                 if constexpr (algo == InvertedIndexAlgo::DAAT_WAND || algo == InvertedIndexAlgo::DAAT_MAXSCORE) {

--- a/src/index/sparse/sparse_inverted_index_config.h
+++ b/src/index/sparse/sparse_inverted_index_config.h
@@ -23,6 +23,7 @@ class SparseInvertedIndexConfig : public BaseConfig {
     CFG_FLOAT drop_ratio_search;
     CFG_INT refine_factor;
     CFG_FLOAT wand_bm25_max_score_ratio;
+    CFG_STRING inverted_index_algo;
     KNOHWERE_DECLARE_CONFIG(SparseInvertedIndexConfig) {
         // NOTE: drop_ratio_build has been deprecated, it won't change anything
         KNOWHERE_CONFIG_DECLARE_FIELD(drop_ratio_build)
@@ -59,6 +60,12 @@ class SparseInvertedIndexConfig : public BaseConfig {
             .set_default(1.05)
             .description("ratio to upscale max score to compensate for avgdl changes")
             .for_train()
+            .for_deserialize()
+            .for_deserialize_from_file();
+        KNOWHERE_CONFIG_DECLARE_FIELD(inverted_index_algo)
+            .description("inverted index algorithm")
+            .set_default("DAAT_MAXSCORE")
+            .for_train_and_search()
             .for_deserialize()
             .for_deserialize_from_file();
     }

--- a/tests/ut/test_sparse.cc
+++ b/tests/ut/test_sparse.cc
@@ -47,6 +47,8 @@ TEST_CASE("Test Mem Sparse Index With Float Vector", "[float metrics]") {
 
     auto metric = GENERATE(knowhere::metric::IP, knowhere::metric::BM25);
 
+    auto inverted_index_algo = GENERATE("TAAT_NAIVE", "DAAT_WAND", "DAAT_MAXSCORE");
+
     auto drop_ratio_search = metric == knowhere::metric::BM25 ? GENERATE(0.0, 0.1) : GENERATE(0.0, 0.3);
 
     auto version = GenTestVersionList();
@@ -62,9 +64,11 @@ TEST_CASE("Test Mem Sparse Index With Float Vector", "[float metrics]") {
         return json;
     };
 
-    auto sparse_inverted_index_gen = [base_gen, drop_ratio_search = drop_ratio_search]() {
+    auto sparse_inverted_index_gen = [base_gen, drop_ratio_search = drop_ratio_search,
+                                      inverted_index_algo = inverted_index_algo]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::DROP_RATIO_SEARCH] = drop_ratio_search;
+        json[knowhere::indexparam::INVERTED_INDEX_ALGO] = inverted_index_algo;
         return json;
     };
 
@@ -460,6 +464,8 @@ TEST_CASE("Test Mem Sparse Index CC", "[float metrics]") {
 
     auto query_ds = doc_vector_gen(nq, dim);
 
+    auto inverted_index_algo = GENERATE("TAAT_NAIVE", "DAAT_WAND", "DAAT_MAXSCORE");
+
     auto drop_ratio_search = GENERATE(0.0, 0.3);
 
     auto metric = GENERATE(knowhere::metric::IP);
@@ -476,9 +482,11 @@ TEST_CASE("Test Mem Sparse Index CC", "[float metrics]") {
         return json;
     };
 
-    auto sparse_inverted_index_gen = [base_gen, drop_ratio_search = drop_ratio_search]() {
+    auto sparse_inverted_index_gen = [base_gen, drop_ratio_search = drop_ratio_search,
+                                      inverted_index_algo = inverted_index_algo]() {
         knowhere::Json json = base_gen();
         json[knowhere::indexparam::DROP_RATIO_SEARCH] = drop_ratio_search;
+        json[knowhere::indexparam::INVERTED_INDEX_ALGO] = inverted_index_algo;
         return json;
     };
 


### PR DESCRIPTION
1. Add DAAT MaxScore support for sparse vector, and set it as default.
2. Remove `use_wand` in `SparseInvertedIndex` and introduce a new `enum InvertedIndexAlgo` to support different search algorithm.
3. Refactor cursor operations used by both WAND and MaxScore.

Different search algorithm test results on a 12c32g machine.

| Dataset | Stats | TAAT_NAIVE | DAAT_WAND | DAAT_MAXSCORE |
| --- | --- | --- | --- | --- |
| msmarco | Search Time (ms) | 56561 | 3367 | 3417 |
| hotpotqa | Search Time (ms) | 44203 | 13318 | 6537 |
| fever | Search Time (ms) | 33938 | 3860 | 2883 |
| nq | Search Time (ms) | 10584 | 1583 | 1125 |