### PR TITLE
fix: add macOS build support and upgrade dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,17 +50,6 @@ set(KNOWHERE_THRID_ROOT ${KNOWHERE_ROOT}/thirdparty)
 knowhere_option(WITH_CARDINAL "Build with cardinal" OFF)
 knowhere_option(CARDINAL_VERSION_FORCE_CHECKOUT
                 "Force checkout cardinal version" OFF)
-# this is needed for clang on ubuntu:20.04, otherwise the linked fails with
-# 'undefined reference' error. fmt v9 was used by the time the error was
-# encountered. clang on ubuntu:22.04 seems to be unaffected. gcc seems to be
-# unaffected.
-add_definitions(-DFMT_HEADER_ONLY)
-
-# this is needed for clang on ubuntu:20.04, otherwise the linked fails with
-# 'undefined reference' error. fmt v9 was used by the time the error was
-# encountered. clang on ubuntu:22.04 seems to be unaffected. gcc seems to be
-# unaffected.
-add_definitions(-DFMT_HEADER_ONLY)
 
 if(KNOWHERE_VERSION)
   message(STATUS "Building KNOWHERE version: ${KNOWHERE_VERSION}")
@@ -111,6 +100,37 @@ find_package(simde REQUIRED)
 
 if(NOT WITH_LIGHT)
   find_package(opentelemetry-cpp REQUIRED)
+  include_directories(${opentelemetry-cpp_INCLUDE_DIRS})
+  add_definitions(-DOPENTELEMETRY_STL_VERSION=2017)
+  if(TARGET opentelemetry-cpp::opentelemetry_exporter_otlp_grpc)
+    add_definitions(-DHAVE_OTLP_GRPC_EXPORTER)
+  endif()
+endif()
+
+if(APPLE)
+  # On macOS, transitive find_package calls (CURL, ZLIB, etc.) resolve to the
+  # SDK sysroot (e.g. .../MacOSX.sdk/usr/include). When CMake adds that path
+  # as -I or -isystem, it places C standard library headers ahead of libc++'s
+  # C++ wrapper headers (cinttypes, cstdio, etc.), breaking compilation.
+  # Strip SDK sysroot include dirs from all imported targets since the compiler
+  # already searches them by default.
+  execute_process(COMMAND xcrun --show-sdk-path OUTPUT_VARIABLE _SDK_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(_SDK_INCLUDE "${_SDK_PATH}/usr/include")
+  get_property(_all_targets DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY IMPORTED_TARGETS)
+  foreach(_tgt IN LISTS _all_targets)
+    foreach(_prop INTERFACE_INCLUDE_DIRECTORIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
+      get_target_property(_dirs ${_tgt} ${_prop})
+      if(_dirs)
+        list(REMOVE_ITEM _dirs "${_SDK_INCLUDE}")
+        foreach(_d IN LISTS _dirs)
+          if(_d MATCHES "/SDKs/MacOSX[0-9]*\\.sdk/usr/include$")
+            list(REMOVE_ITEM _dirs "${_d}")
+          endif()
+        endforeach()
+        set_target_properties(${_tgt} PROPERTIES ${_prop} "${_dirs}")
+      endif()
+    endforeach()
+  endforeach()
 endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_OSX_DEPLOYMENT_TARGET
@@ -200,13 +220,20 @@ list(APPEND KNOWHERE_LINKER_LIBS faiss)
 list(APPEND KNOWHERE_LINKER_LIBS glog::glog)
 list(APPEND KNOWHERE_LINKER_LIBS nlohmann_json::nlohmann_json)
 list(APPEND KNOWHERE_LINKER_LIBS prometheus-cpp::core prometheus-cpp::push)
-list(APPEND KNOWHERE_LINKER_LIBS fmt::fmt-header-only)
+list(APPEND KNOWHERE_LINKER_LIBS fmt::fmt)
 list(APPEND KNOWHERE_LINKER_LIBS Folly::folly)
 list(APPEND KNOWHERE_LINKER_LIBS milvus-common)
 list(APPEND KNOWHERE_LINKER_LIBS simde::simde)
 
 add_library(knowhere SHARED ${KNOWHERE_SRCS})
-add_dependencies(knowhere ${KNOWHERE_LINKER_LIBS})
+if(MILVUS_COMMON_DIR)
+  # Pre-built milvus-common is IMPORTED; filter it from add_dependencies
+  set(_KNOWHERE_BUILD_DEPS ${KNOWHERE_LINKER_LIBS})
+  list(REMOVE_ITEM _KNOWHERE_BUILD_DEPS milvus-common simde::simde)
+  add_dependencies(knowhere ${_KNOWHERE_BUILD_DEPS})
+else()
+  add_dependencies(knowhere ${KNOWHERE_LINKER_LIBS})
+endif()
 if(WITH_CUVS)
   list(
     APPEND

--- a/cmake/libs/libmilvus-common.cmake
+++ b/cmake/libs/libmilvus-common.cmake
@@ -1,44 +1,84 @@
 
-set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( MILVUS-COMMON-VERSION c37f138 )
-set( GIT_REPOSITORY  "https://github.com/zilliztech/milvus-common.git" )
+# When MILVUS_COMMON_DIR is set, use a pre-built local milvus-common.
+# Otherwise fall back to FetchContent from GitHub (upstream default).
 
-message(STATUS "milvus-common repo: ${GIT_REPOSITORY}")
-message(STATUS "milvus-common version: ${MILVUS-COMMON-VERSION}")
-message(STATUS "Building milvus-common-${MILVUS-COMMON-VERSION} from source")
-message(STATUS ${CMAKE_BUILD_TYPE})
+if(MILVUS_COMMON_DIR)
+    message(STATUS "Using pre-built milvus-common from: ${MILVUS_COMMON_DIR}")
 
-list(APPEND CMAKE_PREFIX_PATH ${CONAN_BOOST_ROOT} )
+    find_library(MILVUS_COMMON_LIBRARY
+        NAMES milvus-common
+        PATHS "${MILVUS_COMMON_DIR}/build"
+        NO_DEFAULT_PATH
+    )
 
-include( FetchContent )
+    if(NOT MILVUS_COMMON_LIBRARY)
+        message(FATAL_ERROR
+            "milvus-common library not found in ${MILVUS_COMMON_DIR}/build. "
+            "Please build milvus-common first: cd ${MILVUS_COMMON_DIR} && make"
+        )
+    endif()
 
-find_package(fmt REQUIRED)
-find_package(glog REQUIRED)
-find_package(nlohmann_json REQUIRED)
-find_package(folly REQUIRED)
-find_package(prometheus-cpp REQUIRED)
+    message(STATUS "Found milvus-common library: ${MILVUS_COMMON_LIBRARY}")
 
-FetchContent_Declare(
-        milvus-common
-        GIT_REPOSITORY  ${GIT_REPOSITORY}
-        GIT_TAG         ${MILVUS-COMMON-VERSION}
-        SOURCE_DIR      ${CMAKE_CURRENT_BINARY_DIR}/milvus-common-src
-        BINARY_DIR      ${CMAKE_CURRENT_BINARY_DIR}/milvus-common-build
-        SOURCE_SUBDIR   cpp
-        DOWNLOAD_DIR    ${THIRDPARTY_DOWNLOAD_PATH} )
+    add_library(milvus-common SHARED IMPORTED GLOBAL)
+    set_target_properties(milvus-common PROPERTIES
+        IMPORTED_LOCATION "${MILVUS_COMMON_LIBRARY}"
+    )
 
-FetchContent_GetProperties( milvus-common )
-if ( NOT milvus-common_POPULATED )
-    FetchContent_Populate( milvus-common )
-    # Adding the following target:
-    # milvus-common
-    add_subdirectory( ${milvus-common_SOURCE_DIR}
-                      ${milvus-common_BINARY_DIR} )
+    set(MILVUS_COMMON_INCLUDE_DIR "${MILVUS_COMMON_DIR}/include"
+        CACHE INTERNAL "Path to milvus-common include directory")
 
-    # Link atomic library to milvus-common to fix atomic operations
-    target_link_libraries(milvus-common PUBLIC atomic)
+    if(NOT EXISTS "${MILVUS_COMMON_INCLUDE_DIR}")
+        message(FATAL_ERROR "milvus-common include directory not found: ${MILVUS_COMMON_INCLUDE_DIR}")
+    endif()
+
+    set_target_properties(milvus-common PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${MILVUS_COMMON_INCLUDE_DIR}"
+    )
+
+else()
+    # Upstream default: fetch from git and build as subdirectory
+    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
+    set( MILVUS-COMMON-VERSION dba70b6 )
+    set( GIT_REPOSITORY  "https://github.com/zilliztech/milvus-common.git" )
+
+    message(STATUS "milvus-common repo: ${GIT_REPOSITORY}")
+    message(STATUS "milvus-common version: ${MILVUS-COMMON-VERSION}")
+    message(STATUS "Building milvus-common-${MILVUS-COMMON-VERSION} from source")
+    message(STATUS ${CMAKE_BUILD_TYPE})
+
+    list(APPEND CMAKE_PREFIX_PATH ${CONAN_BOOST_ROOT} )
+
+    include( FetchContent )
+
+    find_package(fmt REQUIRED)
+    find_package(glog REQUIRED)
+    find_package(nlohmann_json REQUIRED)
+    find_package(folly REQUIRED)
+    find_package(prometheus-cpp REQUIRED)
+
+    FetchContent_Declare(
+            milvus-common
+            GIT_REPOSITORY  ${GIT_REPOSITORY}
+            GIT_TAG         ${MILVUS-COMMON-VERSION}
+            SOURCE_DIR      ${CMAKE_CURRENT_BINARY_DIR}/milvus-common-src
+            BINARY_DIR      ${CMAKE_CURRENT_BINARY_DIR}/milvus-common-build
+            DOWNLOAD_DIR    ${THIRDPARTY_DOWNLOAD_PATH} )
+
+    FetchContent_GetProperties( milvus-common )
+    if ( NOT milvus-common_POPULATED )
+        FetchContent_Populate( milvus-common )
+        add_subdirectory( ${milvus-common_SOURCE_DIR}
+                          ${milvus-common_BINARY_DIR} )
+
+        if(NOT APPLE)
+            target_link_libraries(milvus-common PUBLIC atomic)
+        endif()
+    endif()
+
+    set( MILVUS_COMMON_INCLUDE_DIR ${milvus-common_SOURCE_DIR}/include
+         CACHE INTERNAL "Path to milvus-common include directory" )
+
 endif()
-
-set( MILVUS_COMMON_INCLUDE_DIR ${milvus-common_SOURCE_DIR}/include CACHE INTERNAL "Path to milvus-common include directory" )
 
 include_directories(${MILVUS_COMMON_INCLUDE_DIR})

--- a/include/knowhere/tracer.h
+++ b/include/knowhere/tracer.h
@@ -23,8 +23,8 @@ namespace knowhere::tracer {
 struct TraceConfig {
     std::string exporter;
     float sampleFraction;
-    std::string jaegerURL;
     std::string otlpEndpoint;
+    std::string otlpMethod;  // "grpc" (default) or "http"
     bool oltpSecure;
 
     int nodeID;

--- a/tests/ut/CMakeLists.txt
+++ b/tests/ut/CMakeLists.txt
@@ -49,6 +49,7 @@ set_target_properties(knowhere_tests PROPERTIES
 
 target_link_libraries(knowhere_tests PRIVATE
         Catch2::Catch2WithMain
-        atomic
-        stdc++fs
         knowhere)
+if(NOT APPLE)
+  target_link_libraries(knowhere_tests PRIVATE atomic stdc++fs)
+endif()

--- a/tests/ut/test_tracer.cc
+++ b/tests/ut/test_tracer.cc
@@ -43,11 +43,26 @@ TEST_CASE("Test Tracer init", "Init test") {
         CloseRootSpan();
     }
 
-    SECTION("check jaeger") {
+    SECTION("check otlp grpc") {
         auto config = std::make_shared<TraceConfig>();
-        config->exporter = "jaeger";
-        // use default jaeger collector port for test
-        config->jaegerURL = "http://localhost:14268/api/traces";
+        config->exporter = "otlp";
+        config->otlpEndpoint = "localhost:4317";
+        config->nodeID = 1;
+        initTelemetry(*config);
+        auto span = StartSpan("test");
+        REQUIRE(span->IsRecording());
+
+        SetRootSpan(span);
+        AddEvent("sleep");
+        usleep(20000);
+        CloseRootSpan();
+    }
+
+    SECTION("check otlp http") {
+        auto config = std::make_shared<TraceConfig>();
+        config->exporter = "otlp";
+        config->otlpMethod = "http";
+        config->otlpEndpoint = "http://localhost:4318/v1/traces";
         config->nodeID = 1;
         initTelemetry(*config);
         auto span = StartSpan("test");


### PR DESCRIPTION
## Summary

Closes #1463

- Upgrade all dependencies to align with milvus-common [fix/macos-build-support](https://github.com/zilliztech/milvus-common/tree/fix/macos-build-support) (boost 1.83, fmt 11.0.2 linked, otel 1.23.0, folly 2024, grpc 1.67.1, abseil 20250127.0, etc.)
- Add macOS build support (ARM & x86):
  - Dynamic OpenMP path detection via `brew --prefix libomp`
  - SDK sysroot include directory stripping to prevent C/C++ header priority conflicts
  - Platform guards for `atomic` and `stdc++fs` linking
  - `libcurl:with_ssl=darwinssl` and `abseil:shared=True` on macOS
- Replace deprecated Jaeger exporter with OTLP HTTP/gRPC exporters (conditional compilation via `HAVE_OTLP_GRPC_EXPORTER`)
- Add `MILVUS_COMMON_DIR` support for linking pre-built local milvus-common
- Update FetchContent milvus-common version to `dba70b6`
- Add `CMAKE_POLICY_VERSION_MINIMUM` for CMake 4.x compatibility

## Cross-platform Impact

| Change | macOS | Linux | Guard |
|--------|-------|-------|-------|
| OpenMP via Homebrew | ✅ | skipped | `if os == "Macos"` |
| SDK sysroot stripping | ✅ | skipped | `if(APPLE)` |
| darwinssl / abseil shared | ✅ | skipped | `if os == "Macos"` |
| Dependency upgrades | ✅ | ✅ | all platforms |
| fmt linked (not header-only) | ✅ | ✅ | all platforms |
| OTLP gRPC conditional | HTTP fallback | gRPC | `#ifdef HAVE_OTLP_GRPC_EXPORTER` |
| atomic/stdc++fs guard | skipped | linked | `if(NOT APPLE)` |
| FetchContent version update | ✅ | ✅ | all platforms |

## Test plan

- [x] `make build` succeeds on macOS ARM (Apple Silicon)
- [ ] `make build-ut && make test` on macOS
- [ ] CI passes on Linux (Ubuntu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)