### PR TITLE
hnsw binary support

### DIFF
--- a/tests/ut/test_get_vector.cc
+++ b/tests/ut/test_get_vector.cc
@@ -45,7 +45,6 @@ TEST_CASE("Test Binary Get Vector By Ids", "[Binary GetVectorByIds]") {
         return json;
     };
 
-#ifdef KNOWHERE_WITH_CARDINAL
     auto bin_hnsw_gen = [base_bin_gen]() {
         knowhere::Json json = base_bin_gen();
         json[knowhere::indexparam::HNSW_M] = 128;
@@ -53,7 +52,6 @@ TEST_CASE("Test Binary Get Vector By Ids", "[Binary GetVectorByIds]") {
         json[knowhere::indexparam::EF] = 64;
         return json;
     };
-#endif
 
     auto bin_flat_gen = base_bin_gen;
 
@@ -62,9 +60,7 @@ TEST_CASE("Test Binary Get Vector By Ids", "[Binary GetVectorByIds]") {
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_BIN_IDMAP, bin_flat_gen),
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT, bin_ivfflat_gen),
-#ifdef KNOWHERE_WITH_CARDINAL
             make_tuple(knowhere::IndexEnum::INDEX_HNSW, bin_hnsw_gen),
-#endif
         }));
         auto idx = knowhere::IndexFactory::Instance().Create<knowhere::bin1>(name, version).value();
         auto cfg_json = gen().dump();

--- a/tests/ut/test_search.cc
+++ b/tests/ut/test_search.cc
@@ -603,9 +603,7 @@ TEST_CASE("Test Mem Index With Binary Vector", "[float metrics]") {
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_BIN_IDMAP, flat_gen),
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT, ivfflat_gen),
-#ifdef KNOWHERE_WITH_CARDINAL
             make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),
-#endif
         }));
         auto idx = knowhere::IndexFactory::Instance().Create<knowhere::bin1>(name, version).value();
         auto cfg_json = gen().dump();

--- a/thirdparty/faiss/faiss/FaissHook.cpp
+++ b/thirdparty/faiss/faiss/FaissHook.cpp
@@ -17,6 +17,19 @@ sq_sel_quantizer_func_ptr sq_sel_quantizer = sq_select_quantizer_ref;
 sq_sel_inv_list_scanner_func_ptr sq_sel_inv_list_scanner =
         sq_select_inverted_list_scanner_ref;
 
+// Note: The Hamming computer implementation is selected at compile time
+// based on the instruction set in `hamdis-inl.h`, not by runtime hook.
+sq_get_distance_computer_func_ptr sq_get_hamming_distance_computer =
+        sq_get_hamming_distance_computer_ref;
+
+// Note: The Jaccard distance computer uses `__builtin_popcount` for 
+// computation. This function is efficiently implemented by the
+// compiler and automatically utilizes the best available instruction set.
+// Therefore, there is no need to manually adjust or hook the Jaccard computer
+// for different SIMD instruction sets.
+sq_get_distance_computer_func_ptr sq_get_jaccard_distance_computer =
+        sq_get_jaccard_distance_computer_ref;
+
 void sq_hook() {
     // SQ8 always hook best SIMD
 #ifdef __x86_64__

--- a/thirdparty/faiss/faiss/FaissHook.h
+++ b/thirdparty/faiss/faiss/FaissHook.h
@@ -33,6 +33,8 @@ typedef InvertedListScanner* (*sq_sel_inv_list_scanner_func_ptr)(
         bool);
 
 extern sq_get_distance_computer_func_ptr sq_get_distance_computer;
+extern sq_get_distance_computer_func_ptr sq_get_hamming_distance_computer;
+extern sq_get_distance_computer_func_ptr sq_get_jaccard_distance_computer;
 extern sq_sel_quantizer_func_ptr sq_sel_quantizer;
 extern sq_sel_inv_list_scanner_func_ptr sq_sel_inv_list_scanner;
 void sq_hook();

--- a/thirdparty/faiss/faiss/IndexScalarQuantizer.cpp
+++ b/thirdparty/faiss/faiss/IndexScalarQuantizer.cpp
@@ -34,7 +34,8 @@ IndexScalarQuantizer::IndexScalarQuantizer(
     is_trained = qtype == ScalarQuantizer::QT_fp16 ||
             qtype == ScalarQuantizer::QT_8bit_direct ||
             qtype == ScalarQuantizer::QT_bf16 ||
-            qtype == ScalarQuantizer::QT_8bit_direct_signed;
+            qtype == ScalarQuantizer::QT_8bit_direct_signed ||
+            qtype == ScalarQuantizer::QT_1bit_direct;
     code_size = sq.code_size;
 }
 

--- a/thirdparty/faiss/faiss/MetricType.h
+++ b/thirdparty/faiss/faiss/MetricType.h
@@ -52,8 +52,7 @@ using idx_t = int64_t;
 /// this function is used to distinguish between min and max indexes since
 /// we need to support similarity and dis-similarity metrics in a flexible way
 constexpr bool is_similarity_metric(MetricType metric_type) {
-    return ((metric_type == METRIC_INNER_PRODUCT) ||
-            (metric_type == METRIC_Jaccard));
+    return metric_type == METRIC_INNER_PRODUCT;
 }
 
 } // namespace faiss

--- a/thirdparty/faiss/faiss/impl/ScalarQuantizer.h
+++ b/thirdparty/faiss/faiss/impl/ScalarQuantizer.h
@@ -35,6 +35,7 @@ struct ScalarQuantizer : Quantizer {
         QT_bf16,
         QT_8bit_direct_signed, ///< fast indexing of signed int8s ranging from
                                ///< [-128 to 127]
+        QT_1bit_direct, ///< fast indexing of 1 bit per component
     };
 
     QuantizerType qtype = QT_8bit;

--- a/thirdparty/faiss/faiss/impl/ScalarQuantizerCodec_avx.h
+++ b/thirdparty/faiss/faiss/impl/ScalarQuantizerCodec_avx.h
@@ -300,6 +300,9 @@ SQuantizer* select_quantizer_1_avx(
             return new Quantizer8bitDirect_avx<SIMDWIDTH>(d, trained);
         case QuantizerType::QT_8bit_direct_signed:
             return new Quantizer8bitDirectSigned_avx<SIMDWIDTH>(d, trained);
+        case QuantizerType::QT_1bit_direct:
+            // todo: add more SIMDWIDTH support for avx if needed
+            return new Quantizer1bitDirect(d, trained);
     }
     FAISS_THROW_MSG("unknown qtype");
 }

--- a/thirdparty/faiss/faiss/impl/ScalarQuantizerCodec_avx512.h
+++ b/thirdparty/faiss/faiss/impl/ScalarQuantizerCodec_avx512.h
@@ -395,6 +395,9 @@ SQuantizer* select_quantizer_1_avx512(
             return new Quantizer8bitDirect_avx512<SIMDWIDTH>(d, trained);
         case QuantizerType::QT_8bit_direct_signed:
             return new Quantizer8bitDirectSigned_avx512<SIMDWIDTH>(d, trained);
+        case QuantizerType::QT_1bit_direct:
+            // todo: add more SIMDWIDTH support for avx512 if needed
+            return new Quantizer1bitDirect(d, trained);
     }
     FAISS_THROW_MSG("unknown qtype");
 }

--- a/thirdparty/faiss/faiss/impl/ScalarQuantizerCodec_neon.h
+++ b/thirdparty/faiss/faiss/impl/ScalarQuantizerCodec_neon.h
@@ -280,6 +280,9 @@ SQuantizer* select_quantizer_1_neon(
             return new Quantizer8bitDirect_neon<SIMDWIDTH>(d, trained);
         case QuantizerType::QT_8bit_direct_signed:
             return new Quantizer8bitDirectSigned_neon<SIMDWIDTH>(d, trained);
+        case QuantizerType::QT_1bit_direct:
+            // todo: add more SIMDWIDTH support for neon if needed
+            return new Quantizer1bitDirect(d, trained);
     }
     FAISS_THROW_MSG("unknown qtype");
 }

--- a/thirdparty/faiss/faiss/impl/ScalarQuantizerDC.cpp
+++ b/thirdparty/faiss/faiss/impl/ScalarQuantizerDC.cpp
@@ -7,6 +7,8 @@
 
 #include <faiss/impl/ScalarQuantizerDC.h>
 #include <faiss/impl/ScalarQuantizerCodec.h>
+#include <faiss/utils/hamming_distance/hamdis-inl.h>
+#include <faiss/utils/jaccard-inl.h>
 
 namespace faiss {
 
@@ -24,6 +26,68 @@ ScalarQuantizer::SQDistanceComputer* sq_get_distance_computer_ref(
         return select_distance_computer<SimilarityL2<1>>(qtype, dim, trained);
     } else {
         return select_distance_computer<SimilarityIP<1>>(qtype, dim, trained);
+    }
+}
+
+ScalarQuantizer::SQDistanceComputer* sq_get_hamming_distance_computer_ref(
+        MetricType metric,
+        ScalarQuantizer::QuantizerType qtype,
+        size_t dim,
+        const std::vector<float>& trained) {
+    return select_hamming_distance_computer(dim, trained);
+}
+
+SQDistanceComputer* select_hamming_distance_computer(
+        size_t d,
+        const std::vector<float>& trained) {
+    size_t code_size = (d + 7) / 8;
+    switch (code_size) {
+        case 4:
+            return new BinarySQDistanceComputerWrapper<HammingComputer4>(code_size, trained);
+        case 8:
+            return new BinarySQDistanceComputerWrapper<HammingComputer8>(code_size, trained);
+        case 16:
+            return new BinarySQDistanceComputerWrapper<HammingComputer16>(code_size, trained);
+        case 20:
+            return new BinarySQDistanceComputerWrapper<HammingComputer20>(code_size, trained);
+        case 32:
+            return new BinarySQDistanceComputerWrapper<HammingComputer32>(code_size, trained);
+        case 64:
+            return new BinarySQDistanceComputerWrapper<HammingComputer64>(code_size, trained);
+        default:
+            return new BinarySQDistanceComputerWrapper<HammingComputerDefault>(code_size, trained);
+    }
+}
+
+ScalarQuantizer::SQDistanceComputer* sq_get_jaccard_distance_computer_ref(
+        MetricType metric,
+        ScalarQuantizer::QuantizerType qtype,
+        size_t dim,
+        const std::vector<float>& trained) {
+    return select_jaccard_distance_computer(dim, trained);
+}
+
+SQDistanceComputer* select_jaccard_distance_computer(
+        size_t d,
+        const std::vector<float>& trained) {
+    size_t code_size = (d + 7) / 8;
+    switch (code_size) {
+        case 8:
+            return new BinarySQDistanceComputerWrapper<JaccardComputer8>(code_size, trained);
+        case 16:
+            return new BinarySQDistanceComputerWrapper<JaccardComputer16>(code_size, trained);
+        case 32:
+            return new BinarySQDistanceComputerWrapper<JaccardComputer32>(code_size, trained);
+        case 64:
+            return new BinarySQDistanceComputerWrapper<JaccardComputer64>(code_size, trained);
+        case 128:
+            return new BinarySQDistanceComputerWrapper<JaccardComputer128>(code_size, trained);
+        case 256:
+            return new BinarySQDistanceComputerWrapper<JaccardComputer256>(code_size, trained);
+        case 512:
+            return new BinarySQDistanceComputerWrapper<JaccardComputer512>(code_size, trained);
+        default:
+            return new BinarySQDistanceComputerWrapper<JaccardComputerDefault>(code_size, trained);
     }
 }
 

--- a/thirdparty/faiss/faiss/impl/ScalarQuantizerDC.h
+++ b/thirdparty/faiss/faiss/impl/ScalarQuantizerDC.h
@@ -20,6 +20,18 @@ ScalarQuantizer::SQDistanceComputer* sq_get_distance_computer_ref(
         size_t dim,
         const std::vector<float>& trained);
 
+ScalarQuantizer::SQDistanceComputer* sq_get_hamming_distance_computer_ref(
+        MetricType metric,
+        ScalarQuantizer::QuantizerType qtype,
+        size_t dim,
+        const std::vector<float>& trained);
+
+ScalarQuantizer::SQDistanceComputer* sq_get_jaccard_distance_computer_ref(
+        MetricType metric,
+        ScalarQuantizer::QuantizerType qtype,
+        size_t dim,
+        const std::vector<float>& trained);
+
 ScalarQuantizer::SQuantizer* sq_select_quantizer_ref(
         ScalarQuantizer::QuantizerType qtype,
         size_t dim,


### PR DESCRIPTION
feat: add binary vector support for HNSW

- Add QT_1bit_direct quantizer type for binary vectors
- Add BinarySQDistanceComputerWrapper for binary distance computation
- Implement binary data format conversion (bin1) in HNSW index

/kind improvement