### PR TITLE
feat(simd/rvv): add RVV SIMD optimization for int8_vec_inner_product, int8_vec_L2sqr, int8_vec_norm_L2sqr

### DIFF
--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -59,4 +59,13 @@ ivec_inner_product_rvv(const int8_t* x, const int8_t* y, size_t d);
 int32_t
 ivec_L2sqr_rvv(const int8_t* x, const int8_t* y, size_t d);
 
+float
+int8_vec_inner_product_rvv(const int8_t* x, const int8_t* y, size_t d);
+
+float
+int8_vec_L2sqr_rvv(const int8_t* x, const int8_t* y, size_t d);
+
+float
+int8_vec_norm_L2sqr_rvv(const int8_t* x, size_t d);
+
 }  // namespace faiss

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -559,6 +559,10 @@ fvec_hook(std::string& simd_type) {
     ivec_inner_product = ivec_inner_product_rvv;
     ivec_L2sqr = ivec_L2sqr_rvv;
 
+    int8_vec_inner_product = int8_vec_inner_product_rvv;
+    int8_vec_L2sqr = int8_vec_L2sqr_rvv;
+    int8_vec_norm_L2sqr = int8_vec_norm_L2sqr_rvv;
+
     simd_type = "RVV";
     support_pq_fast_scan = false;
 #endif


### PR DESCRIPTION
New and optimized RVV SIMD implementations have been added for the following int8 distance-related functions:

- int8_vec_inner_product_rvv
- int8_vec_L2sqr_rvv
- int8_vec_norm_L2sqr_rvv

All interfaces maintain consistency with the ref/neon implementations, with a return type of float for unified invocation.
Utilizing RVV wide vectors for batch accumulation/differencing/squaring operations significantly boosts computational efficiency for high-dimensional vectors.

​Performance Benchmark Results (tabular data in milliseconds, speedup ratio):​
![image](https://github.com/user-attachments/assets/0695af97-e2f7-4f76-91db-10933e055c02)


/kind improvement