### PR TITLE
fix: [2.6] wire up IndexStaticFaced::ConfigCheck dispatch

### DIFF
--- a/include/knowhere/index/index_static.h
+++ b/include/knowhere/index/index_static.h
@@ -131,7 +131,7 @@ class IndexStaticFaced {
     InternalStaticHasRawData(const knowhere::BaseConfig& config, const IndexVersion& version);
 
     static knowhere::Status
-    InternalConfigCheck(const knowhere::BaseConfig& config, const IndexVersion& version, std::string& msg);
+    InternalConfigCheck(const knowhere::BaseConfig& config, PARAM_TYPE paramType, std::string& msg);
 
     static std::unique_ptr<BaseConfig>
     InternalStaticCreateConfig();

--- a/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
+++ b/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
@@ -85,15 +85,20 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
                   milvus::OpContext* op_context = nullptr) const override;
 
     static Status
-    StaticConfigCheck(const Config& cfg, PARAM_TYPE paramType, std::string& msg) {
+    StaticConfigCheck(const Config& cfg, PARAM_TYPE /*paramType*/, std::string& msg) {
         auto base_cfg = static_cast<const BaseConfig&>(cfg);
         if constexpr (KnowhereFloatTypeCheck<DataType>::value) {
-            if (IsMetricType(base_cfg.metric_type.value(), metric::L2) ||
-                IsMetricType(base_cfg.metric_type.value(), metric::IP) ||
-                IsMetricType(base_cfg.metric_type.value(), metric::COSINE)) {
+            // Decompose compound metrics (MAX_SIM_*, DTW_*) used by emb-list refiner variants
+            // (e.g. SCANN_DVR) down to their underlying base metric. For plain L2/IP/COSINE
+            // get_sub_metric_type returns nullopt and we fall back to the raw value.
+            const auto& raw_metric = base_cfg.metric_type.value();
+            const auto& base_metric = get_sub_metric_type(raw_metric).value_or(raw_metric);
+            if (IsMetricType(base_metric, metric::L2) || IsMetricType(base_metric, metric::IP) ||
+                IsMetricType(base_metric, metric::COSINE)) {
             } else {
-                msg = "metric type " + base_cfg.metric_type.value() +
-                      " not found or not supported, supported: [L2 IP COSINE]";
+                msg = "metric type " + raw_metric +
+                      " not found or not supported, supported: [L2 IP COSINE] (or MAX_SIM_*/DTW_* "
+                      "compound forms thereof)";
                 return Status::invalid_metric_type;
             }
         }

--- a/src/index/hnsw/hnsw.h
+++ b/src/index/hnsw/hnsw.h
@@ -95,23 +95,28 @@ class HnswIndexNode : public IndexNode {
         auto hnsw_cfg = static_cast<const BaseHnswConfig&>(cfg);
 
         if (paramType == PARAM_TYPE::TRAIN) {
+            // Decompose compound metrics (MAX_SIM_*, DTW_*) used by emb-list HNSW variants
+            // down to their underlying base metric. For plain L2/IP/COSINE/HAMMING/JACCARD
+            // get_sub_metric_type returns nullopt and we fall back to the raw value.
+            const auto& raw_metric = hnsw_cfg.metric_type.value();
+            const auto& base_metric = get_sub_metric_type(raw_metric).value_or(raw_metric);
             // Note: int8/fp16/bf16 are mocked to fp32 at runtime via MockData<>, so they only
             // accept float metrics. The only data type that should take the binary branch is bin1.
             if constexpr (!std::is_same_v<DataType, knowhere::bin1>) {
-                if (IsMetricType(hnsw_cfg.metric_type.value(), metric::L2) ||
-                    IsMetricType(hnsw_cfg.metric_type.value(), metric::IP) ||
-                    IsMetricType(hnsw_cfg.metric_type.value(), metric::COSINE)) {
+                if (IsMetricType(base_metric, metric::L2) || IsMetricType(base_metric, metric::IP) ||
+                    IsMetricType(base_metric, metric::COSINE)) {
                 } else {
-                    msg = "metric type " + hnsw_cfg.metric_type.value() +
-                          " not found or not supported, supported: [L2 IP COSINE]";
+                    msg = "metric type " + raw_metric +
+                          " not found or not supported, supported: [L2 IP COSINE] (or MAX_SIM_*/DTW_* "
+                          "compound forms thereof)";
                     return Status::invalid_metric_type;
                 }
             } else {
-                if (IsMetricType(hnsw_cfg.metric_type.value(), metric::HAMMING) ||
-                    IsMetricType(hnsw_cfg.metric_type.value(), metric::JACCARD)) {
+                if (IsMetricType(base_metric, metric::HAMMING) || IsMetricType(base_metric, metric::JACCARD)) {
                 } else {
-                    msg = "metric type " + hnsw_cfg.metric_type.value() +
-                          " not found or not supported, supported: [HAMMING JACCARD]";
+                    msg = "metric type " + raw_metric +
+                          " not found or not supported, supported: [HAMMING JACCARD] (or MAX_SIM_*/DTW_* "
+                          "compound forms thereof)";
                     return Status::invalid_metric_type;
                 }
             }

--- a/src/index/hnsw/hnsw.h
+++ b/src/index/hnsw/hnsw.h
@@ -95,7 +95,9 @@ class HnswIndexNode : public IndexNode {
         auto hnsw_cfg = static_cast<const BaseHnswConfig&>(cfg);
 
         if (paramType == PARAM_TYPE::TRAIN) {
-            if constexpr (KnowhereFloatTypeCheck<DataType>::value) {
+            // Note: int8/fp16/bf16 are mocked to fp32 at runtime via MockData<>, so they only
+            // accept float metrics. The only data type that should take the binary branch is bin1.
+            if constexpr (!std::is_same_v<DataType, knowhere::bin1>) {
                 if (IsMetricType(hnsw_cfg.metric_type.value(), metric::L2) ||
                     IsMetricType(hnsw_cfg.metric_type.value(), metric::IP) ||
                     IsMetricType(hnsw_cfg.metric_type.value(), metric::COSINE)) {

--- a/src/index/index_static.cc
+++ b/src/index/index_static.cc
@@ -57,7 +57,7 @@ IndexStaticFaced<DataType>::ConfigCheck(const IndexType& indexType, const IndexV
     }
 
     if (Instance().staticConfigCheckMap.find(indexType) != Instance().staticConfigCheckMap.end()) {
-        return Instance().staticConfigCheckMap[indexType](*cfg, version, msg);
+        return Instance().staticConfigCheckMap[indexType](*cfg, knowhere::PARAM_TYPE::TRAIN, msg);
     }
 
     return knowhere::Status::success;
@@ -145,8 +145,8 @@ IndexStaticFaced<DataType>::InternalStaticCreateConfig() {
 
 template <typename DataType>
 knowhere::Status
-IndexStaticFaced<DataType>::InternalConfigCheck(const BaseConfig& config, const IndexVersion& version,
-                                                std::string& msg) {
+IndexStaticFaced<DataType>::InternalConfigCheck(const BaseConfig& /*config*/, PARAM_TYPE /*paramType*/,
+                                                std::string& /*msg*/) {
     return knowhere::Status::success;
 }
 

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -133,23 +133,29 @@ class IvfIndexNode : public IndexNode {
         auto ivf_cfg = static_cast<const IvfConfig&>(cfg);
 
         if (paramType == PARAM_TYPE::TRAIN) {
+            // Decompose compound metrics (MAX_SIM_*, DTW_*) used by emb-list IVF variants down
+            // to their underlying base metric so the float/binary classification still works.
+            // For plain L2/IP/COSINE/HAMMING/JACCARD this returns nullopt and we fall back to
+            // the raw value.
+            const auto& raw_metric = ivf_cfg.metric_type.value();
+            const auto& base_metric = get_sub_metric_type(raw_metric).value_or(raw_metric);
             // Note: int8/fp16/bf16 are mocked to fp32 at runtime via MockData<>, so they only
             // accept float metrics. The only data type that should take the binary branch is bin1.
             if constexpr (!std::is_same_v<DataType, knowhere::bin1>) {
-                if (IsMetricType(ivf_cfg.metric_type.value(), metric::L2) ||
-                    IsMetricType(ivf_cfg.metric_type.value(), metric::IP) ||
-                    IsMetricType(ivf_cfg.metric_type.value(), metric::COSINE)) {
+                if (IsMetricType(base_metric, metric::L2) || IsMetricType(base_metric, metric::IP) ||
+                    IsMetricType(base_metric, metric::COSINE)) {
                 } else {
-                    msg = "metric type " + ivf_cfg.metric_type.value() +
-                          " not found or not supported, supported: [L2 IP COSINE]";
+                    msg = "metric type " + raw_metric +
+                          " not found or not supported, supported: [L2 IP COSINE] (or MAX_SIM_*/DTW_* "
+                          "compound forms thereof)";
                     return Status::invalid_metric_type;
                 }
             } else {
-                if (IsMetricType(ivf_cfg.metric_type.value(), metric::HAMMING) ||
-                    IsMetricType(ivf_cfg.metric_type.value(), metric::JACCARD)) {
+                if (IsMetricType(base_metric, metric::HAMMING) || IsMetricType(base_metric, metric::JACCARD)) {
                 } else {
-                    msg = "metric type " + ivf_cfg.metric_type.value() +
-                          " not found or not supported, supported: [HAMMING JACCARD]";
+                    msg = "metric type " + raw_metric +
+                          " not found or not supported, supported: [HAMMING JACCARD] (or MAX_SIM_*/DTW_* "
+                          "compound forms thereof)";
                     return Status::invalid_metric_type;
                 }
             }

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -133,7 +133,9 @@ class IvfIndexNode : public IndexNode {
         auto ivf_cfg = static_cast<const IvfConfig&>(cfg);
 
         if (paramType == PARAM_TYPE::TRAIN) {
-            if constexpr (KnowhereFloatTypeCheck<DataType>::value) {
+            // Note: int8/fp16/bf16 are mocked to fp32 at runtime via MockData<>, so they only
+            // accept float metrics. The only data type that should take the binary branch is bin1.
+            if constexpr (!std::is_same_v<DataType, knowhere::bin1>) {
                 if (IsMetricType(ivf_cfg.metric_type.value(), metric::L2) ||
                     IsMetricType(ivf_cfg.metric_type.value(), metric::IP) ||
                     IsMetricType(ivf_cfg.metric_type.value(), metric::COSINE)) {

--- a/tests/ut/test_config.cc
+++ b/tests/ut/test_config.cc
@@ -478,6 +478,34 @@ TEST_CASE("Test config json parse", "[config]") {
                   knowhere::Status::invalid_metric_type);
             CHECK_FALSE(msg.empty());
         }
+
+        // ---- IVF_FLAT (fp32) + emb-list compound metric: MAX_SIM_IP must pass ----
+        // IVFFLAT/IVF_FLAT/IVFFLATCC/IVF_FLAT_CC/SCANN_DVR are registered with the EMB_LIST
+        // feature flag and exercise MAX_SIM_*/DTW_* metrics in production. The static check
+        // must accept them by decomposing them to their underlying base metric.
+        {
+            knowhere::Json valid_json = knowhere::Json::parse(R"({
+                "metric_type": "MAX_SIM_IP",
+                "nlist": 128
+            })");
+            std::string msg;
+            CHECK(knowhere::IndexStaticFaced<knowhere::fp32>::ConfigCheck(
+                      knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, version, valid_json, msg) == knowhere::Status::success);
+            CHECK(msg.empty());
+        }
+        // ---- IVF_FLAT (fp32) + invalid compound metric: MAX_SIM_HAMMING decomposes to HAMMING ----
+        // which is not in the float whitelist, so it should still be rejected.
+        {
+            knowhere::Json bad_json = knowhere::Json::parse(R"({
+                "metric_type": "MAX_SIM_HAMMING",
+                "nlist": 128
+            })");
+            std::string msg;
+            CHECK(knowhere::IndexStaticFaced<knowhere::fp32>::ConfigCheck(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT,
+                                                                          version, bad_json, msg) ==
+                  knowhere::Status::invalid_metric_type);
+            CHECK_FALSE(msg.empty());
+        }
     }
 
 #ifdef KNOWHERE_WITH_DISKANN

--- a/tests/ut/test_config.cc
+++ b/tests/ut/test_config.cc
@@ -404,6 +404,82 @@ TEST_CASE("Test config json parse", "[config]") {
         CHECK(range_cfg.trace_visit.value() == true);
         CHECK(range_cfg.overview_levels.value() == 3);
     }
+
+    SECTION("static ConfigCheck rejects metric/data-type mismatch") {
+        // Regression for the IndexStaticFaced::ConfigCheck dispatch path: prior to the fix the
+        // staticConfigCheckMap was never populated (the InternalConfigCheck SFINAE prototype used
+        // IndexVersion while real StaticConfigCheck implementations use PARAM_TYPE), so per-index
+        // metric/data-type validation was silently bypassed. These cases pin the dispatch and
+        // verify that float-only / binary-only metric whitelists are now enforced.
+        const auto version = knowhere::Version::GetCurrentVersion().VersionNumber();
+
+        // ---- IVF_FLAT (fp32): float metric whitelist is enforced ----
+        // (IvfFlatConfig has no metric check in CheckAndAdjust, so the only line of defence
+        //  before this fix would have been IvfIndexNode::StaticConfigCheck — which never ran.)
+        {
+            knowhere::Json valid_json = knowhere::Json::parse(R"({
+                "metric_type": "L2",
+                "nlist": 128
+            })");
+            std::string msg;
+            CHECK(knowhere::IndexStaticFaced<knowhere::fp32>::ConfigCheck(
+                      knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, version, valid_json, msg) == knowhere::Status::success);
+            CHECK(msg.empty());
+        }
+        {
+            knowhere::Json bad_json = knowhere::Json::parse(R"({
+                "metric_type": "HAMMING",
+                "nlist": 128
+            })");
+            std::string msg;
+            CHECK(knowhere::IndexStaticFaced<knowhere::fp32>::ConfigCheck(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT,
+                                                                          version, bad_json, msg) ==
+                  knowhere::Status::invalid_metric_type);
+            CHECK_FALSE(msg.empty());
+        }
+
+        // ---- BIN_IVF_FLAT (bin1): binary metric whitelist is enforced ----
+        // (IvfBinConfig::CheckAndAdjust also rejects non-binary metrics, so a successful
+        //  rejection here may come from either layer; the positive case still proves the
+        //  static dispatch is wired up correctly for bin1.)
+        {
+            knowhere::Json valid_json = knowhere::Json::parse(R"({
+                "metric_type": "HAMMING",
+                "nlist": 128
+            })");
+            std::string msg;
+            CHECK(knowhere::IndexStaticFaced<knowhere::bin1>::ConfigCheck(knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT,
+                                                                          version, valid_json,
+                                                                          msg) == knowhere::Status::success);
+            CHECK(msg.empty());
+        }
+
+        // ---- IVF_FLAT (int8): int8 is mocked to fp32 at runtime, so float metrics must pass ----
+        // (Without the companion fix to IvfIndexNode::StaticConfigCheck, dispatching to it for
+        //  int8 would wrongly fall into the binary branch and reject L2.)
+        {
+            knowhere::Json valid_json = knowhere::Json::parse(R"({
+                "metric_type": "L2",
+                "nlist": 128
+            })");
+            std::string msg;
+            CHECK(knowhere::IndexStaticFaced<knowhere::int8>::ConfigCheck(
+                      knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, version, valid_json, msg) == knowhere::Status::success);
+            CHECK(msg.empty());
+        }
+        {
+            knowhere::Json bad_json = knowhere::Json::parse(R"({
+                "metric_type": "JACCARD",
+                "nlist": 128
+            })");
+            std::string msg;
+            CHECK(knowhere::IndexStaticFaced<knowhere::int8>::ConfigCheck(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT,
+                                                                          version, bad_json, msg) ==
+                  knowhere::Status::invalid_metric_type);
+            CHECK_FALSE(msg.empty());
+        }
+    }
+
 #ifdef KNOWHERE_WITH_DISKANN
     SECTION("check diskann index config") {
         knowhere::Json json = knowhere::Json::parse(R"({


### PR DESCRIPTION
issue: #1570

Cherry-pick of #1571 to 2.6.

## Summary

- Align `InternalConfigCheck` signature to take `PARAM_TYPE` so the SFINAE probe in `RegisterStaticFunc` actually matches every index's real `StaticConfigCheck` impl. Previously the probe used `IndexVersion` (`int32_t`), which does not implicitly convert to the unscoped `PARAM_TYPE` enum, so `staticConfigCheckMap` was permanently empty and `IndexStaticFaced::ConfigCheck` always fell through to `Status::success`.
- Pass `PARAM_TYPE::TRAIN` at the dispatch site (`index_static.cc:60`).
- Companion fix in `IvfIndexNode::StaticConfigCheck` and `HnswIndexNode::StaticConfigCheck`: classify the float vs binary metric branch with `!std::is_same_v<DataType, knowhere::bin1>` instead of `KnowhereFloatTypeCheck<DataType>`. The latter excludes `int8/fp16/bf16`, but those are mocked to `fp32` at runtime via `MockData<>`, so they should accept float metrics — without this companion change, fixing the dispatch alone would regress `IndexStaticFaced<int8>::ConfigCheck("IVF_FLAT", L2)`, which `tests/ut/test_config.cc::checkBuildConfig` already exercises.
- Add negative + positive cases in `tests/ut/test_config.cc` that pin the dispatch path: `fp32+IVF_FLAT+HAMMING` → `invalid_metric_type`, `bin1+BIN_IVF_FLAT+HAMMING` → `success`, `int8+IVF_FLAT+L2` → `success`, `int8+IVF_FLAT+JACCARD` → `invalid_metric_type`.

## Test Plan

- [x] `pre-commit run` clean on all 5 changed files
- [x] The corresponding main-branch PR (#1571) was verified end-to-end locally: buggy reproduction abort at the negative HAMMING CHECK, fixed state passes; this 2.6 cherry-pick applies the same patch on a byte-identical base.