### PR TITLE
feat: add IsIndexRefineEnabled and CalcDistByIDs to Index interface

### DIFF
--- a/include/knowhere/index/index.h
+++ b/include/knowhere/index/index.h
@@ -176,11 +176,18 @@ class Index {
     GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_type,
                     milvus::OpContext* op_context = nullptr) const;
 
+    expected<DataSetPtr>
+    CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
+                  const bool is_cosine, milvus::OpContext* op_context = nullptr) const;
+
     bool
     HasRawData(const std::string& metric_type) const;
 
     bool
     IsAdditionalScalarSupported(bool is_mv_only) const;
+
+    bool
+    IsIndexRefineEnabled() const;
 
     expected<DataSetPtr>
     GetIndexMeta(const Json& json) const;

--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -240,6 +240,11 @@ class IndexNode : public Object {
         return false;
     }
 
+    virtual bool
+    IsIndexRefineEnabled() const {
+        return false;
+    }
+
     /**
      * @unused Milvus is not using this method, so it cannot guarantee all indexes implement this method.
      *

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -295,6 +295,13 @@ Index<T>::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_ty
 }
 
 template <typename T>
+inline expected<DataSetPtr>
+Index<T>::CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels,
+                        const size_t labels_len, const bool is_cosine, milvus::OpContext* op_context) const {
+    return this->node->CalcDistByIDs(dataset, bitset, labels, labels_len, is_cosine, op_context);
+}
+
+template <typename T>
 inline bool
 Index<T>::HasRawData(const std::string& metric_type) const {
     return this->node->HasRawData(metric_type);
@@ -304,6 +311,12 @@ template <typename T>
 inline bool
 Index<T>::IsAdditionalScalarSupported(bool is_mv_only) const {
     return this->node->IsAdditionalScalarSupported(is_mv_only);
+}
+
+template <typename T>
+inline bool
+Index<T>::IsIndexRefineEnabled() const {
+    return this->node->IsIndexRefineEnabled();
 }
 
 template <typename T>


### PR DESCRIPTION
## Summary
- Add `IsIndexRefineEnabled()` to `IndexNode` (virtual, default `false`) and `Index<T>` wrapper, allowing callers to query whether an index supports index-level refinement
- Add `CalcDistByIDs()` to `Index<T>` wrapper, delegating brute-force distance calculation by vector IDs to the underlying `IndexNode`

## Test plan
- [ ] Verify existing unit tests pass (no behavior change, only new interfaces)
- [ ] Confirm concrete index implementations can override `IsIndexRefineEnabled()` to return `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

/kind improvement