### PR TITLE
Fix CAGRA-HNSW serialization format

### DIFF
--- a/src/common/cuvs/proto/cuvs_index.cuh
+++ b/src/common/cuvs/proto/cuvs_index.cuh
@@ -268,6 +268,20 @@ struct cuvs_index {
                                      bool include_dataset = true) {
         auto const& underlying_index = index.get_vector_index();
         if constexpr (vector_index_kind == cuvs_index_kind::cagra) {
+            size_t metric_type;
+            if (underlying_index.metric() == cuvs::distance::DistanceType::L2Expanded) {
+                metric_type = 0;
+            } else if (underlying_index.metric() == cuvs::distance::DistanceType::InnerProduct) {
+                metric_type = 1;
+            } else if (underlying_index.metric() == cuvs::distance::DistanceType::CosineExpanded) {
+                metric_type = 2;
+            }
+
+            os.write(reinterpret_cast<char*>(&metric_type), sizeof(metric_type));
+            size_t data_size = underlying_index.dim() * sizeof(float);
+            os.write(reinterpret_cast<char*>(&data_size), sizeof(data_size));
+            size_t dim = underlying_index.dim();
+            os.write(reinterpret_cast<char*>(&dim), sizeof(dim));
             return cuvs::neighbors::cagra::serialize_to_hnswlib(res, os, underlying_index);
         }
     }

--- a/tests/ut/test_gpu_search.cc
+++ b/tests/ut/test_gpu_search.cc
@@ -65,6 +65,15 @@ TEST_CASE("Test All GPU Index", "[search]") {
         return json;
     };
 
+    auto cagra_hnsw_gen = [](auto&& upstream_gen) {
+        return [upstream_gen]() {
+            knowhere::Json json = upstream_gen();
+            json[knowhere::indexparam::ADAPT_FOR_CPU] = true;
+            json[knowhere::indexparam::EF] = 128;
+            return json;
+        };
+    };
+
     auto refined_gen = [](auto&& upstream_gen) {
         return [upstream_gen]() {
             knowhere::Json json = upstream_gen();
@@ -210,6 +219,7 @@ TEST_CASE("Test All GPU Index", "[search]") {
             make_tuple(knowhere::IndexEnum::INDEX_CUVS_IVFPQ, ivfpq_gen),
             make_tuple(knowhere::IndexEnum::INDEX_CUVS_IVFPQ, refined_gen(ivfpq_gen)),
             make_tuple(knowhere::IndexEnum::INDEX_CUVS_CAGRA, cagra_gen),
+            make_tuple(knowhere::IndexEnum::INDEX_CUVS_CAGRA, cagra_hnsw_gen(cagra_gen)),
         }));
 
         auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version).value();


### PR DESCRIPTION
I faced today a bug with using CAGRA-HNSW, that was introduced in the switch from Raft to cuVS.
The `serialize_to_hnsw` serialization function used in knowhere was different from the cuVS one.
I added a test to make sure that bugs in this function will be detected in the future.
issue: #1113