### PR TITLE
feat(simd/rvv): add RVV SIMD optimization for int8_vec batch_4 functions

### DIFF
--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -68,4 +68,11 @@ int8_vec_L2sqr_rvv(const int8_t* x, const int8_t* y, size_t d);
 float
 int8_vec_norm_L2sqr_rvv(const int8_t* x, size_t d);
 
+void
+int8_vec_inner_product_batch_4_rvv(const int8_t* x, const int8_t* y0, const int8_t* y1, const int8_t* y2,
+                                   const int8_t* y3, size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
+void
+int8_vec_L2sqr_batch_4_rvv(const int8_t* x, const int8_t* y0, const int8_t* y1, const int8_t* y2, const int8_t* y3,
+                           size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
+
 }  // namespace faiss

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -562,6 +562,8 @@ fvec_hook(std::string& simd_type) {
     int8_vec_inner_product = int8_vec_inner_product_rvv;
     int8_vec_L2sqr = int8_vec_L2sqr_rvv;
     int8_vec_norm_L2sqr = int8_vec_norm_L2sqr_rvv;
+    int8_vec_inner_product_batch_4 = int8_vec_inner_product_batch_4_rvv;
+    int8_vec_L2sqr_batch_4 = int8_vec_L2sqr_batch_4_rvv;
 
     simd_type = "RVV";
     support_pq_fast_scan = false;


### PR DESCRIPTION
Added and optimized RISC-V RVV SIMD implementations for the following int8 batch distance functions:

- int8_vec_inner_product_batch_4_rvv
- int8_vec_L2sqr_batch_4_rvv

All interfaces maintain compatibility with the ref/neon implementations and support ​4-way parallel computation, enabling efficient batch processing scenarios.

Utilized RVV wide vectors for ​batch accumulation/differencing/squaring, significantly improving batch computation efficiency.
Compared ref and RVV implementations using standardized test programs. All results showed ​zero differences (diff=0)​, confirming full functional equivalence.

​Performance Benchmark Results​ (partial data in milliseconds, speedup ratio):
![image](https://github.com/user-attachments/assets/cfb37aaa-965f-40a6-a9e3-781cc11bdee8)

/kind improvement