### PR TITLE
[bug] fix IVFPQFastScan::RangeSearch() on ARM

### DIFF
--- a/thirdparty/faiss/faiss/impl/simd_result_handlers.h
+++ b/thirdparty/faiss/faiss/impl/simd_result_handlers.h
@@ -792,7 +792,7 @@ struct RangeHandler : ResultHandlerCompare<C, with_id_map> {
         normalizers = norms;
         for (size_t q = 0; q < nq; ++q) {
             thresholds[q] =
-                    normalizers[2 * q] * (radius - normalizers[2 * q + 1]);
+                    int(normalizers[2 * q] * (radius - normalizers[2 * q + 1]));
         }
     }
 


### PR DESCRIPTION
A non-trivial bug in the FAISS code. Check https://github.com/facebookresearch/faiss/pull/4247

> the problem happens if radius - normalizers[2 * q + 1] is negative. Thus, it is possible to provide reasonable parameters to IVFPQFastScan::RangeSearch() and get an empty result.

issue: #1100 