### PR TITLE
feat: add RVV SIMD versions of fvec_L2sqr, fvec_L1, and fvec_Linf

### DIFF
--- a/src/simd/distances_rvv.cc
+++ b/src/simd/distances_rvv.cc
@@ -77,6 +77,144 @@ fvec_inner_product_rvv(const float* x, const float* y, size_t d) {
     return __riscv_vfmv_f_s_f32m1_f32(sum_scalar);
 }
 
+float
+fvec_L2sqr_rvv(const float* x, const float* y, size_t d) {
+    size_t vlmax = __riscv_vsetvlmax_e32m2();
+    vfloat32m2_t vacc0 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    vfloat32m2_t vacc1 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    vfloat32m2_t vacc2 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    vfloat32m2_t vacc3 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    size_t offset = 0;
+    while (d >= 4 * vlmax) {
+        size_t vl = vlmax;
+        vfloat32m2_t vx0 = __riscv_vle32_v_f32m2(x + offset, vl);
+        vfloat32m2_t vy0 = __riscv_vle32_v_f32m2(y + offset, vl);
+        vfloat32m2_t vx1 = __riscv_vle32_v_f32m2(x + offset + vl, vl);
+        vfloat32m2_t vy1 = __riscv_vle32_v_f32m2(y + offset + vl, vl);
+        vfloat32m2_t vx2 = __riscv_vle32_v_f32m2(x + offset + 2 * vl, vl);
+        vfloat32m2_t vy2 = __riscv_vle32_v_f32m2(y + offset + 2 * vl, vl);
+        vfloat32m2_t vx3 = __riscv_vle32_v_f32m2(x + offset + 3 * vl, vl);
+        vfloat32m2_t vy3 = __riscv_vle32_v_f32m2(y + offset + 3 * vl, vl);
+        vfloat32m2_t vtmp0 = __riscv_vfsub_vv_f32m2(vx0, vy0, vl);
+        vfloat32m2_t vtmp1 = __riscv_vfsub_vv_f32m2(vx1, vy1, vl);
+        vfloat32m2_t vtmp2 = __riscv_vfsub_vv_f32m2(vx2, vy2, vl);
+        vfloat32m2_t vtmp3 = __riscv_vfsub_vv_f32m2(vx3, vy3, vl);
+        vacc0 = __riscv_vfmacc_vv_f32m2_tu(vacc0, vtmp0, vtmp0, vl);
+        vacc1 = __riscv_vfmacc_vv_f32m2_tu(vacc1, vtmp1, vtmp1, vl);
+        vacc2 = __riscv_vfmacc_vv_f32m2_tu(vacc2, vtmp2, vtmp2, vl);
+        vacc3 = __riscv_vfmacc_vv_f32m2_tu(vacc3, vtmp3, vtmp3, vl);
+        offset += 4 * vl;
+        d -= 4 * vl;
+    }
+    vacc0 = __riscv_vfadd_vv_f32m2(vacc0, vacc1, vlmax);
+    vacc2 = __riscv_vfadd_vv_f32m2(vacc2, vacc3, vlmax);
+    vacc0 = __riscv_vfadd_vv_f32m2(vacc0, vacc2, vlmax);
+    while (d > 0) {
+        size_t vl = __riscv_vsetvl_e32m2(d);
+        vfloat32m2_t vx = __riscv_vle32_v_f32m2(x + offset, vl);
+        vfloat32m2_t vy = __riscv_vle32_v_f32m2(y + offset, vl);
+        vfloat32m2_t vtmp = __riscv_vfsub_vv_f32m2(vx, vy, vl);
+        vacc0 = __riscv_vfmacc_vv_f32m2_tu(vacc0, vtmp, vtmp, vl);
+        offset += vl;
+        d -= vl;
+    }
+    vfloat32m1_t sum_scalar = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+    sum_scalar = __riscv_vfredusum_vs_f32m2_f32m1(vacc0, sum_scalar, vlmax);
+    return __riscv_vfmv_f_s_f32m1_f32(sum_scalar);
+}
+
+float
+fvec_L1_rvv(const float* x, const float* y, size_t d) {
+    size_t vlmax = __riscv_vsetvlmax_e32m2();
+    vfloat32m2_t vacc0 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    vfloat32m2_t vacc1 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    vfloat32m2_t vacc2 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    vfloat32m2_t vacc3 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    size_t offset = 0;
+    while (d >= 4 * vlmax) {
+        size_t vl = vlmax;
+        vfloat32m2_t vx0 = __riscv_vle32_v_f32m2(x + offset, vl);
+        vfloat32m2_t vy0 = __riscv_vle32_v_f32m2(y + offset, vl);
+        vfloat32m2_t vx1 = __riscv_vle32_v_f32m2(x + offset + vl, vl);
+        vfloat32m2_t vy1 = __riscv_vle32_v_f32m2(y + offset + vl, vl);
+        vfloat32m2_t vx2 = __riscv_vle32_v_f32m2(x + offset + 2 * vl, vl);
+        vfloat32m2_t vy2 = __riscv_vle32_v_f32m2(y + offset + 2 * vl, vl);
+        vfloat32m2_t vx3 = __riscv_vle32_v_f32m2(x + offset + 3 * vl, vl);
+        vfloat32m2_t vy3 = __riscv_vle32_v_f32m2(y + offset + 3 * vl, vl);
+        vfloat32m2_t vtmp0 = __riscv_vfabs_v_f32m2(__riscv_vfsub_vv_f32m2(vx0, vy0, vl), vl);
+        vfloat32m2_t vtmp1 = __riscv_vfabs_v_f32m2(__riscv_vfsub_vv_f32m2(vx1, vy1, vl), vl);
+        vfloat32m2_t vtmp2 = __riscv_vfabs_v_f32m2(__riscv_vfsub_vv_f32m2(vx2, vy2, vl), vl);
+        vfloat32m2_t vtmp3 = __riscv_vfabs_v_f32m2(__riscv_vfsub_vv_f32m2(vx3, vy3, vl), vl);
+        vacc0 = __riscv_vfadd_vv_f32m2(vacc0, vtmp0, vl);
+        vacc1 = __riscv_vfadd_vv_f32m2(vacc1, vtmp1, vl);
+        vacc2 = __riscv_vfadd_vv_f32m2(vacc2, vtmp2, vl);
+        vacc3 = __riscv_vfadd_vv_f32m2(vacc3, vtmp3, vl);
+        offset += 4 * vl;
+        d -= 4 * vl;
+    }
+    vacc0 = __riscv_vfadd_vv_f32m2(vacc0, vacc1, vlmax);
+    vacc2 = __riscv_vfadd_vv_f32m2(vacc2, vacc3, vlmax);
+    vacc0 = __riscv_vfadd_vv_f32m2(vacc0, vacc2, vlmax);
+    while (d > 0) {
+        size_t vl = __riscv_vsetvl_e32m2(d);
+        vfloat32m2_t vx = __riscv_vle32_v_f32m2(x + offset, vl);
+        vfloat32m2_t vy = __riscv_vle32_v_f32m2(y + offset, vl);
+        vfloat32m2_t vtmp = __riscv_vfabs_v_f32m2(__riscv_vfsub_vv_f32m2(vx, vy, vl), vl);
+        vacc0 = __riscv_vfadd_vv_f32m2(vacc0, vtmp, vl);
+        offset += vl;
+        d -= vl;
+    }
+    vfloat32m1_t sum_scalar = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+    sum_scalar = __riscv_vfredusum_vs_f32m2_f32m1(vacc0, sum_scalar, vlmax);
+    return __riscv_vfmv_f_s_f32m1_f32(sum_scalar);
+}
+
+float
+fvec_Linf_rvv(const float* x, const float* y, size_t d) {
+    size_t vlmax = __riscv_vsetvlmax_e32m2();
+    vfloat32m2_t vmax0 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    vfloat32m2_t vmax1 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    vfloat32m2_t vmax2 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    vfloat32m2_t vmax3 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+    size_t offset = 0;
+    while (d >= 4 * vlmax) {
+        size_t vl = vlmax;
+        vfloat32m2_t vx0 = __riscv_vle32_v_f32m2(x + offset, vl);
+        vfloat32m2_t vy0 = __riscv_vle32_v_f32m2(y + offset, vl);
+        vfloat32m2_t vx1 = __riscv_vle32_v_f32m2(x + offset + vl, vl);
+        vfloat32m2_t vy1 = __riscv_vle32_v_f32m2(y + offset + vl, vl);
+        vfloat32m2_t vx2 = __riscv_vle32_v_f32m2(x + offset + 2 * vl, vl);
+        vfloat32m2_t vy2 = __riscv_vle32_v_f32m2(y + offset + 2 * vl, vl);
+        vfloat32m2_t vx3 = __riscv_vle32_v_f32m2(x + offset + 3 * vl, vl);
+        vfloat32m2_t vy3 = __riscv_vle32_v_f32m2(y + offset + 3 * vl, vl);
+        vfloat32m2_t vtmp0 = __riscv_vfabs_v_f32m2(__riscv_vfsub_vv_f32m2(vx0, vy0, vl), vl);
+        vfloat32m2_t vtmp1 = __riscv_vfabs_v_f32m2(__riscv_vfsub_vv_f32m2(vx1, vy1, vl), vl);
+        vfloat32m2_t vtmp2 = __riscv_vfabs_v_f32m2(__riscv_vfsub_vv_f32m2(vx2, vy2, vl), vl);
+        vfloat32m2_t vtmp3 = __riscv_vfabs_v_f32m2(__riscv_vfsub_vv_f32m2(vx3, vy3, vl), vl);
+        vmax0 = __riscv_vfmax_vv_f32m2(vmax0, vtmp0, vl);
+        vmax1 = __riscv_vfmax_vv_f32m2(vmax1, vtmp1, vl);
+        vmax2 = __riscv_vfmax_vv_f32m2(vmax2, vtmp2, vl);
+        vmax3 = __riscv_vfmax_vv_f32m2(vmax3, vtmp3, vl);
+        offset += 4 * vl;
+        d -= 4 * vl;
+    }
+    vmax0 = __riscv_vfmax_vv_f32m2(vmax0, vmax1, vlmax);
+    vmax2 = __riscv_vfmax_vv_f32m2(vmax2, vmax3, vlmax);
+    vmax0 = __riscv_vfmax_vv_f32m2(vmax0, vmax2, vlmax);
+    while (d > 0) {
+        size_t vl = __riscv_vsetvl_e32m2(d);
+        vfloat32m2_t vx = __riscv_vle32_v_f32m2(x + offset, vl);
+        vfloat32m2_t vy = __riscv_vle32_v_f32m2(y + offset, vl);
+        vfloat32m2_t vtmp = __riscv_vfabs_v_f32m2(__riscv_vfsub_vv_f32m2(vx, vy, vl), vl);
+        vmax0 = __riscv_vfmax_vv_f32m2(vmax0, vtmp, vl);
+        offset += vl;
+        d -= vl;
+    }
+    vfloat32m1_t max_scalar = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+    max_scalar = __riscv_vfredmax_vs_f32m2_f32m1(vmax0, max_scalar, vlmax);
+    return __riscv_vfmv_f_s_f32m1_f32(max_scalar);
+}
+
 }  // namespace faiss
 
 #endif

--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -21,4 +21,13 @@ namespace faiss {
 float
 fvec_inner_product_rvv(const float* x, const float* y, size_t d);
 
+float
+fvec_L2sqr_rvv(const float* x, const float* y, size_t d);
+
+float
+fvec_L1_rvv(const float* x, const float* y, size_t d);
+
+float
+fvec_Linf_rvv(const float* x, const float* y, size_t d);
+
 }  // namespace faiss

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -542,6 +542,11 @@ fvec_hook(std::string& simd_type) {
 
 #if defined(__riscv_vector)
     fvec_inner_product = fvec_inner_product_rvv;
+    fvec_L1 = fvec_L1_rvv;
+    fvec_Linf = fvec_Linf_rvv;
+
+    fvec_L2sqr = fvec_L2sqr_rvv;
+
     simd_type = "RVV";
     support_pq_fast_scan = false;
 #endif


### PR DESCRIPTION
This PR adds RISC-V Vector (RVV) SIMD optimized implementations for the following distance functions:

- fvec_L2sqr
- fvec_L1
- fvec_Linf

1. New RVV SIMD kernels for L2, L1, and Linf distance calculations on float vectors.
2. API and results are fully compatible with the existing reference (scalar) implementations.
3. Significant performance improvements observed across a range of vector dimensions.

Benchmark Results:
![image](https://github.com/user-attachments/assets/9bebf405-c3f7-4618-9dbf-103158ef4272)
- All results are numerically consistent with the reference implementation (max absolute difference < 0.003).
- Speedup is measured as (REF time / RVV time) for 10,000 repeats.


