### PR TITLE
[Fix] Correct target for setting RISC-V compile options

### DIFF
--- a/cmake/libs/libfaiss.cmake
+++ b/cmake/libs/libfaiss.cmake
@@ -137,7 +137,7 @@ if(__RISCV64)
   add_library(knowhere_utils STATIC ${UTILS_SRC})
   target_link_libraries(knowhere_utils PUBLIC glog::glog)
   target_link_libraries(knowhere_utils PUBLIC xxHash::xxhash)
-  target_compile_options(faiss PRIVATE
+  target_compile_options(knowhere_utils PRIVATE
     $<$<COMPILE_LANGUAGE:CXX>:-march=rv64gcv_zvfhmin -mabi=lp64d>
     $<$<COMPILE_LANGUAGE:C>:-march=rv64gcv_zvfhmin -mabi=lp64d>
   )


### PR DESCRIPTION
Changed target_compile_options from 'faiss' to 'knowhere_utils'
to resolve CMake configuration error in RISC-V builds.

Original error:
CMake Error at cmake/libs/libfaiss.cmake:140:
  Cannot specify compile options for target "faiss" which is not built by this project

The 'faiss' target is external while 'knowhere_utils' is the correct
local target needing RISC-V V extension flags (-march=rv64gcv_zvfhmin).
This fix enables proper vector optimization on RISC-V hardware.
<img width="1044" height="519" alt="image" src="https://github.com/user-attachments/assets/b09d5c5e-d8ed-45df-bff8-a54dcea24dd2" />
