### PR TITLE
fix openssl version

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -100,7 +100,7 @@ class KnowhereConan(ConanFile):
         self.requires("gflags/2.2.2")
         self.requires("glog/0.6.0")
         self.requires("nlohmann_json/3.11.2")
-        self.requires("openssl/1.1.1t")
+        self.requires("openssl/3.1.2")
         self.requires("prometheus-cpp/1.1.0")
         self.requires("zlib/1.2.12")
         self.requires("double-conversion/3.2.1")


### PR DESCRIPTION
compile will error:
```
/usr/bin/ld: ../milvus-common-build/libmilvus-common.so: undefined reference to `EVP_DigestSignUpdate'
/usr/bin/ld: ../milvus-common-build/libmilvus-common.so: undefined reference to `SSL_get1_peer_certificate'
/usr/bin/ld: ../milvus-common-build/libmilvus-common.so: undefined reference to `EVP_DigestSignUpdate'
/usr/bin/ld: ../milvus-common-build/libmilvus-common.so: undefined reference to `EVP_DigestSignUpdate'
/usr/bin/ld: ../milvus-common-build/libmilvus-common.so: undefined reference to `EVP_DigestSignUpdate'
/usr/bin/ld: ../milvus-common-build/libmilvus-common.so: undefined reference to `SSL_get1_peer_certificate'
/usr/bin/ld: ../milvus-common-build/libmilvus-common.so: undefined reference to `SSL_get1_peer_certificate'
/usr/bin/ld: ../milvus-common-build/libmilvus-common.so: undefined reference to `SSL_get1_peer_certificate'
/usr/bin/ld: ../milvus-common-build/libmilvus-common.so: undefined reference to `EVP_DigestSignUpdate'
/usr/bin/ld: ../milvus-common-build/libmilvus-common.so: undefined reference to `SSL_get1_peer_certificate'
/usr/bin/ld: ../milvus-common-build/libmilvus-common.so: undefined reference to `EVP_DigestSignUpdate'
/usr/bin/ld: ../milvus-common-build/libmilvus-common.so: undefined reference to `SSL_get1_peer_certificate'
```

align with milvus https://github.com/milvus-io/milvus/blob/master/internal/core/conanfile.py#L16

/kind improvement