### PR TITLE
Enable SVE Support for IP Metric Computation in BF16 functions

### DIFF
--- a/src/simd/distances_sve.h
+++ b/src/simd/distances_sve.h
@@ -95,5 +95,13 @@ bf16_vec_L2sqr_batch_4_sve(const knowhere::bf16* x, const knowhere::bf16* y0, co
                            const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0, float& dis1,
                            float& dis2, float& dis3);
 
+float
+bf16_vec_inner_product_sve(const knowhere::bf16* x, const knowhere::bf16* y, size_t d);
+
+void
+bf16_vec_inner_product_batch_4_sve(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                                   const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3);
+
 }  // namespace faiss
 #endif

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -477,13 +477,14 @@ fvec_hook(std::string& simd_type) {
         fp16_vec_norm_L2sqr = fp16_vec_norm_L2sqr_sve;
 
         // bf16
-        bf16_vec_inner_product = bf16_vec_inner_product_neon;
+        bf16_vec_inner_product = bf16_vec_inner_product_sve;
         bf16_vec_L2sqr = bf16_vec_L2sqr_sve;
         bf16_vec_norm_L2sqr = bf16_vec_norm_L2sqr_sve;
         fvec_L2sqr_batch_4 = fvec_L2sqr_batch_4_sve;
         fvec_inner_product_batch_4 = fvec_inner_product_batch_4_sve;
 
         bf16_vec_L2sqr_batch_4 = bf16_vec_L2sqr_batch_4_sve;
+        bf16_vec_inner_product_batch_4 = bf16_vec_inner_product_batch_4_sve;
 
         // int8
         int8_vec_L2sqr = int8_vec_L2sqr_sve;


### PR DESCRIPTION
**Description:**

This PR introduces SVE (Scalable Vector Extension) enablement for IP metric computation in BF16 functions. These enhancements provide notable performance improvements over the existing NEON implementation, especially on ARM platforms with SVE capabilities.

**Changes in This PR:**


- Added SVE optimizations for IP metric computation in BF16 functions.
- Refactored internal compute kernels to utilize SVE BF16 intrinsics.


**Benchmark Results:**

I have created performance test cases by considering a million vectors of dimension 256 as currently I am facing an issue in benchmarking bf16 data type. Issue: https://github.com/zilliztech/knowhere/issues/1193

![image](https://github.com/user-attachments/assets/442c31d8-4d40-4f8a-9c48-9237f49990c1)

**Key observations:**


- All of the functions exhibit performance gains with SVE when compared with NEON.


/kind improvement
Fixes https://github.com/zilliztech/knowhere/issues/782