### PR TITLE
Add IsAdditionalScalarSupported check for mv_only

### DIFF
--- a/include/knowhere/index/index.h
+++ b/include/knowhere/index/index.h
@@ -174,7 +174,7 @@ class Index {
     HasRawData(const std::string& metric_type) const;
 
     bool
-    IsAdditionalScalarSupported() const;
+    IsAdditionalScalarSupported(bool is_mv_only) const;
 
     expected<DataSetPtr>
     GetIndexMeta(const Json& json) const;

--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -350,7 +350,7 @@ class IndexNode : public Object {
     HasRawData(const std::string& metric_type) const = 0;
 
     virtual bool
-    IsAdditionalScalarSupported() const {
+    IsAdditionalScalarSupported(bool is_mv_only) const {
         return false;
     }
 

--- a/src/index/hnsw/faiss_hnsw.cc
+++ b/src/index/hnsw/faiss_hnsw.cc
@@ -68,8 +68,11 @@ class BaseFaissIndexNode : public IndexNode {
     }
 
     bool
-    IsAdditionalScalarSupported() const override {
-        return true;
+    IsAdditionalScalarSupported(bool is_mv_only) const override {
+        if (is_mv_only) {
+            return true;
+        }
+        return false;
     }
 
     //
@@ -1845,11 +1848,11 @@ class HNSWIndexNodeWithFallback : public IndexNode {
     }
 
     bool
-    IsAdditionalScalarSupported() const override {
+    IsAdditionalScalarSupported(bool is_mv_only) const override {
         if (use_base_index) {
-            return base_index->IsAdditionalScalarSupported();
+            return base_index->IsAdditionalScalarSupported(is_mv_only);
         } else {
-            return fallback_search_index->IsAdditionalScalarSupported();
+            return fallback_search_index->IsAdditionalScalarSupported(is_mv_only);
         }
     }
 

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -277,8 +277,8 @@ Index<T>::HasRawData(const std::string& metric_type) const {
 
 template <typename T>
 inline bool
-Index<T>::IsAdditionalScalarSupported() const {
-    return this->node->IsAdditionalScalarSupported();
+Index<T>::IsAdditionalScalarSupported(bool is_mv_only) const {
+    return this->node->IsAdditionalScalarSupported(is_mv_only);
 }
 
 template <typename T>


### PR DESCRIPTION
issue: #1019 
`IsAdditionalScalarSupported` was used to indicate whether vector indexes support building with scalar info, but we need a special path for mv_only

/kind improvement