### PR TITLE
feat(simd-rvv): Add RVV SIMD optimized bf16 patch functions for inner product and L2sqr

### DIFF
--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -93,4 +93,11 @@ void
 bf16_vec_L2sqr_batch_4_rvv(const knowhere::bf16* x, const knowhere::bf16* y0, const knowhere::bf16* y1,
                            const knowhere::bf16* y2, const knowhere::bf16* y3, size_t d, float& dis0, float& dis1,
                            float& dis2, float& dis3);
+
+float
+fvec_inner_product_bf16_patch_rvv(const float* x, const float* y, size_t d);
+
+float
+fvec_L2sqr_bf16_patch_rvv(const float* x, const float* y, size_t d);
+
 }  // namespace faiss

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -556,6 +556,9 @@ fvec_hook(std::string& simd_type) {
     fvec_madd = fvec_madd_rvv;
     fvec_madd_and_argmin = fvec_madd_and_argmin_rvv;
 
+    fvec_inner_product_bf16_patch = fvec_inner_product_bf16_patch_rvv;
+    fvec_L2sqr_bf16_patch = fvec_L2sqr_bf16_patch_rvv;
+
     ivec_inner_product = ivec_inner_product_rvv;
     ivec_L2sqr = ivec_L2sqr_rvv;
 
@@ -570,6 +573,7 @@ fvec_hook(std::string& simd_type) {
     bf16_vec_norm_L2sqr = bf16_vec_norm_L2sqr_rvv;
     bf16_vec_inner_product_batch_4 = bf16_vec_inner_product_batch_4_rvv;
     bf16_vec_L2sqr_batch_4 = bf16_vec_L2sqr_batch_4_rvv;
+
     simd_type = "RVV";
     support_pq_fast_scan = false;
 #endif


### PR DESCRIPTION
This PR implements RISC-V RVV SIMD-optimized bf16 patch distance calculation functions:

- fvec_inner_product_bf16_patch_rvv
- fvec_L2sqr_bf16_patch_rvv

Before SIMD computation, these functions truncate the y vector in bf16 format to meet the low-precision requirements of mainstream AI inference/retrieval scenarios while fully leveraging the parallel capabilities of the RVV instruction set.

**Performance and Accuracy**
For typical dimensions (64~4096), the RVV implementation exhibits minimal numerical error compared to the reference implementation (maximum diff ~1e-3 to 1e-5), fully satisfying engineering precision requirements. In terms of performance, the RVV implementation achieves a 3~7x speedup over the scalar reference implementation, with even higher acceleration ratios for larger dimensions.

**Partial test data is as follows:**
![image](https://github.com/user-attachments/assets/60c0c22a-0eb2-4c46-bca9-109fcb777639)

/kind improvement