### PR TITLE
Support distance calculation use RVV SIMD

### DIFF
--- a/cmake/libs/libfaiss.cmake
+++ b/cmake/libs/libfaiss.cmake
@@ -104,7 +104,7 @@ if(__AARCH64)
 endif()
 
 if(__RISCV64)
-  set(UTILS_SRC src/simd/hook.cc src/simd/distances_ref.cc src/simd/distances_rvv.cc) 
+  set(UTILS_SRC src/simd/hook.cc src/simd/distances_ref.cc src/simd/distances_rvv.cc)
   add_library(knowhere_utils STATIC ${UTILS_SRC})
   target_link_libraries(knowhere_utils PUBLIC glog::glog)
   target_link_libraries(knowhere_utils PUBLIC xxHash::xxhash)

--- a/cmake/libs/libfaiss.cmake
+++ b/cmake/libs/libfaiss.cmake
@@ -104,7 +104,7 @@ if(__AARCH64)
 endif()
 
 if(__RISCV64)
-  set(UTILS_SRC src/simd/hook.cc src/simd/distances_ref.cc)
+  set(UTILS_SRC src/simd/hook.cc src/simd/distances_ref.cc src/simd/distances_rvv.cc) 
   add_library(knowhere_utils STATIC ${UTILS_SRC})
   target_link_libraries(knowhere_utils PUBLIC glog::glog)
   target_link_libraries(knowhere_utils PUBLIC xxHash::xxhash)
@@ -205,8 +205,11 @@ endif()
 
 if(__RISCV64)
   knowhere_file_glob(GLOB FAISS_AVX_SRCS thirdparty/faiss/faiss/impl/*avx.cpp)
-
   list(REMOVE_ITEM FAISS_SRCS ${FAISS_AVX_SRCS})
+
+  knowhere_file_glob(GLOB FAISS_NEON_SRCS thirdparty/faiss/faiss/impl/*neon.cpp)
+  list(REMOVE_ITEM FAISS_SRCS ${FAISS_NEON_SRCS})
+
   add_library(faiss STATIC ${FAISS_SRCS})
 
   target_compile_options(

--- a/src/simd/distances_rvv.cc
+++ b/src/simd/distances_rvv.cc
@@ -18,25 +18,25 @@ namespace faiss {
 
 // =================== float distances ===================
 float fvec_inner_product_rvv(const float* x, const float* y, size_t d) {
-	
+
 size_t vlmax = __riscv_vsetvlmax_e32m2(); // 使用m2以支持4路并行
-    
+
     // 4个累积器
     vfloat32m2_t vacc0 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
     vfloat32m2_t vacc1 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
     vfloat32m2_t vacc2 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
     vfloat32m2_t vacc3 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
-    
+
     size_t offset = 0;
-    
+
     // 4路展开循环
     while (d >= 4 * vlmax) {
         size_t vl = vlmax;
-        
+
         // 预取数据 (如果支持)
         // __builtin_prefetch(x + offset + 4 * vl, 0, 3);
         // __builtin_prefetch(y + offset + 4 * vl, 0, 3);
-        
+
         vfloat32m2_t vx0 = __riscv_vle32_v_f32m2(x + offset, vl);
         vfloat32m2_t vy0 = __riscv_vle32_v_f32m2(y + offset, vl);
         vfloat32m2_t vx1 = __riscv_vle32_v_f32m2(x + offset + vl, vl);
@@ -45,37 +45,37 @@ size_t vlmax = __riscv_vsetvlmax_e32m2(); // 使用m2以支持4路并行
         vfloat32m2_t vy2 = __riscv_vle32_v_f32m2(y + offset + 2*vl, vl);
         vfloat32m2_t vx3 = __riscv_vle32_v_f32m2(x + offset + 3*vl, vl);
         vfloat32m2_t vy3 = __riscv_vle32_v_f32m2(y + offset + 3*vl, vl);
-        
+
         // 并行FMACC操作
         vacc0 = __riscv_vfmacc_vv_f32m2_tu(vacc0, vx0, vy0, vl);
         vacc1 = __riscv_vfmacc_vv_f32m2_tu(vacc1, vx1, vy1, vl);
         vacc2 = __riscv_vfmacc_vv_f32m2_tu(vacc2, vx2, vy2, vl);
         vacc3 = __riscv_vfmacc_vv_f32m2_tu(vacc3, vx3, vy3, vl);
-        
+
         offset += 4 * vl;
         d -= 4 * vl;
     }
-    
+
     // 合并累积器
     vacc0 = __riscv_vfadd_vv_f32m2(vacc0, vacc1, vlmax);
     vacc2 = __riscv_vfadd_vv_f32m2(vacc2, vacc3, vlmax);
     vacc0 = __riscv_vfadd_vv_f32m2(vacc0, vacc2, vlmax);
-    
+
     // 处理剩余元素
     while (d > 0) {
         size_t vl = __riscv_vsetvl_e32m2(d);
         vfloat32m2_t vx = __riscv_vle32_v_f32m2(x + offset, vl);
         vfloat32m2_t vy = __riscv_vle32_v_f32m2(y + offset, vl);
         vacc0 = __riscv_vfmacc_vv_f32m2_tu(vacc0, vx, vy, vl);
-        
+
         offset += vl;
         d -= vl;
     }
-    
+
     // 最终归约
     vfloat32m1_t sum_scalar = __riscv_vfmv_s_f_f32m1(0.0f, 1);
     sum_scalar = __riscv_vfredusum_vs_f32m2_f32m1(vacc0, sum_scalar, vlmax);
-    
+
     return __riscv_vfmv_f_s_f32m1_f32(sum_scalar);
 }
 

--- a/src/simd/distances_rvv.cc
+++ b/src/simd/distances_rvv.cc
@@ -1,0 +1,84 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#if defined(__riscv_vector)
+#pragma GCC optimize("O3,fast-math,inline")
+#include "distances_rvv.h"
+#include <riscv_vector.h>
+#include <math.h>
+
+namespace faiss {
+
+// =================== float distances ===================
+float fvec_inner_product_rvv(const float* x, const float* y, size_t d) {
+	
+size_t vlmax = __riscv_vsetvlmax_e32m2(); // 使用m2以支持4路并行
+    
+    // 4个累积器
+    vfloat32m2_t vacc0 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    vfloat32m2_t vacc1 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    vfloat32m2_t vacc2 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    vfloat32m2_t vacc3 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    
+    size_t offset = 0;
+    
+    // 4路展开循环
+    while (d >= 4 * vlmax) {
+        size_t vl = vlmax;
+        
+        // 预取数据 (如果支持)
+        // __builtin_prefetch(x + offset + 4 * vl, 0, 3);
+        // __builtin_prefetch(y + offset + 4 * vl, 0, 3);
+        
+        vfloat32m2_t vx0 = __riscv_vle32_v_f32m2(x + offset, vl);
+        vfloat32m2_t vy0 = __riscv_vle32_v_f32m2(y + offset, vl);
+        vfloat32m2_t vx1 = __riscv_vle32_v_f32m2(x + offset + vl, vl);
+        vfloat32m2_t vy1 = __riscv_vle32_v_f32m2(y + offset + vl, vl);
+        vfloat32m2_t vx2 = __riscv_vle32_v_f32m2(x + offset + 2*vl, vl);
+        vfloat32m2_t vy2 = __riscv_vle32_v_f32m2(y + offset + 2*vl, vl);
+        vfloat32m2_t vx3 = __riscv_vle32_v_f32m2(x + offset + 3*vl, vl);
+        vfloat32m2_t vy3 = __riscv_vle32_v_f32m2(y + offset + 3*vl, vl);
+        
+        // 并行FMACC操作
+        vacc0 = __riscv_vfmacc_vv_f32m2_tu(vacc0, vx0, vy0, vl);
+        vacc1 = __riscv_vfmacc_vv_f32m2_tu(vacc1, vx1, vy1, vl);
+        vacc2 = __riscv_vfmacc_vv_f32m2_tu(vacc2, vx2, vy2, vl);
+        vacc3 = __riscv_vfmacc_vv_f32m2_tu(vacc3, vx3, vy3, vl);
+        
+        offset += 4 * vl;
+        d -= 4 * vl;
+    }
+    
+    // 合并累积器
+    vacc0 = __riscv_vfadd_vv_f32m2(vacc0, vacc1, vlmax);
+    vacc2 = __riscv_vfadd_vv_f32m2(vacc2, vacc3, vlmax);
+    vacc0 = __riscv_vfadd_vv_f32m2(vacc0, vacc2, vlmax);
+    
+    // 处理剩余元素
+    while (d > 0) {
+        size_t vl = __riscv_vsetvl_e32m2(d);
+        vfloat32m2_t vx = __riscv_vle32_v_f32m2(x + offset, vl);
+        vfloat32m2_t vy = __riscv_vle32_v_f32m2(y + offset, vl);
+        vacc0 = __riscv_vfmacc_vv_f32m2_tu(vacc0, vx, vy, vl);
+        
+        offset += vl;
+        d -= vl;
+    }
+    
+    // 最终归约
+    vfloat32m1_t sum_scalar = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+    sum_scalar = __riscv_vfredusum_vs_f32m2_f32m1(vacc0, sum_scalar, vlmax);
+    
+    return __riscv_vfmv_f_s_f32m1_f32(sum_scalar);
+}
+
+}  // namespace faiss
+
+#endif

--- a/src/simd/distances_rvv.cc
+++ b/src/simd/distances_rvv.cc
@@ -5,21 +5,23 @@
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-// or implied. See the License for the specific language governing permissions and limitations under the License.
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
 
 #if defined(__riscv_vector)
 #pragma GCC optimize("O3,fast-math,inline")
 #include "distances_rvv.h"
-#include <riscv_vector.h>
+
 #include <math.h>
+#include <riscv_vector.h>
 
 namespace faiss {
 
 // =================== float distances ===================
-float fvec_inner_product_rvv(const float* x, const float* y, size_t d) {
-
-size_t vlmax = __riscv_vsetvlmax_e32m2(); // 使用m2以支持4路并行
+float
+fvec_inner_product_rvv(const float* x, const float* y, size_t d) {
+    size_t vlmax = __riscv_vsetvlmax_e32m2();  // 使用m2以支持4路并行
 
     // 4个累积器
     vfloat32m2_t vacc0 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
@@ -41,10 +43,10 @@ size_t vlmax = __riscv_vsetvlmax_e32m2(); // 使用m2以支持4路并行
         vfloat32m2_t vy0 = __riscv_vle32_v_f32m2(y + offset, vl);
         vfloat32m2_t vx1 = __riscv_vle32_v_f32m2(x + offset + vl, vl);
         vfloat32m2_t vy1 = __riscv_vle32_v_f32m2(y + offset + vl, vl);
-        vfloat32m2_t vx2 = __riscv_vle32_v_f32m2(x + offset + 2*vl, vl);
-        vfloat32m2_t vy2 = __riscv_vle32_v_f32m2(y + offset + 2*vl, vl);
-        vfloat32m2_t vx3 = __riscv_vle32_v_f32m2(x + offset + 3*vl, vl);
-        vfloat32m2_t vy3 = __riscv_vle32_v_f32m2(y + offset + 3*vl, vl);
+        vfloat32m2_t vx2 = __riscv_vle32_v_f32m2(x + offset + 2 * vl, vl);
+        vfloat32m2_t vy2 = __riscv_vle32_v_f32m2(y + offset + 2 * vl, vl);
+        vfloat32m2_t vx3 = __riscv_vle32_v_f32m2(x + offset + 3 * vl, vl);
+        vfloat32m2_t vy3 = __riscv_vle32_v_f32m2(y + offset + 3 * vl, vl);
 
         // 并行FMACC操作
         vacc0 = __riscv_vfmacc_vv_f32m2_tu(vacc0, vx0, vy0, vl);

--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -16,7 +16,7 @@
 #include "knowhere/operands.h"
 
 namespace faiss {
-    
+
 float fvec_inner_product_rvv(const float* x, const float* y, size_t d);
 
 }  // namespace faiss

--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -1,0 +1,22 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+
+#include "knowhere/operands.h"
+
+namespace faiss {
+    
+float fvec_inner_product_rvv(const float* x, const float* y, size_t d);
+
+}  // namespace faiss

--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -5,8 +5,9 @@
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-// or implied. See the License for the specific language governing permissions and limitations under the License.
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
 
 #pragma once
 
@@ -17,6 +18,7 @@
 
 namespace faiss {
 
-float fvec_inner_product_rvv(const float* x, const float* y, size_t d);
+float
+fvec_inner_product_rvv(const float* x, const float* y, size_t d);
 
 }  // namespace faiss

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -27,6 +27,10 @@
 #include "distances_neon.h"
 #endif
 
+#if defined(__riscv_vector)
+#include "distances_rvv.h"
+#endif
+
 #if defined(__ARM_FEATURE_SVE)
 #include "distances_sve.h"
 #endif
@@ -530,6 +534,16 @@ fvec_hook(std::string& simd_type) {
         support_pq_fast_scan = true;
 #endif
     }
+#endif
+
+#if defined(__riscv_vector)
+    fvec_inner_product = fvec_inner_product_rvv;
+    simd_type = "RVV";
+    support_pq_fast_scan = true;
+#else
+    fvec_inner_product = fvec_inner_product_ref;
+    simd_type = "GENERIC";
+    support_pq_fast_scan = false;
 #endif
 
 // ToDo MG: include VSX intrinsics via distances_vsx once _ref tests succeed


### PR DESCRIPTION
Adds RISC-V RVV (RISC-V Vector) SIMD optimization for distance calculation kernels, primarily optimizing floating-point vector inner product computation:
1. Implements inner product calculation (`fvec_inner_product_rvv`) using RISC-V RVV instructions
2. Optimizes loop structure with 4-way unrolling
3. Adds RVV distance calculation files: `src/simd/distances_rvv.cc` and `src/simd/distances_rvv.h`
4. Refactors build system to support RVV optimization

Validation on Banana Pi BPI-F3 development board (RVV 1.0 support):
![image](https://github.com/user-attachments/assets/a4f5cd86-ffca-4785-8c85-ea32e6169cc9)

![image](https://github.com/user-attachments/assets/c9a02bb4-b3a0-4718-a19f-869617b0156c)
