### PR TITLE
[SIMD][RVV] Optimize int8 distance functions: ivec_inner_product_rvv & ivec_L2sqr_rvv with RVV SIMD

### DIFF
--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -53,4 +53,10 @@ void
 fvec_L2sqr_batch_4_rvv(const float* x, const float* y0, const float* y1, const float* y2, const float* y3, size_t d,
                        float& dis0, float& dis1, float& dis2, float& dis3);
 
+int32_t
+ivec_inner_product_rvv(const int8_t* x, const int8_t* y, size_t d);
+
+int32_t
+ivec_L2sqr_rvv(const int8_t* x, const int8_t* y, size_t d);
+
 }  // namespace faiss

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -556,6 +556,9 @@ fvec_hook(std::string& simd_type) {
     fvec_madd = fvec_madd_rvv;
     fvec_madd_and_argmin = fvec_madd_and_argmin_rvv;
 
+    ivec_inner_product = ivec_inner_product_rvv;
+    ivec_L2sqr = ivec_L2sqr_rvv;
+
     simd_type = "RVV";
     support_pq_fast_scan = false;
 #endif


### PR DESCRIPTION
This PR introduces RVV SIMD optimized implementations for the following int8 distance functions:

- ivec_inner_product_rvv
- ivec_L2sqr_rvv
- Key changes

Key changes:
Utilized RISC-V Vector (RVV) intrinsics for efficient vectorized computation.
Correctly handled vector length, sign extension, and reduction to ensure accuracy.

Test Results:
Extensive correctness and performance tests were conducted across multiple dimensions.
All results matched the reference implementation (diff=0), and significant speedups were observed:
![image](https://github.com/user-attachments/assets/44d2f864-979f-4863-a16b-200dd478450f)

Summary:
Correctness: All results are bitwise identical to the reference implementation.
Performance: RVV SIMD achieves 2x~8x speedup over the scalar baseline, with greater gains at higher dimensions.