### PR TITLE
[SIMD][RVV] add RVV SIMD optimization for fp16_vec_inner_product_rvv && fp16_vec_L2sqr_rvv && fp16_vec_norm_L2sqr_rvv

### DIFF
--- a/src/simd/distances_rvv.cc
+++ b/src/simd/distances_rvv.cc
@@ -677,6 +677,82 @@ int8_vec_L2sqr_batch_4_rvv(const int8_t* x, const int8_t* y0, const int8_t* y1, 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// fp16
+
+float
+fp16_vec_inner_product_rvv(const knowhere::fp16* x, const knowhere::fp16* y, size_t d) {
+    const size_t original_d = d;
+    vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(0.0f, __riscv_vsetvlmax_e32m8());
+
+    const _Float16* x_ptr = reinterpret_cast<const _Float16*>(x);
+    const _Float16* y_ptr = reinterpret_cast<const _Float16*>(y);
+
+    for (size_t vl; (vl = __riscv_vsetvl_e16m4(d)) > 0; d -= vl) {
+        vfloat16m4_t vx = __riscv_vle16_v_f16m4(x_ptr, vl);
+        vfloat16m4_t vy = __riscv_vle16_v_f16m4(y_ptr, vl);
+
+        vfloat32m8_t vfx = __riscv_vfwcvt_f_f_v_f32m8(vx, vl);
+        vfloat32m8_t vfy = __riscv_vfwcvt_f_f_v_f32m8(vy, vl);
+
+        acc = __riscv_vfmacc_vv_f32m8(acc, vfx, vfy, vl);
+
+        x_ptr += vl;
+        y_ptr += vl;
+    }
+
+    vfloat32m1_t scalar_sum_vec = __riscv_vfredusum_vs_f32m8_f32m1(acc, __riscv_vfmv_s_f_f32m1(0.0f, 1), original_d);
+
+    return __riscv_vfmv_f_s_f32m1_f32(scalar_sum_vec);
+}
+
+float
+fp16_vec_L2sqr_rvv(const knowhere::fp16* x, const knowhere::fp16* y, size_t d) {
+    const size_t original_d = d;
+    vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, __riscv_vsetvlmax_e32m4());
+    const _Float16* x_ptr = reinterpret_cast<const _Float16*>(x);
+    const _Float16* y_ptr = reinterpret_cast<const _Float16*>(y);
+
+    for (size_t vl; (vl = __riscv_vsetvl_e16m2(d)) > 0; d -= vl) {
+        vfloat16m2_t vx = __riscv_vle16_v_f16m2(x_ptr, vl);
+        vfloat16m2_t vy = __riscv_vle16_v_f16m2(y_ptr, vl);
+
+        vfloat32m4_t vfx = __riscv_vfwcvt_f_f_v_f32m4(vx, vl);
+        vfloat32m4_t vfy = __riscv_vfwcvt_f_f_v_f32m4(vy, vl);
+
+        vfloat32m4_t v_diff = __riscv_vfsub_vv_f32m4(vfx, vfy, vl);
+
+        acc = __riscv_vfmacc_vv_f32m4(acc, v_diff, v_diff, vl);
+        x_ptr += vl;
+        y_ptr += vl;
+    }
+
+    vfloat32m1_t scalar_sum_vec = __riscv_vfredusum_vs_f32m4_f32m1(acc, __riscv_vfmv_s_f_f32m1(0.0f, 1), original_d);
+
+    return __riscv_vfmv_f_s_f32m1_f32(scalar_sum_vec);
+}
+
+float
+fp16_vec_norm_L2sqr_rvv(const knowhere::fp16* x, size_t d) {
+    const size_t original_d = d;
+    vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(0.0f, __riscv_vsetvlmax_e32m8());
+    const _Float16* x_ptr = reinterpret_cast<const _Float16*>(x);
+
+    for (size_t vl; (vl = __riscv_vsetvl_e16m4(d)) > 0; d -= vl) {
+        vfloat16m4_t vx = __riscv_vle16_v_f16m4(x_ptr, vl);
+
+        vfloat32m8_t vfx = __riscv_vfwcvt_f_f_v_f32m8(vx, vl);
+
+        acc = __riscv_vfmacc_vv_f32m8(acc, vfx, vfx, vl);
+
+        x_ptr += vl;
+    }
+
+    vfloat32m1_t scalar_sum_vec = __riscv_vfredusum_vs_f32m8_f32m1(acc, __riscv_vfmv_s_f_f32m1(0.0f, 1), original_d);
+
+    return __riscv_vfmv_f_s_f32m1_f32(scalar_sum_vec);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // bf16
 float
 bf16_vec_inner_product_rvv(const knowhere::bf16* x, const knowhere::bf16* y, size_t d) {

--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -77,6 +77,15 @@ int8_vec_L2sqr_batch_4_rvv(const int8_t* x, const int8_t* y0, const int8_t* y1, 
                            size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
 
 float
+fp16_vec_inner_product_rvv(const knowhere::fp16* x, const knowhere::fp16* y, size_t d);
+
+float
+fp16_vec_L2sqr_rvv(const knowhere::fp16* x, const knowhere::fp16* y, size_t d);
+
+float
+fp16_vec_norm_L2sqr_rvv(const knowhere::fp16* x, size_t d);
+
+float
 bf16_vec_inner_product_rvv(const knowhere::bf16* x, const knowhere::bf16* y, size_t d);
 
 float

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -565,6 +565,10 @@ fvec_hook(std::string& simd_type) {
     int8_vec_inner_product_batch_4 = int8_vec_inner_product_batch_4_rvv;
     int8_vec_L2sqr_batch_4 = int8_vec_L2sqr_batch_4_rvv;
 
+    fp16_vec_inner_product = fp16_vec_inner_product_rvv;
+    fp16_vec_L2sqr = fp16_vec_L2sqr_rvv;
+    fp16_vec_norm_L2sqr = fp16_vec_norm_L2sqr_rvv;
+
     bf16_vec_inner_product = bf16_vec_inner_product_rvv;
     bf16_vec_L2sqr = bf16_vec_L2sqr_rvv;
     bf16_vec_norm_L2sqr = bf16_vec_norm_L2sqr_rvv;


### PR DESCRIPTION
Added and optimized RISC-V RVV SIMD implementations for the following FP16 distance functions:
* `fp16_vec_inner_product_rvv`
* `fp16_vec_L2sqr_rvv`
* `fp16_vec_norm_L2sqr_rvv`

These implementations leverage RISC-V Vector (RVV) SIMD instructions to significantly enhance the computational efficiency of FP16 vector operations. Key optimization details include:

* **FP16 to FP32 Conversion:** Each FP16 element is first loaded as `vfloat16mX_t` and then directly converted to `vfloat32mY_t` using `__riscv_vfwcvt_f_f_v_f32mY` intrinsic. This effectively up-converts the half-precision FP16 format to full-precision FP32 for accurate intermediate computations and higher precision accumulation.
* **RVV Wide Vector Operations:** Utilizes RVV wide vectors (e.g., `vfloat32m8_t`, `vfloat32m4_t`) for efficient vectorized accumulation, differencing, and squaring operations, which are critical for accelerating large-scale vector processing tasks. The use of `vfmacc_vv` further optimizes fused multiply-add operations.

All interfaces maintain full compatibility with existing non-RVV implementations, ensuring seamless integration into the current codebase.

Compared reference (REF) and RVV implementations using standardized test programs. All results showed zero differences (diff=0), confirming full functional equivalence and correctness.
Performance Benchmark Results (partial data in milliseconds, speedup ratio):
<img width="1004" height="515" alt="6590ab26-2eef-44db-87bc-d596cf99b126" src="https://github.com/user-attachments/assets/a31a76c2-da81-49d3-a647-c7de772a0172" />
