### PR TITLE
sparse: refactor approx dimension max score ratio

### DIFF
--- a/include/knowhere/comp/index_param.h
+++ b/include/knowhere/comp/index_param.h
@@ -103,7 +103,7 @@ constexpr const char* BM25_K1 = "bm25_k1";
 constexpr const char* BM25_B = "bm25_b";
 // average document length
 constexpr const char* BM25_AVGDL = "bm25_avgdl";
-constexpr const char* WAND_BM25_MAX_SCORE_RATIO = "wand_bm25_max_score_ratio";
+constexpr const char* DIM_MAX_SCORE_RATIO = "dim_max_score_ratio";
 };  // namespace meta
 
 namespace indexparam {

--- a/include/knowhere/sparse_utils.h
+++ b/include/knowhere/sparse_utils.h
@@ -29,6 +29,11 @@
 
 namespace knowhere::sparse {
 
+enum class SparseMetricType {
+    METRIC_IP = 1,
+    METRIC_BM25 = 2,
+};
+
 // integer type in SparseRow
 using table_t = uint32_t;
 // type used to represent the id of a vector in the index interface.

--- a/src/index/sparse/sparse_inverted_index_config.h
+++ b/src/index/sparse/sparse_inverted_index_config.h
@@ -88,6 +88,23 @@ class SparseInvertedIndexConfig : public BaseConfig {
             .for_deserialize()
             .for_deserialize_from_file();
     }
+
+    Status
+    CheckAndAdjust(PARAM_TYPE param_type, std::string* err_msg) override {
+        if (param_type == PARAM_TYPE::TRAIN) {
+            constexpr std::array<std::string_view, 3> legal_inverted_index_algo_list{"TAAT_NAIVE", "DAAT_WAND",
+                                                                                     "DAAT_MAXSCORE"};
+            std::string inverted_index_algo_str = inverted_index_algo.value_or("");
+            if (std::find(legal_inverted_index_algo_list.begin(), legal_inverted_index_algo_list.end(),
+                          inverted_index_algo_str) == legal_inverted_index_algo_list.end()) {
+                std::string msg = "sparse inverted index algo " + inverted_index_algo_str +
+                                  " not found or not supported, supported: [TAAT_NAIVE DAAT_WAND DAAT_MAXSCORE]";
+                return HandleError(err_msg, msg, Status::invalid_args);
+            }
+        }
+
+        return Status::success;
+    }
 };  // class SparseInvertedIndexConfig
 
 }  // namespace knowhere


### PR DESCRIPTION
1. Move the dimension max score ratio from build params to search params, and rename it from `wand_bm25_max_score_ratio` to `dim_max_score_ratio`.

2. Remove template param `bm25` and add a new `SparseMetricType`.

3. Wrap some params of `Search()` to `InvertedIndexSearchParams`.