### PR TITLE
add a missing header (for GCC-15 based compilation)

### DIFF
--- a/include/knowhere/binaryset.h
+++ b/include/knowhere/binaryset.h
@@ -12,6 +12,7 @@
 #ifndef BINARYSET_H
 #define BINARYSET_H
 
+#include <cstdint>
 #include <cstring>
 #include <map>
 #include <memory>


### PR DESCRIPTION
Adds a missing header that allows Knowhere to be compiled using `GCC-15`

/kind improvement

issue: #1296 
also, useful for https://github.com/milvus-io/milvus/issues/43616