### PR TITLE
Enable SVE Support for L2 Metric Computation in INT8 functions

### DIFF
--- a/src/simd/distances_sve.h
+++ b/src/simd/distances_sve.h
@@ -66,5 +66,15 @@ fvec_L2sqr_ny_sve(float* dis, const float* x, const float* y, size_t d, size_t n
 void
 fvec_inner_products_ny_sve(float* ip, const float* x, const float* y, size_t d, size_t ny);
 
+float
+int8_vec_L2sqr_sve(const int8_t* x, const int8_t* y, size_t d);
+
+float
+int8_vec_norm_L2sqr_sve(const int8_t* x, size_t d);
+
+void
+int8_vec_L2sqr_batch_4_sve(const int8_t* x, const int8_t* y0, const int8_t* y1, const int8_t* y2, const int8_t* y3,
+                           const size_t dim, float& dis0, float& dis1, float& dis2, float& dis3);
+
 }  // namespace faiss
 #endif

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -464,6 +464,11 @@ fvec_hook(std::string& simd_type) {
         fvec_L2sqr_batch_4 = fvec_L2sqr_batch_4_sve;
         fvec_inner_product_batch_4 = fvec_inner_product_batch_4_sve;
 
+        // int8
+        int8_vec_L2sqr = int8_vec_L2sqr_sve;
+        int8_vec_norm_L2sqr = int8_vec_norm_L2sqr_sve;
+        int8_vec_L2sqr_batch_4 = int8_vec_L2sqr_batch_4_sve;
+
         simd_type = "SVE";
         support_pq_fast_scan = true;
 #endif


### PR DESCRIPTION
**Description:**

This PR introduces SVE (Scalable Vector Extension) enablement for L2 metric computation in INT8 functions. These enhancements provide notable performance improvements over the existing NEON implementation, especially on ARM platforms with SVE capabilities.

**Changes in This PR:**

Added SVE optimizations for L2 metric computation in INT8 functions.

**Benchmark Results:**

Below are the results from the custom performance test cases we have created using 500000 vectors of dimension 256.

![image](https://github.com/user-attachments/assets/f6b4d5de-b5d0-45c5-bf00-e849a3566b3e)

