### PR TITLE
use iterator-based rangesearch if support ann_iterator (ivf)

### DIFF
--- a/src/index/ivf/ivf_config.h
+++ b/src/index/ivf/ivf_config.h
@@ -39,6 +39,7 @@ class IvfConfig : public BaseConfig {
             .set_default(8)
             .description("number of probes at query time.")
             .for_search()
+            .for_range_search()
             .for_iterator()
             .set_range(1, 65536);
         KNOWHERE_CONFIG_DECLARE_FIELD(use_elkan)


### PR DESCRIPTION
Currently support: `ivfflatcc`, `ivfflat`, `ivfsqcc`, `ivfsq`, `ivf_rbq`
there are some issues with ann_iterator of `IndexScaNN`, need to be fixed by @cqy123456 

/kind improvement