### PR TITLE
feat: extend emb_list metric support for both cosine and ip

### DIFF
--- a/include/knowhere/comp/index_param.h
+++ b/include/knowhere/comp/index_param.h
@@ -229,10 +229,14 @@ constexpr const char* SUBSTRUCTURE = "SUBSTRUCTURE";
 constexpr const char* SUPERSTRUCTURE = "SUPERSTRUCTURE";
 constexpr const char* BM25 = "BM25";
 // emb list
-constexpr const char* MAX_SIM = "MAX_SIM";
-constexpr const char* ORDERED_MAX_SIM = "ORDERED_MAX_SIM";
-constexpr const char* ORDERED_MAX_SIM_WITH_WINDOW = "ORDERED_MAX_SIM_WITH_WINDOW";
-constexpr const char* DTW = "DTW";
+constexpr const char* MAX_SIM = "MAX_SIM";  // same as MAX_SIM_COSINE
+constexpr const char* MAX_SIM_COSINE = "MAX_SIM_COSINE";
+constexpr const char* MAX_SIM_IP = "MAX_SIM_IP";
+constexpr const char* MAX_SIM_L2 = "MAX_SIM_L2";
+constexpr const char* DTW = "DTW";  // same as DTW_COSINE
+constexpr const char* DTW_COSINE = "DTW_COSINE";
+constexpr const char* DTW_IP = "DTW_IP";
+constexpr const char* DTW_L2 = "DTW_L2";
 }  // namespace metric
 
 enum VecType {

--- a/include/knowhere/emb_list_utils.h
+++ b/include/knowhere/emb_list_utils.h
@@ -135,4 +135,55 @@ get_ordered_sum_max_sim(const float* dists, const size_t nq, const size_t el_len
     return scores[el_len - 1];
 }
 
+/*
+ * Get the aggregation function of the emb_list
+ * @note current only support MAX_SIM
+ * @param el_metric_type: the metric type of the emb_list
+ * @return the aggregation function of the emb_list
+ */
+inline std::optional<std::function<std::optional<float>(const float*, size_t, size_t)>>
+get_emb_list_agg_func(const std::string& el_metric_type) {
+    if (el_metric_type == metric::MAX_SIM) {
+        return get_sum_max_sim;
+    }
+    return nullptr;
+}
+
+/*
+ * Get the metric type of the emb_list (MAX_SIM -> MAX_SIM; MAX_SIM_IP -> MAX_SIM; DTW_COSINE -> DTW)
+ * @param metric_type: the metric type of the emb_list
+ * @return the metric type of the emb_list
+ */
+inline std::optional<std::string>
+get_el_metric_type(const std::string& metric_type) {
+    if (metric_type == metric::MAX_SIM || metric_type == metric::MAX_SIM_IP || metric_type == metric::MAX_SIM_L2 ||
+        metric_type == metric::MAX_SIM_COSINE) {
+        return metric::MAX_SIM;
+    } else if (metric_type == metric::DTW || metric_type == metric::DTW_IP || metric_type == metric::DTW_L2 ||
+               metric_type == metric::DTW_COSINE) {
+        return metric::DTW;
+    }
+    return std::nullopt;
+}
+
+/*
+ * Get the sub metric type of the emb_list (MAX_SIM_IP -> IP; DTW -> COSINE; DTW_IP -> IP)
+ * @param metric_type: the metric type of the emb_list
+ * @return the sub metric type of the emb_list (default: cosine)
+ */
+inline std::optional<std::string>
+get_sub_metric_type(const std::string& metric_type) {
+    if (metric_type == metric::MAX_SIM_COSINE || metric_type == metric::MAX_SIM || metric_type == metric::DTW_COSINE ||
+        metric_type == metric::DTW) {
+        return metric::COSINE;
+    }
+    if (metric_type == metric::MAX_SIM_IP || metric_type == metric::DTW_IP) {
+        return metric::IP;
+    }
+    if (metric_type == metric::MAX_SIM_L2 || metric_type == metric::DTW_L2) {
+        return metric::L2;
+    }
+    return std::nullopt;
+}
+
 }  // namespace knowhere

--- a/tests/ut/test_emb_list_hnsw.cc
+++ b/tests/ut/test_emb_list_hnsw.cc
@@ -336,7 +336,7 @@ TEST_CASE("Search for EMBList HNSW Indices", "Benchmark and validation") {
     // various constants and restrictions
 
     // metrics to test
-    const std::vector<std::string> DISTANCE_TYPES = {"MAX_SIM"};
+    const std::vector<std::string> DISTANCE_TYPES = {"MAX_SIM", "MAX_SIM_IP", "MAX_SIM_COSINE"};
 
     // for unit tests
     const std::vector<int32_t> DIMS = {64};

--- a/thirdparty/faiss/faiss/utils/distances.cpp
+++ b/thirdparty/faiss/faiss/utils/distances.cpp
@@ -1233,6 +1233,35 @@ void all_cosine(
     }
 }
 
+// compute and store all cosine distances into output. (only distances, no ids)
+// Output should be preallocated of size nx * ny, each element should be initialized to
+// lowest distance.
+void all_cosine_distances(
+        const float* x,
+        const float* y,
+        const float* y_norms,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        float* output,
+        const IDSelector* sel) {
+    if (sel == nullptr) {
+        CollectAllDistancesHandler<CMax<float, int64_t>, false> res(nx, ny, output);
+        if (nx < distance_compute_blas_threshold) {
+            exhaustive_cosine_seq(x, y, y_norms, d, nx, ny, res);
+        } else {
+            exhaustive_cosine_blas(x, y, y_norms, d, nx, ny, res);
+        }
+    } else {
+        CollectAllDistancesHandler<CMax<float, int64_t>, true> res(nx, ny, output, sel);
+        if (nx < distance_compute_blas_threshold) {
+            exhaustive_cosine_seq(x, y, y_norms, d, nx, ny, res);
+        } else {
+            exhaustive_cosine_blas(x, y, y_norms, d, nx, ny, res);
+        }
+    }
+}
+
 struct NopDistanceCorrection {
     float operator()(float dis, size_t /*qno*/, size_t /*bno*/) const {
         return dis;

--- a/thirdparty/faiss/faiss/utils/distances.h
+++ b/thirdparty/faiss/faiss/utils/distances.h
@@ -340,6 +340,16 @@ void all_cosine(
         std::vector<knowhere::DistId>& output,
         const IDSelector* sel);
 
+void all_cosine_distances(
+        const float* x,
+        const float* y,
+        const float* y_norms,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        float* output,
+        const IDSelector* sel);
+
 // Knowhere-specific function
 void knn_jaccard(
         const float* x,

--- a/thirdparty/faiss/faiss/utils/distances_typed.cpp
+++ b/thirdparty/faiss/faiss/utils/distances_typed.cpp
@@ -448,6 +448,30 @@ void all_cosine_typed(
     return;
 }
 
+template <typename DataType>
+void all_cosine_distances_typed(
+        const DataType* x,
+        const DataType* y,
+        const float* y_norms,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        float* distances,
+        const IDSelector* sel) {
+    CollectAllDistancesHandler<CMax<float, int64_t>> res(nx, ny, distances);
+    if (const auto* sel_bs =
+                dynamic_cast<const knowhere::BitsetViewIDSelector*>(sel)) {
+        exhaustive_cosine_seq_impl_typed(
+                x, y, y_norms, d, nx, ny, res, *sel_bs);
+    } else if (sel == nullptr) {
+        exhaustive_cosine_seq_impl_typed(
+                x, y, y_norms, d, nx, ny, res, IDSelectorAll());
+    } else {
+        exhaustive_cosine_seq_impl_typed(x, y, y_norms, d, nx, ny, res, *sel);
+    }
+    return;
+}
+
 /***************************************************************************
  * Range search
  ***************************************************************************/
@@ -598,6 +622,16 @@ template void faiss::all_cosine_typed<knowhere::fp16>(
         std::vector<knowhere::DistId>&,
         const IDSelector*);
 
+template void faiss::all_cosine_distances_typed<knowhere::fp16>(
+        const knowhere::fp16*,
+        const knowhere::fp16*,
+        const float*,
+        size_t,
+        size_t,
+        size_t,
+        float*,
+        const IDSelector*);
+
 // bf16 knn functions
 template void faiss::knn_inner_product_typed<knowhere::bf16>(
         const knowhere::bf16*,
@@ -672,6 +706,16 @@ template void faiss::all_cosine_typed<knowhere::bf16>(
         std::vector<knowhere::DistId>&,
         const IDSelector*);
 
+template void faiss::all_cosine_distances_typed<knowhere::bf16>(
+        const knowhere::bf16*,
+        const knowhere::bf16*,
+        const float*,
+        size_t,
+        size_t,
+        size_t,
+        float*,
+        const IDSelector*);
+
 // int8 knn functions
 template void faiss::knn_inner_product_typed<knowhere::int8>(
         const knowhere::int8*,
@@ -744,6 +788,16 @@ template void faiss::all_cosine_typed<knowhere::int8>(
         size_t,
         size_t,
         std::vector<knowhere::DistId>&,
+        const IDSelector*);
+
+template void faiss::all_cosine_distances_typed<knowhere::int8>(
+        const knowhere::int8*,
+        const knowhere::int8*,
+        const float*,
+        size_t,
+        size_t,
+        size_t,
+        float*,
         const IDSelector*);
 
 // fp16 range search functions

--- a/thirdparty/faiss/faiss/utils/distances_typed.h
+++ b/thirdparty/faiss/faiss/utils/distances_typed.h
@@ -105,6 +105,17 @@ void all_cosine_typed(
         std::vector<knowhere::DistId>& output,
         const IDSelector* sel = nullptr);
 
+template <typename DataType>
+void all_cosine_distances_typed(
+        const DataType* x,
+        const DataType* y,
+        const float* y_norms,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        float* distances,
+        const IDSelector* sel = nullptr);
+
 /***************************************************************************
  * Range search
  ***************************************************************************/


### PR DESCRIPTION
Emb_list currently supports the following metric types:
- `MAX_SIM_COSINE` - Maximum similarity using cosine distance
- `MAX_SIM_IP` - Maximum similarity using inner product
- `MAX_SIM` - equivalent to `MAX_SIM_COSINE`