### PR TITLE
[SIMD][RVV] add RVV SIMD optimization for bf16_vec_inner_product_batch_4_rvv && bf16_vec_L2sqr_batch_4_rvv

### DIFF
--- a/src/simd/distances_rvv.cc
+++ b/src/simd/distances_rvv.cc
@@ -771,6 +771,131 @@ bf16_vec_norm_L2sqr_rvv(const knowhere::bf16* x, size_t d) {
     return __riscv_vfmv_f_s_f32m1_f32(v_scalar_sum);
 }
 
+void
+bf16_vec_inner_product_batch_4_rvv(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                                   const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3) {
+    size_t temp_d = d;
+    const uint16_t* x_ptr = reinterpret_cast<const uint16_t*>(x);
+    const uint16_t* y0_ptr = reinterpret_cast<const uint16_t*>(y0);
+    const uint16_t* y1_ptr = reinterpret_cast<const uint16_t*>(y1);
+    const uint16_t* y2_ptr = reinterpret_cast<const uint16_t*>(y2);
+    const uint16_t* y3_ptr = reinterpret_cast<const uint16_t*>(y3);
+
+    vfloat32m4_t vacc0 = __riscv_vfmv_v_f_f32m4(0.0f, __riscv_vsetvlmax_e32m4());
+    vfloat32m4_t vacc1 = __riscv_vfmv_v_f_f32m4(0.0f, __riscv_vsetvlmax_e32m4());
+    vfloat32m4_t vacc2 = __riscv_vfmv_v_f_f32m4(0.0f, __riscv_vsetvlmax_e32m4());
+    vfloat32m4_t vacc3 = __riscv_vfmv_v_f_f32m4(0.0f, __riscv_vsetvlmax_e32m4());
+
+    for (size_t vl; (vl = __riscv_vsetvl_e16m2(temp_d)) > 0; temp_d -= vl) {
+        vuint16m2_t vx_u16 = __riscv_vle16_v_u16m2(x_ptr, vl);
+        vfloat32m4_t vx_fp32 =
+            __riscv_vreinterpret_v_u32m4_f32m4(__riscv_vsll_vx_u32m4(__riscv_vwaddu_vx_u32m4(vx_u16, 0, vl), 16, vl));
+
+        // --- Process y0 ---
+        vuint16m2_t vy0_u16 = __riscv_vle16_v_u16m2(y0_ptr, vl);
+        vacc0 = __riscv_vfmacc_vv_f32m4(
+            vacc0, vx_fp32,
+            __riscv_vreinterpret_v_u32m4_f32m4(__riscv_vsll_vx_u32m4(__riscv_vwaddu_vx_u32m4(vy0_u16, 0, vl), 16, vl)),
+            vl);
+
+        // --- Process y1 ---
+        vuint16m2_t vy1_u16 = __riscv_vle16_v_u16m2(y1_ptr, vl);
+        vacc1 = __riscv_vfmacc_vv_f32m4(
+            vacc1, vx_fp32,
+            __riscv_vreinterpret_v_u32m4_f32m4(__riscv_vsll_vx_u32m4(__riscv_vwaddu_vx_u32m4(vy1_u16, 0, vl), 16, vl)),
+            vl);
+
+        // --- Process y2 ---
+        vuint16m2_t vy2_u16 = __riscv_vle16_v_u16m2(y2_ptr, vl);
+        vacc2 = __riscv_vfmacc_vv_f32m4(
+            vacc2, vx_fp32,
+            __riscv_vreinterpret_v_u32m4_f32m4(__riscv_vsll_vx_u32m4(__riscv_vwaddu_vx_u32m4(vy2_u16, 0, vl), 16, vl)),
+            vl);
+
+        // --- Process y3 ---
+        vuint16m2_t vy3_u16 = __riscv_vle16_v_u16m2(y3_ptr, vl);
+        vacc3 = __riscv_vfmacc_vv_f32m4(
+            vacc3, vx_fp32,
+            __riscv_vreinterpret_v_u32m4_f32m4(__riscv_vsll_vx_u32m4(__riscv_vwaddu_vx_u32m4(vy3_u16, 0, vl), 16, vl)),
+            vl);
+
+        x_ptr += vl;
+        y0_ptr += vl;
+        y1_ptr += vl;
+        y2_ptr += vl;
+        y3_ptr += vl;
+    }
+
+    vfloat32m1_t v_scalar_sum_init = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+    dis0 = __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m4_f32m1(vacc0, v_scalar_sum_init, d));
+    dis1 = __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m4_f32m1(vacc1, v_scalar_sum_init, d));
+    dis2 = __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m4_f32m1(vacc2, v_scalar_sum_init, d));
+    dis3 = __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m4_f32m1(vacc3, v_scalar_sum_init, d));
+}
+
+void
+bf16_vec_L2sqr_batch_4_rvv(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                           const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3) {
+    size_t temp_d = d;
+    const uint16_t* x_ptr = reinterpret_cast<const uint16_t*>(x);
+    const uint16_t* y0_ptr = reinterpret_cast<const uint16_t*>(y0);
+    const uint16_t* y1_ptr = reinterpret_cast<const uint16_t*>(y1);
+    const uint16_t* y2_ptr = reinterpret_cast<const uint16_t*>(y2);
+    const uint16_t* y3_ptr = reinterpret_cast<const uint16_t*>(y3);
+
+    vfloat32m2_t vacc0 = __riscv_vfmv_v_f_f32m2(0.0f, __riscv_vsetvlmax_e32m2());
+    vfloat32m2_t vacc1 = __riscv_vfmv_v_f_f32m2(0.0f, __riscv_vsetvlmax_e32m2());
+    vfloat32m2_t vacc2 = __riscv_vfmv_v_f_f32m2(0.0f, __riscv_vsetvlmax_e32m2());
+    vfloat32m2_t vacc3 = __riscv_vfmv_v_f_f32m2(0.0f, __riscv_vsetvlmax_e32m2());
+
+    for (size_t vl; (vl = __riscv_vsetvl_e16m1(temp_d)) > 0; temp_d -= vl) {
+        vfloat32m2_t vx_fp32 = __riscv_vreinterpret_v_u32m2_f32m2(
+            __riscv_vsll_vx_u32m2(__riscv_vwaddu_vx_u32m2(__riscv_vle16_v_u16m1(x_ptr, vl), 0, vl), 16, vl));
+
+        vuint16m1_t vy0_u16 = __riscv_vle16_v_u16m1(y0_ptr, vl);
+        vfloat32m2_t vdiff0 = __riscv_vfsub_vv_f32m2(
+            vx_fp32,
+            __riscv_vreinterpret_v_u32m2_f32m2(__riscv_vsll_vx_u32m2(__riscv_vwaddu_vx_u32m2(vy0_u16, 0, vl), 16, vl)),
+            vl);
+        vacc0 = __riscv_vfmacc_vv_f32m2(vacc0, vdiff0, vdiff0, vl);
+
+        vuint16m1_t vy1_u16 = __riscv_vle16_v_u16m1(y1_ptr, vl);
+        vfloat32m2_t vdiff1 = __riscv_vfsub_vv_f32m2(
+            vx_fp32,
+            __riscv_vreinterpret_v_u32m2_f32m2(__riscv_vsll_vx_u32m2(__riscv_vwaddu_vx_u32m2(vy1_u16, 0, vl), 16, vl)),
+            vl);
+        vacc1 = __riscv_vfmacc_vv_f32m2(vacc1, vdiff1, vdiff1, vl);
+
+        vuint16m1_t vy2_u16 = __riscv_vle16_v_u16m1(y2_ptr, vl);
+        vfloat32m2_t vdiff2 = __riscv_vfsub_vv_f32m2(
+            vx_fp32,
+            __riscv_vreinterpret_v_u32m2_f32m2(__riscv_vsll_vx_u32m2(__riscv_vwaddu_vx_u32m2(vy2_u16, 0, vl), 16, vl)),
+            vl);
+        vacc2 = __riscv_vfmacc_vv_f32m2(vacc2, vdiff2, vdiff2, vl);
+
+        vuint16m1_t vy3_u16 = __riscv_vle16_v_u16m1(y3_ptr, vl);
+        vfloat32m2_t vdiff3 = __riscv_vfsub_vv_f32m2(
+            vx_fp32,
+            __riscv_vreinterpret_v_u32m2_f32m2(__riscv_vsll_vx_u32m2(__riscv_vwaddu_vx_u32m2(vy3_u16, 0, vl), 16, vl)),
+            vl);
+        vacc3 = __riscv_vfmacc_vv_f32m2(vacc3, vdiff3, vdiff3, vl);
+
+        x_ptr += vl;
+        y0_ptr += vl;
+        y1_ptr += vl;
+        y2_ptr += vl;
+        y3_ptr += vl;
+    }
+
+    vfloat32m1_t v_scalar_sum_init = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+    dis0 = __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m2_f32m1(vacc0, v_scalar_sum_init, d));
+    dis1 = __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m2_f32m1(vacc1, v_scalar_sum_init, d));
+    dis2 = __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m2_f32m1(vacc2, v_scalar_sum_init, d));
+    dis3 = __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m2_f32m1(vacc3, v_scalar_sum_init, d));
+}
+
 }  // namespace faiss
 
 #endif

--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -84,4 +84,13 @@ bf16_vec_L2sqr_rvv(const knowhere::bf16* x, const knowhere::bf16* y, size_t d);
 
 float
 bf16_vec_norm_L2sqr_rvv(const knowhere::bf16* x, size_t d);
+
+void
+bf16_vec_inner_product_batch_4_rvv(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                                   const knowhere::bf16* y2, const knowhere::bf16* y3, const size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3);
+void
+bf16_vec_L2sqr_batch_4_rvv(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
+                           const knowhere::bf16* y2, const knowhere::bf16* y3, size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3);
 }  // namespace faiss

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -568,7 +568,8 @@ fvec_hook(std::string& simd_type) {
     bf16_vec_inner_product = bf16_vec_inner_product_rvv;
     bf16_vec_L2sqr = bf16_vec_L2sqr_rvv;
     bf16_vec_norm_L2sqr = bf16_vec_norm_L2sqr_rvv;
-
+    bf16_vec_inner_product_batch_4 = bf16_vec_inner_product_batch_4_rvv;
+    bf16_vec_L2sqr_batch_4 = bf16_vec_L2sqr_batch_4_rvv;
     simd_type = "RVV";
     support_pq_fast_scan = false;
 #endif


### PR DESCRIPTION
Added and optimized RISC-V RVV SIMD implementations for BF16 4-way batch distance functions:

bf16_vec_inner_product_batch_4_rvv: Computes inner products for one 'x' vector against four 'y' vectors simultaneously.
bf16_vec_L2sqr_batch_4_rvv: Computes squared L2 distances for one 'x' vector against four 'y' vectors simultaneously.
These implementations leverage RISC-V Vector (RVV) SIMD instructions to significantly enhance the computational efficiency of BF16 vector operations in batch processing scenarios. Key optimization details include:

BF16 to FP32 Conversion: Each BF16 element is first loaded as uint16_t, zero-extended to uint32_t, left-shifted by 16 bits (<< 16), and then reinterpreted as float32_t. This effectively converts the BF16 format to the upper 16 bits of a standard IEEE 754 single-precision float, enabling direct floating-point computations.
4-Way Batch Parallelism: The functions are designed to process four y vectors against a single x vector in parallel, utilizing multiple independent vector accumulators (vacc0 to vacc3) to maximize throughput.
RVV Wide Vector Operations: Efficiently utilizes RVV wide vectors (e.g., vfloat32m4_t, vfloat32m2_t) for vectorized accumulation, differencing, and squaring operations.
All interfaces maintain full compatibility with existing non-RVV implementations and support the specified 4-way batch computation patterns, ensuring seamless integration into the current codebase.

Compared reference (REF) and RVV implementations using standardized test programs. All results showed zero differences (diff=0), confirming full functional equivalence and correctness.

Performance Benchmark Results (Speedup Ratio for 4-way batch functions):
![image](https://github.com/user-attachments/assets/1e0be2f8-dae0-4cbb-958e-bcae0335e170)
/kind improvement