### PR TITLE
fix: revert MAX_N_SECTOR_READS

### DIFF
--- a/thirdparty/DiskANN/include/diskann/defaults.h
+++ b/thirdparty/DiskANN/include/diskann/defaults.h
@@ -43,7 +43,7 @@ const float GRAPH_SLACK_FACTOR = 1.3;
 // SSD Index related limits
 const uint64_t MAX_GRAPH_DEGREE = 512;
 const uint64_t SECTOR_LEN = 4096;
-const uint64_t MAX_N_SECTOR_READS = 1024;
+const uint64_t MAX_N_SECTOR_READS = 256;
 
 
 // following constants should always be specified, but are useful as a


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/44857

https://github.com/zilliztech/knowhere/pull/1282/files#diff-346a5f156140b229a4d5f6bd0744aa895b9b7cc19d4b4dfc3ce9490efd365a69R46
https://github.com/zilliztech/knowhere/pull/1282/files#diff-5a0a88f523d2a1557f84f66976511638a9d0cc960535003bfabe9c327c3f4fb3L34

The change to this parameter can cause the memory usage of setup_thread_data to increase by 3-4 times, leading to OOM (Out of Memory) issues in some extreme scenarios; revert it for now.

