### PR TITLE
ci: auto-cancel superseded workflow runs on new commits

### DIFF
--- a/.github/workflows/analyzer.yaml
+++ b/.github/workflows/analyzer.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyzer:
     name: analyzer

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -22,6 +22,10 @@ on:
       - "!**.md"
       - "tests/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ut:
     name: ut on ubuntu-22.04


### PR DESCRIPTION
## Summary

- Add `concurrency` groups to `ut.yaml`, `analyzer.yaml`, and `pre-commit.yml`
- When a new commit is pushed to a PR branch, any queued or in-progress CI runs for the same workflow on that PR are automatically cancelled
- Pushes to `main` are never cancelled, so back-to-back merges run independently
- Other workflows (`release.yaml`, `release-python.yml`, `stale.yml`) are unaffected — they use manual or scheduled triggers where concurrency control is unnecessary

## Motivation

Currently, all three PR-triggered workflows lack concurrency control. This means:
- Pushing N commits to a PR triggers N independent sets of CI runs
- Older runs are never cancelled, even when they test outdated code
- The self-hosted UT runner (180-min timeout) can queue up stale runs for hours

For example, PR #1542 pushed 6 commits in ~80 minutes and produced 18 workflow runs — 15 of which tested already-superseded code. PR #1482 had 18 commits producing 60 total runs, all running to completion.

## Changes

Each of the three PR-triggered workflows gets:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- **Group key**: workflow name + PR number (falls back to branch ref for pushes to `main`)
- **cancel-in-progress**: only `true` for `pull_request` events, `false` for pushes to `main` — so back-to-back merges never cancel each other

This follows the same pattern used by [Milvus](https://github.com/milvusio/milvus).

## Test plan

- [x] Push two commits in quick succession to this PR and verify the first run is automatically cancelled
- [x] Verify pushes to `main` still run normally (each push gets a unique ref, and `cancel-in-progress` is false for push events)