### PR TITLE
fix whines of GCC-15 in AISAQ

### DIFF
--- a/thirdparty/DiskANN/include/diskann/utils.h
+++ b/thirdparty/DiskANN/include/diskann/utils.h
@@ -569,8 +569,8 @@ namespace diskann {
         out_writer.write((char*) &npts32, sizeof (uint32_t));
         out_writer.write((char*) &outdims32, sizeof (uint32_t));
 
-        size_t BLOCK_SIZE = 100000;
-        size_t block_size = npts <= BLOCK_SIZE ? npts : BLOCK_SIZE;
+        size_t MAX_BLOCK_SIZE = 100000;
+        size_t block_size = npts <= MAX_BLOCK_SIZE ? npts : MAX_BLOCK_SIZE;
         std::unique_ptr < T[] > in_block_data =
                 std::make_unique < T[]>(block_size * in_dims);
         std::unique_ptr < T[] > out_block_data =
@@ -645,8 +645,8 @@ namespace diskann {
         out_writer.write((char*) &npts32, sizeof (uint32_t));
         out_writer.write((char*) &outdims32, sizeof (uint32_t));
 
-        size_t BLOCK_SIZE = 100000;
-        size_t block_size = npts <= BLOCK_SIZE ? npts : BLOCK_SIZE;
+        size_t MAX_BLOCK_SIZE = 100000;
+        size_t block_size = npts <= MAX_BLOCK_SIZE ? npts : MAX_BLOCK_SIZE;
         std::unique_ptr < T[] > in_block_data =
                 std::make_unique < T[]>(block_size * in_dims);
         std::unique_ptr < T[] > out_block_data =


### PR DESCRIPTION
Somewhy, `GCC-15` produces the following error
```
In file included from /data/knowhere_aisaq/knowhere/thirdparty/DiskANN/src/aisaq_pq_reader.cpp:25:
/data/knowhere_aisaq/knowhere/thirdparty/DiskANN/include/diskann/utils.h: In function ‘float diskann::prepare_base_for_inner_products(std::string, std::string)’:
/data/knowhere_aisaq/knowhere/thirdparty/DiskANN/include/diskann/utils.h:572:9: error: lvalue required as left operand of assignment [-Wtemplate-body]
  572 |         size_t BLOCK_SIZE = 100000;
      |         ^
/data/knowhere_aisaq/knowhere/thirdparty/DiskANN/include/diskann/utils.h: In function ‘std::vector<float> diskann::prepare_base_for_cosine(std::string, std::string)’:
/data/knowhere_aisaq/knowhere/thirdparty/DiskANN/include/diskann/utils.h:648:9: error: lvalue required as left operand of assignment [-Wtemplate-body]
  648 |         size_t BLOCK_SIZE = 100000;
``` 

Maybe, there's interference with `#define BLOCK_SIZE XYZ` statements (?), but I'm not sure.

/kind improvement
issue: #1296
