### PR TITLE
enhance: run UT on self-hosted runner

### DIFF
--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -35,8 +35,8 @@ jobs:
       - name: Install Dependency
         run: |
           sudo apt update \
-          && sudo apt install -y cmake g++ gcc libopenblas-openmp-dev libcurl4-openssl-dev libaio-dev libevent-dev python3 python3-pip lcov ccache \
-          && pip3 install conan==1.61.0 \
+          && sudo apt install -y g++ gcc libopenblas-openmp-dev libcurl4-openssl-dev libaio-dev libevent-dev python3 python3-pip lcov ccache \
+          && sudo pip3 install cmake==3.28.1 conan==1.61.0 \
           && (conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local || true)
       - name: Restore Cache
         uses: ./.github/actions/cache-restore


### PR DESCRIPTION
Switch the unit test job to run on a self-hosted runner instead of GitHub-hosted ubuntu-22.04 runner.

/kind improvement

issue: #1451 