### PR TITLE
bug fix: ci: default with_compile_prune to True in conanfile.py

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -61,7 +61,7 @@ class KnowhereConan(ConanFile):
         "opentelemetry-cpp:with_stl": True,
         "libcurl:with_ssl": False,
         "with_light": False,
-        "with_compile_prune": False,
+        "with_compile_prune": True,
         "folly:shared": True,
     }
 


### PR DESCRIPTION
Fixes #1491

## Context
- Downstream Cardinal CI has resource exhaustion problem in building phase.

## Summary

- Default `with_compile_prune` to `True` in `conanfile.py`, aligning with the CMake default (`knowhere_option(WITH_COMPILE_PRUNE ... ON)`)
- The conan default was `False`, which overrode the CMake default. After PR #1482 switched CI pipelines to the Makefile, the old explicit `-o with_compile_prune=True` flags were lost, causing downstream cardinal E2E build problem.
- Pipelines that need the full (unpruned) build for benchmarking can still pass `-o with_compile_prune=False` explicitly

## Test plan

- [x] Verify knowhere UT CI passes
- [x] Verify cardinal E2E pipelines pass with the Makefile (using "sed" workaround in cardinal pr and verified the pr passed, see screenshot below)
<img width="368" height="66" alt="image" src="https://github.com/user-attachments/assets/f957a675-23fa-4eb6-9c53-7c040afe17fc" />
 