### PR TITLE
Reduce the pq build time

### DIFF
--- a/src/simd/distances_avx.h
+++ b/src/simd/distances_avx.h
@@ -108,6 +108,12 @@ fp16_vec_norm_L2sqr_avx(const knowhere::fp16* x, size_t d);
 float
 bf16_vec_norm_L2sqr_avx(const knowhere::bf16* x, size_t d);
 
+void
+fvec_L2sqr_ny_avx(float* dis, const float* x, const float* y, size_t d, size_t ny);
+
+size_t
+fvec_L2sqr_ny_nearest_avx(float* distances_tmp_buffer, const float* x, const float* y, size_t d, size_t ny);
+
 }  // namespace faiss
 
 #endif /* DISTANCES_AVX_H */

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -214,6 +214,7 @@ fvec_hook(std::string& simd_type) {
         bf16_vec_inner_product_batch_4 = bf16_vec_inner_product_batch_4_avx512;
         fp16_vec_L2sqr_batch_4 = fp16_vec_L2sqr_batch_4_avx512;
         bf16_vec_L2sqr_batch_4 = bf16_vec_L2sqr_batch_4_avx512;
+        fvec_L2sqr_ny_nearest = fvec_L2sqr_ny_nearest_avx;  // avx2 compute small dim faster than avx512
 
         simd_type = "AVX512";
         support_pq_fast_scan = true;
@@ -248,6 +249,7 @@ fvec_hook(std::string& simd_type) {
         fp16_vec_L2sqr_batch_4 = fp16_vec_L2sqr_batch_4_avx;
         bf16_vec_L2sqr_batch_4 = bf16_vec_L2sqr_batch_4_avx;
 
+        fvec_L2sqr_ny_nearest = fvec_L2sqr_ny_nearest_avx;
         simd_type = "AVX2";
         support_pq_fast_scan = true;
     } else if (use_sse4_2 && cpu_support_sse4_2()) {

--- a/thirdparty/faiss/faiss/utils/distances.h
+++ b/thirdparty/faiss/faiss/utils/distances.h
@@ -180,6 +180,15 @@ void pairwise_indexed_inner_product(
         const int64_t* iy,
         float* dis);
 
+void exhaustive_L2sqr_nearest_imp(
+        const float* __restrict x,
+        const float* __restrict y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        float* vals,
+        int64_t* ids);
+
 /***************************************************************************
  * KNN functions
  ***************************************************************************/


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/909
For better support scann_dvr as a growing index, this pr optimize the build time of pq.
Use corhere 256M to test: nlist =128, dsub = 4, one build thread:
build time :
before: 5.12s
after: 1.9s