### PR TITLE
fix param retrieval_ann_ratio bounds checking

### DIFF
--- a/include/knowhere/config.h
+++ b/include/knowhere/config.h
@@ -812,7 +812,6 @@ class BaseConfig : public Config {
         KNOWHERE_CONFIG_DECLARE_FIELD(retrieval_ann_ratio)
             .description("Factor for top-k in the first ANNS round, only used for emb_list")
             .set_default(3.0f)
-            .set_range(0.01f, 100.0f)
             .for_search();
         KNOWHERE_CONFIG_DECLARE_FIELD(emb_list_meta_file_path)
             .description("file name of emb_list meta for mmap load")

--- a/tests/ut/test_diskann.cc
+++ b/tests/ut/test_diskann.cc
@@ -431,7 +431,7 @@ emb_list_search() {
         json["index_prefix"] = metric_dir_map[metric_str];
         json["search_list_size"] = 36;
         json["beamwidth"] = 8;
-        json["retrieval_ann_ratio"] = 2.0f;
+        json["retrieval_ann_ratio"] = 3.0f;
         return json;
     };
 


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/45076

- Removed the upper bound limit for the `retrieval_ann_ratio` parameter. It now only throws an error if the value is below 0.
- Fixed a bug where the `bruteforce` method was incorrectly validating the `retrieval_ann_ratio` parameter even when it was not in use.

/kind improvement