### PR TITLE
ci: reduce ARM e2e pod resources for concurrent scheduling

### DIFF
--- a/ci/pod/e2e-arm-cpu.yaml
+++ b/ci/pod/e2e-arm-cpu.yaml
@@ -19,11 +19,11 @@ spec:
     args: ["cat"]
     resources:
       requests:
-        memory: "16Gi"
-        cpu: "4"
+        memory: "12Gi"
+        cpu: "3"
       limits:
-        memory: "16Gi"
-        cpu: "4"
+        memory: "12Gi"
+        cpu: "3"
     volumeMounts:
       - mountPath: /home/data
         name: db-data


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/1576

## Summary
- Reduce ARM e2e pod resource requests from 4 CPU / 16Gi to 3 CPU / 12Gi
- The ARM e2e node (m7gd.2xlarge, 8 vCPU / 32Gi) currently fits only one e2e pod at a time, causing all other ARM e2e jobs to queue serially (~1.5-2h each)
- At 3 CPU / 12Gi, two pods can be scheduled concurrently (2×3 + 0.6 system = 6.6 < 7.9 allocatable CPU; 2×12 + 4.5 system = 28.5 < 30.5 allocatable memory)

## Test plan
- [x] Verify ARM e2e tests still pass without OOM at 12Gi memory
- [x] Confirm two ARM e2e pods can be scheduled simultaneously on the node