### PR TITLE
enhance: sparse: Add support for persistency of sparse indexes

### DIFF
--- a/include/knowhere/sparse_utils.h
+++ b/include/knowhere/sparse_utils.h
@@ -383,9 +383,9 @@ class GrowableVectorView {
         return reinterpret_cast<T*>(mmap_data_)[i];
     }
 
-    T*
+    const T*
     data() const {
-        return reinterpret_cast<T*>(mmap_data_);
+        return reinterpret_cast<const T*>(mmap_data_);
     }
 
     const T&

--- a/src/index/sparse/sparse_index_node.cc
+++ b/src/index/sparse/sparse_index_node.cc
@@ -270,7 +270,7 @@ class SparseInvertedIndexNode : public IndexNode {
         }
         MemoryIOWriter writer;
         if (version_use_raw_data()) {
-            RETURN_IF_ERROR(index_->Save(writer));
+            RETURN_IF_ERROR(index_->SerializeV0(writer));
         } else {
             RETURN_IF_ERROR(index_->Serialize(writer));
         }
@@ -298,7 +298,7 @@ class SparseInvertedIndexNode : public IndexNode {
         }
         index_ = index_or.value();
         if (version_use_raw_data()) {
-            return index_->Load(reader, 0, "");
+            return index_->DeserializeV0(reader, 0, "");
         } else {
             binary_ = binary;  // save the binary to avoid being freed
             return index_->Deserialize(reader);
@@ -336,7 +336,7 @@ class SparseInvertedIndexNode : public IndexNode {
         MemoryIOReader map_reader(reinterpret_cast<uint8_t*>(mapped_memory), map_size);
         if (version_use_raw_data()) {
             auto supplement_target_filename = filename + ".knowhere_sparse_index_supplement";
-            return index_->Load(map_reader, map_flags, supplement_target_filename);
+            return index_->DeserializeV0(map_reader, map_flags, supplement_target_filename);
         } else {
             mmap_guard_ = std::move(mmap_guard);
             return index_->Deserialize(map_reader);


### PR DESCRIPTION
issue: #1237 

For now, because the saved format uses a forward index, loading a sparse index requires rebuilding the index. This works well for in-memory indexes, but when mmap mode is enabled, the massive and frequent disk I/O makes the loading phase so slow that it becomes unusable.
Thus, add support for an inverted index format. Note that this requires a higher index version, which is 8.