### PR TITLE
ci: fix mergify oscillation for URL-format issue links

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -34,9 +34,8 @@ pull_request_rules:
       - title!=\[automated\]
       - label!=kind/improvement
       - and:
-          - and:
-            - body!=(\#|https://github.com/zilliztech/knowhere/issues/)[0-9]{1,6}
-            - body!=\#[0-9]{1,6}(\s+|$)
+          - body!=\#[0-9]{1,6}(\s+|$)
+          - body!=https://github.com/zilliztech/knowhere/issues/[0-9]{1,6}(\s+|$)
     actions:
       label:
         add:


### PR DESCRIPTION
issue: #1529

## Summary
- Replace broken alternation-group regex `(\#|https://...)[0-9]{1,6}` with two independent conditions in the "Blocking PR if missing a related issue" mergify rule
- Fixes label oscillation (add/remove every ~35s) when PR body uses URL-format issue link with non-`kind/improvement` labels