### PR TITLE
fix: wheel build fails silently when setup.py crashes

### DIFF
--- a/python/build_portable_wheel.sh
+++ b/python/build_portable_wheel.sh
@@ -73,6 +73,11 @@ check_deps() {
 
     command -v "$PYTHON" >/dev/null || { log_error "Python not found: $PYTHON"; exit 1; }
 
+    $PYTHON -c "import numpy" 2>/dev/null || {
+        log_error "numpy not found. Install with: pip3 install 'numpy<2'"
+        exit 1
+    }
+
     [ -f "$BUILD_DIR/libknowhere.so" ] || {
         log_error "libknowhere.so not found at $BUILD_DIR"
         log_error "Please build Knowhere C++ library first:"
@@ -141,15 +146,16 @@ repair_wheel() {
     log_info "Repairing wheel for $platform..." >&2
 
     # Export library paths from libknowhere RUNPATH
-    local lib_paths=$(readelf -d "$BUILD_DIR/libknowhere.so" | \
-                      grep -E 'RUNPATH|RPATH' | \
-                      sed 's/.*\[\(.*\)\]/\1/' | \
-                      tr ':' '\n' | grep -v '^$' | tr '\n' ':')
+    local lib_paths
+    lib_paths=$(readelf -d "$BUILD_DIR/libknowhere.so" | \
+                grep -E 'RUNPATH|RPATH' | \
+                sed 's/.*\[\(.*\)\]/\1/' | \
+                tr ':' '\n' | grep -v '^$' | tr '\n' ':')
 
     export LD_LIBRARY_PATH="${lib_paths}:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu"
 
-    # Run auditwheel repair with full output
-    if ! auditwheel repair "$wheel" -w dist/ --plat "$platform" 2>&1 | tee /dev/stderr; then
+    # Run auditwheel repair (all output to stderr so it doesn't leak into command substitution)
+    if ! auditwheel repair "$wheel" -w dist/ --plat "$platform" 2>&1 >&2; then
         log_error "auditwheel repair failed" >&2
         exit 1
     fi
@@ -233,11 +239,13 @@ main() {
     log_info "Target platform: $platform"
 
     # Build wheel
-    local wheel=$(build_wheel)
+    local wheel
+    wheel=$(build_wheel)
     log_info "Built: $(basename "$wheel")"
 
     # Repair wheel
-    local final_wheel=$(repair_wheel "$wheel" "$platform")
+    local final_wheel
+    final_wheel=$(repair_wheel "$wheel" "$platform")
     log_info "Final: $(basename "$final_wheel")"
 
     # Verify

--- a/python/setup.py
+++ b/python/setup.py
@@ -107,7 +107,9 @@ setup(
     author_email="milvus-team@zilliz.com",
     license='Apache License 2.0',
     keywords="search nearest neighbors",
-    setup_requires=["numpy", "setuptools_scm"],
+    # numpy must be pre-installed (install_deps.sh handles this).
+    # Do NOT use setup_requires — it triggers the deprecated fetch_build_eggs
+    # which makes network calls to PyPI and fails intermittently in CI.
     #use_scm_version={'root': '..', 'local_scheme': 'no-local-version', 'version_scheme': 'release-branch-semver'},
     long_description=get_readme(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixes #1543

## Summary
- Fix bash `local var=$(cmd)` pattern ([SC2155](https://www.shellcheck.net/wiki/SC2155)) that masks exit codes, causing the script to silently continue with an empty wheel path when `setup.py` crashes
- Redirect `auditwheel` output to stderr only, preventing error text from leaking into captured variables
- Remove unused `setuptools_scm` from `setup_requires` and drop `setup_requires` entirely (cleanup — it triggers deprecated `fetch_build_eggs()` and a deprecation warning on every build)
- Add numpy import pre-check for early failure with clear error message

## Problem
The wheel build intermittently fails with `auditwheel: error: cannot access .. No such file`. This is a symptom, not the root cause. The actual error from `setup.py bdist_wheel` is masked by two bash bugs:

1. **`local var=$(cmd)` masks exit codes (SC2155):** `local` always returns 0, so `set -e` never fires when `build_wheel` or `repair_wheel` fail in a command substitution.
2. **`tee /dev/stderr` leaks to stdout:** When `repair_wheel` is called via `$(repair_wheel ...)`, `tee` sends auditwheel's error output to both stderr and stdout. The stdout portion gets captured as the "wheel path".

The cascade: `setup.py` fails for an unknown reason → `$wheel=""` (masked by `local`) → `auditwheel repair ""` → Python `Path("") → PosixPath(".")` → `cannot access .. No such file` (`.` path + sentence period).

**The underlying cause of `setup.py bdist_wheel` failing is not yet known** — the error is hidden in null bytes in the Jenkins log. With this fix, the next failure will show the actual Python traceback instead of the misleading auditwheel error.

## Verified
- Reproduced the exact CI error output in a local container using the CI image
- Confirmed `Path("") → PosixPath(".")` produces `cannot access .. No such file`
- Confirmed the fix: with split `local`, `set -e` catches the failure immediately

## Test plan
- [x] CI passes on this PR (both x86 and arm)
- [x] If CI fails again, the real `setup.py` error is now visible in Jenkins logs