### PR TITLE
Fix ARM duplicate definitions of ivec_inner_product and ivec_L2sqr in hook.cc

### DIFF
--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -515,9 +515,6 @@ fvec_hook(std::string& simd_type) {
         fvec_inner_product_batch_4 = fvec_inner_product_batch_4_neon;
         fvec_L2sqr_batch_4 = fvec_L2sqr_batch_4_neon;
 
-        ivec_inner_product = ivec_inner_product_neon;
-        ivec_L2sqr = ivec_L2sqr_neon;
-
         // fp16
         fp16_vec_inner_product = fp16_vec_inner_product_neon;
         fp16_vec_L2sqr = fp16_vec_L2sqr_neon;


### PR DESCRIPTION
![1](https://github.com/user-attachments/assets/ca75f0cd-b35c-4e19-ba20-02d4f8667318)
Fix ARM duplicate definitions of ivec_inner_product and ivec_L2sqr in hook.cc