### PR TITLE
ci: add GitHub Actions workflow for GPU builder image

### DIFF
--- a/.github/workflows/build-gpu-image.yaml
+++ b/.github/workflows/build-gpu-image.yaml
@@ -1,8 +1,23 @@
+# Builds the GPU builder Docker image and pushes it to Harbor.
+# This replaces the manual Jenkins job ci/BuildGPUBuilderImage.groovy,
+# which required someone to manually trigger a build.
+#
+# This workflow runs:
+# 1. automatically on a weekly schedule (CST midnight) OR
+# 2) whenever the GPU Dockerfile (ci/docker/builder/gpu/ubuntu22.04/Dockerfile) changes,
+# so the image stays current with dependency updates.
+#
+# TODO: Once this workflow is confirmed working, consider removing
+# ci/BuildGPUBuilderImage.groovy (and the CPU/ARM variants) to avoid
+# confusion about which image build process is authoritative.
+#
+# Required secrets: HARBOR_USERNAME, HARBOR_PASSWORD
+
 name: Build GPU Builder Image
 
 on:
   schedule:
-    # Every Sunday at 00:00 UTC
+    # Saturday 16:00 UTC = Sunday 00:00 CST (China Standard Time)
     - cron: '0 16 * * 6'
   push:
     branches:


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automates GPU Docker image builds, replacing the manual Jenkins `BuildGPUBuilderImage` job. The stale image problem (10 months of nightly failures, see #1474) happened because image rebuilds were manual-only.

- **Schedule:** Weekly (Sunday midnight CST / Saturday 16:00 UTC)
- **On push:** When `ci/docker/builder/gpu/ubuntu22.04/**` changes on `main`
- **Manual:** `workflow_dispatch` for ad-hoc rebuilds
- **Registry:** Pushes to `harbor.milvus.io/milvusdb/knowhere-gpu-build`
- **Tag format:** `amd64-ubuntu22.04-YYYYMMDD-<commit>` (same as Jenkins convention)
- **Runner:** `self-hosted` (same pool as `ut.yaml`)

## Admin setup required before merge

This workflow requires two repository secrets. A repo admin must add them in **Settings → Secrets and variables → Actions → New repository secret**:

| Secret | Value |
|--------|-------|
| `HARBOR_USERNAME` | Harbor registry username for `harbor.milvus.io` |
| `HARBOR_PASSWORD` | Harbor registry password/token |

## DO NOT MERGE

This PR is on hold (`do-not-merge/hold`) until:
- [ ] `HARBOR_USERNAME` and `HARBOR_PASSWORD` secrets are added by a repo admin
- [ ] Self-hosted runner confirmed to have Docker daemon available
- [ ] Runner confirmed to have network access to `harbor.milvus.io`

## Test plan

- [ ] After secrets are added, trigger manually via Actions → Build GPU Builder Image → Run workflow
- [ ] Verify image appears at `harbor.milvus.io/milvusdb/knowhere-gpu-build` with correct tag
- [ ] Verify job summary shows the image tag for easy copy-paste

🤖 Generated with [Claude Code](https://claude.com/claude-code)