### PR TITLE
knowhere support riscv

### DIFF
--- a/cmake/libs/libfaiss.cmake
+++ b/cmake/libs/libfaiss.cmake
@@ -95,7 +95,11 @@ if(__AARCH64)
   target_link_libraries(knowhere_utils PUBLIC glog::glog)
 endif()
 
-
+if(__RISCV64)
+  set(UTILS_SRC src/simd/hook.cc src/simd/distances_ref.cc)
+  add_library(knowhere_utils STATIC ${UTILS_SRC})
+  target_link_libraries(knowhere_utils PUBLIC glog::glog)
+endif()
 
 # ToDo: Add distances_vsx.cc for powerpc64 SIMD acceleration
 if(__PPC64)
@@ -183,6 +187,28 @@ if(__AARCH64)
   add_dependencies(faiss knowhere_utils)
   target_link_libraries(faiss PUBLIC OpenMP::OpenMP_CXX ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES}
                                      knowhere_utils)
+  target_compile_definitions(faiss PRIVATE FINTEGER=int)
+endif()
+
+if(__RISCV64)
+  knowhere_file_glob(GLOB FAISS_AVX_SRCS thirdparty/faiss/faiss/impl/*avx.cpp)
+
+  list(REMOVE_ITEM FAISS_SRCS ${FAISS_AVX_SRCS})
+  add_library(faiss STATIC ${FAISS_SRCS})
+
+  target_compile_options(
+    faiss
+    PRIVATE $<$<COMPILE_LANGUAGE:CXX>:
+            -Wno-sign-compare
+            -Wno-unused-variable
+            -Wno-reorder
+            -Wno-unused-local-typedefs
+            -Wno-unused-function
+            -Wno-strict-aliasing>)
+
+  add_dependencies(faiss knowhere_utils)
+  target_link_libraries(faiss PUBLIC OpenMP::OpenMP_CXX ${BLAS_LIBRARIES}
+                                     ${LAPACK_LIBRARIES} knowhere_utils)
   target_compile_definitions(faiss PRIVATE FINTEGER=int)
 endif()
 

--- a/cmake/utils/platform_check.cmake
+++ b/cmake/utils/platform_check.cmake
@@ -4,11 +4,13 @@ macro(detect_target_arch)
   check_symbol_exists(__aarch64__ "" __AARCH64)
   check_symbol_exists(__x86_64__ "" __X86_64)
   check_symbol_exists(__powerpc64__ "" __PPC64)
+  check_symbol_exists(__riscv "" __RISCV64)
 
   if(NOT __AARCH64
      AND NOT __X86_64
-     AND NOT __PPC64)
-    message(FATAL "knowhere only support amd64, ppc64 and arm64 architecture.")
+     AND NOT __PPC64
+     AND NOT __RISCV64)
+    message(FATAL "knowhere only support amd64, ppc64, riscv64 and arm64 architecture.")
   endif()
 endmacro()
 


### PR DESCRIPTION
<img width="687" alt="Image" src="https://github.com/user-attachments/assets/751e6d3f-2549-4ae9-addf-29a8a858281a" />
<img width="535" alt="Image" src="https://github.com/user-attachments/assets/5eb9ce91-9dbc-44ef-b9b3-7b6274648920" />

This update introduces RISC-V 64 architecture recognition in the build system by adding dedicated macro detection (__riscv) to the CMake configuration file, while improving error diagnostics to clearly indicate riscv64 as a supported platform. These modifications ensure proper architecture validation and prevent accidental builds on unsupported platforms, laying foundational support for future RISC-V-specific optimizations like SIMD implementations.