### PR TITLE
fix: default ef in GPU_CAGRA CheckAndAdjust to prevent bad_optional_access

### DIFF
--- a/src/index/gpu_cuvs/gpu_cuvs_cagra_config.h
+++ b/src/index/gpu_cuvs/gpu_cuvs_cagra_config.h
@@ -27,6 +27,7 @@ namespace {
 constexpr const CFG_INT::value_type kSearchWidth = 1;
 constexpr const CFG_INT::value_type kAlignFactor = 32;
 constexpr const CFG_INT::value_type kItopkSize = 64;
+constexpr const CFG_INT::value_type kCagraEfMinValue = 16;
 }  // namespace
 
 struct GpuCuvsCagraConfig : public BaseConfig {
@@ -150,6 +151,15 @@ struct GpuCuvsCagraConfig : public BaseConfig {
                 }
             } else {
                 search_width = std::max((k.value() - 1) / kAlignFactor + 1, kSearchWidth);
+            }
+
+            // Default ef for adapt_for_cpu HNSW search path
+            if (!ef.has_value()) {
+                ef = std::max(k.value(), kCagraEfMinValue);
+            } else if (k.value() > ef.value()) {
+                std::string msg =
+                    "ef(" + std::to_string(ef.value()) + ") should be larger than k(" + std::to_string(k.value()) + ")";
+                return HandleError(err_msg, msg, Status::out_of_range_in_json);
             }
         }
         return Status::success;

--- a/tests/ut/test_gpu_search.cc
+++ b/tests/ut/test_gpu_search.cc
@@ -310,6 +310,36 @@ TEST_CASE("Test All GPU Index", "[search]") {
         }
     }
 
+    SECTION("Test Gpu Index Cagra Adapt For Cpu Without Ef") {
+        using std::make_tuple;
+        auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
+            make_tuple(knowhere::IndexEnum::INDEX_CUVS_CAGRA, cagra_gen),
+        }));
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version).value();
+        auto cfg_json = gen().dump();
+        CAPTURE(name, cfg_json);
+        knowhere::Json json = knowhere::Json::parse(cfg_json);
+        auto train_ds = GenDataSet(nb, dim, seed);
+        auto query_ds = GenDataSet(nq, dim, seed);
+        REQUIRE(idx.Type() == name);
+        auto res = idx.Build(train_ds, json);
+        REQUIRE(res == knowhere::Status::success);
+        knowhere::BinarySet bs;
+        idx.Serialize(bs);
+        auto idx_ = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version).value();
+        knowhere::Json deser_json = json;
+        deser_json[knowhere::indexparam::ADAPT_FOR_CPU] = true;
+        // Intentionally NOT setting ef — this is the bug scenario
+        idx_.Deserialize(bs, deser_json);
+        // Search without ef in params — should not crash
+        auto results = idx_.Search(query_ds, json, nullptr);
+        REQUIRE(results.has_value());
+        auto ids = results.value()->GetIds();
+        for (int i = 1; i < nq; ++i) {
+            CHECK(ids[i] == i);
+        }
+    }
+
     SECTION("Test Gpu Index Search Simple Bitset") {
         using std::make_tuple;
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>(


### PR DESCRIPTION
## Summary
- When using `GPU_CAGRA` with `adapt_for_cpu=true`, searching without an explicit `ef` parameter crashes with `std::bad_optional_access` because `GpuCuvsCagraConfig::CheckAndAdjust` did not provide a default for `ef`
- Add the same defaulting logic as `BaseHnswConfig`: `ef = max(k, 16)`, and validate `ef >= k` when explicitly provided
- Add regression test that searches with `adapt_for_cpu=true` without setting `ef`

Closes https://github.com/zilliztech/knowhere/issues/1510

🤖 Generated with [Claude Code](https://claude.com/claude-code)