### PR TITLE
Enable SVE Support for IP Metric Computation in FP32 functions 

### DIFF
--- a/src/simd/distances_sve.cc
+++ b/src/simd/distances_sve.cc
@@ -41,6 +41,28 @@ fvec_L2sqr_sve(const float* x, const float* y, size_t d) {
 }
 
 float
+fvec_inner_product_sve(const float* x, const float* y, size_t d) {
+    svfloat32_t sum = svdup_f32(0.0f);
+    size_t i = 0;
+
+    svbool_t pg = svptrue_b32();
+
+    while (i < d) {
+        if (d - i < svcntw())
+            pg = svwhilelt_b32(i, d);
+
+        svfloat32_t a = svld1_f32(pg, x + i);
+        svfloat32_t b = svld1_f32(pg, y + i);
+        sum = svmla_f32_m(pg, sum, a, b);
+        i += svcntw();
+    }
+
+    float result = svaddv_f32(svptrue_b32(), sum);
+
+    return result;
+}
+
+float
 fp16_vec_L2sqr_sve(const knowhere::fp16* x, const knowhere::fp16* y, size_t d) {
     svfloat32_t sum1 = svdup_f32(0.0f);
     svfloat32_t sum2 = svdup_f32(0.0f);

--- a/src/simd/distances_sve.h
+++ b/src/simd/distances_sve.h
@@ -23,6 +23,9 @@ float
 fvec_L2sqr_sve(const float* x, const float* y, size_t d);
 
 float
+fvec_inner_product_sve(const float* x, const float* y, size_t d);
+
+float
 fp16_vec_L2sqr_sve(const knowhere::fp16* x, const knowhere::fp16* y, size_t d);
 
 float

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -445,7 +445,7 @@ fvec_hook(std::string& simd_type) {
         fvec_madd = fvec_madd_sve;
         fvec_madd_and_argmin = fvec_madd_and_argmin_sve;
 
-        fvec_inner_product = fvec_inner_product_neon;
+        fvec_inner_product = fvec_inner_product_sve;
         fvec_L2sqr_ny = fvec_L2sqr_ny_sve;
         fvec_inner_products_ny = fvec_inner_products_ny_neon;
 


### PR DESCRIPTION
**Description:**

This PR introduces SVE (Scalable Vector Extension) enablement for IP metric computation in FP32 function. These enhancements provide notable performance improvements over the existing NEON implementation, especially on ARM platforms with SVE capabilities.

**Changes in This PR:**

- Added SVE optimizations for IP metric computation in FP32.
- Refactored internal compute kernels to utilize SVE FP32 intrinsics.

**Benchmark Results:**

Performance benchmarks were conducted comparing NEON and SVE on ARM. The table below summarizes execution time (in seconds) across supported algorithms:
![image](https://github.com/user-attachments/assets/a0f00c18-b1fa-4b17-9ac1-97b33b99f0bf)

**Key observations:**

- All of the algorithms exhibit performance gains with SVE when compared with NEON.

/kind improvement
Fixes https://github.com/zilliztech/knowhere/issues/782