### PR TITLE
ci: update e2e PVC and checkout knowhere_compat_test branch

### DIFF
--- a/ci/E2E-arm.groovy
+++ b/ci/E2E-arm.groovy
@@ -52,7 +52,7 @@ pipeline {
                             }
                         }
                     }
-                    checkout([$class: 'GitSCM', branches: [[name: '*/knowhere_compat_test']], extensions: [],
+                    checkout([$class: 'GitSCM', branches: [[name: '*/main']], extensions: [],
                     userRemoteConfigs: [[credentialsId: 'milvus-ci', url: 'https://github.com/milvus-io/knowhere-test.git']]])
                     dir('tests'){
                       unarchive mapping: ["${knowhere_wheel}": "${knowhere_wheel}"]

--- a/ci/E2E2-SSE.groovy
+++ b/ci/E2E2-SSE.groovy
@@ -63,7 +63,7 @@ pipeline {
                             }
                         }
                     }
-                    checkout([$class: 'GitSCM', branches: [[name: '*/knowhere_compat_test']], extensions: [],
+                    checkout([$class: 'GitSCM', branches: [[name: '*/main']], extensions: [],
                     userRemoteConfigs: [[credentialsId: 'milvus-ci', url: 'https://github.com/milvus-io/knowhere-test.git']]])
                     dir('tests'){
                       unarchive mapping: ["${knowhere_wheel}": "${knowhere_wheel}"]

--- a/ci/E2E2.groovy
+++ b/ci/E2E2.groovy
@@ -53,7 +53,7 @@ pipeline {
                             }
                         }
                     }
-                    checkout([$class: 'GitSCM', branches: [[name: '*/knowhere_compat_test']], extensions: [],
+                    checkout([$class: 'GitSCM', branches: [[name: '*/main']], extensions: [],
                     userRemoteConfigs: [[credentialsId: 'milvus-ci', url: 'https://github.com/milvus-io/knowhere-test.git']]])
                     dir('tests'){
                       unarchive mapping: ["${knowhere_wheel}": "${knowhere_wheel}"]

--- a/ci/E2E_GPU.groovy
+++ b/ci/E2E_GPU.groovy
@@ -58,7 +58,7 @@ pipeline {
                             }
                         }
                     }
-                    checkout([$class: 'GitSCM', branches: [[name: '*/knowhere_compat_test']], extensions: [],
+                    checkout([$class: 'GitSCM', branches: [[name: '*/main']], extensions: [],
                     userRemoteConfigs: [[credentialsId: 'milvus-ci', url: 'https://github.com/milvus-io/knowhere-test.git']]])
                     dir('tests'){
                       unarchive mapping: ["${knowhere_wheel}": "${knowhere_wheel}"]


### PR DESCRIPTION
Closes Issue [1514](https://github.com/zilliztech/knowhere/issues/1514)

## Summary
- Update PVC claim from `db-data` to `db-data-pvc-ci-cluster` for e2e x86 pod YAMLs (e2e-cpu, e2e-gpu, e2e-sse)

**Related:** [milvus-io/knowhere-test#233](https://github.com/milvus-io/knowhere-test/pull/233) introduces the backward compatibility tests that this PR integrates into the CI pipeline.

## Test plan
- [x] Verify e2e CI jobs pick up the correct PVC on ci-cluster
- [x] Verify e2e tests run against knowhere_compat_test branch