### PR TITLE
[SIMD][RVV] add RVV SIMD optimization for fp16_vec_inner_product_batch_4_rvv && fp16_vec_L2sqr_batch_4_rvv

### DIFF
--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -85,6 +85,16 @@ fp16_vec_L2sqr_rvv(const knowhere::fp16* x, const knowhere::fp16* y, size_t d);
 float
 fp16_vec_norm_L2sqr_rvv(const knowhere::fp16* x, size_t d);
 
+void
+fp16_vec_inner_product_batch_4_rvv(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                                   const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3);
+
+void
+fp16_vec_L2sqr_batch_4_rvv(const knowhere::fp16* x, const knowhere::fp16* y0, const knowhere::fp16* y1,
+                           const knowhere::fp16* y2, const knowhere::fp16* y3, const size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3);
+
 float
 bf16_vec_inner_product_rvv(const knowhere::bf16* x, const knowhere::bf16* y, size_t d);
 

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -573,6 +573,8 @@ fvec_hook(std::string& simd_type) {
     fp16_vec_inner_product = fp16_vec_inner_product_rvv;
     fp16_vec_L2sqr = fp16_vec_L2sqr_rvv;
     fp16_vec_norm_L2sqr = fp16_vec_norm_L2sqr_rvv;
+    fp16_vec_inner_product_batch_4 = fp16_vec_inner_product_batch_4_rvv;
+    fp16_vec_L2sqr_batch_4 = fp16_vec_L2sqr_batch_4_rvv;
 
     bf16_vec_inner_product = bf16_vec_inner_product_rvv;
     bf16_vec_L2sqr = bf16_vec_L2sqr_rvv;


### PR DESCRIPTION
Added and optimized RISC-V RVV SIMD implementations for the following FP16 distance functions:

* `fp16_vec_inner_product_batch_4_rvv`
* `fp16_vec_L2sqr_batch_4_rvv`

These implementations leverage **RISC-V Vector (RVV) SIMD instructions** to significantly enhance the computational efficiency of FP16 vector operations, particularly when processing **batch data**. By handling 4 vectors concurrently, these optimizations aim to maximize throughput on RISC-V architectures.


* **Efficient FP16 to FP32 Conversion**:
    Each FP16 element is first loaded as a `vfloat16mX_t` and then directly converted to `vfloat32mY_t` using the `__riscv_vfwcvt_f_f_v_f32mY` intrinsic. This effectively up-converts the half-precision FP16 format to full-precision FP32 for accurate intermediate computations and higher precision accumulation.

* **RVV Wide Vector Operations**:
    The implementations utilize RVV wide vectors (e.g., `vfloat32m4_t`) for efficient vectorized accumulation, differencing, and squaring operations. These are critical for accelerating large-scale vector processing tasks. The use of `__riscv_vfmacc_vv_f32m4` further optimizes **fused multiply-add** operations.

* **Batch Processing (Batch 4) Strategy**:
    Both functions are specifically designed to process **4 vectors simultaneously**. This parallelization of multiple distance calculations significantly improves processing efficiency, delivering superior performance in scenarios like batch queries.


All interfaces maintain full compatibility with existing non-RVV implementations, ensuring seamless integration into the current codebase.

Compared reference (REF) and RVV implementations using standardized test programs. All results showed zero differences (diff=0), confirming full functional equivalence and correctness.
Performance Benchmark Results (partial data in milliseconds, speedup ratio):
<img width="1063" height="531" alt="image" src="https://github.com/user-attachments/assets/f009336a-e85e-4d80-b645-deea20384bdd" />
/kind improvement
