### PR TITLE
feat: add IndexIVFRaBitQFastScan

### DIFF
--- a/include/knowhere/comp/index_param.h
+++ b/include/knowhere/comp/index_param.h
@@ -36,6 +36,7 @@ constexpr const char* INDEX_FAISS_SCANN_DVR = "SCANN_DVR";
 constexpr const char* INDEX_FAISS_IVFSQ8 = "IVF_SQ8";
 constexpr const char* INDEX_FAISS_IVFSQ_CC = "IVF_SQ_CC";
 constexpr const char* INDEX_FAISS_IVFRABITQ = "IVF_RABITQ";
+constexpr const char* INDEX_FAISS_IVFRABITQ_FASTSCAN = "IVF_RABITQ_FASTSCAN";
 
 constexpr const char* INDEX_FAISS_GPU_IDMAP = "GPU_FAISS_FLAT";
 constexpr const char* INDEX_FAISS_GPU_IVFFLAT = "GPU_FAISS_IVF_FLAT";

--- a/include/knowhere/index/index_table.h
+++ b/include/knowhere/index/index_table.h
@@ -62,6 +62,10 @@ static std::set<std::pair<std::string, VecType>> legal_knowhere_index = {
     {IndexEnum::INDEX_FAISS_IVFRABITQ, VecType::VECTOR_FLOAT16},
     {IndexEnum::INDEX_FAISS_IVFRABITQ, VecType::VECTOR_BFLOAT16},
 
+    {IndexEnum::INDEX_FAISS_IVFRABITQ_FASTSCAN, VecType::VECTOR_FLOAT},
+    {IndexEnum::INDEX_FAISS_IVFRABITQ_FASTSCAN, VecType::VECTOR_FLOAT16},
+    {IndexEnum::INDEX_FAISS_IVFRABITQ_FASTSCAN, VecType::VECTOR_BFLOAT16},
+
     // gpu index
     {IndexEnum::INDEX_GPU_BRUTEFORCE, VecType::VECTOR_FLOAT},
     {IndexEnum::INDEX_GPU_BRUTEFORCE, VecType::VECTOR_FLOAT16},
@@ -128,6 +132,7 @@ static std::set<std::string> legal_support_mmap_knowhere_index = {
     IndexEnum::INDEX_FAISS_IVFSQ8,
     IndexEnum::INDEX_FAISS_IVFSQ_CC,
     IndexEnum::INDEX_FAISS_IVFRABITQ,
+    IndexEnum::INDEX_FAISS_IVFRABITQ_FASTSCAN,
 
     // hnsw
     IndexEnum::INDEX_HNSW,

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -16,6 +16,9 @@
 #include <faiss/cppcontrib/knowhere/IndexScaNN.h>
 
 #include "common/metric.h"
+#include "faiss/IndexIVFRaBitQ.h"
+#include "faiss/IndexIVFRaBitQFastScan.h"
+#include "faiss/IndexRefine.h"
 #include "faiss/VectorTransform.h"
 #include "faiss/cppcontrib/knowhere/IndexBinaryFlat.h"
 #include "faiss/cppcontrib/knowhere/IndexBinaryIVF.h"
@@ -26,10 +29,12 @@
 #include "faiss/cppcontrib/knowhere/IndexIVFRaBitQ.h"
 #include "faiss/cppcontrib/knowhere/IndexScalarQuantizer.h"
 #include "faiss/cppcontrib/knowhere/index_io.h"
+#include "faiss/index_io.h"
 #include "index/clustering_config.h"
 #include "index/data_view_dense_index/index_node_with_data_view_refiner.h"
 #include "index/ivf/ivf_config.h"
 #include "index/ivf/ivf_wrapper.h"
+#include "index/ivf/ivfrbq_fastscan_wrapper.h"
 #include "index/ivf/ivfrbq_wrapper.h"
 #include "io/memory_io.h"
 #include "knowhere/bitsetview_idselector.h"
@@ -71,7 +76,8 @@ class IvfIndexNode : public IndexNode {
                           std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>::value ||
                           std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexScaNN>::value ||
                           std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC>::value ||
-                          std::is_same<IndexType, IndexIVFRaBitQWrapper>::value,
+                          std::is_same<IndexType, IndexIVFRaBitQWrapper>::value ||
+                          std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value,
                       "not support");
         static_assert(std::is_same_v<DataType, fp32> || std::is_same_v<DataType, bin1>,
                       "IvfIndexNode only support float/binary");
@@ -178,7 +184,8 @@ class IvfIndexNode : public IndexNode {
         if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexBinaryIVF, IndexType>::value) {
             return true;
         }
-        if constexpr (std::is_same<IndexIVFRaBitQWrapper, IndexType>::value) {
+        if constexpr (std::is_same<IndexIVFRaBitQWrapper, IndexType>::value ||
+                      std::is_same<IndexIVFRaBitQFastScanWrapper, IndexType>::value) {
             return false;
         }
         return false;
@@ -249,6 +256,9 @@ class IvfIndexNode : public IndexNode {
         if constexpr (std::is_same<IndexIVFRaBitQWrapper, IndexType>::value) {
             return std::make_unique<IvfRaBitQConfig>();
         }
+        if constexpr (std::is_same<IndexIVFRaBitQFastScanWrapper, IndexType>::value) {
+            return std::make_unique<IvfRaBitQFastScanConfig>();
+        }
     };
 
     std::unique_ptr<BaseConfig>
@@ -304,6 +314,9 @@ class IvfIndexNode : public IndexNode {
         if constexpr (std::is_same<IndexType, IndexIVFRaBitQWrapper>::value) {
             return index_->size();
         }
+        if constexpr (std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value) {
+            return index_->size();
+        }
     };
     int64_t
     Count() const override {
@@ -338,6 +351,9 @@ class IvfIndexNode : public IndexNode {
         if constexpr (std::is_same<IndexType, IndexIVFRaBitQWrapper>::value) {
             return knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ;
         }
+        if constexpr (std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value) {
+            return knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ_FASTSCAN;
+        }
     };
 
  private:
@@ -359,7 +375,8 @@ class IvfIndexNode : public IndexNode {
         return std::is_same_v<IndexType, IndexIVFPQWrapper> || std::is_same_v<IndexType, IndexIVFSQWrapper> ||
                std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC> ||
                std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexScaNN> ||
-               std::is_same_v<IndexType, IndexIVFRaBitQWrapper>;
+               std::is_same_v<IndexType, IndexIVFRaBitQWrapper> ||
+               std::is_same_v<IndexType, IndexIVFRaBitQFastScanWrapper>;
     }
 
  private:
@@ -530,7 +547,8 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
 
     // do normalize for COSINE metric type
     if constexpr (std::is_same_v<IndexIVFPQWrapper, IndexType> || std::is_same_v<IndexIVFSQWrapper, IndexType> ||
-                  std::is_same_v<IndexIVFRaBitQWrapper, IndexType>) {
+                  std::is_same_v<IndexIVFRaBitQWrapper, IndexType> ||
+                  std::is_same_v<IndexIVFRaBitQFastScanWrapper, IndexType>) {
         if (is_cosine) {
             NormalizeDataset<DataType>(dataset);
         }
@@ -782,6 +800,22 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
         // apply clustering config
         ApplyClusteringConfig(index->get_ivfrabitq_index()->cp);
         // train
+        index->train(rows, (const float*)data);
+    }
+    if constexpr (std::is_same<IndexIVFRaBitQFastScanWrapper, IndexType>::value) {
+        const IvfRaBitQFastScanConfig& fs_cfg = static_cast<const IvfRaBitQFastScanConfig&>(*cfg);
+        auto nlist = MatchNlist(rows, fs_cfg.nlist.value());
+        auto result = IndexIVFRaBitQFastScanWrapper::create(dim, nlist, fs_cfg, metric.value());
+        if (!result.has_value()) {
+            return result.error();
+        }
+        index = std::move(result.value());
+        // Clustering parameters still belong to the underlying IVF index, so
+        // reach through the wrapper before training.
+        auto* fs_idx = index->get_fastscan_index();
+        if (fs_idx) {
+            ApplyClusteringConfig(fs_idx->cp);
+        }
         index->train(rows, (const float*)data);
     }
     index_ = std::move(index);
@@ -1067,6 +1101,32 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, std::unique_
                         index_->search(1, cur_query, k, distances.get() + offset, ids.get() + offset,
                                        &ivf_search_params);
                     }
+                } else if constexpr (std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value) {
+                    auto cur_query = (const float*)data + index * dim;
+                    if (is_cosine) {
+                        copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
+                        cur_query = copied_query.get();
+                    }
+
+                    const IvfRaBitQFastScanConfig& fs_cfg = static_cast<const IvfRaBitQFastScanConfig&>(*cfg);
+
+                    // FastScan uses core Faiss IVF search params. When refine
+                    // is enabled, the outer IndexRefineFlat receives core
+                    // IndexRefineSearchParameters and forwards the base params
+                    // to IndexIVFRaBitQFastScan unchanged.
+                    faiss::IVFSearchParameters fs_base_params;
+                    fs_base_params.nprobe = nprobe;
+                    fs_base_params.sel = id_selector;
+
+                    if (index_->has_refine() && fs_cfg.refine_k.has_value()) {
+                        faiss::IndexRefineSearchParameters fs_refine_params;
+                        fs_refine_params.k_factor = fs_cfg.refine_k.value_or(1);
+                        fs_refine_params.base_index_params = &fs_base_params;
+                        index_->search(1, cur_query, k, distances.get() + offset, ids.get() + offset,
+                                       &fs_refine_params);
+                    } else {
+                        index_->search(1, cur_query, k, distances.get() + offset, ids.get() + offset, &fs_base_params);
+                    }
                 } else if constexpr (std::is_same<IndexType, IndexIVFPQWrapper>::value) {
                     auto cur_query = (const float*)data + index * dim;
                     if (is_cosine) {
@@ -1229,10 +1289,18 @@ template <typename DataType, typename IndexType>
 expected<DataSetPtr>
 IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, std::unique_ptr<Config> cfg,
                                                const BitsetView& bitset, milvus::OpContext* op_context) const {
-    // if support ann_iterator, use iterator-based range_search (IndexNode::RangeSearch)
+    // If the index supports iterators, use iterator-based range_search.
+    // Exception: FastScan backend does not support iterators, so it falls
+    // through to the direct range_search path below.
     constexpr bool use_iterator_for_range_search = is_ann_iterator_supported();
     if (use_iterator_for_range_search) {
-        return IndexNode::RangeSearch(dataset, std::move(cfg), bitset, op_context);
+        bool skip_iterator = false;
+        if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQFastScanWrapper>) {
+            skip_iterator = true;
+        }
+        if (!skip_iterator) {
+            return IndexNode::RangeSearch(dataset, std::move(cfg), bitset, op_context);
+        }
     }
     if (!this->index_) {
         LOG_KNOWHERE_WARNING_ << "range search on empty index";
@@ -1347,6 +1415,29 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, std::un
                         index_->range_search(1, cur_query, radius, &res, &refine_search_params);
                     } else {
                         index_->range_search(1, cur_query, radius, &res, &ivf_search_params);
+                    }
+                } else if constexpr (std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value) {
+                    auto cur_query = (const float*)xq + index * dim;
+                    if (is_cosine) {
+                        copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
+                        cur_query = copied_query.get();
+                    }
+                    const IvfRaBitQFastScanConfig& fs_cfg = static_cast<const IvfRaBitQFastScanConfig&>(*cfg);
+
+                    // Range search should examine every probed list, so use
+                    // the wrapper's trained nlist here instead of the request's
+                    // top-k search nprobe.
+                    faiss::IVFSearchParameters fs_base_params;
+                    fs_base_params.nprobe = index_->get_nlist();
+                    fs_base_params.sel = id_selector;
+
+                    if (index_->has_refine() && fs_cfg.refine_k.has_value()) {
+                        faiss::IndexRefineSearchParameters fs_refine_params;
+                        fs_refine_params.k_factor = fs_cfg.refine_k.value_or(1);
+                        fs_refine_params.base_index_params = &fs_base_params;
+                        index_->range_search(1, cur_query, radius, &res, &fs_refine_params);
+                    } else {
+                        index_->range_search(1, cur_query, radius, &res, &fs_base_params);
                     }
                 } else if constexpr (std::is_same<IndexType, IndexIVFPQWrapper>::value) {
                     auto cur_query = (const float*)xq + index * dim;
@@ -1482,7 +1573,16 @@ IvfIndexNode<DataType, IndexType>::AnnIterator(const DataSetPtr dataset, std::un
         LOG_KNOWHERE_WARNING_ << "Current index_type: " << Type()
                               << ", only IVFFlat, IVFFlatCC, IVF_SQ8, IVF_SQ_CC, SCANN and IVFRABITQ support Iterator.";
         return expected<std::vector<IndexNode::IteratorPtr>>::Err(Status::not_implemented, "index not supported");
-    } else {
+    }
+
+    // FastScan backend does not support iterators in this version.
+    if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQFastScanWrapper>) {
+        LOG_KNOWHERE_WARNING_ << "IVF_RABITQ_FASTSCAN does not support iterators";
+        return expected<std::vector<IndexNode::IteratorPtr>>::Err(Status::not_implemented,
+                                                                  "IVF_RABITQ_FASTSCAN does not support iterators");
+    }
+
+    if constexpr (is_ann_iterator_supported()) {
         auto dim = dataset->GetDim();
         auto rows = dataset->GetRows();
         auto data = dataset->GetTensor();
@@ -1649,7 +1749,11 @@ IvfIndexNode<DataType, IndexType>::SerializeImpl(BinarySet& binset) const {
         if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>::value) {
             faiss::cppcontrib::knowhere::write_index_binary(index_.get(), &writer);
         } else if constexpr (std::is_same<IndexType, IndexIVFRaBitQWrapper>::value) {
+            // Legacy IVFRaBitQ stays on knowhere cppcontrib IO.
             faiss::cppcontrib::knowhere::write_index(index_->index.get(), &writer);
+        } else if constexpr (std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value) {
+            // FastScan uses core Faiss types end-to-end, so serialize with core IO.
+            faiss::write_index(index_->index.get(), &writer);
         } else if constexpr (std::is_same<IndexType, IndexIVFPQWrapper>::value) {
             faiss::cppcontrib::knowhere::write_index(index_->index.get(), &writer);
         } else if constexpr (std::is_same<IndexType, IndexIVFSQWrapper>::value) {
@@ -1692,6 +1796,15 @@ IvfIndexNode<DataType, IndexType>::Deserialize(const BinarySet& binset, std::sha
             }
 
             // use the wrapper
+            index_ = std::move(index_wr);
+        } else if constexpr (std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value) {
+            // FastScan stays on the core Faiss IO path end-to-end.
+            auto index_raw = std::unique_ptr<faiss::Index>(faiss::read_index(&reader));
+            auto index_wr = IndexIVFRaBitQFastScanWrapper::from_deserialized(std::move(index_raw));
+            if (index_wr == nullptr) {
+                LOG_KNOWHERE_ERROR_ << "The deserialized index does not look like an IVF_RABITQ_FASTSCAN";
+                return Status::invalid_serialized_index_type;
+            }
             index_ = std::move(index_wr);
         } else if constexpr (std::is_same<IndexType, IndexIVFPQWrapper>::value) {
             // deserialize
@@ -1761,6 +1874,16 @@ IvfIndexNode<DataType, IndexType>::DeserializeFromFile(const std::string& filena
             }
 
             // use the wrapper
+            index_ = std::move(index_wr);
+        } else if constexpr (std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value) {
+            // File deserialization mirrors the in-memory BinarySet path above:
+            // use core Faiss IO and then validate the wrapper shape.
+            auto index_raw = std::unique_ptr<faiss::Index>(faiss::read_index(filename.data(), io_flags));
+            auto index_wr = IndexIVFRaBitQFastScanWrapper::from_deserialized(std::move(index_raw));
+            if (index_wr == nullptr) {
+                LOG_KNOWHERE_ERROR_ << "The deserialized index does not look like an IVF_RABITQ_FASTSCAN";
+                return Status::invalid_serialized_index_type;
+            }
             index_ = std::move(index_wr);
         } else if constexpr (std::is_same<IndexType, IndexIVFPQWrapper>::value) {
             // deserialize into a wrapper
@@ -1839,6 +1962,8 @@ KNOWHERE_MOCK_REGISTER_DENSE_FLOAT_ALL_GLOBAL(IVF_SQ_CC, IvfIndexNode, knowhere:
                                               faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC)
 KNOWHERE_MOCK_REGISTER_DENSE_FLOAT_ALL_GLOBAL(IVFRABITQ, IvfIndexNode, knowhere::feature::MMAP, IndexIVFRaBitQWrapper)
 KNOWHERE_MOCK_REGISTER_DENSE_FLOAT_ALL_GLOBAL(IVF_RABITQ, IvfIndexNode, knowhere::feature::MMAP, IndexIVFRaBitQWrapper)
+KNOWHERE_MOCK_REGISTER_DENSE_FLOAT_ALL_GLOBAL(IVF_RABITQ_FASTSCAN, IvfIndexNode, knowhere::feature::MMAP,
+                                              IndexIVFRaBitQFastScanWrapper)
 // int
 KNOWHERE_MOCK_REGISTER_DENSE_INT_GLOBAL(IVFFLAT, IvfIndexNode, knowhere::feature::MMAP | knowhere::feature::EMB_LIST,
                                         faiss::cppcontrib::knowhere::IndexIVFFlat)

--- a/src/index/ivf/ivf_config.h
+++ b/src/index/ivf/ivf_config.h
@@ -417,6 +417,79 @@ class IvfRaBitQConfig : public IvfConfig {
     }
 };
 
+// Config for the dedicated FastScan IVFRaBitQ index type.
+// FastScan is intentionally modeled as a separate index family because it has
+// different backend types, IO, and feature support from the legacy IVFRaBitQ
+// path.
+//
+// Current limitations in this wrapper:
+//   - always uses index-level qb=8
+//   - supports flat/fp32 refine only
+//   - does not support iterators
+class IvfRaBitQFastScanConfig : public IvfConfig {
+ public:
+    CFG_BOOL refine;
+    CFG_FLOAT refine_k;
+    CFG_STRING refine_type;
+
+    // Declared so that passing rbq_bits_query > 0 is caught and rejected
+    // rather than silently ignored. FastScan always uses qb=8 internally.
+    CFG_INT rbq_bits_query;
+    KNOHWERE_DECLARE_CONFIG(IvfRaBitQFastScanConfig) {
+        KNOWHERE_CONFIG_DECLARE_FIELD(rbq_bits_query)
+            .description("not supported on IVF_RABITQ_FASTSCAN; must be 0 or omitted")
+            .set_default(0)
+            .set_range(0, 8)
+            .for_search()
+            .for_range_search();
+        KNOWHERE_CONFIG_DECLARE_FIELD(refine)
+            .description("whether the refine is used during the train")
+            .set_default(false)
+            .for_train()
+            .for_static();
+        KNOWHERE_CONFIG_DECLARE_FIELD(refine_k)
+            .description("refine k")
+            .set_default(1)
+            .set_range(1, std::numeric_limits<CFG_FLOAT::value_type>::max())
+            .for_search();
+        KNOWHERE_CONFIG_DECLARE_FIELD(refine_type)
+            .description("the type of a refine index")
+            .allow_empty_without_default()
+            .for_train()
+            .for_static();
+    }
+
+    Status
+    CheckAndAdjust(PARAM_TYPE param_type, std::string* err_msg) override {
+        const auto base_status = IvfConfig::CheckAndAdjust(param_type, err_msg);
+        if (base_status != Status::success) {
+            return base_status;
+        }
+
+        if (param_type == PARAM_TYPE::SEARCH || param_type == PARAM_TYPE::RANGE_SEARCH) {
+            if (rbq_bits_query.value_or(0) > 0) {
+                return HandleError(err_msg,
+                                   "rbq_bits_query > 0 is not supported on IVF_RABITQ_FASTSCAN "
+                                   "(FastScan always uses index-level qb=8)",
+                                   Status::invalid_args);
+            }
+        }
+
+        if (param_type == PARAM_TYPE::TRAIN) {
+            // Only flat/fp32 refine is supported.
+            if (refine.value_or(false) && refine_type.has_value()) {
+                std::string rt = str_to_lower(refine_type.value());
+                if (rt != "fp32" && rt != "flat") {
+                    return HandleError(
+                        err_msg, "IVF_RABITQ_FASTSCAN only supports refine_type=flat/fp32, got: " + refine_type.value(),
+                        Status::invalid_args);
+                }
+            }
+        }
+        return Status::success;
+    }
+};
+
 }  // namespace knowhere
 
 #endif /* IVF_CONFIG_H */

--- a/src/index/ivf/ivfrbq_fastscan_wrapper.cc
+++ b/src/index/ivf/ivfrbq_fastscan_wrapper.cc
@@ -1,0 +1,205 @@
+// Copyright (C) 2019-2025 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#include "index/ivf/ivfrbq_fastscan_wrapper.h"
+
+// Safe to include here: this TU does not transitively include
+// knowhere's patched simd_result_handlers.h.
+#include <faiss/IndexFlat.h>
+#include <faiss/IndexIVFRaBitQFastScan.h>
+#include <faiss/IndexPreTransform.h>
+#include <faiss/IndexRefine.h>
+#include <faiss/index_io.h>
+
+#include <memory>
+#include <stdexcept>
+
+#include "faiss/impl/io.h"
+#include "knowhere/expected.h"
+
+namespace knowhere {
+
+expected<std::unique_ptr<IndexIVFRaBitQFastScanWrapper>>
+IndexIVFRaBitQFastScanWrapper::create(const faiss::idx_t d, const size_t nlist, const IvfRaBitQFastScanConfig& cfg,
+                                      const faiss::MetricType metric) {
+    // NOTE: `metric` is already converted by the caller (TrainInternal):
+    //   COSINE → METRIC_INNER_PRODUCT (data is pre-normalized).
+    // Build the core Faiss stack first:
+    //   IndexFlat -> IndexIVFRaBitQFastScan -> RandomRotation pretransform
+    // Optional refine is layered on top afterwards so the whole chain remains
+    // serializable through core Faiss IO.
+    auto idx_flat = std::make_unique<faiss::IndexFlat>(d, metric);
+    auto idx_fastscan = std::make_unique<faiss::IndexIVFRaBitQFastScan>(idx_flat.release(), d, nlist, metric,
+                                                                        /*bbs=*/32, /*own_invlists=*/true,
+                                                                        /*nb_bits=*/1);
+    idx_fastscan->own_fields = true;
+    // FastScan requires qb in [1,8]. Use qb=8 (upstream default) for best accuracy.
+    idx_fastscan->qb = 8;
+
+    // Keep the same random-rotation structure as the legacy IVFRaBitQ path.
+    auto rr = std::make_unique<faiss::RandomRotationMatrix>(d, d);
+    auto idx_rr = std::make_unique<faiss::IndexPreTransform>(rr.release(), idx_fastscan.release());
+    idx_rr->own_fields = true;
+
+    std::unique_ptr<faiss::Index> idx_final;
+    if (cfg.refine.value_or(false)) {
+        // v1 only supports refine-flat so the whole stack stays in core Faiss
+        // types and can be serialized with faiss::write_index/read_index.
+        auto idx_refine = std::make_unique<faiss::IndexRefineFlat>(idx_rr.release());
+        idx_refine->own_fields = true;
+        idx_refine->own_refine_index = true;
+        idx_final = std::move(idx_refine);
+    } else {
+        idx_final = std::move(idx_rr);
+    }
+
+    return std::make_unique<IndexIVFRaBitQFastScanWrapper>(std::move(idx_final));
+}
+
+IndexIVFRaBitQFastScanWrapper::IndexIVFRaBitQFastScanWrapper(std::unique_ptr<faiss::Index>&& index_in)
+    : Index{index_in->d, index_in->metric_type}, index{std::move(index_in)} {
+    ntotal = index->ntotal;
+    is_trained = index->is_trained;
+    verbose = index->verbose;
+    metric_arg = index->metric_arg;
+    detect_refine_state();
+}
+
+void
+IndexIVFRaBitQFastScanWrapper::detect_refine_state() {
+    has_refine_ = (dynamic_cast<faiss::IndexRefine*>(index.get()) != nullptr);
+}
+
+std::unique_ptr<IndexIVFRaBitQFastScanWrapper>
+IndexIVFRaBitQFastScanWrapper::from_deserialized(std::unique_ptr<faiss::Index>&& index_in) {
+    // Probe through optional refine to find IndexPreTransform -> IndexIVFRaBitQFastScan.
+    faiss::IndexPreTransform* index_pt = dynamic_cast<faiss::IndexPreTransform*>(index_in.get());
+    if (index_pt == nullptr) {
+        auto* refine = dynamic_cast<faiss::IndexRefine*>(index_in.get());
+        if (refine != nullptr) {
+            index_pt = dynamic_cast<faiss::IndexPreTransform*>(refine->base_index);
+        }
+    }
+    if (index_pt == nullptr) {
+        return nullptr;
+    }
+    if (dynamic_cast<faiss::IndexIVFRaBitQFastScan*>(index_pt->index) == nullptr) {
+        return nullptr;
+    }
+
+    return std::make_unique<IndexIVFRaBitQFastScanWrapper>(std::move(index_in));
+}
+
+void
+IndexIVFRaBitQFastScanWrapper::train(faiss::idx_t n, const float* x) {
+    index->train(n, x);
+    is_trained = index->is_trained;
+}
+
+void
+IndexIVFRaBitQFastScanWrapper::add(faiss::idx_t n, const float* x) {
+    index->add(n, x);
+    this->ntotal = index->ntotal;
+}
+
+void
+IndexIVFRaBitQFastScanWrapper::search(faiss::idx_t n, const float* x, faiss::idx_t k, float* distances,
+                                      faiss::idx_t* labels, const faiss::SearchParameters* params) const {
+    index->search(n, x, k, distances, labels, params);
+}
+
+void
+IndexIVFRaBitQFastScanWrapper::range_search(faiss::idx_t n, const float* x, float radius,
+                                            faiss::RangeSearchResult* result,
+                                            const faiss::SearchParameters* params) const {
+    index->range_search(n, x, radius, result, params);
+}
+
+void
+IndexIVFRaBitQFastScanWrapper::reset() {
+    index->reset();
+    this->ntotal = 0;
+}
+
+void
+IndexIVFRaBitQFastScanWrapper::merge_from(faiss::Index& otherIndex, faiss::idx_t add_id) {
+    index->merge_from(otherIndex, add_id);
+}
+
+faiss::DistanceComputer*
+IndexIVFRaBitQFastScanWrapper::get_distance_computer() const {
+    return index->get_distance_computer();
+}
+
+faiss::IndexIVFRaBitQFastScan*
+IndexIVFRaBitQFastScanWrapper::get_fastscan_index() {
+    // The public wrapper always owns either:
+    //   IndexPreTransform(FastScan), or
+    //   IndexRefineFlat(IndexPreTransform(FastScan)).
+    // Unwrap those layers here so ivf.cc can configure/train/search against
+    // the actual FastScan base index without knowing the wrapper shape.
+    faiss::Index* target = index.get();
+    auto* refine = dynamic_cast<faiss::IndexRefine*>(target);
+    if (refine != nullptr) {
+        target = refine->base_index;
+    }
+    auto* pt = dynamic_cast<faiss::IndexPreTransform*>(target);
+    if (pt == nullptr) {
+        return nullptr;
+    }
+    return dynamic_cast<faiss::IndexIVFRaBitQFastScan*>(pt->index);
+}
+
+const faiss::IndexIVFRaBitQFastScan*
+IndexIVFRaBitQFastScanWrapper::get_fastscan_index() const {
+    // Const version of the same unwrapping logic as above.
+    const faiss::Index* target = index.get();
+    auto* refine = dynamic_cast<const faiss::IndexRefine*>(target);
+    if (refine != nullptr) {
+        target = refine->base_index;
+    }
+    auto* pt = dynamic_cast<const faiss::IndexPreTransform*>(target);
+    if (pt == nullptr) {
+        return nullptr;
+    }
+    return dynamic_cast<const faiss::IndexIVFRaBitQFastScan*>(pt->index);
+}
+
+size_t
+IndexIVFRaBitQFastScanWrapper::get_nlist() const {
+    const auto* fs = get_fastscan_index();
+    return (fs != nullptr) ? fs->nlist : 0;
+}
+
+namespace {
+struct FaissSizeCounter : faiss::IOWriter {
+    size_t total_size = 0;
+    size_t
+    operator()(const void*, size_t size, size_t nitems) override {
+        total_size += size * nitems;
+        return nitems;
+    }
+};
+}  // namespace
+
+size_t
+IndexIVFRaBitQFastScanWrapper::size() const {
+    if (index == nullptr) {
+        return 0;
+    }
+    // Count the serialized size on demand. This is not a hot path and avoids
+    // keeping cache invalidation state in the wrapper.
+    FaissSizeCounter counter;
+    faiss::write_index(index.get(), &counter);
+    return counter.total_size;
+}
+
+}  // namespace knowhere

--- a/src/index/ivf/ivfrbq_fastscan_wrapper.h
+++ b/src/index/ivf/ivfrbq_fastscan_wrapper.h
@@ -1,0 +1,93 @@
+// Copyright (C) 2019-2025 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "faiss/Index.h"
+#include "index/ivf/ivf_config.h"
+#include "knowhere/expected.h"
+
+// Forward declaration — full header included only in .cc to avoid
+// simd_result_handlers.h conflict with knowhere's patched copy.
+namespace faiss {
+struct IndexIVFRaBitQFastScan;
+struct IndexRefine;
+}  // namespace faiss
+
+namespace knowhere {
+
+/// Wrapper for the core Faiss IndexIVFRaBitQFastScan backend.
+///
+/// This mirrors the legacy IVFRaBitQ wrapper structure: ivf.cc should not need
+/// to know whether the actual Faiss object is wrapped in an IndexPreTransform
+/// and optionally an IndexRefineFlat.
+///
+/// Inner index is one of:
+///   - IndexPreTransform(RR, IndexIVFRaBitQFastScan)
+///   - IndexRefineFlat(IndexPreTransform(RR, IndexIVFRaBitQFastScan))
+///
+/// All types are core Faiss, so serialization/deserialization stays on the
+/// core faiss::write_index/read_index path.
+struct IndexIVFRaBitQFastScanWrapper : faiss::Index {
+    std::unique_ptr<faiss::Index> index;
+
+    explicit IndexIVFRaBitQFastScanWrapper(std::unique_ptr<faiss::Index>&& index_in);
+
+    static expected<std::unique_ptr<IndexIVFRaBitQFastScanWrapper>>
+    create(faiss::idx_t d, size_t nlist, const IvfRaBitQFastScanConfig& cfg, faiss::MetricType metric);
+
+    /// Deserialization. Returns nullptr if the index type doesn't match.
+    static std::unique_ptr<IndexIVFRaBitQFastScanWrapper>
+    from_deserialized(std::unique_ptr<faiss::Index>&& index_in);
+
+    void
+    train(faiss::idx_t n, const float* x) override;
+    void
+    add(faiss::idx_t n, const float* x) override;
+    void
+    search(faiss::idx_t n, const float* x, faiss::idx_t k, float* distances, faiss::idx_t* labels,
+           const faiss::SearchParameters* params) const override;
+    void
+    range_search(faiss::idx_t n, const float* x, float radius, faiss::RangeSearchResult* result,
+                 const faiss::SearchParameters* params) const override;
+    void
+    reset() override;
+    void
+    merge_from(faiss::Index& otherIndex, faiss::idx_t add_id) override;
+    faiss::DistanceComputer*
+    get_distance_computer() const override;
+
+    /// Accessor for the underlying FastScan index through the optional
+    /// refine/pretransform wrappers.
+    faiss::IndexIVFRaBitQFastScan*
+    get_fastscan_index();
+    const faiss::IndexIVFRaBitQFastScan*
+    get_fastscan_index() const;
+
+    bool
+    has_refine() const {
+        return has_refine_;
+    }
+    size_t
+    get_nlist() const;
+    size_t
+    size() const;
+
+ private:
+    bool has_refine_ = false;
+    void
+    detect_refine_state();
+};
+
+}  // namespace knowhere

--- a/tests/ut/test_search.cc
+++ b/tests/ut/test_search.cc
@@ -1106,3 +1106,252 @@ TEST_CASE("Test RangeSearch Cancellation", "[range_search][cancellation]") {
         REQUIRE(results2.has_value());
     }
 }
+
+TEST_CASE("Test IVF_RABITQ_FASTSCAN", "[ivf_rabitq_fastscan]") {
+    const int64_t nb = 1000, nq = 10;
+    const int64_t dim = 128;
+    const int64_t topk = 10;
+
+    auto metric = GENERATE(as<std::string>{}, knowhere::metric::L2, knowhere::metric::COSINE);
+    auto version = GenTestVersionList();
+
+    const auto train_ds = GenDataSet(nb, dim);
+    const auto query_ds = GenDataSet(nq, dim);
+
+    knowhere::Json json;
+    json[knowhere::meta::DIM] = dim;
+    json[knowhere::meta::METRIC_TYPE] = metric;
+    json[knowhere::meta::TOPK] = topk;
+    json[knowhere::indexparam::NLIST] = 16;
+    json[knowhere::indexparam::NPROBE] = 8;
+
+    const auto idx_type = knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ_FASTSCAN;
+
+    SECTION("build and search") {
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx.has_value());
+        REQUIRE(idx.value().Build(train_ds, json) == knowhere::Status::success);
+
+        auto results = idx.value().Search(query_ds, json, nullptr);
+        REQUIRE(results.has_value());
+        auto ids = results.value()->GetIds();
+        for (int i = 0; i < nq; i++) {
+            REQUIRE(ids[i * topk] >= 0);
+            REQUIRE(ids[i * topk] < nb);
+        }
+    }
+
+    SECTION("serialize/deserialize round-trip") {
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx.has_value());
+        REQUIRE(idx.value().Build(train_ds, json) == knowhere::Status::success);
+
+        auto results_before = idx.value().Search(query_ds, json, nullptr);
+        REQUIRE(results_before.has_value());
+
+        knowhere::BinarySet bs;
+        REQUIRE(idx.value().Serialize(bs) == knowhere::Status::success);
+
+        auto idx2 = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx2.has_value());
+        REQUIRE(idx2.value().Deserialize(bs, json) == knowhere::Status::success);
+
+        auto results_after = idx2.value().Search(query_ds, json, nullptr);
+        REQUIRE(results_after.has_value());
+
+        auto ids_before = results_before.value()->GetIds();
+        auto ids_after = results_after.value()->GetIds();
+        for (int i = 0; i < nq * topk; i++) {
+            REQUIRE(ids_before[i] == ids_after[i]);
+        }
+    }
+
+    SECTION("range search") {
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx.has_value());
+        REQUIRE(idx.value().Build(train_ds, json) == knowhere::Status::success);
+
+        knowhere::Json range_json = json;
+        if (knowhere::IsMetricType(metric, knowhere::metric::L2)) {
+            range_json[knowhere::meta::RADIUS] = 1000000.0f;
+            range_json[knowhere::meta::RANGE_FILTER] = 0.0f;
+        } else {
+            range_json[knowhere::meta::RADIUS] = 0.0f;
+            range_json[knowhere::meta::RANGE_FILTER] = 1.0f;
+        }
+        REQUIRE(idx.value().RangeSearch(query_ds, range_json, nullptr).has_value());
+    }
+
+    SECTION("refine flat build/search") {
+        knowhere::Json refine_json = json;
+        refine_json["refine"] = true;
+        refine_json["refine_type"] = "FLAT";
+        refine_json["refine_k"] = 2.0f;
+
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx.has_value());
+        REQUIRE(idx.value().Build(train_ds, refine_json) == knowhere::Status::success);
+        REQUIRE(idx.value().Search(query_ds, refine_json, nullptr).has_value());
+    }
+
+    SECTION("refine flat range search") {
+        knowhere::Json refine_json = json;
+        refine_json["refine"] = true;
+        refine_json["refine_type"] = "FLAT";
+        refine_json["refine_k"] = 2.0f;
+        if (knowhere::IsMetricType(metric, knowhere::metric::L2)) {
+            refine_json[knowhere::meta::RADIUS] = 1000000.0f;
+            refine_json[knowhere::meta::RANGE_FILTER] = 0.0f;
+        } else {
+            refine_json[knowhere::meta::RADIUS] = 0.0f;
+            refine_json[knowhere::meta::RANGE_FILTER] = 1.0f;
+        }
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx.has_value());
+        REQUIRE(idx.value().Build(train_ds, refine_json) == knowhere::Status::success);
+        REQUIRE(idx.value().RangeSearch(query_ds, refine_json, nullptr).has_value());
+    }
+
+    SECTION("refine flat serialize/deserialize") {
+        knowhere::Json refine_json = json;
+        refine_json["refine"] = true;
+        refine_json["refine_type"] = "FLAT";
+        refine_json["refine_k"] = 2.0f;
+
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx.has_value());
+        REQUIRE(idx.value().Build(train_ds, refine_json) == knowhere::Status::success);
+
+        // Search before serialization and verify that a round-trip preserves
+        // the same top-k output for the same queries.
+        auto results_before = idx.value().Search(query_ds, refine_json, nullptr);
+        REQUIRE(results_before.has_value());
+
+        knowhere::BinarySet bs;
+        REQUIRE(idx.value().Serialize(bs) == knowhere::Status::success);
+
+        auto idx2 = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx2.has_value());
+        REQUIRE(idx2.value().Deserialize(bs, refine_json) == knowhere::Status::success);
+
+        auto results_after = idx2.value().Search(query_ds, refine_json, nullptr);
+        REQUIRE(results_after.has_value());
+
+        auto ids_before = results_before.value()->GetIds();
+        auto ids_after = results_after.value()->GetIds();
+        for (int i = 0; i < nq * topk; i++) {
+            REQUIRE(ids_before[i] == ids_after[i]);
+        }
+    }
+
+    SECTION("rbq_bits_query > 0 rejected at search") {
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx.has_value());
+        REQUIRE(idx.value().Build(train_ds, json) == knowhere::Status::success);
+
+        knowhere::Json bad_json = json;
+        bad_json[knowhere::indexparam::RABITQ_QUERY_BITS] = 4;
+        REQUIRE_FALSE(idx.value().Search(query_ds, bad_json, nullptr).has_value());
+    }
+
+    SECTION("non-flat refine type rejected") {
+        knowhere::Json bad_json = json;
+        bad_json["refine"] = true;
+        bad_json["refine_type"] = "SQ8";
+
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx.has_value());
+        REQUIRE(idx.value().Build(train_ds, bad_json) != knowhere::Status::success);
+    }
+
+    SECTION("iterator rejected") {
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx.has_value());
+        REQUIRE(idx.value().Build(train_ds, json) == knowhere::Status::success);
+        REQUIRE_FALSE(idx.value().AnnIterator(query_ds, json, nullptr).has_value());
+    }
+
+    SECTION("bitset filtering works") {
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx.has_value());
+        REQUIRE(idx.value().Build(train_ds, json) == knowhere::Status::success);
+
+        std::vector<uint8_t> bitset_data((nb + 7) / 8, 0);
+        for (int i = 0; i < nb / 2; i++) {
+            bitset_data[i >> 3] |= (1 << (i & 7));
+        }
+        knowhere::BitsetView bitset(bitset_data.data(), nb);
+        auto results = idx.value().Search(query_ds, json, bitset);
+        REQUIRE(results.has_value());
+        auto ids = results.value()->GetIds();
+        for (int i = 0; i < nq * topk; i++) {
+            if (ids[i] >= 0) {
+                REQUIRE_FALSE(bitset.test(ids[i]));
+            }
+        }
+    }
+
+    SECTION("bitset filtering works with refine") {
+        knowhere::Json refine_json = json;
+        refine_json["refine"] = true;
+        refine_json["refine_type"] = "FLAT";
+        refine_json["refine_k"] = 2.0f;
+
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx.has_value());
+        REQUIRE(idx.value().Build(train_ds, refine_json) == knowhere::Status::success);
+
+        std::vector<uint8_t> bitset_data((nb + 7) / 8, 0);
+        for (int i = 0; i < nb / 2; i++) {
+            bitset_data[i >> 3] |= (1 << (i & 7));
+        }
+        knowhere::BitsetView bitset(bitset_data.data(), nb);
+        auto results = idx.value().Search(query_ds, refine_json, bitset);
+        REQUIRE(results.has_value());
+        auto ids = results.value()->GetIds();
+        for (int i = 0; i < nq * topk; i++) {
+            if (ids[i] >= 0) {
+                REQUIRE_FALSE(bitset.test(ids[i]));
+            }
+        }
+    }
+
+    SECTION("range search with bitset filtering works") {
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx.has_value());
+        REQUIRE(idx.value().Build(train_ds, json) == knowhere::Status::success);
+
+        knowhere::Json range_json = json;
+        if (knowhere::IsMetricType(metric, knowhere::metric::L2)) {
+            range_json[knowhere::meta::RADIUS] = 1000000.0f;
+            range_json[knowhere::meta::RANGE_FILTER] = 0.0f;
+        } else {
+            range_json[knowhere::meta::RADIUS] = 0.0f;
+            range_json[knowhere::meta::RANGE_FILTER] = 1.0f;
+        }
+
+        std::vector<uint8_t> bitset_data((nb + 7) / 8, 0);
+        for (int i = 0; i < nb / 2; i++) {
+            bitset_data[i >> 3] |= (1 << (i & 7));
+        }
+        knowhere::BitsetView bitset(bitset_data.data(), nb);
+        auto results = idx.value().RangeSearch(query_ds, range_json, bitset);
+        REQUIRE(results.has_value());
+        auto lims = results.value()->GetLims();
+        auto ids = results.value()->GetIds();
+        for (int64_t q = 0; q < nq; q++) {
+            for (size_t j = lims[q]; j < lims[q + 1]; j++) {
+                if (ids[j] >= 0) {
+                    REQUIRE_FALSE(bitset.test(ids[j]));
+                }
+            }
+        }
+    }
+
+    SECTION("search without bitset works") {
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(idx_type, version);
+        REQUIRE(idx.has_value());
+        REQUIRE(idx.value().Build(train_ds, json) == knowhere::Status::success);
+        REQUIRE(idx.value().Search(query_ds, json, nullptr).has_value());
+    }
+}


### PR DESCRIPTION
Add rbq_use_fastscan config flag (default false) that enables the upstream faiss::IndexIVFRaBitQFastScan SIMD batch backend for 1-bit IVFRaBitQ. The legacy backend remains the default and is unchanged.

Explicitly unsupported on FastScan in this version:
- Per-search rbq_bits_query > 0 (rejected at search/range_search)
- AnnIterator (rejected at runtime)

