### PR TITLE
fix: initialize nearest_idx to -1 in k=1 L2 fast path

### DIFF
--- a/thirdparty/faiss/faiss/utils/distances.cpp
+++ b/thirdparty/faiss/faiss/utils/distances.cpp
@@ -1015,7 +1015,7 @@ void exhaustive_L2sqr_nearest_imp(
         float dis_buffer[ny_batch_size];
         for (size_t i = i0; i < i1; i++) {
             const float* x_i = x + i * d;
-            size_t nearest_idx = 0;
+            int64_t nearest_idx = -1;
             float min_dis = HUGE_VALF;
             // compute distances
             for (auto j = 0; j < ny; j += ny_batch_size) {


### PR DESCRIPTION
When all L2 distances overflow to infinity (e.g. max-float vectors), the loop in exhaustive_L2sqr_nearest_imp never updates nearest_idx, returning 0 instead of -1 (no valid result).

Backport of zilliztech/knowhere#1533 to 2.6.