### PR TITLE
feat: Extend BitsetView for 1-hop ID mapping in hierarchical index_nodes

### DIFF
--- a/include/knowhere/bitsetview_idselector.h
+++ b/include/knowhere/bitsetview_idselector.h
@@ -19,33 +19,14 @@ namespace knowhere {
 
 struct BitsetViewIDSelector final : faiss::IDSelector {
     const BitsetView bitset_view;
-    const size_t id_offset;
 
-    inline BitsetViewIDSelector(BitsetView bitset_view, const size_t offset = 0)
-        : bitset_view{bitset_view}, id_offset(offset) {
+    inline BitsetViewIDSelector(BitsetView bitset_view) : bitset_view{bitset_view} {
     }
 
     inline bool
     is_member(faiss::idx_t id) const override final {
         // it is by design that bitset_view.empty() is not tested here
-        return (!bitset_view.test(id + id_offset));
-    }
-};
-
-struct BitsetViewWithMappingIDSelector final : faiss::IDSelector {
-    const BitsetView bitset_view;
-    const uint32_t* out_id_mapping;
-    const size_t id_offset;
-
-    inline BitsetViewWithMappingIDSelector(BitsetView bitset_view, const uint32_t* out_id_mapping,
-                                           const size_t offset = 0)
-        : bitset_view{bitset_view}, out_id_mapping(out_id_mapping), id_offset(offset) {
-    }
-
-    inline bool
-    is_member(faiss::idx_t id) const override final {
-        // it is by design that out_id_mapping == nullptr is not tested here
-        return (!bitset_view.test(out_id_mapping[id + id_offset]));
+        return (!bitset_view.test(id));
     }
 };
 

--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -433,6 +433,28 @@ class IndexNode : public Object {
     virtual std::string
     Type() const = 0;
 
+    /**
+     * @brief Gets the mapping from internal IDs to external IDs.
+     *
+     * @return A reference to the mapping vector.
+     */
+    virtual std::shared_ptr<std::vector<uint32_t>>
+    GetInternalIdToExternalIdMap() const {
+        throw std::runtime_error("GetInterIdToOuterIdMap not implemented");
+    }
+
+    /**
+     * @brief Sets the mapping from internal IDs to "most external" IDs for 1-hop bitset check!
+     * Only used for hierarchical indexnode, such as emb_list + hnsw, each index node has its own relayout mapping.
+     *
+     * @param map The mapping vector to set.
+     * @return Status indicating success or failure of the mapping.
+     */
+    virtual Status
+    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) {
+        throw std::runtime_error("SetInternalIdToMostExternalIdMap not implemented");
+    }
+
     virtual ~IndexNode() {
     }
 

--- a/src/index/hnsw/faiss_hnsw.cc
+++ b/src/index/hnsw/faiss_hnsw.cc
@@ -335,6 +335,38 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
         return writer.total_size;
     }
 
+    std::shared_ptr<std::vector<uint32_t>>
+    GetInternalIdToExternalIdMap() const override {
+        auto internal_offset_to_label = std::make_shared<std::vector<uint32_t>>();
+        assert(indexes.size() > 0);
+        if (indexes.size() == 1) {
+            // without mv-only labels, the id mapping is the same as the internal offset.
+            internal_offset_to_label->resize(Count());
+            std::iota(internal_offset_to_label->begin(), internal_offset_to_label->end(), 0);
+        } else {
+            // faiss_hnsw has stored mv-only labels (id mapping for each mv-index) *separately*, not a contiguous
+            // memory block. Note that the mv-only labels have a fixed serialization format; changing the design of
+            // labels would affect index version compatibility.
+            // so a temporary vector must be created to memcpy all id mappings.
+            auto total_size = index_rows_sum[index_rows_sum.size() - 1];
+            assert(total_size == Count());
+            internal_offset_to_label->resize(total_size);
+            for (auto par_idx = 0; par_idx < index_rows_sum.size() - 1; ++par_idx) {
+                auto par_size = index_rows_sum[par_idx + 1] - index_rows_sum[par_idx];
+                assert(par_size == labels[par_idx]->size());
+                std::memcpy(internal_offset_to_label->data() + index_rows_sum[par_idx], labels[par_idx]->data(),
+                            par_size * sizeof(uint32_t));
+            }
+        }
+        return internal_offset_to_label;
+    }
+
+    Status
+    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) override {
+        internal_offset_to_most_external_id = std::move(map);
+        return Status::success;
+    }
+
  protected:
     // it is std::shared_ptr, not std::unique_ptr, because it can be
     //    shared with FaissHnswIterator
@@ -346,6 +378,8 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
     std::vector<uint32_t> index_rows_sum;
     // label to locate internal offset
     std::vector<uint32_t> label_to_internal_offset;
+    // internal offset to most external id, only for 1-hop bitset check
+    std::vector<uint32_t> internal_offset_to_most_external_id;
 
     int
     getIndexToSearchByScalarInfo(const FaissHnswConfig& config, const BitsetView& bitset) const {
@@ -362,8 +396,11 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
             return 0;
         }
         size_t first_valid_index = bitset.get_first_valid_index();
-        auto it = std::lower_bound(index_rows_sum.begin(), index_rows_sum.end(),
-                                   label_to_internal_offset[first_valid_index] + 1);
+        if (!bitset.has_out_ids()) {
+            first_valid_index = label_to_internal_offset[first_valid_index];
+        }
+        auto it = std::upper_bound(index_rows_sum.begin(), index_rows_sum.end(), first_valid_index);
+
         if (it == index_rows_sum.end()) {
             LOG_KNOWHERE_WARNING_ << "can not find vector of offset " << label_to_internal_offset[first_valid_index];
             return -1;
@@ -979,14 +1016,9 @@ class FaissHnswIterator : public IndexIterator {
             filter_type sel;
 
             next_batch(batch_handler, sel);
-        } else if (labels == nullptr) {
+        } else {
             using filter_type = knowhere::BitsetViewIDSelector;
             filter_type sel(workspace.bitset);
-
-            next_batch(batch_handler, sel);
-        } else {
-            using filter_type = knowhere::BitsetViewWithMappingIDSelector;
-            filter_type sel(workspace.bitset, labels->data());
 
             next_batch(batch_handler, sel);
         }
@@ -997,6 +1029,12 @@ class FaissHnswIterator : public IndexIterator {
         if (label_to_internal_offset.empty()) {
             return workspace.qdis_refine->operator()(id);
         }
+        // todo: Currently, next-batch returns quant results that have already been mapped to labels (external_id),
+        // but refine requires the internal offset within the mv-index, so we need to map them back.
+        // This reverse mapping is actually quite wasteful.
+        // The best solution is to detect if need refine in next-batch, and directly return the internal offset of the
+        // mv-index. After refine computation, convert it back to the label (external_id).
+        // This involves changing the iterator interface in the base class in index_node.h, which will take some time.
         auto mv_internal_offset = label_to_internal_offset[id] - mv_base_offset;
         return workspace.qdis_refine->operator()(mv_internal_offset);
     }
@@ -1151,7 +1189,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
     }
 
     expected<DataSetPtr>
-    Search(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset) const override {
+    Search(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset_) const override {
         if (this->indexes.empty()) {
             return expected<DataSetPtr>::Err(Status::empty_index, "index not loaded");
         }
@@ -1170,10 +1208,27 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
         const auto hnsw_cfg = static_cast<const FaissHnswConfig&>(*cfg);
         const auto k = hnsw_cfg.k.value();
+
+        BitsetView bitset(bitset_);
+        if (!internal_offset_to_most_external_id.empty()) {
+            bitset.set_out_ids(internal_offset_to_most_external_id.data(), internal_offset_to_most_external_id.size());
+        }
         auto index_id = getIndexToSearchByScalarInfo(hnsw_cfg, bitset);
         if (index_id < 0) {
             return expected<DataSetPtr>::Err(Status::invalid_args, "partition key value not correctly set");
         }
+        if (indexes.size() > 1) {
+            // calculate more accurate filter statistics for the single mv-index.
+            size_t num_mv_ids = labels[index_id].get()->size();
+            size_t num_mv_filtered_out_ids = num_mv_ids - (bitset.size() - bitset.count());
+            if (!bitset.has_out_ids()) {
+                bitset.set_out_ids(labels[index_id].get()->data(), num_mv_ids, num_mv_filtered_out_ids);
+            } else {
+                bitset.set_out_ids(internal_offset_to_most_external_id.data(), num_mv_ids, num_mv_filtered_out_ids);
+                bitset.set_id_offset(index_rows_sum[index_id]);
+            }
+        }
+
         feder::hnsw::FederResultUniq feder_result;
         if (hnsw_cfg.trace_visit.value()) {
             if (rows != 1) {
@@ -1229,16 +1284,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
         // set up a selector
         BitsetViewIDSelector bw_idselector(bitset);
-        BitsetViewWithMappingIDSelector bw_mapping_idselector(
-            bitset, labels.empty() ? nullptr : labels[index_id].get()->data());
-        faiss::IDSelector* id_selector = nullptr;
-        if (!bitset.empty()) {
-            if (labels.empty()) {
-                id_selector = &bw_idselector;
-            } else {
-                id_selector = &bw_mapping_idselector;
-            }
-        }
+        faiss::IDSelector* id_selector = &bw_idselector;
         hnsw_search_params.sel = id_selector;
 
         // run
@@ -1337,10 +1383,10 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
     }
 
     expected<DataSetPtr>
-    RangeSearch(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset) const override {
+    RangeSearch(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset_) const override {
         // if support ann_iterator, use iterator-based range_search (IndexNode::RangeSearch)
         if (is_ann_iterator_supported()) {
-            return IndexNode::RangeSearch(dataset, std::move(cfg), bitset);
+            return IndexNode::RangeSearch(dataset, std::move(cfg), bitset_);
         }
         if (this->indexes.empty()) {
             return expected<DataSetPtr>::Err(Status::empty_index, "index not loaded");
@@ -1359,9 +1405,23 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         const auto* data = dataset->GetTensor();
 
         const auto hnsw_cfg = static_cast<const FaissHnswConfig&>(*cfg);
+        BitsetView bitset(bitset_);
+        if (!internal_offset_to_most_external_id.empty()) {
+            bitset.set_out_ids(internal_offset_to_most_external_id.data(), internal_offset_to_most_external_id.size());
+        }
         auto index_id = getIndexToSearchByScalarInfo(hnsw_cfg, bitset);
         if (index_id < 0) {
             return expected<DataSetPtr>::Err(Status::invalid_args, "partition key value not correctly set");
+        }
+        if (indexes.size() > 1) {
+            size_t num_mv_ids = labels[index_id].get()->size();
+            size_t num_mv_filtered_out_ids = num_mv_ids - (bitset.size() - bitset.count());
+            if (!bitset.has_out_ids()) {
+                bitset.set_out_ids(labels[index_id].get()->data(), num_mv_ids, num_mv_filtered_out_ids);
+            } else {
+                bitset.set_out_ids(internal_offset_to_most_external_id.data(), num_mv_ids, num_mv_filtered_out_ids);
+                bitset.set_id_offset(index_rows_sum[index_id]);
+            }
         }
 
         const bool is_similarity_metric = faiss::is_similarity_metric(indexes[index_id]->metric_type);
@@ -1413,16 +1473,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
         // set up a selector
         BitsetViewIDSelector bw_idselector(bitset);
-        BitsetViewWithMappingIDSelector bw_mapping_idselector(
-            bitset, labels.empty() ? nullptr : labels[index_id].get()->data());
-        faiss::IDSelector* id_selector = nullptr;
-        if (!bitset.empty()) {
-            if (labels.empty()) {
-                id_selector = &bw_idselector;
-            } else {
-                id_selector = &bw_mapping_idselector;
-            }
-        }
+        faiss::IDSelector* id_selector = &bw_idselector;
         hnsw_search_params.sel = id_selector;
 
         ////////////////////////////////////////////////////////////////
@@ -1661,7 +1712,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
     }
 
     expected<std::vector<IndexNode::IteratorPtr>>
-    AnnIterator(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset,
+    AnnIterator(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset_,
                 bool use_knowhere_search_pool) const override {
         if (isIndexEmpty()) {
             LOG_KNOWHERE_ERROR_ << "creating iterator on empty index";
@@ -1681,10 +1732,24 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         auto vec = std::vector<IndexNode::IteratorPtr>(n_queries, nullptr);
 
         const FaissHnswConfig& hnsw_cfg = static_cast<const FaissHnswConfig&>(*cfg);
+        BitsetView bitset(bitset_);
+        if (!internal_offset_to_most_external_id.empty()) {
+            bitset.set_out_ids(internal_offset_to_most_external_id.data(), internal_offset_to_most_external_id.size());
+        }
         int index_id = getIndexToSearchByScalarInfo(hnsw_cfg, bitset);
         if (index_id < 0) {
             return expected<std::vector<IndexNode::IteratorPtr>>::Err(Status::invalid_args,
                                                                       "partition key value not correctly set");
+        }
+        if (indexes.size() > 1) {
+            size_t num_mv_ids = labels[index_id].get()->size();
+            size_t num_mv_filtered_out_ids = num_mv_ids - (bitset.size() - bitset.count());
+            if (!bitset.has_out_ids()) {
+                bitset.set_out_ids(labels[index_id].get()->data(), num_mv_ids, num_mv_filtered_out_ids);
+            } else {
+                bitset.set_out_ids(internal_offset_to_most_external_id.data(), num_mv_ids, num_mv_filtered_out_ids);
+                bitset.set_id_offset(index_rows_sum[index_id]);
+            }
         }
         const bool is_cosine = IsMetricType(hnsw_cfg.metric_type.value(), knowhere::metric::COSINE);
         const bool larger_is_closer = (IsMetricType(hnsw_cfg.metric_type.value(), knowhere::metric::IP) || is_cosine);
@@ -2025,6 +2090,24 @@ class HNSWIndexNodeWithFallback : public IndexNode {
             return base_index->AnnIterator(dataset, std::move(cfg), bitset, use_knowhere_search_pool);
         } else {
             return fallback_search_index->AnnIterator(dataset, std::move(cfg), bitset, use_knowhere_search_pool);
+        }
+    }
+
+    std::shared_ptr<std::vector<uint32_t>>
+    GetInternalIdToExternalIdMap() const override {
+        if (use_base_index) {
+            return base_index->GetInternalIdToExternalIdMap();
+        } else {
+            return fallback_search_index->GetInternalIdToExternalIdMap();
+        }
+    }
+
+    Status
+    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) override {
+        if (use_base_index) {
+            return base_index->SetInternalIdToMostExternalIdMap(std::move(map));
+        } else {
+            return fallback_search_index->SetInternalIdToMostExternalIdMap(std::move(map));
         }
     }
 

--- a/src/index/hnsw/impl/IndexBruteForceWrapper.cc
+++ b/src/index/hnsw/impl/IndexBruteForceWrapper.cc
@@ -44,21 +44,6 @@ struct BitsetViewIDSelectorWrapper final {
     }
 };
 
-struct BitsetViewWithMappingIDSelectorWrapper final {
-    const BitsetView bitset_view;
-    const uint32_t* out_id_mapping;
-
-    inline BitsetViewWithMappingIDSelectorWrapper(BitsetView bitset_view, const uint32_t* out_id_mapping)
-        : bitset_view{bitset_view}, out_id_mapping{out_id_mapping} {
-    }
-
-    [[nodiscard]] inline bool
-    is_member(faiss::idx_t id) const {
-        // it is by design that bitset_view.empty() and out_id_mapping == nullptr is not tested here
-        return (!bitset_view.test(out_id_mapping[id]));
-    }
-};
-
 //
 IndexBruteForceWrapper::IndexBruteForceWrapper(faiss::Index* underlying_index)
     : faiss::cppcontrib::knowhere::IndexWrapper{underlying_index} {
@@ -88,18 +73,9 @@ IndexBruteForceWrapper::search(faiss::idx_t n, const float* __restrict x, faiss:
             using C = faiss::CMin<float, idx_t>;
 
             // try knowhere-specific filter
-            if (const knowhere::BitsetViewWithMappingIDSelector* __restrict bw_idselector =
-                    dynamic_cast<const knowhere::BitsetViewWithMappingIDSelector*>(sel);
+            if (const knowhere::BitsetViewIDSelector* __restrict bw_idselector =
+                    dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel);
                 bw_idselector && !bw_idselector->bitset_view.empty()) {
-                BitsetViewWithMappingIDSelectorWrapper bw_idselector_w(bw_idselector->bitset_view,
-                                                                       bw_idselector->out_id_mapping);
-
-                faiss::cppcontrib::knowhere::brute_force_search_impl<C, faiss::DistanceComputer,
-                                                                     BitsetViewWithMappingIDSelectorWrapper>(
-                    index->ntotal, *dis, bw_idselector_w, k, local_distances, local_ids);
-            } else if (const knowhere::BitsetViewIDSelector* __restrict bw_idselector =
-                           dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel);
-                       bw_idselector && !bw_idselector->bitset_view.empty()) {
                 BitsetViewIDSelectorWrapper bw_idselector_w(bw_idselector->bitset_view);
 
                 faiss::cppcontrib::knowhere::brute_force_search_impl<C, faiss::DistanceComputer,
@@ -114,18 +90,9 @@ IndexBruteForceWrapper::search(faiss::idx_t n, const float* __restrict x, faiss:
             using C = faiss::CMax<float, idx_t>;
 
             // try knowhere-specific filter
-            if (const knowhere::BitsetViewWithMappingIDSelector* __restrict bw_idselector =
-                    dynamic_cast<const knowhere::BitsetViewWithMappingIDSelector*>(sel);
+            if (const knowhere::BitsetViewIDSelector* __restrict bw_idselector =
+                    dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel);
                 bw_idselector && !bw_idselector->bitset_view.empty()) {
-                BitsetViewWithMappingIDSelectorWrapper bw_idselector_w(bw_idselector->bitset_view,
-                                                                       bw_idselector->out_id_mapping);
-
-                faiss::cppcontrib::knowhere::brute_force_search_impl<C, faiss::DistanceComputer,
-                                                                     BitsetViewWithMappingIDSelectorWrapper>(
-                    index->ntotal, *dis, bw_idselector_w, k, local_distances, local_ids);
-            } else if (const knowhere::BitsetViewIDSelector* __restrict bw_idselector =
-                           dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel);
-                       bw_idselector && !bw_idselector->bitset_view.empty()) {
                 BitsetViewIDSelectorWrapper bw_idselector_w(bw_idselector->bitset_view);
 
                 faiss::cppcontrib::knowhere::brute_force_search_impl<C, faiss::DistanceComputer,

--- a/src/index/hnsw/impl/IndexHNSWWrapper.cc
+++ b/src/index/hnsw/impl/IndexHNSWWrapper.cc
@@ -135,41 +135,9 @@ IndexHNSWWrapper::search(idx_t n, const float* __restrict x, idx_t k, float* __r
         faiss::IDSelector* sel = (params == nullptr) ? nullptr : params->sel;
 
         // try knowhere-specific filter
-        if (const knowhere::BitsetViewWithMappingIDSelector* __restrict bw_idselector =
-                dynamic_cast<const knowhere::BitsetViewWithMappingIDSelector*>(sel);
+        if (const knowhere::BitsetViewIDSelector* __restrict bw_idselector =
+                dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel);
             bw_idselector && !bw_idselector->bitset_view.empty()) {
-            // with filter
-            // feder templating is important, bcz it removes an unneeded 'CALL' instruction.
-            if (feder == nullptr) {
-                // no feder
-                DummyVisitor graph_visitor;
-
-                using searcher_type =
-                    faiss::cppcontrib::knowhere::v2_hnsw_searcher<faiss::DistanceComputer, DummyVisitor,
-                                                                  faiss::cppcontrib::knowhere::Bitset,
-                                                                  knowhere::BitsetViewWithMappingIDSelector>;
-
-                searcher_type searcher{hnsw,           *(dis.get()), graph_visitor, bitset_visited_nodes,
-                                       *bw_idselector, kAlpha,       params};
-
-                local_stats = searcher.search(k, distances + i * k, labels + i * k);
-            } else {
-                // use feder
-                FederVisitor graph_visitor(feder);
-
-                using searcher_type =
-                    faiss::cppcontrib::knowhere::v2_hnsw_searcher<faiss::DistanceComputer, FederVisitor,
-                                                                  faiss::cppcontrib::knowhere::Bitset,
-                                                                  knowhere::BitsetViewWithMappingIDSelector>;
-
-                searcher_type searcher{hnsw,           *(dis.get()), graph_visitor, bitset_visited_nodes,
-                                       *bw_idselector, kAlpha,       params};
-
-                local_stats = searcher.search(k, distances + i * k, labels + i * k);
-            }
-        } else if (const knowhere::BitsetViewIDSelector* __restrict bw_idselector =
-                       dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel);
-                   bw_idselector && !bw_idselector->bitset_view.empty()) {
             // with filter, no mapping
 
             // feder templating is important, bcz it removes an unneeded 'CALL' instruction.
@@ -332,42 +300,9 @@ IndexHNSWWrapper::range_search(idx_t n, const float* __restrict x, float radius_
         faiss::IDSelector* sel = (params == nullptr) ? nullptr : params->sel;
 
         // try knowhere-specific filter
-        if (const knowhere::BitsetViewWithMappingIDSelector* __restrict bw_idselector =
-                dynamic_cast<const knowhere::BitsetViewWithMappingIDSelector*>(sel);
+        if (const knowhere::BitsetViewIDSelector* __restrict bw_idselector =
+                dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel);
             bw_idselector && !bw_idselector->bitset_view.empty()) {
-            // with filter
-
-            // feder templating is important, bcz it removes an unneeded 'CALL' instruction.
-            if (feder == nullptr) {
-                // no feder
-                DummyVisitor graph_visitor;
-
-                using searcher_type =
-                    faiss::cppcontrib::knowhere::v2_hnsw_searcher<faiss::DistanceComputer, DummyVisitor,
-                                                                  faiss::cppcontrib::knowhere::Bitset,
-                                                                  knowhere::BitsetViewWithMappingIDSelector>;
-
-                searcher_type searcher{hnsw,           *(dis.get()), graph_visitor, bitset_visited_nodes,
-                                       *bw_idselector, kAlpha,       params};
-
-                local_stats = searcher.range_search(radius, &res_min);
-            } else {
-                // use feder
-                FederVisitor graph_visitor(feder);
-
-                using searcher_type =
-                    faiss::cppcontrib::knowhere::v2_hnsw_searcher<faiss::DistanceComputer, FederVisitor,
-                                                                  faiss::cppcontrib::knowhere::Bitset,
-                                                                  knowhere::BitsetViewWithMappingIDSelector>;
-
-                searcher_type searcher{hnsw,           *(dis.get()), graph_visitor, bitset_visited_nodes,
-                                       *bw_idselector, kAlpha,       params};
-
-                local_stats = searcher.range_search(radius, &res_min);
-            }
-        } else if (const knowhere::BitsetViewIDSelector* __restrict bw_idselector =
-                       dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel);
-                   bw_idselector && !bw_idselector->bitset_view.empty()) {
             // with filter, no mapping
 
             // feder templating is important, bcz it removes an unneeded 'CALL' instruction.

--- a/tests/ut/utils.h
+++ b/tests/ut/utils.h
@@ -298,22 +298,19 @@ CheckDistanceInScope(const knowhere::DataSet& result, float low_bound, float hig
 }
 
 inline std::unordered_map<int64_t, std::vector<std::vector<uint32_t>>>
-GenerateScalarInfo(size_t n) {
+GenerateScalarInfo(size_t n, size_t partition_num = 2) {
     std::vector<std::vector<uint32_t>> scalar_info;
-    scalar_info.reserve(2);
-    std::vector<uint32_t> scalar1;
-    scalar1.reserve(n / 2);
-    std::vector<uint32_t> scalar2;
-    scalar2.reserve(n - n / 2);
-    for (size_t i = 0; i < n; ++i) {
-        if (i % 2 == 0) {
-            scalar2.emplace_back(i);
-        } else {
-            scalar1.emplace_back(i);
+    scalar_info.reserve(partition_num);
+    for (size_t i = 0; i < partition_num; ++i) {
+        std::vector<uint32_t> scalar;
+        scalar.reserve(n / partition_num + 1);
+        for (size_t j = 0; j < n; ++j) {
+            if (j % partition_num == i) {
+                scalar.emplace_back(j);
+            }
         }
+        scalar_info.emplace_back(std::move(scalar));
     }
-    scalar_info.emplace_back(std::move(scalar1));
-    scalar_info.emplace_back(std::move(scalar2));
     std::unordered_map<int64_t, std::vector<std::vector<uint32_t>>> scalar_map;
     scalar_map[0] = std::move(scalar_info);
     return scalar_map;

--- a/thirdparty/faiss/faiss/utils/distances.cpp
+++ b/thirdparty/faiss/faiss/utils/distances.cpp
@@ -151,10 +151,9 @@ struct IDSelectorHelper {
 struct BitsetViewSelectorHelper {
     // todo aguzhva: use avx gather instruction
     const knowhere::BitsetView bitset;
-    const size_t id_offset = 0;
 
     inline bool is_member(const size_t idx) const {
-        return !bitset.test(idx + id_offset);
+        return !bitset.test(idx);
     }
 };
 
@@ -254,9 +253,8 @@ void exhaustive_inner_product_seq(
     if (const auto* bitsetview_sel = dynamic_cast<const knowhere::BitsetViewIDSelector*>(res.sel)) {
         // A specialized case for Knowhere
         auto bitset = bitsetview_sel->bitset_view;
-        auto id_offset = bitsetview_sel->id_offset;
         if (!bitset.empty()) {
-            BitsetViewSelectorHelper bitset_helper{bitset, id_offset};
+            BitsetViewSelectorHelper bitset_helper{bitset};
             exhaustive_inner_product_seq_impl<BlockResultHandler, BitsetViewSelectorHelper>(
                 x, y, d, nx, ny, res, bitset_helper);
             return;
@@ -368,9 +366,8 @@ void exhaustive_L2sqr_seq(
     if (const auto* bitsetview_sel = dynamic_cast<const knowhere::BitsetViewIDSelector*>(res.sel)) {
         // A specialized case for Knowhere
         auto bitset = bitsetview_sel->bitset_view;
-        auto id_offset = bitsetview_sel->id_offset;
         if (!bitset.empty()) {
-            BitsetViewSelectorHelper bitset_helper{bitset, id_offset};
+            BitsetViewSelectorHelper bitset_helper{bitset};
             exhaustive_L2sqr_seq_impl<BlockResultHandler, BitsetViewSelectorHelper>(
                 x, y, d, nx, ny, res, bitset_helper);
             return;
@@ -494,9 +491,8 @@ void exhaustive_cosine_seq(
     if (const auto* bitsetview_sel = dynamic_cast<const knowhere::BitsetViewIDSelector*>(res.sel)) {
         // A specialized case for Knowhere
         auto bitset = bitsetview_sel->bitset_view;
-        auto id_offset = bitsetview_sel->id_offset;
         if (!bitset.empty()) {
-            BitsetViewSelectorHelper bitset_helper{bitset, id_offset};
+            BitsetViewSelectorHelper bitset_helper{bitset};
             exhaustive_cosine_seq_impl<BlockResultHandler, BitsetViewSelectorHelper>(
                 x, y, y_norms, d, nx, ny, res, bitset_helper);
             return;


### PR DESCRIPTION
Implements a 1-hop ID mapping mechanism to accelerate bitset checks in hierarchical index nodes. This avoids costly multi-level ID translations by composing nested ID maps into a single lookup table.

- `BitsetView` is extended to support an `out_id_map` and `offset`.
- `index_node` now exposes its internal ID map and accepts an external map from its parent, enabling the composition of multi-level re-layouts.
- `BitsetViewWithMappingIDSelector` is removed, and `BitsetViewIDSelector` is simplified to a basic wrapper.
- Adds comprehensive tests for the new external ID map functionality.

/kind feature