### PR TITLE
enhance: opt minhash bf search

### DIFF
--- a/src/index/minhash/minhash_index_node.cc
+++ b/src/index/minhash/minhash_index_node.cc
@@ -286,7 +286,8 @@ MinHashLSHNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
         return expected<DataSetPtr>::Err(Status::empty_index, "Minhash index not loaded");
     }
     auto search_conf = static_cast<const MinHashLSHConfig&>(*cfg);
-    auto stat = MinhashConfigCheck(dataset->GetDim(), DataFormatEnum::bin1, PARAM_TYPE::SEARCH, &search_conf, &bitset);
+    auto stat =
+        minhash::MinhashConfigCheck(dataset->GetDim(), DataFormatEnum::bin1, PARAM_TYPE::SEARCH, &search_conf, &bitset);
     if (stat != Status::success) {
         return expected<DataSetPtr>::Err(Status::invalid_args, "MinhashConfigCheck() failed, please check the config.");
     }

--- a/src/index/minhash/minhash_util.cc
+++ b/src/index/minhash/minhash_util.cc
@@ -9,7 +9,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 #include "index/minhash/minhash_util.h"
-namespace knowhere {
+namespace knowhere::minhash {
 namespace {
 using JcaccardSim = faiss::CMin<float, idx_t>;
 using DIST1FUNC = float (*)(const char* x, const char* y, size_t element_length, size_t element_size);
@@ -46,19 +46,6 @@ minhash_jaccard_batch_4_native(const char* x, const char* y0, const char* y1, co
     dis2 /= size;
     dis3 /= size;
     return;
-}
-
-inline float
-minhash_lsh_hit(const char* x, const char* y, size_t size, size_t mh_lsh_band) {
-    size_t r = size / (mh_lsh_band);
-    for (size_t i = 0; i < mh_lsh_band; i++) {
-        const char* x_b = x + r * i;
-        const char* y_b = y + r * i;
-        if (std::memcmp(x_b, y_b, r) == 0) {
-            return 1.0f;
-        }
-    }
-    return 0.0f;
 }
 
 // use minhash jaccard distance
@@ -99,26 +86,218 @@ struct MinHashJaccardComputer : faiss::DistanceComputer {
     void
     distances_batch_4(const idx_t idx0, const idx_t idx1, const idx_t idx2, const idx_t idx3, float& dis0, float& dis1,
                       float& dis2, float& dis3) override {
-        const char* xb_0 = base + idx0 * vec_size;
-        const char* xb_1 = base + idx1 * vec_size;
-        const char* xb_2 = base + idx2 * vec_size;
-        const char* xb_3 = base + idx3 * vec_size;
-        dist4(q, xb_0, xb_1, xb_2, xb_3, element_length, element_size, dis0, dis1, dis2, dis3);
+        const char* y_0 = base + idx0 * vec_size;
+        const char* y_1 = base + idx1 * vec_size;
+        const char* y_2 = base + idx2 * vec_size;
+        const char* y_3 = base + idx3 * vec_size;
+        dist4(q, y_0, y_1, y_2, y_3, element_length, element_size, dis0, dis1, dis2, dis3);
     }
     float
     symmetric_dis(idx_t i, idx_t j) override {
         return dist1(base + i * vec_size, base + j * vec_size, element_length, element_size);
     }
 };
+
+/**
+ * @brief Optimized MinHash LSH search with top1 results using hash table lookup
+ *
+ * Performs LSH band matching using binary search for efficient hash matching.
+ * Uses multi-threading for batch processing of queries.
+ */
+Status
+minhash_lsh_hit_with_topk1_opt_search(const char* x, const char* y, size_t u8_dim, size_t mh_lsh_band, size_t nx,
+                                      size_t ny, size_t topk, const BitsetView& bitset, float* distances,
+                                      int64_t* labels) {
+    std::vector<minhash::KeyType> base_hash_k;
+    std::vector<minhash::ValueType> base_hash_v;
+    base_hash_k.reserve(ny * mh_lsh_band);
+    base_hash_v.reserve(ny * mh_lsh_band);
+    {
+        auto base_kv = minhash::GenTransposedHashKV((const char*)y, ny, u8_dim, mh_lsh_band);
+        minhash::SortHashKV(base_kv, ny, mh_lsh_band);
+        for (auto i = 0; i < ny * mh_lsh_band; i++) {
+            base_hash_k.emplace_back(base_kv[i].Key);
+            base_hash_v.emplace_back(base_kv[i].Value);
+        }
+    }
+    std::vector<minhash::KeyType> query_hash_k;
+    query_hash_k.reserve(nx * mh_lsh_band);
+    {
+        auto query_kv = minhash::GenHashKV((const char*)x, nx, u8_dim, mh_lsh_band);
+        for (auto i = 0; i < nx * mh_lsh_band; i++) {
+            query_hash_k.emplace_back(query_kv[i].Key);
+        }
+    }
+
+    std::vector<MinHashLSHResultHandler> all_res;
+    all_res.reserve(nx);
+    for (size_t i = 0; i < nx; i++) {
+        all_res.emplace_back(labels + i * topk, distances + i * topk, topk);
+    }
+    auto pool = ThreadPool::GetGlobalSearchThreadPool();
+    std::vector<folly::Future<folly::Unit>> futs;
+    size_t run_times = (nx + kQueryBatch - 1) / kQueryBatch;
+    futs.reserve(run_times);
+    for (size_t row = 0; row < run_times; ++row) {
+        futs.emplace_back(pool->push([&query_hash_k, &base_hash_k, &base_hash_v, &all_res, mh_lsh_band, ny,
+                                      query_beg = row * kQueryBatch,
+                                      query_end = std::min((size_t)((row + 1) * kQueryBatch), (size_t)nx)]() {
+            for (size_t query_id = query_beg; query_id < query_end; query_id++) {
+                auto query_key = query_hash_k.data() + mh_lsh_band * query_id;
+                for (auto i = 0; i < mh_lsh_band; i++) {
+                    auto hit_id = faiss::u64_binary_search_eq(base_hash_k.data() + i * ny, ny, query_key[i]);
+                    if (hit_id != -1) {
+                        all_res[query_id].push(base_hash_v[hit_id], 1.0f);
+                        while (!all_res[query_id].full() && hit_id < mh_lsh_band &&
+                               base_hash_k[i * mh_lsh_band + hit_id] == query_key[i]) {
+                            all_res[query_id].push(base_hash_v[hit_id], 1.0f);
+                            hit_id++;
+                        }
+                        if (all_res[query_id].full()) {
+                            break;
+                        }
+                    }
+                }
+            }
+        }));
+    }
+    RETURN_IF_ERROR(WaitAllSuccess(futs));
+    return Status::success;
+}
+
+/**
+ * @brief Batch processing function for MinHash vector search
+ *
+ * Processes multiple query vectors in batches using either LSH band matching
+ * or exact Jaccard distance computation based on configuration.
+ */
+Status
+minhash_ny_batch_search(const char* x, const char* y, size_t u8_dim, size_t mh_lsh_band, size_t mh_element_bit_width,
+                        size_t nx, size_t ny, size_t topk, bool mh_search_with_jaccard, const BitsetView& bitset,
+                        float* distances, int64_t* labels) {
+    auto pool = ThreadPool::GetGlobalSearchThreadPool();
+    std::vector<folly::Future<Status>> futs;
+    const int batch_size = 128;
+    int num_batches = (nx + batch_size - 1) / batch_size;
+    futs.reserve(num_batches);
+
+    for (int batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
+        futs.emplace_back(pool->push([&, batch_idx] {
+            ThreadPool::ScopedSearchOmpSetter setter(1);
+            int start_query = batch_idx * batch_size;
+            int end_query = std::min(size_t(start_query + batch_size), nx);
+
+            for (int i = start_query; i < end_query; ++i) {
+                auto cur_labels = labels + topk * i;
+                auto cur_distances = distances + topk * i;
+
+                if (mh_search_with_jaccard) {
+                    size_t hash_element_size = mh_element_bit_width / 8;  // in bytes
+                    size_t hash_element_length = u8_dim / hash_element_size;
+                    auto cur_query = (const char*)x + u8_dim * i;
+                    MinHashJaccardKNNSearchByNy(cur_query, (const char*)y, hash_element_length, hash_element_size, ny,
+                                                topk, bitset, cur_distances, cur_labels);
+                } else {
+                    auto cur_query = (const char*)x + u8_dim * i;
+                    MinHashLSHHitByNy(cur_query, (const char*)y, u8_dim, mh_lsh_band, ny, topk, bitset, cur_distances,
+                                      cur_labels);
+                }
+            }
+            return Status::success;
+        }));
+    }
+
+    RETURN_IF_ERROR(WaitAllSuccess(futs));
+    return Status::success;
+}
 }  // namespace
 
+std::shared_ptr<minhash::KVPair[]>
+GenHashKV(const char* data, size_t rows, size_t data_size, size_t band) {
+    auto res_kv = std::shared_ptr<minhash::KVPair[]>(new minhash::KVPair[band * rows]);
+    auto batch_num = (rows + kBatch - 1) / kBatch;
+    auto build_pool = ThreadPool::GetGlobalBuildThreadPool();
+    std::vector<folly::Future<folly::Unit>> futures;
+    for (size_t i = 0; i < batch_num; i++) {
+        futures.emplace_back(build_pool->push([&, idx = i]() {
+            auto beg_id = idx * kBatch;
+            auto end_id = std::min((idx + 1) * kBatch, rows);
+            for (size_t j = beg_id; j < end_id; j++) {
+                const char* data_j = data + data_size * j;
+                size_t b = 0;
+                for (; b + 4 <= band; b += 4) {
+                    res_kv.get()[j * band + b] = {GetHashKey(data_j, data_size, band, b), minhash::ValueType(j)};
+                    res_kv.get()[j * band + b + 1] = {GetHashKey(data_j, data_size, band, b + 1),
+                                                      minhash::ValueType(j)};
+                    res_kv.get()[j * band + b + 2] = {GetHashKey(data_j, data_size, band, b + 2),
+                                                      minhash::ValueType(j)};
+                    res_kv.get()[j * band + b + 3] = {GetHashKey(data_j, data_size, band, b + 3),
+                                                      minhash::ValueType(j)};
+                }
+                for (; b < band; b++) {
+                    minhash::KVPair kv = {GetHashKey(data_j, data_size, band, b), minhash::ValueType(j)};
+                    res_kv.get()[j * band + b] = kv;
+                }
+            }
+        }));
+    }
+    WaitAllSuccess(futures);
+    return res_kv;
+}
+
+std::shared_ptr<minhash::KVPair[]>
+GenTransposedHashKV(const char* data, size_t rows, size_t data_size, size_t band) {
+    auto res_kv = std::shared_ptr<minhash::KVPair[]>(new minhash::KVPair[band * rows]);
+    auto batch_num = (rows + kBatch - 1) / kBatch;
+    auto build_pool = ThreadPool::GetGlobalBuildThreadPool();
+    std::vector<folly::Future<folly::Unit>> futures;
+    for (size_t i = 0; i < batch_num; i++) {
+        futures.emplace_back(build_pool->push([&, idx = i]() {
+            auto beg_id = idx * kBatch;
+            auto end_id = std::min((idx + 1) * kBatch, rows);
+            for (size_t j = beg_id; j < end_id; j++) {
+                const char* data_j = data + data_size * j;
+                size_t b = 0;
+                for (; b + 4 <= band; b += 4) {
+                    res_kv.get()[b * rows + j] = {GetHashKey(data_j, data_size, band, b), minhash::ValueType(j)};
+                    res_kv.get()[(b + 1) * rows + j] = {GetHashKey(data_j, data_size, band, b + 1),
+                                                        minhash::ValueType(j)};
+                    res_kv.get()[(b + 2) * rows + j] = {GetHashKey(data_j, data_size, band, b + 2),
+                                                        minhash::ValueType(j)};
+                    res_kv.get()[(b + 3) * rows + j] = {GetHashKey(data_j, data_size, band, b + 3),
+                                                        minhash::ValueType(j)};
+                }
+                for (; b < band; b++) {
+                    minhash::KVPair kv = {GetHashKey(data_j, data_size, band, b), minhash::ValueType(j)};
+                    res_kv.get()[b * rows + j] = kv;
+                }
+            }
+        }));
+    }
+    WaitAllSuccess(futures);
+    return res_kv;
+}
+
 void
-minhash_lsh_hit_ny(const char* x, const char* y, size_t dim, size_t mh_lsh_band, size_t ny, size_t topk,
-                   const BitsetView& bitset, float* vals, int64_t* ids) {
+SortHashKV(const std::shared_ptr<KVPair[]> kv_code, size_t rows, size_t band) {
+    auto build_pool = ThreadPool::GetGlobalBuildThreadPool();
+    std::vector<folly::Future<folly::Unit>> futures;
+    for (size_t i = 0; i < band; i++) {
+        futures.emplace_back(build_pool->push([&, idx = i]() {
+            std::sort(kv_code.get() + rows * idx, kv_code.get() + rows * (idx + 1),
+                      [](const KVPair& a, const KVPair& b) { return a.Key < b.Key; });
+        }));
+    }
+    WaitAllSuccess(futures);
+}
+
+void
+MinHashLSHHitByNy(const char* x, const char* y, size_t dim, size_t mh_lsh_band, size_t ny, size_t topk,
+                  const BitsetView& bitset, float* vals, int64_t* ids) {
     MinHashLSHResultHandler res(ids, vals, topk);
     for (size_t i = 0; i < ny; i++) {
         if (bitset.empty() || !bitset.test(i)) {
-            res.push(i, minhash_lsh_hit(x, y + dim * i, dim, mh_lsh_band));
+            res.push(i, faiss::minhash_lsh_hit(x, y + dim * i, dim, mh_lsh_band));
             if (res.full()) {
                 break;
             }
@@ -127,8 +306,8 @@ minhash_lsh_hit_ny(const char* x, const char* y, size_t dim, size_t mh_lsh_band,
 }
 
 void
-minhash_jaccard_knn_ny(const char* x, const char* y, size_t length, size_t element_size, size_t ny, size_t topk,
-                       const BitsetView& bitset, float* vals, int64_t* ids) {
+MinHashJaccardKNNSearchByNy(const char* x, const char* y, size_t length, size_t element_size, size_t ny, size_t topk,
+                            const BitsetView& bitset, float* vals, int64_t* ids) {
     // init
     for (size_t i = 0; i < topk; i++) {
         vals[i] = 0.0f;
@@ -145,11 +324,12 @@ minhash_jaccard_knn_ny(const char* x, const char* y, size_t length, size_t eleme
         }
     };
     faiss::distance_compute_if(ny, computer.get(), filter, apply);
+    faiss::heap_reorder<JcaccardSim>(topk, vals, ids);
 }
 
 void
-minhash_jaccard_knn_ny_by_ids(const char* x, const char* y, const int64_t* sel_ids, size_t length, size_t element_size,
-                              size_t sel_ids_num, size_t topk, float* res_vals, int64_t* res_ids) {
+MinHashJaccardKNNSearchByIDs(const char* x, const char* y, const int64_t* sel_ids, size_t length, size_t element_size,
+                             size_t sel_ids_num, size_t topk, float* res_vals, int64_t* res_ids) {
     // init
     for (size_t i = 0; i < topk; i++) {
         res_vals[i] = 0.0;
@@ -175,6 +355,20 @@ minhash_jaccard_knn_ny_by_ids(const char* x, const char* y, const int64_t* sel_i
         auto dis = computer->operator()(sel_ids[i]);
         apply(dis, sel_ids[i]);
         i++;
+    }
+    faiss::heap_reorder<JcaccardSim>(topk, res_vals, res_ids);
+}
+
+Status
+MinHashVecSearch(const char* x, const char* y, size_t u8_dim, size_t mh_lsh_band, size_t mh_element_bit_width,
+                 size_t nx, size_t ny, size_t topk, bool mh_search_with_jaccard, const BitsetView& bitset,
+                 float* distances, int64_t* labels) {
+    if (topk == 1 && !mh_search_with_jaccard) {  // most common case : topk = 1 and mh_search_with_jaccard == false
+        return minhash_lsh_hit_with_topk1_opt_search(x, y, u8_dim, mh_lsh_band, nx, ny, topk, bitset, distances,
+                                                     labels);
+    } else {
+        return minhash_ny_batch_search(x, y, u8_dim, mh_lsh_band, mh_element_bit_width, nx, ny, topk,
+                                       mh_search_with_jaccard, bitset, distances, labels);
     }
 }
 
@@ -203,4 +397,4 @@ MinhashConfigCheck(const size_t dim, const DataFormatEnum data_type, const uint3
     }
     return Status::success;
 }
-}  // namespace knowhere
+}  // namespace knowhere::minhash

--- a/src/index/minhash/minhash_util.h
+++ b/src/index/minhash/minhash_util.h
@@ -13,14 +13,24 @@
 
 #include "faiss/utils/distances_if.h"
 #include "knowhere/bitsetview.h"
+#include "knowhere/comp/task.h"
 #include "knowhere/config.h"
 #include "knowhere/operands.h"
-namespace knowhere {
-Status
-MinhashConfigCheck(const size_t dim, const DataFormatEnum data_type, const uint32_t fun_type, const BaseConfig* cfg,
-                   const BitsetView* bitset);
-
+#include "knowhere/thread_pool.h"
+namespace knowhere::minhash {
 using idx_t = faiss::idx_t;
+using KeyType = uint64_t;
+using ValueType = idx_t;
+struct KVPair {
+    KeyType Key;
+    ValueType Value;
+};
+
+constexpr int kBatch = 4096;
+constexpr int kQueryBatch = 64;
+constexpr int kQueryBandBatch = 4;
+using idx_t = faiss::idx_t;
+
 struct MinHashLSHResultHandler {
     idx_t* ids_list_;
     float* dis_list_;
@@ -39,8 +49,12 @@ struct MinHashLSHResultHandler {
     }
     void
     push(const idx_t id, const float dis) {
-        if (id == -1 || dis < 0.000001f)
+        if (this->full()) {
             return;
+        }
+        if (id == -1 || dis < 0.000001f) {
+            return;
+        }
         if (topk_ > 1 && find(id)) {
             return;
         }
@@ -58,15 +72,97 @@ struct MinHashLSHResultHandler {
     }
 };
 
-void
-minhash_lsh_hit_ny(const char* x, const char* y, size_t dim, size_t mh_lsh_band, size_t ny, size_t topk,
-                   const BitsetView& bitset, float* vals, int64_t* ids);
+inline minhash::KeyType
+GetHashKey(const char* data, size_t size /*in bytes*/, size_t band, size_t band_i) {
+    const size_t r = size / band;
+    auto band_i_data = data + r * band_i;
+    return faiss::calculate_hash((const char*)band_i_data, r);
+}
+
+std::shared_ptr<minhash::KVPair[]>
+GenHashKV(const char* data, size_t rows, size_t data_size, size_t band);
+
+std::shared_ptr<minhash::KVPair[]>
+GenTransposedHashKV(const char* data, size_t rows, size_t data_size, size_t band);
 
 void
-minhash_jaccard_knn_ny(const char* x, const char* y, size_t length, size_t element_size, size_t ny, size_t topk,
-                       const BitsetView& bitset, float* vals, int64_t* ids);
+SortHashKV(const std::shared_ptr<KVPair[]> kv_code, size_t rows, size_t band);
 
+Status
+MinhashConfigCheck(const size_t dim, const DataFormatEnum data_type, const uint32_t fun_type, const BaseConfig* cfg,
+                   const BitsetView* bitset);
+/**
+ * @brief returning LSH band hit results on a specified number of vectors as MinHash LSH does
+ *
+ * @param x Pointer to query vector data containing vectors to search for
+ * @param y Pointer to base dataset
+ * @param dim  vector dimension size
+ * @param mh_lsh_band Number of LSH bands, used to control the balance between recall and precision
+ * @param ny Number of vectors in the base dataset
+ * @param topk Number of most similar results to return
+ * @param bitset Bitset view for filtering vectors that should not be searched (marked vectors will be skipped)
+ * @param vals Output parameter: array to store returned similarity scores
+ * @param ids Output parameter: array to store returned vector IDs
+ */
 void
-minhash_jaccard_knn_ny_by_ids(const char* x, const char* y, const int64_t* sel_ids, size_t length, size_t element_size,
-                              size_t sel_ids_num, size_t topk, float* res_vals, int64_t* res_ids);
-}  // namespace knowhere
+MinHashLSHHitByNy(const char* x, const char* y, size_t u8_dim, size_t mh_lsh_band, size_t ny, size_t topk,
+                  const BitsetView& bitset, float* vals, int64_t* ids);
+/**
+ * @brief Returns the top-k vectors with smallest Jaccard distances to the query MinHash vector
+ *
+ * This function computes exact Jaccard similarity between MinHash vectors and returns the k most
+ * similar vectors based on Jaccard distance (smaller distance means higher similarity).
+ *
+ * @param x Pointer to query MinHash vector data
+ * @param y Pointer to base dataset
+ * @param length minhash vector length in bytes
+ * @param element_size Size of each MinHash element in bytes
+ * @param ny Number of vectors in the base dataset
+ * @param topk Number of nearest neighbors to return (top-k with smallest Jaccard distances)
+ * @param bitset Bitset view for vector filtering
+ * @param vals Output parameter: array to store Jaccard distances (smaller values indicate higher similarity)
+ * @param ids Output parameter: array to store corresponding vector IDs
+ */
+void
+MinHashJaccardKNNSearchByNy(const char* x, const char* y, size_t length, size_t element_size, size_t ny, size_t topk,
+                            const BitsetView& bitset, float* vals, int64_t* ids);
+/**
+ * @brief Performs MinHash KNN search using Jaccard similarity on vectors with specified ID list
+ *
+ * @param x Pointer to query data
+ * @param y Pointer to base dataset
+ * @param sel_ids Array of specified vector IDs to search
+ * @param length Data length
+ * @param element_size Size of each element in bytes
+ * @param sel_ids_num Number of selected IDs
+ * @param topk Number of most similar results to return
+ * @param res_vals Output parameter: array to store similarity scores
+ * @param res_ids Output parameter: array to store corresponding result vector IDs
+ */
+void
+MinHashJaccardKNNSearchByIDs(const char* x, const char* y, const int64_t* sel_ids, size_t length, size_t element_size,
+                             size_t sel_ids_num, size_t topk, float* res_vals, int64_t* res_ids);
+
+/**
+ * @brief General MinHash vector search
+ *
+ * @param x Pointer to query vectors
+ * @param y Pointer to base dataset vectors
+ * @param u8_dim Vector dimension in uint8 units
+ * @param mh_lsh_band Number of LSH bands for locality sensitive hashing
+ * @param mh_element_bit_width Bit width for each MinHash element
+ * @param nx Number of query vectors
+ * @param ny Number of base vectors
+ * @param topk Number of most similar results to return for each query
+ * @param mh_search_with_jaccard Flag to enable Jaccard similarity calculation in search
+ * @param bitset Bitset view for filtering vectors during search
+ * @param vals Output parameter: array to store similarity scores
+ * @param ids Output parameter: array to store corresponding vector IDs
+ * @return Status indicating success or failure of the operation
+ */
+Status
+MinHashVecSearch(const char* x, const char* y, size_t u8_dim, size_t mh_lsh_band, size_t mh_element_bit_width,
+                 size_t nx, size_t ny, size_t topk, bool mh_search_with_jaccard, const BitsetView& bitset, float* vals,
+                 int64_t* ids);
+
+}  // namespace knowhere::minhash

--- a/src/simd/distances_ref.cc
+++ b/src/simd/distances_ref.cc
@@ -577,7 +577,18 @@ minhash_lsh_hit_ref(const char* x, const char* y, size_t dim, size_t mh_lsh_band
         const char* y_b = y + r * i;
         size_t j = r;
         bool eq = true;
-        while (j > 0) {
+        while (j >= 16) {
+            if (*(const uint64_t*)(x_b + 8) != *(const uint64_t*)(y_b + 8)) {
+                goto next_band;
+            }
+            if (*(const uint64_t*)(x_b) != *(const uint64_t*)(y_b)) {
+                goto next_band;
+            }
+            j -= 16;
+            x_b += 16;
+            y_b += 16;
+        }
+        if (j >= 8) {
             if (*(const uint64_t*)(x_b) != *(const uint64_t*)(y_b)) {
                 goto next_band;
             }

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -115,6 +115,7 @@ decltype(calculate_hash) calculate_hash = calculate_hash_ref;
 decltype(u32_jaccard_distance) u32_jaccard_distance = u32_jaccard_distance_ref;
 decltype(u32_jaccard_distance_batch_4) u32_jaccard_distance_batch_4 = u32_jaccard_distance_batch_4_ref;
 decltype(u64_jaccard_distance) u64_jaccard_distance = u64_jaccard_distance_ref;
+decltype(minhash_lsh_hit) minhash_lsh_hit = minhash_lsh_hit_ref;
 decltype(u64_jaccard_distance_batch_4) u64_jaccard_distance_batch_4 = u64_jaccard_distance_batch_4_ref;
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(__x86_64__)

--- a/src/simd/hook.h
+++ b/src/simd/hook.h
@@ -132,6 +132,7 @@ extern float (*u64_jaccard_distance)(const char*, const char*, size_t size, size
 extern void (*u64_jaccard_distance_batch_4)(const char*, const char*, const char*, const char*, const char*, size_t,
                                             size_t, float&, float&, float&, float&);
 extern uint64_t (*calculate_hash)(const char*, size_t);
+extern float (*minhash_lsh_hit)(const char* x, const char* y, size_t dim, size_t mh_lsh_band);
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(__x86_64__)
 bool

--- a/tests/ut/test_minhash_index.cc
+++ b/tests/ut/test_minhash_index.cc
@@ -102,6 +102,13 @@ TEST_CASE("Test MinHashLSHIndexNode with MinHashLSH hit", "[minhash_lsh_index]")
         auto base_json = base_gen();
         auto result_knn = knowhere::BruteForce::Search<knowhere::bin1>(base_ds, query_ds, base_json, nullptr);
         lsh_gt_ptr = result_knn.value();
+        float lsh_recall = 0;
+        auto res_dis = lsh_gt_ptr->GetDistance();
+        for (int64_t i = 0; i < query_ds->GetRows(); i++) {
+            lsh_recall += (res_dis[i * kK] == 1.0);
+        }
+        lsh_recall /= query_ds->GetRows();
+        REQUIRE(lsh_recall == 1.0);
     }
 
     SECTION("Basic Test") {


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/1320
- dataset: A randomly generated dataset base was used for testing, and the query vectors were processed by masking the base with random bands.
-  max growing segment size in milvus: 128MB data （780d *32bit， band = 60) and (120d * 32bit, band = 10)
- Two scenarios were tested:  a single brute-force search and a serial brute-force search processing 128 rows of data (the processing method of milvus segcore).
- result@(topk = 1, search without jaccard):
<img width="793" height="367" alt="image" src="https://github.com/user-attachments/assets/6b36fe79-647b-42d2-b788-52b36000238c" />
<img width="805" height="369" alt="image" src="https://github.com/user-attachments/assets/85aaac80-2605-4e02-a737-6cbcc1a1f91c" />


