### PR TITLE
ci: add Makefile, conanfile.py to ut.yaml path filter

### DIFF
--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -17,6 +17,8 @@ on:
       - "!cmake/libs/libcardinal.cmake"
       - ".github/workflows/ut.yaml"
       - "CMakeLists.txt"
+      - "Makefile"
+      - "conanfile.py"
       - "!**.md"
       - "tests/**"
 


### PR DESCRIPTION
## Summary
- Add `Makefile`, 'conanfile.py' to the `pull_request.paths` filter in `.github/workflows/ut.yaml` so that Makefile changes trigger unit tests.
- Based on PR https://github.com/zilliztech/knowhere/pull/1520 which fixes the Makefile — this PR tests that the UT workflow runs correctly with the Makefile changes.

## Test plan
- This PR should trigger the UT workflow, confirming the Makefile fix from #1520 passes unit tests.

Signed-off-by: jamesgao-jpg <james.gao@zilliz.com>