### PR TITLE
feat(simd/rvv): add RVV SIMD optimized fvec_madd_and_argmin_batch_4 functions

### DIFF
--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -42,4 +42,15 @@ fvec_inner_products_ny_rvv(float* ip, const float* x, const float* y, size_t d, 
 void
 fvec_madd_rvv(size_t n, const float* a, float bf, const float* b, float* c);
 
+int
+fvec_madd_and_argmin_rvv(size_t n, const float* a, float bf, const float* b, float* c);
+
+void
+fvec_inner_product_batch_4_rvv(const float* x, const float* y0, const float* y1, const float* y2, const float* y3,
+                               size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
+
+void
+fvec_L2sqr_batch_4_rvv(const float* x, const float* y0, const float* y1, const float* y2, const float* y3, size_t d,
+                       float& dis0, float& dis1, float& dis2, float& dis3);
+
 }  // namespace faiss

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -548,10 +548,13 @@ fvec_hook(std::string& simd_type) {
 
     fvec_L2sqr = fvec_L2sqr_rvv;
     fvec_inner_products_ny = fvec_inner_products_ny_rvv;
+    fvec_inner_product_batch_4 = fvec_inner_product_batch_4_rvv;
+    fvec_L2sqr_batch_4 = fvec_L2sqr_batch_4_rvv;
 
     fvec_norm_L2sqr = fvec_norm_L2sqr_rvv;
     fvec_L2sqr_ny = fvec_L2sqr_ny_rvv;
     fvec_madd = fvec_madd_rvv;
+    fvec_madd_and_argmin = fvec_madd_and_argmin_rvv;
 
     simd_type = "RVV";
     support_pq_fast_scan = false;


### PR DESCRIPTION
Added RISC-V RVV SIMD optimized distance calculation functions:  
-fvec_madd_and_argmin_rvv  
-fvec_inner_product_batch_4_rvv  
-fvec_L2sqr_batch_4_rvv  

All these functions support the `float` type, with interfaces compatible with the ref/NEON versions for seamless switching.  
The corresponding header file `distances_rvv.h` has been updated with declarations, and test cases have been covered.

Performance and Correctness Verification​:

- ​Correctness: All new functions have been verified through element-wise comparison with the reference implementation, with differences within floating-point error margins. The argmin indices are completely consistent.
- ​Performance: For typical dimensions (8–4096), the RVV SIMD optimizations achieve ​4x–5x speedup​ in medium-to-high dimensions (128–1024). In higher dimensions, the speedup ratio slightly decreases due to memory bandwidth limitations. For detailed results, refer to the test tables.

![image](https://github.com/user-attachments/assets/6fa194df-b093-4c21-8e93-a2b741f1a9e4)
