### PR TITLE
 [SIMD][RVV] add RVV SIMD optimization for bf16_vec_inner_product_rvv && bf16_vec_L2sqr_rvv && bf16_vec_norm_L2sqr_rvv

### DIFF
--- a/src/simd/distances_rvv.cc
+++ b/src/simd/distances_rvv.cc
@@ -676,6 +676,101 @@ int8_vec_L2sqr_batch_4_rvv(const int8_t* x, const int8_t* y0, const int8_t* y1, 
     dis3 = (float)acc3;
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// bf16
+float
+bf16_vec_inner_product_rvv(const knowhere::bf16* x, const knowhere::bf16* y, size_t d) {
+    const size_t original_d = d;
+    const uint16_t* x_ptr = reinterpret_cast<const uint16_t*>(x);
+    const uint16_t* y_ptr = reinterpret_cast<const uint16_t*>(y);
+
+    size_t vlmax_m8 = __riscv_vsetvlmax_e32m8();
+    vfloat32m8_t v_acc = __riscv_vfmv_v_f_f32m8(0.0f, vlmax_m8);
+
+    for (size_t vl; (vl = __riscv_vsetvl_e16m4(d)) > 0; d -= vl) {
+        vuint16m4_t v_x_u16 = __riscv_vle16_v_u16m4(x_ptr, vl);
+        vuint16m4_t v_y_u16 = __riscv_vle16_v_u16m4(y_ptr, vl);
+
+        vuint32m8_t v_x_u32 = __riscv_vwaddu_vx_u32m8(v_x_u16, 0, vl);
+        vuint32m8_t v_y_u32 = __riscv_vwaddu_vx_u32m8(v_y_u16, 0, vl);
+
+        vuint32m8_t v_x_shifted = __riscv_vsll_vx_u32m8(v_x_u32, 16, vl);
+        vuint32m8_t v_y_shifted = __riscv_vsll_vx_u32m8(v_y_u32, 16, vl);
+
+        vfloat32m8_t v_x_w = __riscv_vreinterpret_v_u32m8_f32m8(v_x_shifted);
+        vfloat32m8_t v_y_w = __riscv_vreinterpret_v_u32m8_f32m8(v_y_shifted);
+
+        v_acc = __riscv_vfmacc_vv_f32m8(v_acc, v_x_w, v_y_w, vl);
+
+        x_ptr += vl;
+        y_ptr += vl;
+    }
+    vfloat32m1_t v_scalar_sum = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+    size_t vl_for_reduction = __riscv_vsetvl_e32m8(original_d);
+    v_scalar_sum = __riscv_vfredusum_vs_f32m8_f32m1(v_acc, v_scalar_sum, vl_for_reduction);
+    return __riscv_vfmv_f_s_f32m1_f32(v_scalar_sum);
+}
+
+float
+bf16_vec_L2sqr_rvv(const knowhere::bf16* x, const knowhere::bf16* y, size_t d) {
+    const size_t original_d = d;
+    const uint16_t* x_ptr = reinterpret_cast<const uint16_t*>(x);
+    const uint16_t* y_ptr = reinterpret_cast<const uint16_t*>(y);
+
+    size_t vlmax_m4 = __riscv_vsetvlmax_e32m4();
+    vfloat32m4_t v_acc = __riscv_vfmv_v_f_f32m4(0.0f, vlmax_m4);
+
+    for (size_t vl; (vl = __riscv_vsetvl_e16m2(d)) > 0; d -= vl) {
+        vuint16m2_t v_x_u16 = __riscv_vle16_v_u16m2(x_ptr, vl);
+        vuint16m2_t v_y_u16 = __riscv_vle16_v_u16m2(y_ptr, vl);
+
+        vuint32m4_t v_x_u32 = __riscv_vwaddu_vx_u32m4(v_x_u16, 0, vl);
+        vuint32m4_t v_y_u32 = __riscv_vwaddu_vx_u32m4(v_y_u16, 0, vl);
+
+        vuint32m4_t v_x_shifted = __riscv_vsll_vx_u32m4(v_x_u32, 16, vl);
+        vuint32m4_t v_y_shifted = __riscv_vsll_vx_u32m4(v_y_u32, 16, vl);
+
+        vfloat32m4_t v_x_w = __riscv_vreinterpret_v_u32m4_f32m4(v_x_shifted);
+        vfloat32m4_t v_y_w = __riscv_vreinterpret_v_u32m4_f32m4(v_y_shifted);
+
+        vfloat32m4_t v_diff = __riscv_vfsub_vv_f32m4(v_x_w, v_y_w, vl);
+
+        v_acc = __riscv_vfmacc_vv_f32m4(v_acc, v_diff, v_diff, vl);
+
+        x_ptr += vl;
+        y_ptr += vl;
+    }
+
+    vfloat32m1_t v_scalar_sum = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+    size_t vl_for_reduction = __riscv_vsetvl_e32m4(original_d);
+    v_scalar_sum = __riscv_vfredusum_vs_f32m4_f32m1(v_acc, v_scalar_sum, vl_for_reduction);
+    return __riscv_vfmv_f_s_f32m1_f32(v_scalar_sum);
+}
+
+float
+bf16_vec_norm_L2sqr_rvv(const knowhere::bf16* x, size_t d) {
+    const size_t original_d = d;
+    const uint16_t* x_ptr = reinterpret_cast<const uint16_t*>(x);
+
+    size_t vlmax_m8 = __riscv_vsetvlmax_e32m8();
+    vfloat32m8_t v_acc = __riscv_vfmv_v_f_f32m8(0.0f, vlmax_m8);
+
+    for (size_t vl; (vl = __riscv_vsetvl_e16m4(d)) > 0; d -= vl) {
+        vuint16m4_t v_x_u16 = __riscv_vle16_v_u16m4(x_ptr, vl);
+
+        vuint32m8_t v_x_u32 = __riscv_vwaddu_vx_u32m8(v_x_u16, 0, vl);
+        vuint32m8_t v_x_shifted = __riscv_vsll_vx_u32m8(v_x_u32, 16, vl);
+        vfloat32m8_t v_x_fp32 = __riscv_vreinterpret_v_u32m8_f32m8(v_x_shifted);
+
+        v_acc = __riscv_vfmacc_vv_f32m8(v_acc, v_x_fp32, v_x_fp32, vl);
+        x_ptr += vl;
+    }
+    vfloat32m1_t v_scalar_sum = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+    size_t vl_for_reduction = __riscv_vsetvl_e32m8(original_d);
+    v_scalar_sum = __riscv_vfredusum_vs_f32m8_f32m1(v_acc, v_scalar_sum, vl_for_reduction);
+    return __riscv_vfmv_f_s_f32m1_f32(v_scalar_sum);
+}
+
 }  // namespace faiss
 
 #endif

--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <cstdio>
 
+#include "hook.h"
 #include "knowhere/operands.h"
 
 namespace faiss {
@@ -75,4 +76,6 @@ void
 int8_vec_L2sqr_batch_4_rvv(const int8_t* x, const int8_t* y0, const int8_t* y1, const int8_t* y2, const int8_t* y3,
                            size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
 
+float
+bf16_vec_norm_L2sqr_rvv(const knowhere::bf16* x, size_t d);
 }  // namespace faiss

--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -77,5 +77,11 @@ int8_vec_L2sqr_batch_4_rvv(const int8_t* x, const int8_t* y0, const int8_t* y1, 
                            size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
 
 float
+bf16_vec_inner_product_rvv(const knowhere::bf16* x, const knowhere::bf16* y, size_t d);
+
+float
+bf16_vec_L2sqr_rvv(const knowhere::bf16* x, const knowhere::bf16* y, size_t d);
+
+float
 bf16_vec_norm_L2sqr_rvv(const knowhere::bf16* x, size_t d);
 }  // namespace faiss

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -565,10 +565,10 @@ fvec_hook(std::string& simd_type) {
     int8_vec_inner_product_batch_4 = int8_vec_inner_product_batch_4_rvv;
     int8_vec_L2sqr_batch_4 = int8_vec_L2sqr_batch_4_rvv;
 
-
     bf16_vec_inner_product = bf16_vec_inner_product_rvv;
     bf16_vec_L2sqr = bf16_vec_L2sqr_rvv;
     bf16_vec_norm_L2sqr = bf16_vec_norm_L2sqr_rvv;
+
     simd_type = "RVV";
     support_pq_fast_scan = false;
 #endif

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -565,6 +565,10 @@ fvec_hook(std::string& simd_type) {
     int8_vec_inner_product_batch_4 = int8_vec_inner_product_batch_4_rvv;
     int8_vec_L2sqr_batch_4 = int8_vec_L2sqr_batch_4_rvv;
 
+
+    bf16_vec_inner_product = bf16_vec_inner_product_rvv;
+    bf16_vec_L2sqr = bf16_vec_L2sqr_rvv;
+    bf16_vec_norm_L2sqr = bf16_vec_norm_L2sqr_rvv;
     simd_type = "RVV";
     support_pq_fast_scan = false;
 #endif


### PR DESCRIPTION
Added and optimized RISC-V RVV SIMD implementations for the following BF16 distance functions:
- **bf16_vec_inner_product_rvv**
- **bf16_vec_L2sqr_rvv**
- **bf16_vec_norm_L2sqr_rvv**

These implementations leverage **RISC-V Vector (RVV) SIMD instructions** to significantly enhance the computational efficiency of BF16 vector operations. Key optimization details include:
- **BF16 to FP32 Conversion**: Each BF16 element is first loaded as `uint16_t`, zero-extended to `uint32_t`, left-shifted by 16 bits (`<< 16`), and then reinterpreted as `float32_t`. This effectively converts the BF16 format to the upper 16 bits of a standard IEEE 754 single-precision float, enabling direct floating-point computations.
- **RVV Wide Vector Operations**: Utilizes RVV wide vectors (e.g., `vfloat32m8_t`, `vfloat32m4_t`) for efficient vectorized accumulation, differencing, and squaring operations, which are critical for accelerating large-scale vector processing tasks.

All interfaces maintain **full compatibility** with existing non-RVV implementations, ensuring seamless integration into the current codebase.

Compared reference (REF) and RVV implementations using standardized test programs. All results showed **zero differences (diff=0)**, confirming full functional equivalence and correctness.

**Performance Benchmark Results** (partial data in milliseconds, speedup ratio):
![0eb0a51b-47a8-4e5b-a29b-fe1f179500a3](https://github.com/user-attachments/assets/f95eb956-645d-44bd-b209-d508231ac0f8)
/kind improvement