### PR TITLE
get rid of C++ Variable Length Arrays in diskann

### DIFF
--- a/thirdparty/DiskANN/include/diskann/maybe_vector.h
+++ b/thirdparty/DiskANN/include/diskann/maybe_vector.h
@@ -1,0 +1,74 @@
+// My old code from the bitset for Milvus
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include <type_traits>
+
+namespace diskann {
+
+// A structure that allocates an array of elements.
+// If the number of elements is small, 
+//     then an allocation will be done on the stack.
+// If the number of elements is large, 
+//     then an allocation will be done on the heap.
+// This struct is designed to avoid performing memory
+//     allocations on small objects.
+template<typename T>
+struct MaybeVector {
+public:
+    static_assert(std::is_scalar_v<T>);
+    
+    MaybeVector(const size_t n_elements) {
+        m_size = n_elements;
+
+        if (n_elements < num_array_elements) {
+            m_data = maybe_array.data();
+        } else {
+            maybe_memory = std::make_unique<T[]>(m_size);
+            m_data = maybe_memory.get();
+        }
+    }
+
+    MaybeVector(const size_t n_elements, const T default_value) {
+        m_size = n_elements;
+
+        if (n_elements < num_array_elements) {
+            m_data = maybe_array.data();
+        } else {
+            maybe_memory = std::make_unique<T[]>(m_size);
+            m_data = maybe_memory.get();
+        }
+
+        std::fill(m_data, m_data + m_size, default_value);
+    }
+
+    MaybeVector(const MaybeVector&) = delete;
+    MaybeVector(MaybeVector&&) = delete;
+    MaybeVector& operator =(const MaybeVector&) = delete;
+    MaybeVector& operator =(MaybeVector&&) = delete;
+
+    inline size_t size() const { return m_size; }
+    inline T* data() { return m_data; }
+    inline const T* data() const { return m_data; }
+
+    inline T* begin() { return m_data; }
+    inline T* end() { return m_data + m_size; }
+
+    inline T& operator[](const size_t idx) { return m_data[idx]; }
+    inline const T& operator[](const size_t idx) const { return m_data[idx]; }
+
+private:
+    size_t m_size = 0;
+
+    T* m_data = nullptr;
+
+    // we're not expecting to use anything, but small primitive types here
+    static constexpr size_t num_array_elements = 4096;
+
+    std::unique_ptr<T[]> maybe_memory;
+    std::array<T, num_array_elements> maybe_array;
+};
+
+}

--- a/thirdparty/DiskANN/include/diskann/pq_flash_index.h
+++ b/thirdparty/DiskANN/include/diskann/pq_flash_index.h
@@ -272,7 +272,7 @@ namespace diskann {
                  : sector_buf + (node_id % nnodes_per_sector) * max_node_len;
     }
 
-    inline void copy_vec_base_data(T *des, const int64_t des_idx, void *src);
+    void copy_vec_base_data(T *des, const int64_t des_idx, void *src);
 
     // Init thread data and returns query norm if avaialble.
     // If there is no value, there is nothing to do with the given query

--- a/thirdparty/DiskANN/src/aisaq_pq_reader.cpp
+++ b/thirdparty/DiskANN/src/aisaq_pq_reader.cpp
@@ -624,14 +624,14 @@ int AisaqPQReader_aio::read_pq_vectors_wait_completion(AisaqPQReaderContext &ctx
     }
     uint32_t __max_events = max_events - rcount;
     if (__max_events > 0 && aio_ctx.m_pending_io_count > 0) {
-        struct io_event evts[__max_events];
+        std::unique_ptr<io_event[]> evts = std::make_unique<io_event[]>(__max_events);
         if (nr_events > __max_events) {
             nr_events = __max_events;
         }
         if (nr_events > aio_ctx.m_pending_io_count) {
             nr_events = aio_ctx.m_pending_io_count;
         }
-        int ret = io_getevents(aio_ctx.m_aio_ctx, (int64_t)nr_events, (int64_t)__max_events, evts, nullptr);
+        int ret = io_getevents(aio_ctx.m_aio_ctx, (int64_t)nr_events, (int64_t)__max_events, evts.get(), nullptr);
         if (ret <= 0) {
             LOG_KNOWHERE_ERROR_ << "io_getevents() failed; returned " << ret
                       << ", ernno=" << errno << "=" << ::strerror(-ret);
@@ -687,10 +687,10 @@ void AisaqPQReader_aio::drain_ios(AisaqPQReaderContext_aio &aio_ctx)
 {
     if (aio_ctx.m_pending_io_count > 0) {
         int retries = 5;
-        struct io_event evts[aio_ctx.m_pending_io_count];
+        std::unique_ptr<io_event[]> evts = std::make_unique<io_event[]>(aio_ctx.m_pending_io_count);
         do {
             int ret = io_getevents(aio_ctx.m_aio_ctx, (int64_t) aio_ctx.m_pending_io_count,
-                                   (int64_t) aio_ctx.m_pending_io_count, evts, nullptr);
+                                   (int64_t) aio_ctx.m_pending_io_count, evts.get(), nullptr);
             if (ret > 0) {
                 aio_ctx.m_pending_io_count-= ret;
                 continue;

--- a/thirdparty/DiskANN/src/partition_and_pq.cpp
+++ b/thirdparty/DiskANN/src/partition_and_pq.cpp
@@ -47,6 +47,8 @@
 #include "diskann/diskann_gpu.h"
 #endif
 
+#include "diskann/maybe_vector.h"
+
 // block size for reading/ processing large files and matrices in blocks
 #define BLOCK_SIZE 1000000
 
@@ -723,7 +725,7 @@ int estimate_cluster_sizes(float *test_data_float, size_t num_test,
         for (size_t p = 0; p < cur_blk_size; p++) {
             const size_t* cand = (const size_t*)block_closest_centers.get() + p * k_candidates;
 
-            bool used[k_candidates] = {false};
+            diskann::MaybeVector<bool> used(k_candidates, false);
 
             for (size_t assign = 0; assign < k_base; assign++) {
                 size_t best_idx = SIZE_MAX;
@@ -952,7 +954,7 @@ int shard_data_into_clusters_only_ids(const std::string data_file,
         for (size_t p = 0; p < cur_blk_size; p++) {
             size_t* cand = (size_t*)block_closest_centers.get() + p * k_candidates;
 
-            bool used[k_candidates] = {false};
+            diskann::MaybeVector<bool> used(k_candidates, false);
 
             for (size_t assign = 0; assign < k_base; assign++) {
                 size_t best_idx = SIZE_MAX;

--- a/thirdparty/DiskANN/src/pq_flash_aisaq_index.cpp
+++ b/thirdparty/DiskANN/src/pq_flash_aisaq_index.cpp
@@ -16,6 +16,8 @@
 #include "diskann/memory_mapper.h"
 #include "diskann/aio_context_pool.h"
 
+#include "diskann/maybe_vector.h"
+
 #define READ_U64(stream, val) stream.read((char *)&val, sizeof(uint64_t))
 #define READ_U32(stream, val) stream.read((char *)&val, sizeof(uint32_t))
 #define READ_UNSIGNED(stream, val) stream.read((char *)&val, sizeof(unsigned))
@@ -339,11 +341,14 @@ static int aisaq_read_pq_vectors(class AisaqPQReader &aisaq_pq_vectors_reader,
             LOG_KNOWHERE_ERROR_ << "failed to read pq vectors";
             return -1;
         }
-        uint32_t read_vec[count]; /* index array */
-        uint8_t
-            *pq_read_buffers[count]; /* pointers of where the vectors read to */
+
+        /* index array */
+        MaybeVector<uint32_t> read_vec(count);
+        /* pointers of where the vectors read to */
+        MaybeVector<uint8_t*> pq_read_buffers(count);
+
         if (aisaq_pq_vectors_reader.read_pq_vectors_wait_completion(
-                ctx, read_vec, pq_read_buffers, count, count, tmp) != 0) {
+                ctx, read_vec.data(), pq_read_buffers.data(), count, count, tmp) != 0) {
             LOG_KNOWHERE_ERROR_ << "failed to read pq vectors";
             return -1;
         }
@@ -1455,8 +1460,11 @@ void PQFlashAisaqIndex<T>::aisaq_cached_beam_search(
             throw ANNException("Failed read PQ vectors submit",
                                -1, __FUNCSIG__, __FILE__, __LINE__);
         }
-        uint32_t read_vec[n_ids]; /* index array */
-        uint8_t *read_coords[n_ids];
+
+        /* index array */
+        MaybeVector<uint32_t> read_vec(n_ids);
+        MaybeVector<uint8_t*> read_coords(n_ids);
+
         uint32_t rcount, min_events = 8, read_remain = n_ids, i;
         /* wait completion */
         do {
@@ -1464,7 +1472,7 @@ void PQFlashAisaqIndex<T>::aisaq_cached_beam_search(
                 min_events = read_remain;
             }
             if (_aisaq_pq_vectors_reader->read_pq_vectors_wait_completion(
-                    ctx, read_vec, read_coords, min_events, read_remain,
+                    ctx, read_vec.data(), read_coords.data(), min_events, read_remain,
                     rcount) != 0) {
             	release_data();
                 throw ANNException("Failed read PQ wait",
@@ -1517,7 +1525,7 @@ void PQFlashAisaqIndex<T>::aisaq_cached_beam_search(
         cached_nhoods;
     cached_nhoods.reserve(2 * beam_width);
 
-    struct aisaq_node_placement np[bv];
+    std::unique_ptr<aisaq_node_placement[]> np = std::make_unique<aisaq_node_placement[]>(bv);
     uint32_t bv_count;
     tsl::robin_map<uint32_t, char *> frontier_items;
     T *node_fp_coords;
@@ -1525,10 +1533,10 @@ void PQFlashAisaqIndex<T>::aisaq_cached_beam_search(
     uint32_t *node_nbrs;
     uint32_t agg_nnbrs;
     uint32_t agg_nnbrs_inline;
-    uint32_t agg_node_nbrs[bv * this->max_degree];
-    uint32_t agg_node_nbrs_inline[bv * this->max_degree];
-    float agg_dist_scratch[bv * this->max_degree];
-    float agg_dist_scratch_inline[bv * this->max_degree];
+    std::unique_ptr<uint32_t[]> agg_node_nbrs = std::make_unique<uint32_t[]>(bv * this->max_degree);
+    std::unique_ptr<uint32_t[]> agg_node_nbrs_inline = std::make_unique<uint32_t[]>(bv * this->max_degree);
+    std::unique_ptr<float[]> agg_dist_scratch = std::make_unique<float[]>(bv * this->max_degree);
+    std::unique_ptr<float[]> agg_dist_scratch_inline = std::make_unique<float[]>(bv * this->max_degree);
 
     float cur_expanded_dist;
     std::vector<uint32_t> free_ids;
@@ -1541,8 +1549,8 @@ void PQFlashAisaqIndex<T>::aisaq_cached_beam_search(
         float *dist_list;
         const uint32_t &size;
     } agg_nbrs_lists[] = {
-        {agg_node_nbrs, agg_dist_scratch, agg_nnbrs},
-        {agg_node_nbrs_inline, agg_dist_scratch_inline, agg_nnbrs_inline},
+        {agg_node_nbrs.get(), agg_dist_scratch.get(), agg_nnbrs},
+        {agg_node_nbrs_inline.get(), agg_dist_scratch_inline.get(), agg_nnbrs_inline},
     };
     /* initialize free nodes pool */
     cpu_timer.reset();
@@ -1743,7 +1751,7 @@ void PQFlashAisaqIndex<T>::aisaq_cached_beam_search(
                 diskann::pq_dist_lookup(
                     (uint8_t *)inline_pq_vectors_buff, inline_limit,
                     this->n_chunks, pq_dists,
-                    agg_dist_scratch_inline + agg_nnbrs_inline);
+                    agg_dist_scratch_inline.get() + agg_nnbrs_inline);
                 uint32_t __iv_count = 0;
                 for (; m < inline_limit; m++) {
                     idn = node_nbrs[m];
@@ -1775,7 +1783,7 @@ void PQFlashAisaqIndex<T>::aisaq_cached_beam_search(
                 if (pqvb != nullptr) {
                     /* vector is in cache */
                     diskann::pq_dist_lookup(pqvb, 1, this->n_chunks, pq_dists,
-                                            agg_dist_scratch_inline +
+                                            agg_dist_scratch_inline.get() +
                                                 agg_nnbrs_inline);
                     agg_node_nbrs_inline[agg_nnbrs_inline] = idn;
                     agg_nnbrs_inline++;
@@ -1792,7 +1800,7 @@ void PQFlashAisaqIndex<T>::aisaq_cached_beam_search(
                uint32_t computed_count = 0;
                do {
 				  uint32_t _nids = std::min(agg_nnbrs - computed_count, (uint32_t)max_ios);
-				  compute_dists(agg_node_nbrs + computed_count, _nids, agg_dist_scratch + computed_count, *aisaq_data.aisaq_pq_reader_ctx, stats);
+				  compute_dists(agg_node_nbrs.get() + computed_count, _nids, agg_dist_scratch.get() + computed_count, *aisaq_data.aisaq_pq_reader_ctx, stats);
 				  computed_count +=  _nids;
                } while (computed_count < agg_nnbrs);
         }

--- a/thirdparty/DiskANN/src/pq_flash_index.cpp
+++ b/thirdparty/DiskANN/src/pq_flash_index.cpp
@@ -2076,9 +2076,9 @@ namespace diskann {
     }
   }
 
-  template class IteratorWorkspace<float>;
-  template class IteratorWorkspace<knowhere::bf16>;
-  template class IteratorWorkspace<knowhere::fp16>;
+  template struct IteratorWorkspace<float>;
+  template struct IteratorWorkspace<knowhere::bf16>;
+  template struct IteratorWorkspace<knowhere::fp16>;
 
   // knowhere not support uint8/int8 diskann
   // template class PQFlashIndex<_u8>;


### PR DESCRIPTION
removes unexpected errors when compiling using `clang`.

Replace constructs like 
```C++
  uint32_t some_array[non_constant];
```
to either `std::unique_ptr<T[]>`, or `MaybeArray<T>` (which is used for avoid excessive allocations for tiny arrays)
 