### PR TITLE
 Fix undeclared identifier error in RVV SIMD hook.cc

### DIFF
--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -555,11 +555,6 @@ fvec_hook(std::string& simd_type) {
     fvec_madd = fvec_madd_rvv;
     fvec_madd_and_argmin = fvec_madd_and_argmin_rvv;
 
-    fvec_inner_product_bf16_patch = fvec_inner_product_bf16_patch_rvv;
-    fvec_L2sqr_bf16_patch = fvec_L2sqr_bf16_patch_rvv;
-    fvec_inner_product_batch_4_bf16_patch = fvec_inner_product_batch_4_bf16_patch_rvv;
-    fvec_L2sqr_batch_4_bf16_patch = fvec_L2sqr_batch_4_bf16_patch_rvv;
-
     ivec_inner_product = ivec_inner_product_rvv;
     ivec_L2sqr = ivec_L2sqr_rvv;
 


### PR DESCRIPTION
During compilation, the build fails with an "undeclared identifier" error at src/simd/hook.cc:559 due to the nonexistent function fvec_inner_product_bf16_patch. 
<img width="1477" height="456" alt="image" src="https://github.com/user-attachments/assets/cbe46565-8bdc-47c1-bbe3-693112127624" />
