### PR TITLE
fix: align conan dependency options with milvus-common

### DIFF
--- a/.github/workflows/analyzer.yaml
+++ b/.github/workflows/analyzer.yaml
@@ -27,7 +27,7 @@ jobs:
           pip3 install conan==1.65.0 && conan --version && (conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local || true)
       - name: Build & Analyzer
         run: |
-          mkdir build && cd build && conan install .. --build=missing --build=liburing -s compiler.cppstd=17 -o with_ut=True -o with_diskann=True -s compiler.libcxx=libstdc++11 && conan build .. \
+          mkdir build && cd build && conan install .. --update --build=missing --build=liburing -s compiler.cppstd=17 -o with_ut=True -o with_diskann=True -s compiler.libcxx=libstdc++11 && conan build .. \
           && cd .. && find src -type f | grep -E "\.cc$" | xargs /usr/bin/run-clang-tidy-14.py -quiet -p=./build/Release
       - name: Save Cache
         uses: ./.github/actions/cache-save

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -42,7 +42,7 @@ jobs:
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311*"
           CIBW_SKIP: "*musllinux*" # faiss-cpu fails to build on musllinux
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BEFORE_ALL_LINUX: "bash scripts/python_deps.sh && rm -rf build && mkdir build && cd build && conan install .. --build=missing -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .. && cd -"
+          CIBW_BEFORE_ALL_LINUX: "bash scripts/python_deps.sh && rm -rf build && mkdir build && cd build && conan install .. --update --build=missing -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .. && cd -"
           # Use portable wheel build script instead of plain setup.py
           CIBW_BEFORE_BUILD: "pip3 install pytest numpy faiss-cpu bfloat16 auditwheel"
           # Custom build command using our portable wheel builder

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
           ARTIFACT_NAME: ${{ env.RELEASE_NAME }}-${{ matrix.os }}
         run: |
           mkdir build && cd build \
-          && conan install .. --build=missing -s build_type=Release -o with_diskann=True -s compiler.libcxx=libstdc++11 \
+          && conan install .. --update --build=missing -s build_type=Release -o with_diskann=True -s compiler.libcxx=libstdc++11 \
           && conan build .. \
           && cd ..
           mkdir -p artifacts/${{ env.ARTIFACT_NAME }}/lib

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Build
         run: |
           mkdir build && cd build \
-          && conan install .. --build=missing --build=liburing -s build_type=Release -s compiler.cppstd=17 -o with_ut=True -o with_diskann=True -o with_asan=True -s compiler.libcxx=libstdc++11 \
+          && conan install .. --update --build=missing --build=liburing -s build_type=Release -s compiler.cppstd=17 -o with_ut=True -o with_diskann=True -o with_asan=True -s compiler.libcxx=libstdc++11 \
           && conan build .. \
           && ./Release/tests/ut/knowhere_tests
       - name: Save Cache
@@ -84,7 +84,7 @@ jobs:
         run: |
           mkdir build \
           && cd build \
-          && conan install .. --build=missing --build=liburing -s compiler.cppstd=17 -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release \
+          && conan install .. --update --build=missing --build=liburing -s compiler.cppstd=17 -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release \
           && conan build ..
       - name: Save Cache
         uses: ./.github/actions/cache-save

--- a/ci/E2E-arm.groovy
+++ b/ci/E2E-arm.groovy
@@ -31,7 +31,7 @@ pipeline {
                         sh "pip3 install -U setuptools"
                         sh "cmake --version"
                         sh "mkdir build"
-                        sh "cd build/ && conan install .. --build=missing --build=liburing -s compiler.cppstd=17 -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .."
+                        sh "cd build/ && conan install .. --update --build=missing --build=liburing -s compiler.cppstd=17 -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .."
                         sh "pip3 install auditwheel"
                         sh "cd python && VERSION=${version} ./build_portable_wheel.sh"
                         dir('python/dist'){

--- a/ci/E2E2-SSE.groovy
+++ b/ci/E2E2-SSE.groovy
@@ -32,7 +32,7 @@ pipeline {
                         sh "pip3 install -U setuptools"
                         sh "cmake --version"
                         sh "mkdir build"
-                        sh "cd build/ && conan install .. --build=missing --build=liburing -s compiler.cppstd=17 -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .."
+                        sh "cd build/ && conan install .. --update --build=missing --build=liburing -s compiler.cppstd=17 -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .."
                         sh "pip3 install auditwheel"
                         sh "cd python && VERSION=${version} ./build_portable_wheel.sh"
                         dir('python/dist'){

--- a/ci/E2E2.groovy
+++ b/ci/E2E2.groovy
@@ -32,7 +32,7 @@ pipeline {
                         sh "pip3 install -U setuptools"
                         sh "cmake --version"
                         sh "mkdir build"
-                        sh "cd build/ && conan install .. --build=missing --build=liburing -s compiler.cppstd=17 -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .."
+                        sh "cd build/ && conan install .. --update --build=missing --build=liburing -s compiler.cppstd=17 -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .."
                         sh "pip3 install auditwheel"
                         sh "cd python && VERSION=${version} ./build_portable_wheel.sh"
                         dir('python/dist'){

--- a/ci/E2E_GPU.groovy
+++ b/ci/E2E_GPU.groovy
@@ -37,7 +37,7 @@ pipeline {
                         sh "nvidia-smi --query-gpu=name --format=csv,noheader"
                         sh "./scripts/prepare_gpu_build.sh"
                         sh "mkdir build"
-                        sh "cd build/ && conan install .. --build=missing -s compiler.cppstd=17 -o with_diskann=True -o with_cuvs=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .."
+                        sh "cd build/ && conan install .. --update --build=missing -s compiler.cppstd=17 -o with_diskann=True -o with_cuvs=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .."
                         sh "pip3 install auditwheel"
                         sh "cd python && VERSION=${version} ./build_portable_wheel.sh"
                         dir('python/dist'){

--- a/ci/UT_GPU.groovy
+++ b/ci/UT_GPU.groovy
@@ -33,7 +33,7 @@ pipeline {
                         sh "nvidia-smi --query-gpu=name --format=csv,noheader"
                         sh "./scripts/prepare_gpu_build.sh"
                         sh "mkdir build"
-                        sh "cd build/ && conan install .. --build=missing -s compiler.cppstd=17 -s build_type=Release -o with_diskann=True -o with_ut=True -o with_cuvs=True -s compiler.libcxx=libstdc++11 \
+                        sh "cd build/ && conan install .. --update --build=missing -s compiler.cppstd=17 -s build_type=Release -o with_diskann=True -o with_ut=True -o with_cuvs=True -s compiler.libcxx=libstdc++11 \
                               && conan build .. \
                               && ./Release/tests/ut/knowhere_tests"
                     }

--- a/conanfile.py
+++ b/conanfile.py
@@ -47,13 +47,15 @@ class KnowhereConan(ConanFile):
         "with_ut": False,
         "glog:shared": True,
         "glog:with_gflags": True,
-        "gtest:build_gmock": False,
+        "gtest:build_gmock": True,
         "prometheus-cpp:with_pull": False,
         "with_benchmark": False,
         "with_coverage": False,
         "boost:without_locale": False,
         "boost:without_test": True,
         "boost:without_stacktrace": True,
+        "openssl:shared": True,
+        "gflags:shared": True,
         "fmt:header_only": False,
         "with_faiss_tests": False,
         "opentelemetry-cpp:with_stl": True,
@@ -92,7 +94,7 @@ class KnowhereConan(ConanFile):
         if self.options.with_light:
             self.options["boost"].without_locale = True
         if self.settings.os == "Macos":
-            self.options["libcurl"].with_ssl = "darwinssl"
+            self.options["libcurl"].with_ssl = "openssl"
 
     def configure(self):
         if self.options.shared:
@@ -109,21 +111,21 @@ class KnowhereConan(ConanFile):
         self.requires("zlib/1.3.1")
         self.requires("double-conversion/3.3.0")
         self.requires("xz_utils/5.4.5")
-        self.requires("protobuf/5.27.0@milvus/dev", force=True, override=True)
+        self.requires("protobuf/5.27.0@milvus/dev#6fff8583e2fe32babef04a9097f1d581", force=True, override=True)
         self.requires("lz4/1.9.4", force=True, override=True)
         if self.settings.os == "Linux":
             self.requires("liburing/2.8", force=True, override=True)
         self.requires("fmt/11.0.2")
         self.requires("libevent/2.1.12")
-        self.requires("grpc/1.67.1@milvus/dev")
-        self.requires("folly/2024.08.12.00@milvus/dev")
+        self.requires("grpc/1.67.1@milvus/dev#5aa62c51bced448b83d7db9e5b3a13c7")
+        self.requires("folly/2024.08.12.00@milvus/dev#e09fc71826ce6b4568441910665f0889")
         self.requires("libcurl/8.10.1")
         self.requires("simde/0.8.2")
         self.requires("xxhash/0.8.3")
         if self.settings.os == "Android":
             self.requires("openblas/0.3.27")
         if not self.options.with_light:
-            self.requires("opentelemetry-cpp/1.23.0@milvus/dev")
+            self.requires("opentelemetry-cpp/1.23.0@milvus/dev#bcd65b63b8db8447178ed93bbc94dcc0")
         if self.settings.os not in ["Macos", "Android"]:
             self.requires("libunwind/1.8.1")
         if self.options.with_ut:


### PR DESCRIPTION
## Summary
- Set `gtest:build_gmock=True` to match milvus-common
- Add `openssl:shared=True` and `gflags:shared=True` to avoid shared/static linking mismatch
- Pin recipe revision hashes for `protobuf`, `grpc`, `folly`, `opentelemetry-cpp` to match milvus-common exactly

Closes #1478

## Test plan
- [ ] CI build passes with updated conan options
- [ ] Verify no linking conflicts when building with milvus-common

🤖 Generated with [Claude Code](https://claude.com/claude-code)