### PR TITLE
fix: initialize nearest_idx to -1 in k=1 L2 fast path

### DIFF
--- a/thirdparty/faiss/faiss/cppcontrib/knowhere/utils/distances.cpp
+++ b/thirdparty/faiss/faiss/cppcontrib/knowhere/utils/distances.cpp
@@ -972,7 +972,7 @@ void exhaustive_L2sqr_nearest_imp(
         float dis_buffer[ny_batch_size];
         for (size_t i = i0; i < i1; i++) {
             const float* x_i = x + i * d;
-            size_t nearest_idx = 0;
+            int64_t nearest_idx = -1;
             float min_dis = HUGE_VALF;
             // compute distances
             for (auto j = 0; j < ny; j += ny_batch_size) {


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/1538
/kind improvement


When all L2 distances overflow to infinity (e.g., max-float vectors), exhaustive_L2sqr_nearest_imp returns nearest_idx=0 (initial value) because no distance satisfies `dis < HUGE_VALF`. This is inconsistent with HeapBlockResultHandler which initializes ids to -1 via heap_heapify, correctly signaling "no valid result".

Change nearest_idx from size_t(0) to int64_t(-1) to match the general path behavior.