### PR TITLE
Enable SVE Support for IP Metric Computation in FP16 and NY functions

### DIFF
--- a/src/simd/distances_sve.h
+++ b/src/simd/distances_sve.h
@@ -29,6 +29,9 @@ float
 fp16_vec_L2sqr_sve(const knowhere::fp16* x, const knowhere::fp16* y, size_t d);
 
 float
+fp16_vec_inner_product_sve(const knowhere::fp16* x, const knowhere::fp16* y, size_t d);
+
+float
 fvec_L1_sve(const float* x, const float* y, size_t d);
 
 float
@@ -59,6 +62,9 @@ fvec_L2sqr_batch_4_sve(const float* x, const float* y0, const float* y1, const f
 
 void
 fvec_L2sqr_ny_sve(float* dis, const float* x, const float* y, size_t d, size_t ny);
+
+void
+fvec_inner_products_ny_sve(float* ip, const float* x, const float* y, size_t d, size_t ny);
 
 }  // namespace faiss
 #endif

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -447,13 +447,13 @@ fvec_hook(std::string& simd_type) {
 
         fvec_inner_product = fvec_inner_product_sve;
         fvec_L2sqr_ny = fvec_L2sqr_ny_sve;
-        fvec_inner_products_ny = fvec_inner_products_ny_neon;
+        fvec_inner_products_ny = fvec_inner_products_ny_sve;
 
         ivec_inner_product = ivec_inner_product_neon;
         ivec_L2sqr = ivec_L2sqr_neon;
 
         // fp16
-        fp16_vec_inner_product = fp16_vec_inner_product_neon;
+        fp16_vec_inner_product = fp16_vec_inner_product_sve;
         fp16_vec_L2sqr = fp16_vec_L2sqr_sve;
         fp16_vec_norm_L2sqr = fp16_vec_norm_L2sqr_sve;
 


### PR DESCRIPTION
**Description:**

This PR introduces SVE (Scalable Vector Extension) enablement for IP metric computation in FP16 and NY functions. These enhancements provide notable performance improvements over the existing NEON implementation, especially on ARM platforms with SVE capabilities.

**Changes in This PR:**

- Added SVE optimizations for IP metric computation in FP16 and NY functions.
- Refactored internal compute kernels to utilize SVE FP16 intrinsics.

**Benchmark Results:**

Performance benchmarks were conducted comparing NEON and SVE on ARM. The table below summarizes execution time (in seconds) across supported algorithms:
![image](https://github.com/user-attachments/assets/ba74914e-ecaf-4b7b-80a9-57970a091efd)


**Key observations:**
 
- All of the algorithms exhibit performance gains with SVE when compared with NEON.

/kind improvement
Fixes https://github.com/zilliztech/knowhere/issues/782
