### PR TITLE
ci: use -body~= instead of body!= in mergify blocking-issue rule

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -34,8 +34,8 @@ pull_request_rules:
       - title!=\[automated\]
       - label!=kind/improvement
       - and:
-          - body!=\#[0-9]{1,6}(\s+|$)
-          - body!=https://github.com/zilliztech/knowhere/issues/[0-9]{1,6}(\s+|$)
+          - -body~=\#[0-9]{1,6}(\s+|$)
+          - -body~=https://github.com/zilliztech/knowhere/issues/[0-9]{1,6}(\s+|$)
     actions:
       label:
         add:


### PR DESCRIPTION
issue: #1529

## Summary

The "Blocking PR if missing a related issue" rule (introduced in #1530) uses `body!=` as the operator. `body!=` is **string equality negation**, not regex negation, so the literal pattern string `\#[0-9]{1,6}(\s+|$)` never equals any real PR body and the condition evaluates to `True` for every PR. As a result, the rule fires unconditionally on every PR and adds `do-not-merge/missing-related-issue`, then the "Dismiss block label if related issue be added into PR" rule (which correctly uses `body~=`) immediately removes it. The toggle repeats every ~35 seconds.

The PR is not actually blocked from merging (the dismiss rule cleans the label within 1 second), but the timeline gets flooded with label add/remove events and Mergify dashboard shows constant churn.

## Fix

Use `-body~=` (negated regex match), matching:
- the dismiss rule in the same file (which already uses positive `body~=`)
- the equivalent rule in `milvus-io/milvus` (`.github/mergify.yml`)

```diff
       - and:
-          - body!=\#[0-9]{1,6}(\s+|$)
-          - body!=https://github.com/zilliztech/knowhere/issues/[0-9]{1,6}(\s+|$)
+          - -body~=\#[0-9]{1,6}(\s+|$)
+          - -body~=https://github.com/zilliztech/knowhere/issues/[0-9]{1,6}(\s+|$)
```

Two-line change, no functional code change.

## Test Plan

- [x] Verified on PRs #1571 and #1573 that the toggling pattern reproduces with the current rule even when the PR body explicitly contains `issue: #1570`.
- [ ] Once merged, the toggling will stop on future PRs (cannot test in this PR itself before merge).
