### PR TITLE
ci: centralize conan install flags into scripts/conan_build.sh

### DIFF
--- a/.github/workflows/analyzer.yaml
+++ b/.github/workflows/analyzer.yaml
@@ -27,7 +27,7 @@ jobs:
           pip3 install conan==1.65.0 && conan --version && (conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local || true)
       - name: Build & Analyzer
         run: |
-          mkdir build && cd build && ../ci/conan_build.sh --cpu --ut \
+          mkdir build && cd build && ../scripts/conan_build.sh --cpu --ut \
           && cd .. && find src -type f | grep -E "\.cc$" | xargs /usr/bin/run-clang-tidy-14.py -quiet -p=./build/Release
       - name: Save Cache
         uses: ./.github/actions/cache-save

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -42,7 +42,7 @@ jobs:
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311*"
           CIBW_SKIP: "*musllinux*" # faiss-cpu fails to build on musllinux
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BEFORE_ALL_LINUX: "bash scripts/python_deps.sh && rm -rf build && mkdir build && cd build && ../ci/conan_build.sh --release --no-cppstd && cd -"
+          CIBW_BEFORE_ALL_LINUX: "bash scripts/python_deps.sh && rm -rf build && mkdir build && cd build && ../scripts/conan_build.sh --release --no-cppstd && cd -"
           # Use portable wheel build script instead of plain setup.py
           CIBW_BEFORE_BUILD: "pip3 install pytest numpy faiss-cpu bfloat16 auditwheel"
           # Custom build command using our portable wheel builder

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
           ARTIFACT_NAME: ${{ env.RELEASE_NAME }}-${{ matrix.os }}
         run: |
           mkdir build && cd build \
-          && ../ci/conan_build.sh --release --no-cppstd \
+          && ../scripts/conan_build.sh --release --no-cppstd \
           && cd ..
           mkdir -p artifacts/${{ env.ARTIFACT_NAME }}/lib
           mv build/Release/*.a artifacts/${{ env.ARTIFACT_NAME }}/lib

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Build
         run: |
           mkdir build && cd build \
-          && ../ci/conan_build.sh --cpu --ut --asan --release \
+          && ../scripts/conan_build.sh --cpu --ut --asan --release \
           && ./Release/tests/ut/knowhere_tests
       - name: Save Cache
         uses: ./.github/actions/cache-save
@@ -83,7 +83,7 @@ jobs:
         run: |
           mkdir build \
           && cd build \
-          && ../ci/conan_build.sh --cpu --release
+          && ../scripts/conan_build.sh --cpu --release
       - name: Save Cache
         uses: ./.github/actions/cache-save
         with:

--- a/ci/E2E-arm.groovy
+++ b/ci/E2E-arm.groovy
@@ -31,7 +31,7 @@ pipeline {
                         sh "pip3 install -U setuptools"
                         sh "cmake --version"
                         sh "mkdir build"
-                        sh "cd build/ && ../ci/conan_build.sh --cpu --release"
+                        sh "cd build/ && ../scripts/conan_build.sh --cpu --release"
                         sh "pip3 install auditwheel"
                         sh "cd python && VERSION=${version} ./build_portable_wheel.sh"
                         dir('python/dist'){

--- a/ci/E2E2-SSE.groovy
+++ b/ci/E2E2-SSE.groovy
@@ -32,7 +32,7 @@ pipeline {
                         sh "pip3 install -U setuptools"
                         sh "cmake --version"
                         sh "mkdir build"
-                        sh "cd build/ && ../ci/conan_build.sh --cpu --release"
+                        sh "cd build/ && ../scripts/conan_build.sh --cpu --release"
                         sh "pip3 install auditwheel"
                         sh "cd python && VERSION=${version} ./build_portable_wheel.sh"
                         dir('python/dist'){

--- a/ci/E2E2.groovy
+++ b/ci/E2E2.groovy
@@ -32,7 +32,7 @@ pipeline {
                         sh "pip3 install -U setuptools"
                         sh "cmake --version"
                         sh "mkdir build"
-                        sh "cd build/ && ../ci/conan_build.sh --cpu --release"
+                        sh "cd build/ && ../scripts/conan_build.sh --cpu --release"
                         sh "pip3 install auditwheel"
                         sh "cd python && VERSION=${version} ./build_portable_wheel.sh"
                         dir('python/dist'){

--- a/ci/E2E_GPU.groovy
+++ b/ci/E2E_GPU.groovy
@@ -37,7 +37,7 @@ pipeline {
                         sh "nvidia-smi --query-gpu=name --format=csv,noheader"
                         sh "./scripts/prepare_gpu_build.sh"
                         sh "mkdir build"
-                        sh "cd build/ && ../ci/conan_build.sh --gpu --release"
+                        sh "cd build/ && ../scripts/conan_build.sh --gpu --release"
                         sh "pip3 install auditwheel"
                         sh "cd python && VERSION=${version} ./build_portable_wheel.sh"
                         dir('python/dist'){

--- a/ci/UT_GPU.groovy
+++ b/ci/UT_GPU.groovy
@@ -33,7 +33,7 @@ pipeline {
                         sh "nvidia-smi --query-gpu=name --format=csv,noheader"
                         sh "./scripts/prepare_gpu_build.sh"
                         sh "mkdir build"
-                        sh "cd build/ && ../ci/conan_build.sh --gpu --ut --release && ./Release/tests/ut/knowhere_tests"
+                        sh "cd build/ && ../scripts/conan_build.sh --gpu --ut --release && ./Release/tests/ut/knowhere_tests"
                     }
                 }
             }

--- a/scripts/conan_build.sh
+++ b/scripts/conan_build.sh
@@ -2,7 +2,7 @@
 # Centralized conan build configuration for all CI pipelines.
 # Single source of truth for conan install flags — update HERE, not in each pipeline file.
 #
-# Usage: ci/conan_build.sh [options]
+# Usage: scripts/conan_build.sh [options]
 #   --gpu        Enable cuVS GPU support (-o with_cuvs=True)
 #   --cardinal   Enable Cardinal support (-o with_cardinal=True)
 #   --ut         Enable unit tests (-o with_ut=True)


### PR DESCRIPTION
## Summary
- Adds `scripts/conan_build.sh` — single source of truth for conan install flags
- Updates all 5 Jenkins Groovy pipelines and 4 GitHub Actions workflows to call it
- Eliminates flag duplication that caused #1479 to miss test-jobs/nightly.groovy

## Motivation
Every time a conan flag changes (e.g. `--update` in #1479, `-s compiler.cppstd=17` in #1474), 10+ files across 2 repos need updating. Files in test-jobs are always missed because there's no link between the repos. This script centralizes the flags so future changes only need one edit.

## Script interface
```
scripts/conan_build.sh [--gpu] [--cardinal] [--ut] [--asan] [--cpu] [--release] [--no-cppstd] [--no-build]
```
Base flags (always applied): `--update --build=missing -s compiler.libcxx=libstdc++11 -s compiler.cppstd=17 -o with_diskann=True`

## No behavioral changes
- `release.yaml` and `release-python.yml` use `--no-cppstd` to preserve their existing behavior (they historically built without `-s compiler.cppstd=17`)
- All other pipelines produce identical conan commands as before

## Test plan
- [x] `ut.yaml` CI passes on this PR (exercises `--cpu --ut --asan --release` and `--cpu --release`)
- [x] Manual review: each pipeline's old flags match the new script call

## Follow-up
- test-jobs PR to update `nightly.groovy` and `nightly-arm.groovy` (depends on this PR merging first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)