### PR TITLE
fix the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,13 @@ WITH_CARDINAL ?=
 WITH_DEBUG ?=
 CONAN_PROFILE ?=
 
+# Prevent build-flag variables from leaking into the environment of child
+# processes (conan / cmake).  Without this, GNU Make exports command-line
+# variables such as WITH_ASAN to every sub-process, which causes the custom
+# folly recipe to pick up $ENV{WITH_ASAN} and compile folly itself with
+# -fsanitize=address — breaking the build on GCC.
+unexport WITH_GPU WITH_UT WITH_ASAN WITH_CARDINAL WITH_DEBUG
+
 # ---------- Derived settings ----------
 ifdef WITH_DEBUG
     BUILD_TYPE := Debug


### PR DESCRIPTION
The summary from `Claude` is the following.

**Problem**: When running make `WITH_ASAN`=True, GNU Make exports command-line variables as environment variables to all child processes. The custom `milvus/dev` `folly` recipe's `folly-deps.cmake:269` checks `$ENV{WITH_ASAN}` and, when set, compiles `folly` with `-fsanitize=address,undefined`. This causes `static_assert(folly::to_bool(::recvmmsg))` to fail on `GCC` because `ASAN` interceptors make `recvmmsg`/`sendmmsg` function pointers non-`constexpr`.

**Fix**: Added `unexport WITH_GPU WITH_UT WITH_ASAN WITH_CARDINAL WITH_DEBUG` to the `Makefile` (after the variable definitions, before derived settings). This prevents these Make variables from leaking into the environment while still allowing them to work as Make variables for composing `conan` flags.