### PR TITLE
feat(simd-rvv): Add RVV SIMD optimized batch-4 bf16 patch functions

### DIFF
--- a/build_history.txt
+++ b/build_history.txt
@@ -1,5 +1,0 @@
-56dfbaa0 2025-07-14T01:03:44+00:00 feat(simd-rvv): Add RVV SIMD optimized bf16 patch functions for inner product and L2sqr
-9160972e 2025-07-10T21:48:42+08:00 FEAT: Implement initial RVV optimizations for BF16_batch_4 functions (#1248)
-78ab62af 2025-07-10T20:56:42+08:00 fix: sparse: all entries should use span in version 8 (#1251)
-95f0e5e1 2025-07-10T11:08:41+08:00 fix: sparse vector dup key error in bruteforce range search (#1246)
-c02bd225 2025-07-09T23:18:42+08:00  [SIMD][RVV] add RVV SIMD optimization for bf16_vec_inner_product_rvv && bf16_vec_L2sqr_rvv && bf16_vec_norm_L2sqr_rvv (#1244)

--- a/build_history.txt
+++ b/build_history.txt
@@ -1,0 +1,5 @@
+56dfbaa0 2025-07-14T01:03:44+00:00 feat(simd-rvv): Add RVV SIMD optimized bf16 patch functions for inner product and L2sqr
+9160972e 2025-07-10T21:48:42+08:00 FEAT: Implement initial RVV optimizations for BF16_batch_4 functions (#1248)
+78ab62af 2025-07-10T20:56:42+08:00 fix: sparse: all entries should use span in version 8 (#1251)
+95f0e5e1 2025-07-10T11:08:41+08:00 fix: sparse vector dup key error in bruteforce range search (#1246)
+c02bd225 2025-07-09T23:18:42+08:00  [SIMD][RVV] add RVV SIMD optimization for bf16_vec_inner_product_rvv && bf16_vec_L2sqr_rvv && bf16_vec_norm_L2sqr_rvv (#1244)

--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -109,4 +109,13 @@ fvec_inner_product_bf16_patch_rvv(const float* x, const float* y, size_t d);
 float
 fvec_L2sqr_bf16_patch_rvv(const float* x, const float* y, size_t d);
 
+void
+fvec_inner_product_batch_4_bf16_patch_rvv(const float* x, const float* y0, const float* y1, const float* y2,
+                                          const float* y3, size_t d, float& dis0, float& dis1, float& dis2,
+                                          float& dis3);
+
+void
+fvec_L2sqr_batch_4_bf16_patch_rvv(const float* x, const float* y0, const float* y1, const float* y2, const float* y3,
+                                  size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
+
 }  // namespace faiss

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -558,6 +558,8 @@ fvec_hook(std::string& simd_type) {
 
     fvec_inner_product_bf16_patch = fvec_inner_product_bf16_patch_rvv;
     fvec_L2sqr_bf16_patch = fvec_L2sqr_bf16_patch_rvv;
+    fvec_inner_product_batch_4_bf16_patch = fvec_inner_product_batch_4_bf16_patch_rvv;
+    fvec_L2sqr_batch_4_bf16_patch = fvec_L2sqr_batch_4_bf16_patch_rvv;
 
     ivec_inner_product = ivec_inner_product_rvv;
     ivec_L2sqr = ivec_L2sqr_rvv;


### PR DESCRIPTION
This PR implements RISC-V RVV SIMD-optimized bf16 patch batch distance calculation functions:

- fvec_inner_product_batch_4_bf16_patch_rvv
- fvec_L2sqr_batch_4_bf16_patch_rvv

These functions target efficient computation of 4-way batched vector distances, suitable for high-throughput scenarios such as ANN/retrieval. The implementation follows the NEON/AVX512 design approach, fully leveraging the parallel capabilities of the RVV instruction set and vectorized bf16 conversion.

​Performance and Accuracy​
Under typical dimensions (64–4096), the RVV implementation exhibits minimal numerical error compared to the reference implementation (maximum diff ≈ 1e-3), fully meeting engineering precision requirements. Performance-wise, the RVV implementation achieves 2–5x speedup over the scalar reference version, with even faster speeds observed for larger dimensions.

Partial test data is shown below:
<img width="1464" height="468" alt="image" src="https://github.com/user-attachments/assets/d600605c-87c2-4865-a633-c0022549e127" />

/kind improvement