### PR TITLE
fix: move arm_sve.h include inside __ARM_FEATURE_SVE guard

### DIFF
--- a/src/simd/distances_sve.cc
+++ b/src/simd/distances_sve.cc
@@ -11,12 +11,11 @@
 
 #include "distances_sve.h"
 
-#include <arm_sve.h>
-
 #include <cmath>
 
 #include "faiss/impl/platform_macros.h"
 #if defined(__ARM_FEATURE_SVE)
+#include <arm_sve.h>
 namespace faiss {
 namespace cppcontrib {
 namespace knowhere {

--- a/src/simd/distances_sve.h
+++ b/src/simd/distances_sve.h
@@ -9,14 +9,13 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
-#include <arm_sve.h>
-
 #include <cstdint>
 #include <cstdio>
 
 #include "knowhere/operands.h"
 
 #if defined(__ARM_FEATURE_SVE)
+#include <arm_sve.h>
 namespace faiss {
 namespace cppcontrib {
 namespace knowhere {


### PR DESCRIPTION
## Summary
- `distances_sve.cc` and `distances_sve.h` included `<arm_sve.h>` unconditionally outside the `#if defined(__ARM_FEATURE_SVE)` block
- On platforms without SVE (e.g. Apple Silicon), the file is compiled without SVE flags, causing `arm_sve.h` to emit `#error "SVE support not enabled"`
- Move the include inside the existing `#ifdef` guard, consistent with how `hook.cc` and upstream faiss already handle it

issue: #1470

## Test plan
- [x] Verified local build on Apple Silicon (M-series) compiles successfully
- [ ] CI passes on ARM64 Linux (SVE enabled) — no functional change expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)