### PR TITLE
Enable SVE Support for L2 Metric Computation in FP16 and NY functions

### DIFF
--- a/src/simd/distances_sve.cc
+++ b/src/simd/distances_sve.cc
@@ -41,6 +41,40 @@ fvec_L2sqr_sve(const float* x, const float* y, size_t d) {
 }
 
 float
+fp16_vec_L2sqr_sve(const knowhere::fp16* x, const knowhere::fp16* y, size_t d) {
+    svfloat32_t sum1 = svdup_f32(0.0f);
+    svfloat32_t sum2 = svdup_f32(0.0f);
+    size_t i = 0;
+
+    svbool_t pg_16 = svptrue_b16();
+    svbool_t pg_32 = svptrue_b32();
+
+    while (i < d) {
+        if (d - i < svcnth())
+            pg_16 = svwhilelt_b16(i, d);
+
+        svfloat16_t a_fp16 = svld1_f16(pg_16, reinterpret_cast<const __fp16*>(x + i));
+        svfloat16_t b_fp16 = svld1_f16(pg_16, reinterpret_cast<const __fp16*>(y + i));
+
+        svfloat32_t a_fp32_low = svcvt_f32_f16_z(pg_32, svtrn1_f16(a_fp16, a_fp16));
+        svfloat32_t a_fp32_high = svcvt_f32_f16_z(pg_32, svtrn2_f16(a_fp16, a_fp16));
+        svfloat32_t b_fp32_low = svcvt_f32_f16_z(pg_32, svtrn1_f16(b_fp16, b_fp16));
+        svfloat32_t b_fp32_high = svcvt_f32_f16_z(pg_32, svtrn2_f16(b_fp16, b_fp16));
+
+        svfloat32_t diff_fp32_low = svsub_f32_m(pg_32, a_fp32_low, b_fp32_low);
+        svfloat32_t diff_fp32_high = svsub_f32_m(pg_32, a_fp32_high, b_fp32_high);
+
+        sum1 = svmla_f32_m(pg_32, sum1, diff_fp32_low, diff_fp32_low);
+        sum2 = svmla_f32_m(pg_32, sum2, diff_fp32_high, diff_fp32_high);
+
+        i += svcnth();
+    }
+
+    svfloat32_t total_sum = svadd_f32_m(pg_32, sum1, sum2);
+    return svaddv_f32(pg_32, total_sum);
+}
+
+float
 fvec_L1_sve(const float* x, const float* y, size_t d) {
     svfloat32_t sum = svdup_f32(0.0f);
     size_t i = 0;
@@ -99,6 +133,36 @@ fvec_norm_L2sqr_sve(const float* x, size_t d) {
     }
 
     return svaddv_f32(svptrue_b32(), sum);
+}
+
+float
+fp16_vec_norm_L2sqr_sve(const knowhere::fp16* x, size_t d) {
+    svfloat32_t sum1 = svdup_f32(0.0f);
+    svfloat32_t sum2 = svdup_f32(0.0f);
+    size_t i = 0;
+
+    svbool_t pg_16 = svptrue_b16();
+    svbool_t pg_32 = svptrue_b32();
+
+    while (i < d) {
+        if (d - i < svcnth())
+            pg_16 = svwhilelt_b16(i, d);
+
+        svfloat16_t a_fp16 = svld1_f16(pg_16, reinterpret_cast<const __fp16*>(x + i));
+
+        svfloat32_t a_fp32_low = svcvt_f32_f16_z(pg_32, svtrn1_f16(a_fp16, a_fp16));
+        svfloat32_t a_fp32_high = svcvt_f32_f16_z(pg_32, svtrn2_f16(a_fp16, a_fp16));
+
+        svfloat32_t square_fp32_low = svmul_f32_m(pg_32, a_fp32_low, a_fp32_low);
+        svfloat32_t square_fp32_high = svmul_f32_m(pg_32, a_fp32_high, a_fp32_high);
+
+        sum1 = svadd_f32_m(pg_32, sum1, square_fp32_low);
+        sum2 = svadd_f32_m(pg_32, sum2, square_fp32_high);
+
+        i += svcnth();
+    }
+
+    return svaddv_f32(pg_32, sum1) + svaddv_f32(pg_32, sum2);
 }
 
 void
@@ -212,6 +276,14 @@ fvec_L2sqr_batch_4_sve(const float* x, const float* y0, const float* y1, const f
     dis1 = d1;
     dis2 = d2;
     dis3 = d3;
+}
+
+void
+fvec_L2sqr_ny_sve(float* dis, const float* x, const float* y, size_t d, size_t ny) {
+    for (size_t i = 0; i < ny; ++i) {
+        dis[i] = fvec_L2sqr_sve(x, y, d);
+        y += d;
+    }
 }
 
 }  // namespace faiss

--- a/src/simd/distances_sve.h
+++ b/src/simd/distances_sve.h
@@ -13,11 +13,17 @@
 
 #include <cstdint>
 #include <cstdio>
+
+#include "knowhere/operands.h"
+
 #if defined(__ARM_FEATURE_SVE)
 namespace faiss {
 
 float
 fvec_L2sqr_sve(const float* x, const float* y, size_t d);
+
+float
+fp16_vec_L2sqr_sve(const knowhere::fp16* x, const knowhere::fp16* y, size_t d);
 
 float
 fvec_L1_sve(const float* x, const float* y, size_t d);
@@ -27,6 +33,9 @@ fvec_Linf_sve(const float* x, const float* y, size_t d);
 
 float
 fvec_norm_L2sqr_sve(const float* x, size_t d);
+
+float
+fp16_vec_norm_L2sqr_sve(const knowhere::fp16* x, size_t d);
 
 void
 fvec_madd_sve(size_t n, const float* a, float bf, const float* b, float* c);
@@ -44,6 +53,9 @@ fvec_inner_product_batch_4_sve(const float* x, const float* y0, const float* y1,
 void
 fvec_L2sqr_batch_4_sve(const float* x, const float* y0, const float* y1, const float* y2, const float* y3,
                        const size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
+
+void
+fvec_L2sqr_ny_sve(float* dis, const float* x, const float* y, size_t d, size_t ny);
 
 }  // namespace faiss
 #endif

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -414,7 +414,7 @@ fvec_hook(std::string& simd_type) {
         fvec_madd_and_argmin = fvec_madd_and_argmin_sve;
 
         fvec_inner_product = fvec_inner_product_neon;
-        fvec_L2sqr_ny = fvec_L2sqr_ny_neon;
+        fvec_L2sqr_ny = fvec_L2sqr_ny_sve;
         fvec_inner_products_ny = fvec_inner_products_ny_neon;
 
         ivec_inner_product = ivec_inner_product_neon;
@@ -422,8 +422,8 @@ fvec_hook(std::string& simd_type) {
 
         // fp16
         fp16_vec_inner_product = fp16_vec_inner_product_neon;
-        fp16_vec_L2sqr = fp16_vec_L2sqr_neon;
-        fp16_vec_norm_L2sqr = fp16_vec_norm_L2sqr_neon;
+        fp16_vec_L2sqr = fp16_vec_L2sqr_sve;
+        fp16_vec_norm_L2sqr = fp16_vec_norm_L2sqr_sve;
 
         // bf16
         bf16_vec_inner_product = bf16_vec_inner_product_neon;


### PR DESCRIPTION
**Description:**
This PR introduces SVE (Scalable Vector Extension) enablement for L2 metric computation in FP16 and for the NY function. These enhancements provide notable performance improvements over the existing NEON implementation, especially on ARM platforms with SVE capabilities.

**Changes in This PR:**

Added SVE optimizations for L2 metric computation in FP16.

Implemented SVE-accelerated version of the NY function.

Refactored internal compute kernels to utilize SVE FP16 intrinsics.

Benchmark Results:
Performance benchmarks (32 vCPUs) were conducted comparing NEON and SVE on ARM. The table below summarizes execution time (in seconds) across supported algorithms:

![image](https://github.com/user-attachments/assets/357698da-1309-466d-b5a5-c2c29a3a9deb)


**Key observations:**

Both L2 (FP16) and NY function demonstrate consistent speed-ups with SVE over NEON.

issue: #1143 
