### PR TITLE
Enable SVE Support for IP Metric Computation in INT8 functions

### DIFF
--- a/src/simd/distances_sve.h
+++ b/src/simd/distances_sve.h
@@ -77,6 +77,14 @@ int8_vec_L2sqr_batch_4_sve(const int8_t* x, const int8_t* y0, const int8_t* y1, 
                            const size_t dim, float& dis0, float& dis1, float& dis2, float& dis3);
 
 float
+int8_vec_inner_product_sve(const int8_t* x, const int8_t* y, size_t d);
+
+void
+int8_vec_inner_product_batch_4_sve(const int8_t* x, const int8_t* y0, const int8_t* y1, const int8_t* y2,
+                                   const int8_t* y3, const size_t dim, float& dis0, float& dis1, float& dis2,
+                                   float& dis3);
+
+float
 bf16_vec_L2sqr_sve(const knowhere::bf16* x, const knowhere::bf16* y, size_t d);
 
 float

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -485,6 +485,8 @@ fvec_hook(std::string& simd_type) {
         int8_vec_L2sqr = int8_vec_L2sqr_sve;
         int8_vec_norm_L2sqr = int8_vec_norm_L2sqr_sve;
         int8_vec_L2sqr_batch_4 = int8_vec_L2sqr_batch_4_sve;
+        int8_vec_inner_product = int8_vec_inner_product_sve;
+        int8_vec_inner_product_batch_4 = int8_vec_inner_product_batch_4_sve;
 
         simd_type = "SVE";
         support_pq_fast_scan = true;


### PR DESCRIPTION
**Description:**

This PR introduces SVE (Scalable Vector Extension) enablement for IP metric computation in INT8 functions. These enhancements provide notable performance improvements over the existing NEON implementation, especially on ARM platforms with SVE capabilities.

**Changes in This PR:**

Added SVE optimizations for IP metric computation in INT8 functions.

**Benchmark Results:**

Below are the results from the custom performance test cases we have created using 500000 vectors of dimension 256.

![image](https://github.com/user-attachments/assets/efa468ac-26c1-403e-ad61-0bde0e90220e)
