### PR TITLE
support brute-force range search for binary sub/superstructure

### DIFF
--- a/src/common/comp/brute_force.cc
+++ b/src/common/comp/brute_force.cc
@@ -1078,6 +1078,14 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                             id_selector);
                         break;
                     }
+                    case faiss::METRIC_Substructure:
+                    case faiss::METRIC_Superstructure: {
+                        auto cur_query = (const uint8_t*)xq + (dim / 8) * index;
+                        faiss::cppcontrib::knowhere::binary_range_search<faiss::CMin<float, int64_t>, float>(
+                            faiss_metric_type, cur_query, (const uint8_t*)xb, 1, nb, radius, dim / 8, &res,
+                            id_selector);
+                        break;
+                    }
                     default: {
                         LOG_KNOWHERE_ERROR_ << "Invalid metric type: " << cfg.metric_type.value();
                         return Status::invalid_metric_type;

--- a/tests/ut/test_bruteforce.cc
+++ b/tests/ut/test_bruteforce.cc
@@ -236,13 +236,13 @@ TEST_CASE("Test Brute Force", "[binary vector]") {
     }
 
     SECTION("Test Range Search") {
-        if (metric == knowhere::metric::SUPERSTRUCTURE || metric == knowhere::metric::SUBSTRUCTURE) {
-            return;
-        }
-
         // set radius for different metric type
         auto cfg = conf;
-        cfg[knowhere::meta::RADIUS] = radius_map[metric];
+        if (metric == knowhere::metric::SUPERSTRUCTURE || metric == knowhere::metric::SUBSTRUCTURE) {
+            cfg[knowhere::meta::RADIUS] = 1.0f;
+        } else {
+            cfg[knowhere::meta::RADIUS] = radius_map[metric];
+        }
 
         auto res = knowhere::BruteForce::RangeSearch<knowhere::bin1>(train_ds, query_ds, cfg, nullptr);
         REQUIRE(res.has_value());

--- a/thirdparty/faiss/faiss/cppcontrib/knowhere/utils/binary_distances.cpp
+++ b/thirdparty/faiss/faiss/cppcontrib/knowhere/utils/binary_distances.cpp
@@ -595,6 +595,38 @@ void binary_range_search(
     }
 }
 
+template <class C, typename T, class StructureComputer>
+void binary_range_search_structure(
+        const uint8_t* a,
+        const uint8_t* b,
+        size_t na,
+        size_t nb,
+        T radius,
+        size_t code_size,
+        RangeSearchResult* res,
+        const IDSelector* sel = nullptr) {
+#pragma omp parallel
+    {
+        RangeSearchPartialResult pres(res);
+#pragma omp for
+        for (int64_t i = 0; i < na; i++) {
+            StructureComputer mc(a + i * code_size, code_size);
+            RangeQueryResult& qres = pres.new_result(i);
+            for (size_t j = 0; j < nb; j++) {
+                if (!sel || sel->is_member(j)) {
+                    if (mc.compute(b + j * code_size)) {
+                        T dis = static_cast<T>(0);
+                        if (C::cmp(dis, radius)) {
+                            qres.add(dis, j);
+                        }
+                    }
+                }
+            }
+        }
+        pres.finalize();
+    }
+}
+
 template <class C, typename T>
 void binary_range_search(
         MetricType metric_type,
@@ -661,8 +693,66 @@ void binary_range_search(
             }
             break;
         }
-        case METRIC_Superstructure:
-        case METRIC_Substructure:
+        case METRIC_Substructure: {
+            {
+                switch (code_size) {
+#define binary_range_search_substructure(ncodes)                                  \
+    case ncodes:                                                                  \
+        binary_range_search_structure<                                           \
+                C,                                                               \
+                T,                                                               \
+                faiss::cppcontrib::knowhere::StructureComputer##ncodes<false>>(  \
+                a, b, na, nb, radius, code_size, res, sel);                      \
+        break;
+                    binary_range_search_substructure(8);
+                    binary_range_search_substructure(16);
+                    binary_range_search_substructure(32);
+                    binary_range_search_substructure(64);
+                    binary_range_search_substructure(128);
+                    binary_range_search_substructure(256);
+                    binary_range_search_substructure(512);
+#undef binary_range_search_substructure
+                    default:
+                        binary_range_search_structure<
+                                C,
+                                T,
+                                faiss::cppcontrib::knowhere::StructureComputerDefault<false>>(
+                                a, b, na, nb, radius, code_size, res, sel);
+                        break;
+                }
+            }
+            break;
+        }
+        case METRIC_Superstructure: {
+            {
+                switch (code_size) {
+#define binary_range_search_superstructure(ncodes)                                \
+    case ncodes:                                                                  \
+        binary_range_search_structure<                                           \
+                C,                                                               \
+                T,                                                               \
+                faiss::cppcontrib::knowhere::StructureComputer##ncodes<true>>(   \
+                a, b, na, nb, radius, code_size, res, sel);                      \
+        break;
+                    binary_range_search_superstructure(8);
+                    binary_range_search_superstructure(16);
+                    binary_range_search_superstructure(32);
+                    binary_range_search_superstructure(64);
+                    binary_range_search_superstructure(128);
+                    binary_range_search_superstructure(256);
+                    binary_range_search_superstructure(512);
+#undef binary_range_search_superstructure
+                    default:
+                        binary_range_search_structure<
+                                C,
+                                T,
+                                faiss::cppcontrib::knowhere::StructureComputerDefault<true>>(
+                                a, b, na, nb, radius, code_size, res, sel);
+                        break;
+                }
+            }
+            break;
+        }
         default:
             break;
     }


### PR DESCRIPTION
issue: #1574

## Summary
- add brute-force binary range search support for `SUBSTRUCTURE` and `SUPERSTRUCTURE`
- route binary sub/superstructure range search through the existing binary matcher
- enable brute-force UT coverage for the new range search path

## Context
This PR closes a capability gap in binary brute-force range search by extending support to `SUBSTRUCTURE` and `SUPERSTRUCTURE`.
It adds coverage for missing cases rather than fixing a regression.

## Test
- `LD_LIBRARY_PATH=/home/zilliz/.conan/data/gflags/2.2.2/_/_/package/ef45d1cd7d44c3c89fa6456b370ced89171f282b/lib:/home/zilliz/.conan/data/glog/0.7.1/_/_/package/926e0eaeed666f528abdc8d0c87a9035fe0b0adf/lib:$LD_LIBRARY_PATH ./tests/ut/knowhere_tests "Test Brute Force"`
- `pre-commit run --files src/common/comp/brute_force.cc thirdparty/faiss/faiss/cppcontrib/knowhere/utils/binary_distances.cpp tests/ut/test_bruteforce.cc`
