### PR TITLE
knowhere support riscv

### DIFF
--- a/cmake/utils/platform_check.cmake
+++ b/cmake/utils/platform_check.cmake
@@ -4,11 +4,13 @@ macro(detect_target_arch)
   check_symbol_exists(__aarch64__ "" __AARCH64)
   check_symbol_exists(__x86_64__ "" __X86_64)
   check_symbol_exists(__powerpc64__ "" __PPC64)
+  check_symbol_exists(__riscv "" __RISCV64)
 
   if(NOT __AARCH64
      AND NOT __X86_64
-     AND NOT __PPC64)
-    message(FATAL "knowhere only support amd64, ppc64 and arm64 architecture.")
+     AND NOT __PPC64
+     AND NOT __RISCV64)
+    message(FATAL "knowhere only support amd64, ppc64, riscv64 and arm64 architecture.")
   endif()
 endmacro()
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/36a082ee-bdb1-41cc-8cb6-b35d8a6f027a)
![image](https://github.com/user-attachments/assets/dff3c578-b3dc-4d90-a3e0-47ca3837d908)


This update introduces RISC-V 64 architecture recognition in the build system by adding dedicated macro detection (__riscv) to the CMake configuration file, while improving error diagnostics to clearly indicate riscv64 as a supported platform. These modifications ensure proper architecture validation and prevent accidental builds on unsupported platforms, laying foundational support for future RISC-V-specific optimizations like SIMD implementations.