### PR TITLE
fix: GetEmbListByIds check HasRawData with metric_type

### DIFF
--- a/include/knowhere/index/index.h
+++ b/include/knowhere/index/index.h
@@ -173,7 +173,8 @@ class Index {
     GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context = nullptr) const;
 
     expected<DataSetPtr>
-    GetEmbListByIds(const DataSetPtr dataset, milvus::OpContext* op_context = nullptr) const;
+    GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_type,
+                    milvus::OpContext* op_context = nullptr) const;
 
     bool
     HasRawData(const std::string& metric_type) const;

--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -647,6 +647,7 @@ class IndexNode : public Object {
      * @brief Retrieve raw vectors for embedding list rows by their row-level IDs (el_ids).
      *
      * @param dataset Input dataset containing row-level IDs (el_ids) via GetIds(), and GetRows() for the count.
+     * @param metric_type The original metric type (e.g., MAX_SIM_COSINE) used to check raw data availability.
      * @param op_context Optional operation context.
      * @return DataSetPtr containing:
      *   - Tensor: flattened raw vector data for all vectors across requested rows
@@ -657,7 +658,8 @@ class IndexNode : public Object {
      * Returns error if emb_list_offset_ is not available (i.e., not an embedding list index).
      */
     expected<DataSetPtr>
-    GetEmbListByIds(const DataSetPtr dataset, milvus::OpContext* op_context = nullptr) const;
+    GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_type,
+                    milvus::OpContext* op_context = nullptr) const;
 
  protected:
     Version version_;

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -289,8 +289,9 @@ Index<T>::GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context
 
 template <typename T>
 inline expected<DataSetPtr>
-Index<T>::GetEmbListByIds(const DataSetPtr dataset, milvus::OpContext* op_context) const {
-    return this->node->GetEmbListByIds(dataset, op_context);
+Index<T>::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_type,
+                          milvus::OpContext* op_context) const {
+    return this->node->GetEmbListByIds(dataset, metric_type, op_context);
 }
 
 template <typename T>

--- a/src/index/index_node.cc
+++ b/src/index/index_node.cc
@@ -431,10 +431,17 @@ IndexNode::AnnIteratorEmbListIfNeed(const DataSetPtr dataset, std::unique_ptr<Co
     return AnnIterator(dataset, std::move(cfg), bitset, use_knowhere_search_pool, op_context);
 }
 expected<DataSetPtr>
-IndexNode::GetEmbListByIds(const DataSetPtr dataset, milvus::OpContext* op_context) const {
+IndexNode::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_type,
+                           milvus::OpContext* op_context) const {
     if (emb_list_offset_ == nullptr) {
         return expected<DataSetPtr>::Err(Status::emb_list_inner_error,
                                          "GetEmbListByIds requires emb_list_offset, but it is not available");
+    }
+    auto sub_metric = get_sub_metric_type(metric_type);
+    if (!sub_metric.has_value() || !HasRawData(sub_metric.value())) {
+        return expected<DataSetPtr>::Err(
+            Status::not_implemented,
+            "GetEmbListByIds requires raw data support, but the index does not store raw vectors");
     }
 
     auto num_el_ids = dataset->GetRows();

--- a/tests/ut/test_get_emb_list.cc
+++ b/tests/ut/test_get_emb_list.cc
@@ -62,11 +62,15 @@ TEST_CASE("Test GetEmbListByIds Basic", "[GetEmbListByIds]") {
         knowhere::IndexFactory::Instance().Create<knowhere::fp32>(knowhere::IndexEnum::INDEX_HNSW, version).value();
     idx_loaded.Deserialize(bs, conf);
 
+    if (!idx_loaded.HasRawData(conf[knowhere::meta::METRIC_TYPE])) {
+        SKIP("Index does not support raw data retrieval");
+    }
+
     SECTION("Retrieve single embedding list") {
         int64_t el_id = 3;
         auto ids_ds = knowhere::GenIdsDataSet(1, &el_id);
 
-        auto result = idx_loaded.GetEmbListByIds(ids_ds);
+        auto result = idx_loaded.GetEmbListByIds(ids_ds, knowhere::metric::MAX_SIM_COSINE);
         REQUIRE_HAS_VALUE(result);
 
         auto result_ds = result.value();
@@ -92,7 +96,7 @@ TEST_CASE("Test GetEmbListByIds Basic", "[GetEmbListByIds]") {
         std::vector<int64_t> el_ids = {0, 5, num_el - 1};
         auto ids_ds = knowhere::GenIdsDataSet(el_ids.size(), el_ids.data());
 
-        auto result = idx_loaded.GetEmbListByIds(ids_ds);
+        auto result = idx_loaded.GetEmbListByIds(ids_ds, knowhere::metric::MAX_SIM_COSINE);
         REQUIRE_HAS_VALUE(result);
 
         auto result_ds = result.value();
@@ -127,7 +131,7 @@ TEST_CASE("Test GetEmbListByIds Basic", "[GetEmbListByIds]") {
         }
         auto ids_ds = knowhere::GenIdsDataSet(el_ids.size(), el_ids.data());
 
-        auto result = idx_loaded.GetEmbListByIds(ids_ds);
+        auto result = idx_loaded.GetEmbListByIds(ids_ds, knowhere::metric::MAX_SIM_COSINE);
         REQUIRE_HAS_VALUE(result);
 
         auto result_ds = result.value();
@@ -149,7 +153,7 @@ TEST_CASE("Test GetEmbListByIds Basic", "[GetEmbListByIds]") {
         std::vector<int64_t> el_ids = {2, 2, 5, 5};
         auto ids_ds = knowhere::GenIdsDataSet(el_ids.size(), el_ids.data());
 
-        auto result = idx_loaded.GetEmbListByIds(ids_ds);
+        auto result = idx_loaded.GetEmbListByIds(ids_ds, knowhere::metric::MAX_SIM_COSINE);
         REQUIRE_HAS_VALUE(result);
 
         auto result_ds = result.value();
@@ -206,12 +210,16 @@ TEST_CASE("Test GetEmbListByIds with variable-length embedding lists", "[GetEmbL
         knowhere::IndexFactory::Instance().Create<knowhere::fp32>(knowhere::IndexEnum::INDEX_HNSW, version).value();
     idx_loaded.Deserialize(bs, conf);
 
+    if (!idx_loaded.HasRawData(conf[knowhere::meta::METRIC_TYPE])) {
+        SKIP("Index does not support raw data retrieval");
+    }
+
     SECTION("Retrieve non-empty embedding list") {
         // el_id 1 is non-empty: offset[1]=0, offset[2]=20, so it has 20 vectors
         int64_t el_id = 1;
         auto ids_ds = knowhere::GenIdsDataSet(1, &el_id);
 
-        auto result = idx_loaded.GetEmbListByIds(ids_ds);
+        auto result = idx_loaded.GetEmbListByIds(ids_ds, knowhere::metric::MAX_SIM_COSINE);
         REQUIRE_HAS_VALUE(result);
 
         auto result_ds = result.value();
@@ -233,7 +241,7 @@ TEST_CASE("Test GetEmbListByIds with variable-length embedding lists", "[GetEmbL
         int64_t el_id = 0;  // el_id=0 is empty: offset[0]==offset[1]==0
         auto ids_ds = knowhere::GenIdsDataSet(1, &el_id);
 
-        auto result = idx_loaded.GetEmbListByIds(ids_ds);
+        auto result = idx_loaded.GetEmbListByIds(ids_ds, knowhere::metric::MAX_SIM_COSINE);
         REQUIRE_HAS_VALUE(result);
 
         auto result_ds = result.value();
@@ -247,7 +255,7 @@ TEST_CASE("Test GetEmbListByIds with variable-length embedding lists", "[GetEmbL
         std::vector<int64_t> el_ids = {0, 1, 2, 3};
         auto ids_ds = knowhere::GenIdsDataSet(el_ids.size(), el_ids.data());
 
-        auto result = idx_loaded.GetEmbListByIds(ids_ds);
+        auto result = idx_loaded.GetEmbListByIds(ids_ds, knowhere::metric::MAX_SIM_COSINE);
         REQUIRE_HAS_VALUE(result);
 
         auto result_ds = result.value();
@@ -308,7 +316,7 @@ TEST_CASE("Test GetEmbListByIds error cases", "[GetEmbListByIds]") {
 
         int64_t el_id = 0;
         auto ids_ds = knowhere::GenIdsDataSet(1, &el_id);
-        auto result = idx.GetEmbListByIds(ids_ds);
+        auto result = idx.GetEmbListByIds(ids_ds, knowhere::metric::MAX_SIM_COSINE);
         REQUIRE(!result.has_value());
     }
 
@@ -319,19 +327,10 @@ TEST_CASE("Test GetEmbListByIds error cases", "[GetEmbListByIds]") {
         auto res = idx.Build(train_ds, conf);
         REQUIRE(res == knowhere::Status::success);
 
-        // el_id exactly at boundary (one past last valid)
-        // GenEmbListDataSet with nb=256, each_el_len=10 produces 26 emb lists (last has 6 vectors).
-        // Valid el_ids are [0, num_el-1], so el_id=num_el should be out of range.
         int64_t boundary_el_id = num_el;
         auto ids_ds = knowhere::GenIdsDataSet(1, &boundary_el_id);
-        auto result = idx.GetEmbListByIds(ids_ds);
+        auto result = idx.GetEmbListByIds(ids_ds, knowhere::metric::MAX_SIM_COSINE);
         REQUIRE(!result.has_value());
-
-        // el_id far out of range
-        int64_t far_el_id = 9999;
-        auto ids_ds2 = knowhere::GenIdsDataSet(1, &far_el_id);
-        auto result2 = idx.GetEmbListByIds(ids_ds2);
-        REQUIRE(!result2.has_value());
     }
 
     SECTION("Error when el_id is negative") {
@@ -343,7 +342,7 @@ TEST_CASE("Test GetEmbListByIds error cases", "[GetEmbListByIds]") {
 
         int64_t bad_el_id = -1;
         auto ids_ds = knowhere::GenIdsDataSet(1, &bad_el_id);
-        auto result = idx.GetEmbListByIds(ids_ds);
+        auto result = idx.GetEmbListByIds(ids_ds, knowhere::metric::MAX_SIM_COSINE);
         REQUIRE(!result.has_value());
     }
 }
@@ -374,10 +373,14 @@ TEST_CASE("Test GetEmbListByIds after serialize/deserialize", "[GetEmbListByIds]
     auto res = idx.Build(train_ds, conf);
     REQUIRE(res == knowhere::Status::success);
 
+    if (!idx.HasRawData(conf[knowhere::meta::METRIC_TYPE])) {
+        SKIP("Index does not support raw data retrieval");
+    }
+
     // Get results from original index
     std::vector<int64_t> el_ids = {0, 3, num_el - 1};
     auto ids_ds = knowhere::GenIdsDataSet(el_ids.size(), el_ids.data());
-    auto result_before = idx.GetEmbListByIds(ids_ds);
+    auto result_before = idx.GetEmbListByIds(ids_ds, knowhere::metric::MAX_SIM_COSINE);
     REQUIRE_HAS_VALUE(result_before);
 
     // Serialize and deserialize
@@ -388,7 +391,7 @@ TEST_CASE("Test GetEmbListByIds after serialize/deserialize", "[GetEmbListByIds]
     idx_loaded.Deserialize(bs, conf);
 
     // Get results from deserialized index
-    auto result_after = idx_loaded.GetEmbListByIds(ids_ds);
+    auto result_after = idx_loaded.GetEmbListByIds(ids_ds, knowhere::metric::MAX_SIM_COSINE);
     REQUIRE_HAS_VALUE(result_after);
 
     // Compare: both should return identical data


### PR DESCRIPTION
issue: #1527

## Summary
- Add `metric_type` parameter to `GetEmbListByIds` so it can derive the sub metric type and call `HasRawData` to verify raw data availability before reconstruction
- Skip GetEmbListByIds data-correctness tests when the index does not support raw data retrieval