### PR TITLE
feat: Add RISC-V Vector Extension optimization for fvec_L2sqr_ny_nearest_rvv & fvec_L2sqr_ny_nearest_y_transposed_rvv

### DIFF
--- a/src/simd/distances_rvv.cc
+++ b/src/simd/distances_rvv.cc
@@ -1475,6 +1475,35 @@ fvec_L2sqr_ny_transposed_rvv(float* dis, const float* x, const float* y, const f
     }
 }
 
+size_t
+fvec_L2sqr_ny_nearest_rvv(float* distances_tmp_buffer, const float* x, const float* y, size_t d, size_t ny) {
+    fvec_L2sqr_ny_rvv(distances_tmp_buffer, x, y, d, ny);
+    size_t nearest_idx = 0;
+    float min_dis = HUGE_VALF;
+    for (size_t i = 0; i < ny; ++i) {
+        if (distances_tmp_buffer[i] < min_dis) {
+            min_dis = distances_tmp_buffer[i];
+            nearest_idx = i;
+        }
+    }
+    return nearest_idx;
+}
+
+size_t
+fvec_L2sqr_ny_nearest_y_transposed_rvv(float* distances_tmp_buffer, const float* x, const float* y,
+                                       const float* y_sqlen, size_t d, size_t d_offset, size_t ny) {
+    fvec_L2sqr_ny_transposed_rvv(distances_tmp_buffer, x, y, y_sqlen, d, d_offset, ny);
+    size_t nearest_idx = 0;
+    float min_dis = HUGE_VALF;
+    for (size_t i = 0; i < ny; ++i) {
+        if (distances_tmp_buffer[i] < min_dis) {
+            min_dis = distances_tmp_buffer[i];
+            nearest_idx = i;
+        }
+    }
+    return nearest_idx;
+}
+
 }  // namespace faiss
 
 #endif

--- a/src/simd/distances_rvv.h
+++ b/src/simd/distances_rvv.h
@@ -132,4 +132,11 @@ void
 fvec_L2sqr_ny_transposed_rvv(float* dis, const float* x, const float* y, const float* y_sqlen, size_t d,
                              size_t d_offset, size_t ny);
 
+size_t
+fvec_L2sqr_ny_nearest_rvv(float* distances_tmp_buffer, const float* x, const float* y, size_t d, size_t ny);
+
+size_t
+fvec_L2sqr_ny_nearest_y_transposed_rvv(float* distances_tmp_buffer, const float* x, const float* y,
+                                       const float* y_sqlen, size_t d, size_t d_offset, size_t ny);
+
 }  // namespace faiss

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -553,6 +553,8 @@ fvec_hook(std::string& simd_type) {
 
     fvec_norm_L2sqr = fvec_norm_L2sqr_rvv;
     fvec_L2sqr_ny = fvec_L2sqr_ny_rvv;
+    fvec_L2sqr_ny_nearest = fvec_L2sqr_ny_nearest_rvv;
+    fvec_L2sqr_ny_nearest_y_transposed = fvec_L2sqr_ny_nearest_y_transposed_rvv;
     fvec_madd = fvec_madd_rvv;
     fvec_madd_and_argmin = fvec_madd_and_argmin_rvv;
 


### PR DESCRIPTION
This PR introduces two key functions optimized for the RISC-V Vector (RVV) instruction set, significantly improving the performance of nearest neighbor search in high-dimensional vector spaces:

- fvec_L2sqr_ny_nearest_rvv
- fvec_L2sqr_ny_nearest_y_transposed_rvv

fvec_L2sqr_ny_nearest_rvv ​Performance improvements:​​
5.38x-7.61x speedup for dimension 2048 (ny: 4-64)
4.95x-8.74x speedup for dimension 4096 (ny: 4-64)
​Best performance:​​ 9.34x speedup (ny=4, d=1024)
<img width="1161" height="633" alt="image" src="https://github.com/user-attachments/assets/b1e2ee40-7251-40ba-b13a-b208ca826f54" />

​fvec_L2sqr_ny_nearest_y_transposed_rvv Performance improvements:​​
1.72x-2.66x speedup for dimension 2048 (ny: 4-64)
1.65x-3.11x speedup for dimension 4096 (ny: 4-64)
​Best performance:​​ 3.11x speedup (ny=32, d=4096)
<img width="1155" height="624" alt="image" src="https://github.com/user-attachments/assets/9b4bb64c-7d6c-496e-8bca-35e620a2d4bf" />

/kind improvement