### PR TITLE
enhance: split CLAUDE.md into skills for better context loading

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: architecture
+description: Use when exploring codebase structure, understanding index implementations (HNSW, IVF, DISKANN, Sparse, MinHash), working with third-party libraries (faiss, hnswlib, DiskANN, Cardinal), or locating specific functionality
+---
+
+# Knowhere Architecture
+
+## Directory Structure
+
+| Directory | Purpose |
+|-----------|---------|
+| `include/knowhere/` | Public headers |
+| `src/index/` | Index implementations (flat/, hnsw/, ivf/, gpu/, diskann/, sparse/, minhash/) |
+| `src/common/` | Threading, tracing, metrics utilities |
+| `src/cluster/` | Clustering algorithms (KMeans) |
+| `tests/ut/` | Unit tests |
+| `thirdparty/` | Forked third-party libraries |
+
+## Core Components
+
+**Index Factory** (`include/knowhere/index/index_factory.h`)
+- Singleton factory pattern for creating indexes
+- Uses macro-based static registration (`KNOWHERE_SIMPLE_REGISTER_GLOBAL`)
+
+**Index Interface** (`include/knowhere/index/index.h`)
+- Template-based `Index<IndexNode>` wrapper
+- Operations: Build, Search, RangeSearch
+
+**Configuration** (`include/knowhere/config.h`)
+- JSON-based config system
+- Compile-time and runtime parameter validation
+
+**Data Types** (`include/knowhere/operands.h`)
+- fp32, fp16, bf16, int8, bin1 (binary), sparse_u32_f32
+
+**Error Handling** (`include/knowhere/expected.h`)
+- Custom `expected<T>` type with Status enum
+
+## Metric Types
+
+L2, IP (Inner Product), COSINE, Jaccard, Hamming, BM25
+
+## Detailed Reference
+
+- **Index types**: See [index-types.md](index-types.md) for each index's capabilities and use cases
+- **Third-party libraries**: See [dependencies.md](dependencies.md) for faiss, hnswlib, DiskANN, Cardinal details

--- a/.claude/skills/architecture/dependencies.md
+++ b/.claude/skills/architecture/dependencies.md
@@ -1,0 +1,52 @@
+# Third-Party Dependencies
+
+Located in `thirdparty/`, these are forked/customized versions of core algorithm libraries.
+
+## faiss
+
+- **Source**: Meta's similarity search library
+- **Location**: `thirdparty/faiss/`
+- **Provides**: IVF, PQ, and flat index implementations
+- **Used by**: IVF_FLAT, IVF_PQ, IVF_SQ8, Flat indexes
+- **Key features**:
+  - Vector quantization (PQ, SQ)
+  - Clustering (KMeans)
+  - SIMD-optimized distance computations
+
+## hnswlib
+
+- **Source**: Header-only HNSW implementation
+- **Location**: `thirdparty/hnswlib/`
+- **Provides**: Graph-based approximate nearest neighbor search
+- **Used by**: HNSW index
+- **Key features**:
+  - Hierarchical graph structure
+  - Fast search with configurable accuracy
+  - Support for incremental insertions
+
+## DiskANN
+
+- **Source**: Microsoft's disk-based ANN library
+- **Location**: `thirdparty/DiskANN/`
+- **Provides**: Billion-scale search on SSDs
+- **Used by**: DISKANN, AISAQ indexes
+- **Key features**:
+  - Graph index stored on disk
+  - Minimal memory footprint
+  - SSD-optimized I/O patterns
+- **AISAQ extension**: KIOXIA's enhancement with PQ compression and optimized I/O
+
+## Cardinal
+
+- **Source**: Zilliz's enterprise extensions
+- **Location**: `thirdparty/cardinalv1/`, `thirdparty/cardinalv2/`
+- **Provides**: Extended index implementations with additional features
+- **Note**: Enterprise/proprietary variants
+
+## Build Dependencies
+
+| Dependency | Required For | Build Option |
+|------------|--------------|--------------|
+| OpenBLAS | All builds | Always required |
+| libaio | DISKANN, AISAQ | `-o with_diskann=True` |
+| CUDA | GPU indexes | `-o with_cuvs=True` |

--- a/.claude/skills/architecture/index-types.md
+++ b/.claude/skills/architecture/index-types.md
@@ -1,0 +1,132 @@
+# Index Types
+
+## Overview
+
+| Index Family | Type | Best For | Metric Support |
+|--------------|------|----------|----------------|
+| Flat | Brute force | Small datasets, 100% recall | L2, IP, COSINE |
+| HNSW | Graph-based | Low latency, high recall | L2, IP, COSINE |
+| IVF | Inverted file | Large datasets, balanced | L2, IP, COSINE |
+| SCANN | IVF + Anisotropic | Fast search, good recall | L2, IP, COSINE |
+| DISKANN | Disk-based | Billion-scale, limited RAM | L2, IP, COSINE |
+| AISAQ | Disk-based + PQ | Billion-scale, optimized I/O | L2, IP, COSINE |
+| SPARSE_INVERTED_INDEX | Inverted index | Sparse vectors, text search | IP, BM25 |
+| SPARSE_WAND | Inverted index (WAND) | Sparse vectors, optimized top-k | IP, BM25 |
+| MinHash | LSH | Jaccard similarity | Jaccard |
+| GPU (CUVS) | CUDA-accelerated | High throughput | L2, IP |
+
+## Index Details
+
+### Flat
+- Location: `src/index/flat/`
+- Brute force search, no training required
+- 100% recall, O(n) search complexity
+
+### HNSW Series
+- Location: `src/index/hnsw/`
+- Hierarchical Navigable Small World graph
+- Key params: `M` (connections), `efConstruction`, `ef` (search)
+
+| Variant | Quantization | Use Case |
+|---------|--------------|----------|
+| HNSW | None | Best recall, higher memory |
+| HNSW_SQ | Scalar (8-bit) | Balanced memory/recall |
+| HNSW_PQ | Product | Lower memory, good recall |
+| HNSW_PRQ | Product Residual | Lowest memory, acceptable recall |
+
+### IVF Series
+- Location: `src/index/ivf/`
+- Inverted file with clustering
+- Key params: `nlist` (clusters), `nprobe` (search clusters)
+- Growing variants (concurrent read/write): IVF_FLAT_CC, IVF_SQ_CC support real-time insertion
+
+| Variant | Quantization | Data Type | Use Case |
+|---------|--------------|-----------|----------|
+| IVF_FLAT | None | Dense float/int8 | Best recall in IVF family |
+| IVF_SQ | Scalar | Dense float/int8 | Balanced memory/recall |
+| IVF_PQ | Product | Dense float/int8 | Lower memory, training required |
+| IVF_RABITQ | RaBitQ | Dense float | Ultra compression (~32x) |
+| BIN_IVF_FLAT | None | Binary | Binary vector search |
+
+### SCANN
+- Location: `src/index/ivf/ivf.cc` (uses `faiss::IndexScaNN`)
+- Score-aware quantization with anisotropic vector quantization
+- Based on Google's ScaNN algorithm
+- Key params: `nlist`, `nprobe`, `with_raw_data`, `reorder_k`
+- SCANN_DVR variant: with DataViewRefiner for optimized reranking
+
+### DISKANN
+- Location: `src/index/diskann/`
+- Disk-based graph index for billion-scale
+- Requires: `-o with_diskann=True` build option
+- Key params: `R` (degree), `L` (search list size)
+
+### AISAQ
+- Location: `src/index/diskann/diskann_aisaq.cc`
+- Enhanced DISKANN with PQ compression and I/O optimization (by KIOXIA)
+- Requires: `-o with_diskann=True` build option
+- Key params: `vectors_beamwidth`, `inline_pq`, `pq_cache_size`, `num_entry_points`
+
+### Sparse Series
+- Location: `src/index/sparse/`
+- Inverted index for sparse vectors
+- Data type: `sparse_u32_f32`
+- Metrics: IP (inner product), BM25 (text relevance)
+- BM25 params: `k1`, `b`, `avgdl`
+
+| Variant | Description |
+|---------|-------------|
+| SPARSE_INVERTED_INDEX | Standard inverted index |
+| SPARSE_WAND | WAND algorithm for optimized top-k retrieval |
+
+### MinHash
+- Location: `src/index/minhash/`
+- MinHash LSH for Jaccard similarity
+- For binary/set data
+
+### GPU (CUVS)
+- Location: `src/index/gpu_cuvs/`
+- CUDA-accelerated implementations via NVIDIA cuVS
+- Requires: `-o with_cuvs=True` build option
+
+| Variant | Description | Data Types |
+|---------|-------------|------------|
+| GPU_CAGRA | Graph-based (CAGRA algorithm) | fp32, fp16, int8, binary |
+| GPU_BRUTE_FORCE | Exact search | fp32, fp16 |
+| GPU_IVF_FLAT | IVF without quantization | fp32, fp16, int8 |
+| GPU_IVF_PQ | IVF with product quantization | fp32, fp16, int8 |
+
+## Quantization Types
+
+| Type | Abbreviation | Description | Memory Reduction |
+|------|--------------|-------------|------------------|
+| Scalar 4-bit | SQ4U | 4-bit uniform scalar quantization | ~8x |
+| Scalar 6-bit | SQ6 | 6-bit scalar quantization | ~5x |
+| Scalar 8-bit | SQ8 | 8-bit scalar quantization | ~4x |
+| Product | PQ | Vector split into subvectors, each quantized | ~8-32x |
+| Product Residual | PRQ | PQ applied to residuals iteratively | ~8-32x |
+| RaBitQ | RaBitQ | Random Binary Quantization | ~32x |
+
+## Data Type Support
+
+| Index | fp32 | fp16 | bf16 | int8 | binary | sparse_u32_f32 |
+|-------|------|------|------|------|--------|----------------|
+| Flat | ✓ | ✓ | ✓ | ✓ | ✓ | - |
+| **HNSW Series** |
+| HNSW | ✓ | ✓ | ✓ | ✓ | - | - |
+| HNSW_SQ | ✓ | ✓ | ✓ | ✓ | - | - |
+| HNSW_PQ | ✓ | ✓ | ✓ | ✓ | - | - |
+| HNSW_PRQ | ✓ | ✓ | ✓ | ✓ | - | - |
+| **IVF Series** |
+| IVF_FLAT | ✓ | ✓ | ✓ | ✓ | - | - |
+| IVF_SQ | ✓ | ✓ | ✓ | ✓ | - | - |
+| IVF_PQ | ✓ | ✓ | ✓ | ✓ | - | - |
+| IVF_RABITQ | ✓ | ✓ | ✓ | - | - | - |
+| BIN_IVF_FLAT | - | - | - | - | ✓ | - |
+| **Others** |
+| SCANN | ✓ | ✓ | ✓ | ✓ | - | - |
+| DISKANN | ✓ | ✓ | ✓ | - | - | - |
+| AISAQ | ✓ | ✓ | ✓ | - | - | - |
+| SPARSE_INVERTED_INDEX | - | - | - | - | - | ✓ |
+| SPARSE_WAND | - | - | - | - | - | ✓ |
+| MinHash | - | - | - | - | ✓ | - |

--- a/.claude/skills/building/SKILL.md
+++ b/.claude/skills/building/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: building
+description: Use when building knowhere from source, configuring build options (CPU/GPU/DISKANN/ASAN), or troubleshooting compilation errors
+---
+
+# Building Knowhere
+
+## Prerequisites
+
+```bash
+# Ubuntu/Debian
+sudo apt install build-essential libopenblas-openmp-dev libaio-dev python3-dev python3-pip
+pip3 install conan==1.61.0 --user
+export PATH=$PATH:$HOME/.local/bin
+```
+
+## Build Commands
+
+```bash
+mkdir build && cd build
+conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local
+```
+
+| Build Type | Command |
+|------------|---------|
+| CPU Release | `conan install .. --build=missing -o with_ut=True -s compiler.libcxx=libstdc++11 -s build_type=Release` |
+| CPU Debug | `conan install .. --build=missing -o with_ut=True -s compiler.libcxx=libstdc++11 -s build_type=Debug` |
+| GPU (CUVS) | `conan install .. --build=missing -o with_ut=True -o with_cuvs=True -s compiler.libcxx=libstdc++11 -s build_type=Release` |
+| DISKANN | `conan install .. --build=missing -o with_ut=True -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release` |
+| ASAN (CI default) | `conan install .. --build=missing -o with_ut=True -o with_diskann=True -o with_asan=True -s compiler.libcxx=libstdc++11 -s build_type=Release` |
+| macOS | `conan install .. --build=missing -o with_ut=True -s compiler.libcxx=libc++ -s build_type=Release` |
+
+Then run: `conan build ..`
+
+## Build Options
+
+| Option | Description |
+|--------|-------------|
+| `with_ut` | Enable unit tests |
+| `with_diskann` | Enable DISKANN index support |
+| `with_cuvs` | Enable GPU (CUVS) support |
+| `with_asan` | Enable AddressSanitizer for memory error detection |
+
+## Common Issues
+
+- **libstdc++ errors**: Ensure `-s compiler.libcxx=libstdc++11` matches your system
+- **Missing dependencies**: Run `conan install` with `--build=missing`
+- **macOS**: Use `libc++` instead of `libstdc++11`
+- **ASAN failures**: Check for memory leaks, use-after-free, buffer overflows
+
+---
+
+> If this build relates to new features or interface changes, consider updating documentation. See `documenting` skill.

--- a/.claude/skills/code-quality/SKILL.md
+++ b/.claude/skills/code-quality/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: code-quality
+description: Use when checking code style, running pre-commit hooks, or before committing changes to ensure compliance with Google style guide
+---
+
+# Code Quality
+
+## Code Style
+
+- **Standard**: Google C++ Style Guide
+- **Line limit**: 120 characters
+- **Indent**: 4 spaces
+- **Config**: See `.clang-format` in repo root
+
+## Pre-commit Hooks
+
+### Setup
+
+```bash
+pip3 install pre-commit
+pre-commit install --hook-type pre-commit --hook-type pre-push
+```
+
+### Usage
+
+```bash
+# Run on staged files
+pre-commit run
+
+# Run on specific files
+pre-commit run --files src/index/hnsw/hnsw.cc include/knowhere/index/index.h
+
+# Run on all files
+pre-commit run --all-files
+```
+
+## Commit Workflow
+
+```bash
+# 1. Make changes
+# 2. Run pre-commit on changed files
+pre-commit run --files <changed-files>
+
+# 3. Stage and commit
+git add .
+git commit -m "message"
+```
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| Formatting errors | Run `clang-format -i <file>` or let pre-commit fix it |
+| Line too long | Break line at logical points, max 120 chars |
+| Include order | Follow Google style: related header, C system, C++ standard, other libs, project headers |
+
+---
+
+> Pre-commit hooks run automatically on commit. Fix any failures before pushing.

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: git-workflow
+description: Use when committing and pushing code changes, ensures DCO compliance and pre-commit validation
+---
+
+# Git Workflow
+
+## Before Committing
+
+Always run pre-commit validation:
+
+```bash
+# Validate specific files
+pre-commit run --files <changed-files>
+
+# Or validate all staged files
+pre-commit run
+```
+
+Fix any issues before proceeding.
+
+## DCO (Developer Certificate of Origin)
+
+All commits must include a Signed-off-by line for DCO compliance:
+
+```bash
+git commit -s -m "commit message"
+```
+
+Or add manually:
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+## Commit Workflow
+
+1. **Stage changes**
+   ```bash
+   git add <files>
+   ```
+
+2. **Run pre-commit**
+   ```bash
+   pre-commit run
+   ```
+
+3. **Fix any issues** and re-stage if needed
+
+4. **Commit with DCO sign-off**
+   ```bash
+   git commit -s -m "type: description"
+   ```
+
+## Commit Message Format
+
+```
+type: short description
+
+Optional longer description.
+
+Signed-off-by: Name <email>
+```
+
+Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
+
+## Push
+
+```bash
+git push origin <branch>
+```
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Pre-commit check | `pre-commit run` |
+| Commit with DCO | `git commit -s -m "message"` |
+| Amend with DCO | `git commit --amend -s` |
+| Push | `git push origin <branch>` |

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: testing
+description: Use when running unit tests, debugging test failures, or adding new test cases using Catch2 framework
+---
+
+# Testing Knowhere
+
+## Running Tests
+
+```bash
+# Run all tests
+./Release/tests/ut/knowhere_tests
+./Debug/tests/ut/knowhere_tests
+
+# Run specific test by name pattern
+./Release/tests/ut/knowhere_tests "[float metrics]"
+./Release/tests/ut/knowhere_tests "Test Mem Index*"
+
+# List all test names
+./Release/tests/ut/knowhere_tests --list-tests
+```
+
+## Catch2 Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `[tag]` | Run tests with specific tag |
+| `"Test Name*"` | Run tests matching pattern |
+| `--list-tests` | List all available tests |
+| `--list-tags` | List all available tags |
+| `-s` | Show successful test output |
+| `-d yes` | Show test durations |
+
+## Test Location
+
+Tests are located in `tests/ut/`. Key test files:
+
+| File | Tests |
+|------|-------|
+| `test_index.cc` | Index build/search operations |
+| `test_float_metrics.cc` | Float vector metrics (L2, IP, COSINE) |
+| `test_binary_metrics.cc` | Binary vector metrics (Hamming, Jaccard) |
+| `test_sparse.cc` | Sparse vector index |
+
+## Writing New Tests
+
+```cpp
+#include "catch2/catch_test_macros.hpp"
+#include "knowhere/index/index_factory.h"
+
+TEST_CASE("Test Description", "[tag1][tag2]") {
+    // Setup
+    auto index = knowhere::IndexFactory::Instance().Create(...);
+
+    // Test
+    REQUIRE(index.has_value());
+
+    // Sections for sub-tests
+    SECTION("sub-test 1") {
+        // ...
+    }
+}
+```
+
+---
+
+> If adding tests for new features, consider updating documentation. See `documenting` skill.

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ CMakeUserPresets.json
 # python
 .eggs
 *.egg-info
+
+# Claude Code plans (local only)
+docs/plans/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,122 +1,17 @@
-# CLAUDE.md
+# Knowhere
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+C++ vector search library, core engine for Milvus. Provides unified ANN interface supporting multiple data types (fp32, fp16, bf16, int8, binary, sparse) and index implementations (HNSW, IVF, Flat, DISKANN, Sparse, MinHash).
 
-## Project Overview
+## Code Style
 
-Knowhere is a C++ vector search library that serves as the core engine for Milvus. It provides a unified interface for Approximate Nearest Neighbor (ANN) algorithms supporting multiple data types (fp32, fp16, bf16, int8, binary, sparse vectors) and index implementations (HNSW, IVF, Flat, DISKANN, MinHash).
+- Google C++ style, 120 char line limit, 4 space indent
+- Run `pre-commit run` before committing
 
-## Build Commands
+## Skills
 
-### Prerequisites
-```bash
-# Ubuntu/Debian
-sudo apt install build-essential libopenblas-openmp-dev libaio-dev python3-dev python3-pip
-pip3 install conan==1.61.0 --user
-export PATH=$PATH:$HOME/.local/bin
-```
-
-### Building
-```bash
-mkdir build && cd build
-conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local
-
-# CPU Release
-conan install .. --build=missing -o with_ut=True -s compiler.libcxx=libstdc++11 -s build_type=Release
-
-# CPU Debug
-conan install .. --build=missing -o with_ut=True -s compiler.libcxx=libstdc++11 -s build_type=Debug
-
-# GPU (CUVS) build
-conan install .. --build=missing -o with_ut=True -o with_cuvs=True -s compiler.libcxx=libstdc++11 -s build_type=Release
-
-# DISKANN support
-conan install .. --build=missing -o with_ut=True -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release
-
-# Build
-conan build ..
-```
-
-### macOS
-```bash
-conan install .. --build=missing -o with_ut=True -s compiler.libcxx=libc++ -s build_type=Release
-conan build ..
-```
-
-## Running Tests
-
-Uses Catch2 framework:
-```bash
-# Run all tests
-./Release/tests/ut/knowhere_tests
-./Debug/tests/ut/knowhere_tests
-
-# Run specific test by name pattern
-./Release/tests/ut/knowhere_tests "[float metrics]"
-./Release/tests/ut/knowhere_tests "Test Mem Index*"
-
-# List all test names
-./Release/tests/ut/knowhere_tests --list-tests
-```
-
-## Code Quality
-
-```bash
-pip3 install pre-commit
-pre-commit install --hook-type pre-commit --hook-type pre-push
-
-# Run checks manually
-pre-commit run
-```
-
-Code style: Google style with 120 char line limit, 4 space indent (see `.clang-format`).
-
-## Workflow
-
-Before committing changes, always run pre-commit validation:
-```bash
-pre-commit run --files <changed-files>  # or: pre-commit run --all-files
-git add . && git commit -m "message"
-```
-
-## Architecture
-
-### Directory Structure
-- `include/knowhere/` - Public headers
-- `src/index/` - Index implementations (flat/, hnsw/, ivf/, gpu/, diskann/, sparse/, minhash/)
-- `src/common/` - Threading, tracing, metrics utilities
-- `src/cluster/` - Clustering algorithms (KMeans)
-- `tests/ut/` - Unit tests
-
-### Key Components
-
-**Index Factory** (`include/knowhere/index/index_factory.h`): Singleton factory pattern for creating indexes. Uses macro-based static registration (`KNOWHERE_SIMPLE_REGISTER_GLOBAL`).
-
-**Index Interface** (`include/knowhere/index/index.h`): Template-based `Index<IndexNode>` wrapper providing Build, Search, RangeSearch operations.
-
-**Configuration** (`include/knowhere/config.h`): JSON-based config system with compile-time and runtime parameter validation.
-
-**Data Types** (`include/knowhere/operands.h`): Supported types include fp32, fp16, bf16, int8, bin1 (binary), sparse_u32_f32 (sparse vectors).
-
-**Error Handling** (`include/knowhere/expected.h`): Custom `expected<T>` type with Status enum for type-safe error propagation.
-
-### Index Types
-- **Flat**: Brute force search
-- **HNSW**: Hierarchical Navigable Small World graph
-- **IVF**: Inverted File indexes (IVF_FLAT, IVF_PQ, IVF_SQ8)
-- **DISKANN**: Disk-based ANN for large datasets
-- **Sparse**: Sparse vector indexes (inverted index)
-- **MinHash**: MinHash LSH for Jaccard similarity
-- **GPU**: CUDA-accelerated implementations (CUVS)
-
-### Metric Types
-L2, IP (Inner Product), COSINE, Jaccard, Hamming
-
-### Third-Party Dependencies (`thirdparty/`)
-
-Forked/customized versions of core algorithm libraries:
-
-- **faiss/** - Meta's similarity search library. Provides IVF, PQ, and flat index implementations. Core algorithms for vector quantization and clustering.
-- **hnswlib/** - Header-only HNSW implementation. Graph-based approximate nearest neighbor search algorithm.
-- **DiskANN/** - Microsoft's disk-based ANN library. Enables billion-scale search on SSDs without loading full index into memory.
-- **cardinalv1/, cardinalv2/** - Zilliz's enterprise Cardinal variants. Extended index implementations with additional features.
+Project-specific skills available in `.claude/skills/`:
+- `building` - Build configuration and compilation
+- `testing` - Running and writing tests
+- `code-quality` - Code style and pre-commit
+- `architecture` - Codebase structure, index types, dependencies
+- `git-workflow` - Committing and pushing with DCO and pre-commit


### PR DESCRIPTION
- Simplify CLAUDE.md to ~17 lines with project overview and skill references
- Add .claude/skills/ with 5 specialized skills:
  - building: build configuration and compilation options (CPU/GPU/DISKANN/ASAN)
  - testing: Catch2 test running and writing
  - code-quality: pre-commit and Google style guide
  - architecture: codebase structure, index types, dependencies
  - documenting: reference documentation updates
- Add docs/reference/ for human-readable documentation:
  - index-capabilities.md: index feature matrix
  - performance-guide.md: resource usage guidelines
  - implementation-log.md: change history
- Add docs/plans/ to .gitignore (local design documents)

Skills are auto-discovered by Claude Code via description metadata, enabling precise context loading based on task requirements.

/kind improvement