### PR TITLE
feat: Enable RVV support for knowhere_utils library

### DIFF
--- a/cmake/libs/libfaiss.cmake
+++ b/cmake/libs/libfaiss.cmake
@@ -135,6 +135,7 @@ if(__RISCV64)
   add_library(knowhere_utils STATIC ${UTILS_SRC})
   target_link_libraries(knowhere_utils PUBLIC glog::glog)
   target_link_libraries(knowhere_utils PUBLIC xxHash::xxhash)
+  target_compile_options(knowhere_utils PRIVATE $<$<COMPILE_LANGUAGE>:-march=rv64gcv_zvfhmin -mabi=lp64d>)
 endif()
 
 # ToDo: Add distances_vsx.cc for powerpc64 SIMD acceleration


### PR DESCRIPTION
This PR fixes the issue where the knowhere_utils library was compiled without the necessary RVV compiler options. The previous configuration prevented the RVV-optimized code path from being activated, even on hardware that supports it.
I've added the -march=rv64gcv_zvfhmin compiler option to knowhere_utils in cmake/libs/libfaiss.cmake. This ensures that hook.cc correctly recognizes and enables RVV-related optimizations during compilation.

Expected Outcome:
On a RISC-V platform with RVV support, simd_type will now correctly display as RVV.
<img width="1621" height="555" alt="image" src="https://github.com/user-attachments/assets/ff38393b-a3e4-4554-b8b8-9376ce6fa7ab" />
