### PR TITLE
Add index-type prometheus latency metrics

### DIFF
--- a/include/knowhere/config.h
+++ b/include/knowhere/config.h
@@ -573,7 +573,7 @@ class Config {
     }
 };
 
-#define KNOHWERE_DECLARE_CONFIG(CONFIG) CONFIG()
+#define KNOWHERE_DECLARE_CONFIG(CONFIG) CONFIG()
 
 #define KNOWHERE_CONFIG_DECLARE_FIELD(PARAM)                                                                     \
     __DICT__[#PARAM] = knowhere::Config::VarEntry(std::in_place_type<knowhere::Entry<decltype(PARAM)>>, &PARAM); \
@@ -655,7 +655,7 @@ class BaseConfig : public Config {
     CFG_INT lemur_seed;               // random seed for LEMUR
     CFG_INT lemur_num_layers;         // number of layers in feature_extractor
     CFG_BOOL emb_list_rerank;         // whether to perform MaxSim reranking after ANN search
-    KNOHWERE_DECLARE_CONFIG(BaseConfig) {
+    KNOWHERE_DECLARE_CONFIG(BaseConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(dim).allow_empty_without_default().description("vector dim").for_train();
         KNOWHERE_CONFIG_DECLARE_FIELD(metric_type)
             .set_default("L2")

--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -13,6 +13,7 @@
 #define INDEX_NODE_H
 
 #include <functional>
+#include <mutex>
 #include <queue>
 #include <utility>
 #include <vector>
@@ -324,6 +325,40 @@ class IndexNode : public Object {
     virtual std::string
     Type() const = 0;
 
+#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
+    struct LatencyMetricCache {
+        mutable std::once_flag once;
+        mutable prometheus::Histogram* metric{nullptr};
+    };
+
+    prometheus::Histogram&
+    GetLatencyMetric(LatencyMetricCache& cache, prometheus::Family<prometheus::Histogram>& family) const {
+        std::call_once(cache.once,
+                       [this, &cache, &family] { cache.metric = &GetPrometheusHistogram(family, "knowhere", Type()); });
+        return *cache.metric;
+    }
+
+    prometheus::Histogram&
+    GetBuildLatencyMetric() const {
+        return GetLatencyMetric(prometheus_metrics_.build, build_latency_family);
+    }
+
+    prometheus::Histogram&
+    GetLoadLatencyMetric() const {
+        return GetLatencyMetric(prometheus_metrics_.load, load_latency_family);
+    }
+
+    prometheus::Histogram&
+    GetSearchLatencyMetric() const {
+        return GetLatencyMetric(prometheus_metrics_.search, search_latency_family);
+    }
+
+    prometheus::Histogram&
+    GetRangeSearchLatencyMetric() const {
+        return GetLatencyMetric(prometheus_metrics_.range_search, range_search_latency_family);
+    }
+#endif
+
     /**
      * @brief Gets the mapping from internal IDs to external IDs.
      *
@@ -610,6 +645,16 @@ class IndexNode : public Object {
     // vectors (not raw), this IndexFlat stores original vectors for exact distance
     // computation during MaxSim reranking.
     std::shared_ptr<faiss::cppcontrib::knowhere::IndexFlat> emb_list_raw_index_;
+
+#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
+    struct PrometheusMetrics {
+        LatencyMetricCache build;
+        LatencyMetricCache load;
+        LatencyMetricCache search;
+        LatencyMetricCache range_search;
+    };
+    mutable PrometheusMetrics prometheus_metrics_;
+#endif
 };
 
 // Common superclass for iterators that expand search range as needed. Subclasses need

--- a/include/knowhere/prometheus_client.h
+++ b/include/knowhere/prometheus_client.h
@@ -20,7 +20,10 @@
 #include <prometheus/text_serializer.h>
 
 #include <memory>
+#include <mutex>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "knowhere/log.h"
 
@@ -50,103 +53,139 @@ class PrometheusClient {
     std::shared_ptr<prometheus::Registry> registry_ = std::make_shared<prometheus::Registry>();
 };
 
+class PrometheusHistogramCache {
+ public:
+    void
+    RegisterMetrics(prometheus::Family<prometheus::Histogram>& family, const std::string& module,
+                    const std::vector<std::string>& index_types,
+                    const prometheus::Histogram::BucketBoundaries& buckets);
+
+    prometheus::Histogram&
+    GetMetric(prometheus::Family<prometheus::Histogram>& family, const std::string& module,
+              const std::string& index_type, const prometheus::Histogram::BucketBoundaries& buckets);
+
+ private:
+    std::mutex mutex_;
+    std::unordered_map<std::string, prometheus::Histogram*> metrics_;
+};
+
 /*****************************************************************************/
 // prometheus metrics
 extern const prometheus::Histogram::BucketBoundaries defaultBuckets;
 extern const std::unique_ptr<PrometheusClient> prometheusClient;
+extern PrometheusHistogramCache prometheusHistogramCache;
 
-#define CONCATENATE(x, y) x##_##y
+#define KNOWHERE_PROMETHEUS_CONCATENATE(x, y) x##_##y
 #define PROMETHEUS_LABEL_KNOWHERE knowhere
 #define PROMETHEUS_LABEL_CARDINAL cardinal
 
-#define DEFINE_PROMETHEUS_GAUGE_FAMILY(name, desc)                     \
-    prometheus::Family<prometheus::Gauge>& CONCATENATE(name, family) = \
+#define KNOWHERE_DEFINE_PROMETHEUS_GAUGE_FAMILY(name, desc)                                \
+    prometheus::Family<prometheus::Gauge>& KNOWHERE_PROMETHEUS_CONCATENATE(name, family) = \
         prometheus::BuildGauge().Name(#name).Help(desc).Register(knowhere::prometheusClient->GetRegistry());
 
-#define DEFINE_PROMETHEUS_GAUGE(name, module) \
-    prometheus::Gauge& CONCATENATE(module, name) = CONCATENATE(name, family).Add({{"module", #module}});
+#define KNOWHERE_DEFINE_PROMETHEUS_GAUGE(name, module)                 \
+    prometheus::Gauge& KNOWHERE_PROMETHEUS_CONCATENATE(module, name) = \
+        KNOWHERE_PROMETHEUS_CONCATENATE(name, family).Add({{"module", #module}});
 
-#define DEFINE_PROMETHEUS_COUNTER_FAMILY(name, desc)                     \
-    prometheus::Family<prometheus::Counter>& CONCATENATE(name, family) = \
+#define KNOWHERE_DEFINE_PROMETHEUS_COUNTER_FAMILY(name, desc)                                \
+    prometheus::Family<prometheus::Counter>& KNOWHERE_PROMETHEUS_CONCATENATE(name, family) = \
         prometheus::BuildCounter().Name(#name).Help(desc).Register(knowhere::prometheusClient->GetRegistry());
 
-#define DEFINE_PROMETHEUS_COUNTER(name, module) \
-    prometheus::Counter& CONCATENATE(module, name) = CONCATENATE(name, family).Add({{"module", #module}});
+#define KNOWHERE_DEFINE_PROMETHEUS_COUNTER(name, module)                 \
+    prometheus::Counter& KNOWHERE_PROMETHEUS_CONCATENATE(module, name) = \
+        KNOWHERE_PROMETHEUS_CONCATENATE(name, family).Add({{"module", #module}});
 
-#define DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(name, desc)                     \
-    prometheus::Family<prometheus::Histogram>& CONCATENATE(name, family) = \
+#define KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(name, desc)                                \
+    prometheus::Family<prometheus::Histogram>& KNOWHERE_PROMETHEUS_CONCATENATE(name, family) = \
         prometheus::BuildHistogram().Name(#name).Help(desc).Register(knowhere::prometheusClient->GetRegistry());
 
-#define DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(name, module, buckets) \
-    prometheus::Histogram& CONCATENATE(module, name) = CONCATENATE(name, family).Add({{"module", #module}}, buckets);
+#define KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(name, module, buckets) \
+    prometheus::Histogram& KNOWHERE_PROMETHEUS_CONCATENATE(module, name) =       \
+        KNOWHERE_PROMETHEUS_CONCATENATE(name, family).Add({{"module", #module}}, buckets);
 
-#define DEFINE_PROMETHEUS_HISTOGRAM(name, module) DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(name, module, defaultBuckets)
+#define KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(name, module) \
+    KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(name, module, defaultBuckets)
 
-#define DECLARE_PROMETHEUS_GAUGE(name, module) extern prometheus::Gauge& CONCATENATE(module, name);
-#define DECLARE_PROMETHEUS_COUNTER(name, module) extern prometheus::Counter& CONCATENATE(module, name);
-#define DECLARE_PROMETHEUS_HISTOGRAM(name, module) extern prometheus::Histogram& CONCATENATE(module, name);
+#define KNOWHERE_DECLARE_PROMETHEUS_GAUGE(name, module) \
+    extern prometheus::Gauge& KNOWHERE_PROMETHEUS_CONCATENATE(module, name);
+#define KNOWHERE_DECLARE_PROMETHEUS_COUNTER(name, module) \
+    extern prometheus::Counter& KNOWHERE_PROMETHEUS_CONCATENATE(module, name);
+#define KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(name, module) \
+    extern prometheus::Histogram& KNOWHERE_PROMETHEUS_CONCATENATE(module, name);
 
-#define DECLARE_PROMETHEUS_GAUGE_FAMILY(name, module) \
-    extern prometheus::Family<prometheus::Gauge>& CONCATENATE(name, family);
-#define DECLARE_PROMETHEUS_COUNTER_FAMILY(name, module) \
-    extern prometheus::Family<prometheus::Counter>& CONCATENATE(name, family);
-#define DECLARE_PROMETHEUS_HISTOGRAM_FAMILY(name, module) \
-    extern prometheus::Family<prometheus::Histogram>& CONCATENATE(name, family);
+#define KNOWHERE_DECLARE_PROMETHEUS_GAUGE_FAMILY(name, module) \
+    extern prometheus::Family<prometheus::Gauge>& KNOWHERE_PROMETHEUS_CONCATENATE(name, family);
+#define KNOWHERE_DECLARE_PROMETHEUS_COUNTER_FAMILY(name, module) \
+    extern prometheus::Family<prometheus::Counter>& KNOWHERE_PROMETHEUS_CONCATENATE(name, family);
+#define KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM_FAMILY(name, module) \
+    extern prometheus::Family<prometheus::Histogram>& KNOWHERE_PROMETHEUS_CONCATENATE(name, family);
 
-DECLARE_PROMETHEUS_HISTOGRAM(build_latency, PROMETHEUS_LABEL_KNOWHERE);
-DECLARE_PROMETHEUS_HISTOGRAM(build_latency, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(build_latency, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(load_latency, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM_FAMILY(build_latency, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM_FAMILY(load_latency, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(search_latency, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM_FAMILY(search_latency, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(range_search_latency, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM_FAMILY(range_search_latency, PROMETHEUS_LABEL_KNOWHERE);
 
-DECLARE_PROMETHEUS_HISTOGRAM(load_latency, PROMETHEUS_LABEL_KNOWHERE);
-DECLARE_PROMETHEUS_HISTOGRAM(load_latency, PROMETHEUS_LABEL_CARDINAL);
+void
+ObserveBuildLatencyByIndexType(const std::string& module, const std::string& index_type, double value);
 
-DECLARE_PROMETHEUS_HISTOGRAM(search_latency, PROMETHEUS_LABEL_KNOWHERE);
-DECLARE_PROMETHEUS_HISTOGRAM(search_latency, PROMETHEUS_LABEL_CARDINAL);
+void
+ObserveLoadLatencyByIndexType(const std::string& module, const std::string& index_type, double value);
 
-// cardinal uses the RangeSearch function of the parent class `IndexNode` (index_node.h).
-// both use the knowhere metric uniformly.
-DECLARE_PROMETHEUS_HISTOGRAM(range_search_latency, PROMETHEUS_LABEL_KNOWHERE);
+void
+ObserveSearchLatencyByIndexType(const std::string& module, const std::string& index_type, double value);
 
-DECLARE_PROMETHEUS_HISTOGRAM(ann_iterator_init_latency, PROMETHEUS_LABEL_KNOWHERE);
-DECLARE_PROMETHEUS_HISTOGRAM(ann_iterator_init_latency, PROMETHEUS_LABEL_CARDINAL);
+void
+ObserveRangeSearchLatencyByIndexType(const std::string& module, const std::string& index_type, double value);
 
-DECLARE_PROMETHEUS_HISTOGRAM(search_topk, PROMETHEUS_LABEL_KNOWHERE);
-DECLARE_PROMETHEUS_HISTOGRAM(search_topk, PROMETHEUS_LABEL_CARDINAL);
+prometheus::Histogram&
+GetPrometheusHistogram(prometheus::Family<prometheus::Histogram>& family, const std::string& module,
+                       const std::string& index_type);
 
-DECLARE_PROMETHEUS_HISTOGRAM(search_emb_list_1st_ann_latency, PROMETHEUS_LABEL_KNOWHERE);
-DECLARE_PROMETHEUS_HISTOGRAM(search_emb_list_1st_ann_latency, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(search_emb_list_2nd_bf_agg_latency, PROMETHEUS_LABEL_KNOWHERE);
-DECLARE_PROMETHEUS_HISTOGRAM(search_emb_list_2nd_bf_agg_latency, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(search_emb_list_retrieval_ann_ratio, PROMETHEUS_LABEL_KNOWHERE);
-DECLARE_PROMETHEUS_HISTOGRAM(search_emb_list_retrieval_ann_ratio, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(ann_iterator_init_latency, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(ann_iterator_init_latency, PROMETHEUS_LABEL_CARDINAL);
 
-DECLARE_PROMETHEUS_HISTOGRAM(search_level, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(bitset_ratio, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(quant_compute_cnt, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(raw_compute_cnt, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(cache_hit_cnt, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(io_cnt, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(queue_latency, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(exec_latency, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(search_topk, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(search_topk, PROMETHEUS_LABEL_CARDINAL);
 
-DECLARE_PROMETHEUS_HISTOGRAM(graph_search_cnt, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(ivf_search_cnt, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(bf_search_cnt, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(re_search_cnt, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(search_emb_list_1st_ann_latency, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(search_emb_list_1st_ann_latency, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(search_emb_list_2nd_bf_agg_latency, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(search_emb_list_2nd_bf_agg_latency, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(search_emb_list_retrieval_ann_ratio, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(search_emb_list_retrieval_ann_ratio, PROMETHEUS_LABEL_CARDINAL);
 
-DECLARE_PROMETHEUS_HISTOGRAM(filter_connectivity_ratio, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(filter_mv_only_cnt, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(filter_mv_activated_fields_cnt, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(filter_mv_change_base_cnt, PROMETHEUS_LABEL_CARDINAL);
-DECLARE_PROMETHEUS_HISTOGRAM(filter_mv_supplement_ep_bool_cnt, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(search_level, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(bitset_ratio, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(quant_compute_cnt, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(raw_compute_cnt, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(cache_hit_cnt, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(io_cnt, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(queue_latency, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(exec_latency, PROMETHEUS_LABEL_CARDINAL);
 
-DECLARE_PROMETHEUS_HISTOGRAM(hnsw_bitset_ratio, PROMETHEUS_LABEL_KNOWHERE);
-DECLARE_PROMETHEUS_HISTOGRAM(hnsw_search_hops, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(graph_search_cnt, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(ivf_search_cnt, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(bf_search_cnt, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(re_search_cnt, PROMETHEUS_LABEL_CARDINAL);
 
-DECLARE_PROMETHEUS_HISTOGRAM(diskann_bitset_ratio, PROMETHEUS_LABEL_KNOWHERE);
-DECLARE_PROMETHEUS_HISTOGRAM(diskann_search_hops, PROMETHEUS_LABEL_KNOWHERE);
-DECLARE_PROMETHEUS_HISTOGRAM(diskann_range_search_iters, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(filter_connectivity_ratio, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(filter_mv_only_cnt, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(filter_mv_activated_fields_cnt, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(filter_mv_change_base_cnt, PROMETHEUS_LABEL_CARDINAL);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(filter_mv_supplement_ep_bool_cnt, PROMETHEUS_LABEL_CARDINAL);
 
-DECLARE_PROMETHEUS_HISTOGRAM_FAMILY(sparse_dataset_nnz_len, PROMETHEUS_LABEL_KNOWHERE);
-DECLARE_PROMETHEUS_HISTOGRAM_FAMILY(sparse_inverted_index_posting_list_len, PROMETHEUS_LABEL_KNOWHERE);
-DECLARE_PROMETHEUS_GAUGE_FAMILY(sparse_inverted_index_size, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(hnsw_bitset_ratio, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(hnsw_search_hops, PROMETHEUS_LABEL_KNOWHERE);
+
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(diskann_bitset_ratio, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(diskann_search_hops, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM(diskann_range_search_iters, PROMETHEUS_LABEL_KNOWHERE);
+
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM_FAMILY(sparse_dataset_nnz_len, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_HISTOGRAM_FAMILY(sparse_inverted_index_posting_list_len, PROMETHEUS_LABEL_KNOWHERE);
+KNOWHERE_DECLARE_PROMETHEUS_GAUGE_FAMILY(sparse_inverted_index_size, PROMETHEUS_LABEL_KNOWHERE);
 }  // namespace knowhere

--- a/src/common/prometheus_client.cc
+++ b/src/common/prometheus_client.cc
@@ -11,6 +11,8 @@
 
 #include "knowhere/prometheus_client.h"
 
+#include "knowhere/comp/index_param.h"
+
 namespace knowhere {
 
 const prometheus::Histogram::BucketBoundaries defaultBuckets = {1,     2,     4,     8,      16,     32,     64,
@@ -21,6 +23,82 @@ const prometheus::Histogram::BucketBoundaries ratioBuckets = {
     0.0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0};
 
 const std::unique_ptr<PrometheusClient> prometheusClient = std::make_unique<PrometheusClient>();
+PrometheusHistogramCache prometheusHistogramCache;
+
+namespace {
+
+const std::vector<std::string>&
+KnownIndexTypes() {
+    static const std::vector<std::string> index_types = {IndexEnum::INDEX_FAISS_BIN_IDMAP,
+                                                         IndexEnum::INDEX_FAISS_BIN_IVFFLAT,
+                                                         IndexEnum::INDEX_FAISS_IDMAP,
+                                                         IndexEnum::INDEX_FAISS_IVFFLAT,
+                                                         IndexEnum::INDEX_FAISS_IVFFLAT_CC,
+                                                         IndexEnum::INDEX_FAISS_IVFPQ,
+                                                         IndexEnum::INDEX_FAISS_SCANN,
+                                                         IndexEnum::INDEX_FAISS_SCANN_DVR,
+                                                         IndexEnum::INDEX_FAISS_IVFSQ8,
+                                                         IndexEnum::INDEX_FAISS_IVFSQ_CC,
+                                                         IndexEnum::INDEX_FAISS_IVFRABITQ,
+                                                         IndexEnum::INDEX_FAISS_GPU_IDMAP,
+                                                         IndexEnum::INDEX_FAISS_GPU_IVFFLAT,
+                                                         IndexEnum::INDEX_FAISS_GPU_IVFPQ,
+                                                         IndexEnum::INDEX_FAISS_GPU_IVFSQ8,
+                                                         IndexEnum::INDEX_CUVS_BRUTEFORCE,
+                                                         IndexEnum::INDEX_CUVS_IVFFLAT,
+                                                         IndexEnum::INDEX_CUVS_IVFPQ,
+                                                         IndexEnum::INDEX_CUVS_CAGRA,
+                                                         IndexEnum::INDEX_GPU_BRUTEFORCE,
+                                                         IndexEnum::INDEX_GPU_IVFFLAT,
+                                                         IndexEnum::INDEX_GPU_IVFPQ,
+                                                         IndexEnum::INDEX_GPU_CAGRA,
+                                                         IndexEnum::INDEX_HNSW,
+                                                         IndexEnum::INDEX_HNSW_SQ,
+                                                         IndexEnum::INDEX_HNSW_PQ,
+                                                         IndexEnum::INDEX_HNSW_PRQ,
+                                                         IndexEnum::INDEX_DISKANN,
+                                                         IndexEnum::INDEX_AISAQ,
+                                                         IndexEnum::INDEX_MINHASH_LSH,
+                                                         IndexEnum::INDEX_SPARSE_INVERTED_INDEX,
+                                                         IndexEnum::INDEX_SPARSE_WAND,
+                                                         IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC,
+                                                         IndexEnum::INDEX_SPARSE_WAND_CC,
+                                                         IndexEnum::INDEX_CARDINAL_TIERED};
+    return index_types;
+}
+
+}  // namespace
+
+void
+PrometheusHistogramCache::RegisterMetrics(prometheus::Family<prometheus::Histogram>& family, const std::string& module,
+                                          const std::vector<std::string>& index_types,
+                                          const prometheus::Histogram::BucketBoundaries& buckets) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto& index_type : index_types) {
+        const auto key = module + '\n' + index_type + '\n' + std::to_string(reinterpret_cast<uintptr_t>(&family));
+        if (metrics_.find(key) != metrics_.end()) {
+            continue;
+        }
+        auto& metric = family.Add({{"module", module}, {"index_type", index_type}}, buckets);
+        metrics_.emplace(key, &metric);
+    }
+}
+
+prometheus::Histogram&
+PrometheusHistogramCache::GetMetric(prometheus::Family<prometheus::Histogram>& family, const std::string& module,
+                                    const std::string& index_type,
+                                    const prometheus::Histogram::BucketBoundaries& buckets) {
+    const auto key = module + '\n' + index_type + '\n' + std::to_string(reinterpret_cast<uintptr_t>(&family));
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = metrics_.find(key);
+    if (it != metrics_.end()) {
+        return *(it->second);
+    }
+
+    auto& metric = family.Add({{"module", module}, {"index_type", index_type}}, buckets);
+    metrics_.emplace(key, &metric);
+    return metric;
+}
 
 /*******************************************************************************
  * !!! NOT use SUMMARY metrics here, because when parse SUMMARY metrics in Milvus,
@@ -29,113 +107,148 @@ const std::unique_ptr<PrometheusClient> prometheusClient = std::make_unique<Prom
  *   An error has occurred while serving metrics:
  *   text format parsing error in line 50: expected float as value, got "=\"0.9\"}"
  ******************************************************************************/
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(build_latency, "index build latency (s)")
-DEFINE_PROMETHEUS_HISTOGRAM(build_latency, PROMETHEUS_LABEL_KNOWHERE)
-DEFINE_PROMETHEUS_HISTOGRAM(build_latency, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(build_latency, "index build latency (s)")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(build_latency, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(load_latency, "index load latency (ms)")
-DEFINE_PROMETHEUS_HISTOGRAM(load_latency, PROMETHEUS_LABEL_KNOWHERE)
-DEFINE_PROMETHEUS_HISTOGRAM(load_latency, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(load_latency, "index load latency (ms)")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(load_latency, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(search_latency, "search latency (ms)")
-DEFINE_PROMETHEUS_HISTOGRAM(search_latency, PROMETHEUS_LABEL_KNOWHERE)
-DEFINE_PROMETHEUS_HISTOGRAM(search_latency, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(search_latency, "search latency (ms)")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(search_latency, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(range_search_latency, "range search latency (ms)")
-DEFINE_PROMETHEUS_HISTOGRAM(range_search_latency, PROMETHEUS_LABEL_KNOWHERE)
-DEFINE_PROMETHEUS_HISTOGRAM(range_search_latency, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(range_search_latency, "range search latency (ms)")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(range_search_latency, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(ann_iterator_init_latency, "ann iterator init latency (ms)")
-DEFINE_PROMETHEUS_HISTOGRAM(ann_iterator_init_latency, PROMETHEUS_LABEL_KNOWHERE)
-DEFINE_PROMETHEUS_HISTOGRAM(ann_iterator_init_latency, PROMETHEUS_LABEL_CARDINAL)
+const int preregister_index_type_metrics = []() {
+    const auto& known_index_types = KnownIndexTypes();
+    prometheusHistogramCache.RegisterMetrics(build_latency_family, "knowhere", known_index_types, defaultBuckets);
+    prometheusHistogramCache.RegisterMetrics(load_latency_family, "knowhere", known_index_types, defaultBuckets);
+    prometheusHistogramCache.RegisterMetrics(search_latency_family, "knowhere", known_index_types, defaultBuckets);
+    prometheusHistogramCache.RegisterMetrics(range_search_latency_family, "knowhere", known_index_types,
+                                             defaultBuckets);
+    return 0;
+}();
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(search_topk, "search topk")
-DEFINE_PROMETHEUS_HISTOGRAM(search_topk, PROMETHEUS_LABEL_KNOWHERE)
-DEFINE_PROMETHEUS_HISTOGRAM(search_topk, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(ann_iterator_init_latency, "ann iterator init latency (ms)")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(ann_iterator_init_latency, PROMETHEUS_LABEL_KNOWHERE)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(ann_iterator_init_latency, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(search_emb_list_1st_ann_latency, "emb_list search 1st ann latency (ms)")
-DEFINE_PROMETHEUS_HISTOGRAM(search_emb_list_1st_ann_latency, PROMETHEUS_LABEL_KNOWHERE)
-DEFINE_PROMETHEUS_HISTOGRAM(search_emb_list_1st_ann_latency, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(search_topk, "search topk")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(search_topk, PROMETHEUS_LABEL_KNOWHERE)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(search_topk, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(search_emb_list_2nd_bf_agg_latency, "emb_list search 2nd bf and agg latency (ms)")
-DEFINE_PROMETHEUS_HISTOGRAM(search_emb_list_2nd_bf_agg_latency, PROMETHEUS_LABEL_KNOWHERE)
-DEFINE_PROMETHEUS_HISTOGRAM(search_emb_list_2nd_bf_agg_latency, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(search_emb_list_1st_ann_latency, "emb_list search 1st ann latency (ms)")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(search_emb_list_1st_ann_latency, PROMETHEUS_LABEL_KNOWHERE)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(search_emb_list_1st_ann_latency, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(search_emb_list_retrieval_ann_ratio,
-                                   "retrieval ann ratio of emb_list search (default 3.0)")
-DEFINE_PROMETHEUS_HISTOGRAM(search_emb_list_retrieval_ann_ratio, PROMETHEUS_LABEL_KNOWHERE)
-DEFINE_PROMETHEUS_HISTOGRAM(search_emb_list_retrieval_ann_ratio, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(search_emb_list_2nd_bf_agg_latency,
+                                            "emb_list search 2nd bf and agg latency (ms)")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(search_emb_list_2nd_bf_agg_latency, PROMETHEUS_LABEL_KNOWHERE)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(search_emb_list_2nd_bf_agg_latency, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(search_level, "search level")
-DEFINE_PROMETHEUS_HISTOGRAM(search_level, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(search_emb_list_retrieval_ann_ratio,
+                                            "retrieval ann ratio of emb_list search (default 3.0)")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(search_emb_list_retrieval_ann_ratio, PROMETHEUS_LABEL_KNOWHERE)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(search_emb_list_retrieval_ann_ratio, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(bitset_ratio, "bitset ratio")
-DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(bitset_ratio, PROMETHEUS_LABEL_CARDINAL, ratioBuckets)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(search_level, "search level")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(search_level, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(quant_compute_cnt, "quant compute cnt per request")
-DEFINE_PROMETHEUS_HISTOGRAM(quant_compute_cnt, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(bitset_ratio, "bitset ratio")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(bitset_ratio, PROMETHEUS_LABEL_CARDINAL, ratioBuckets)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(raw_compute_cnt, "raw compute cnt per request")
-DEFINE_PROMETHEUS_HISTOGRAM(raw_compute_cnt, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(quant_compute_cnt, "quant compute cnt per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(quant_compute_cnt, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(cache_hit_cnt, "cache hit cnt per request")
-DEFINE_PROMETHEUS_HISTOGRAM(cache_hit_cnt, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(raw_compute_cnt, "raw compute cnt per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(raw_compute_cnt, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(io_cnt, "io cnt per request")
-DEFINE_PROMETHEUS_HISTOGRAM(io_cnt, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(cache_hit_cnt, "cache hit cnt per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(cache_hit_cnt, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(queue_latency, "queue latency per request")
-DEFINE_PROMETHEUS_HISTOGRAM(queue_latency, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(io_cnt, "io cnt per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(io_cnt, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(exec_latency, "execute latency per request")
-DEFINE_PROMETHEUS_HISTOGRAM(exec_latency, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(queue_latency, "queue latency per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(queue_latency, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(graph_search_cnt, "number of graph search per request")
-DEFINE_PROMETHEUS_HISTOGRAM(graph_search_cnt, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(exec_latency, "execute latency per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(exec_latency, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(ivf_search_cnt, "number of ivf search per request")
-DEFINE_PROMETHEUS_HISTOGRAM(ivf_search_cnt, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(graph_search_cnt, "number of graph search per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(graph_search_cnt, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(bf_search_cnt, "number of bf search per request")
-DEFINE_PROMETHEUS_HISTOGRAM(bf_search_cnt, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(ivf_search_cnt, "number of ivf search per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(ivf_search_cnt, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(re_search_cnt, "number of fallback search per request")
-DEFINE_PROMETHEUS_HISTOGRAM(re_search_cnt, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(bf_search_cnt, "number of bf search per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(bf_search_cnt, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(filter_connectivity_ratio, "avg connectivity ratio set under filtering per request")
-DEFINE_PROMETHEUS_HISTOGRAM(filter_connectivity_ratio, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(re_search_cnt, "number of fallback search per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(re_search_cnt, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(filter_mv_only_cnt, "mv only cnt per request")
-DEFINE_PROMETHEUS_HISTOGRAM(filter_mv_only_cnt, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(filter_connectivity_ratio,
+                                            "avg connectivity ratio set under filtering per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(filter_connectivity_ratio, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(filter_mv_activated_fields_cnt, "avg mv activated fields per request")
-DEFINE_PROMETHEUS_HISTOGRAM(filter_mv_activated_fields_cnt, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(filter_mv_only_cnt, "mv only cnt per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(filter_mv_only_cnt, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(filter_mv_change_base_cnt, "mv change base cnt per request")
-DEFINE_PROMETHEUS_HISTOGRAM(filter_mv_change_base_cnt, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(filter_mv_activated_fields_cnt, "avg mv activated fields per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(filter_mv_activated_fields_cnt, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(filter_mv_supplement_ep_bool_cnt,
-                                   "mv supplement ep from bitset boolean cnt per request")
-DEFINE_PROMETHEUS_HISTOGRAM(filter_mv_supplement_ep_bool_cnt, PROMETHEUS_LABEL_CARDINAL)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(filter_mv_change_base_cnt, "mv change base cnt per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(filter_mv_change_base_cnt, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(hnsw_bitset_ratio, "HNSW bitset ratio for search and range search")
-DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(hnsw_bitset_ratio, PROMETHEUS_LABEL_KNOWHERE, ratioBuckets)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(filter_mv_supplement_ep_bool_cnt,
+                                            "mv supplement ep from bitset boolean cnt per request")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(filter_mv_supplement_ep_bool_cnt, PROMETHEUS_LABEL_CARDINAL)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(hnsw_search_hops, "HNSW search hops in layer 0")
-DEFINE_PROMETHEUS_HISTOGRAM(hnsw_search_hops, PROMETHEUS_LABEL_KNOWHERE)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(hnsw_bitset_ratio, "HNSW bitset ratio for search and range search")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(hnsw_bitset_ratio, PROMETHEUS_LABEL_KNOWHERE, ratioBuckets)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(diskann_bitset_ratio, "DISKANN bitset ratio for search and range search")
-DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(diskann_bitset_ratio, PROMETHEUS_LABEL_KNOWHERE, ratioBuckets)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(hnsw_search_hops, "HNSW search hops in layer 0")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(hnsw_search_hops, PROMETHEUS_LABEL_KNOWHERE)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(diskann_search_hops, "DISKANN search hops")
-DEFINE_PROMETHEUS_HISTOGRAM(diskann_search_hops, PROMETHEUS_LABEL_KNOWHERE)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(diskann_bitset_ratio, "DISKANN bitset ratio for search and range search")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(diskann_bitset_ratio, PROMETHEUS_LABEL_KNOWHERE, ratioBuckets)
+
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(diskann_search_hops, "DISKANN search hops")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM(diskann_search_hops, PROMETHEUS_LABEL_KNOWHERE)
 
 const prometheus::Histogram::BucketBoundaries diskannRangeSearchIterBuckets = {2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22};
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(diskann_range_search_iters, "DISKANN range search iterations")
-DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(diskann_range_search_iters, PROMETHEUS_LABEL_KNOWHERE,
-                                         diskannRangeSearchIterBuckets)
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(diskann_range_search_iters, "DISKANN range search iterations")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(diskann_range_search_iters, PROMETHEUS_LABEL_KNOWHERE,
+                                                  diskannRangeSearchIterBuckets)
 
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(sparse_dataset_nnz_len, "sparse dataset nnz length")
-DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(sparse_inverted_index_posting_list_len, "sparse inverted index posting list length")
-DEFINE_PROMETHEUS_GAUGE_FAMILY(sparse_inverted_index_size, "sparse inverted index size (MB)")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(sparse_dataset_nnz_len, "sparse dataset nnz length")
+KNOWHERE_DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(sparse_inverted_index_posting_list_len,
+                                            "sparse inverted index posting list length")
+KNOWHERE_DEFINE_PROMETHEUS_GAUGE_FAMILY(sparse_inverted_index_size, "sparse inverted index size (MB)")
+
+void
+ObserveBuildLatencyByIndexType(const std::string& module, const std::string& index_type, double value) {
+    GetPrometheusHistogram(build_latency_family, module, index_type).Observe(value);
+}
+
+void
+ObserveLoadLatencyByIndexType(const std::string& module, const std::string& index_type, double value) {
+    GetPrometheusHistogram(load_latency_family, module, index_type).Observe(value);
+}
+
+void
+ObserveSearchLatencyByIndexType(const std::string& module, const std::string& index_type, double value) {
+    GetPrometheusHistogram(search_latency_family, module, index_type).Observe(value);
+}
+
+void
+ObserveRangeSearchLatencyByIndexType(const std::string& module, const std::string& index_type, double value) {
+    GetPrometheusHistogram(range_search_latency_family, module, index_type).Observe(value);
+}
+
+prometheus::Histogram&
+GetPrometheusHistogram(prometheus::Family<prometheus::Histogram>& family, const std::string& module,
+                       const std::string& index_type) {
+    return prometheusHistogramCache.GetMetric(family, module, index_type, defaultBuckets);
+}
 }  // namespace knowhere

--- a/src/common/prometheus_client.cc
+++ b/src/common/prometheus_client.cc
@@ -40,6 +40,7 @@ KnownIndexTypes() {
                                                          IndexEnum::INDEX_FAISS_IVFSQ8,
                                                          IndexEnum::INDEX_FAISS_IVFSQ_CC,
                                                          IndexEnum::INDEX_FAISS_IVFRABITQ,
+                                                         IndexEnum::INDEX_FAISS_IVFRABITQ_FASTSCAN,
                                                          IndexEnum::INDEX_FAISS_GPU_IDMAP,
                                                          IndexEnum::INDEX_FAISS_GPU_IVFFLAT,
                                                          IndexEnum::INDEX_FAISS_GPU_IVFPQ,

--- a/src/index/data_view_dense_index/data_view_index_config.h
+++ b/src/index/data_view_dense_index/data_view_index_config.h
@@ -55,7 +55,7 @@ namespace knowhere {
 class IndexWithDataViewRefinerBaseConfig : public BaseConfig {
  public:
     DECLARE_DATA_VIEW_REFINER_MEMBERS()
-    KNOHWERE_DECLARE_CONFIG(IndexWithDataViewRefinerBaseConfig) {
+    KNOWHERE_DECLARE_CONFIG(IndexWithDataViewRefinerBaseConfig) {
         REGISTER_DATA_VIEW_REFINER_CONFIG()
     }
 };
@@ -63,7 +63,7 @@ class IndexWithDataViewRefinerBaseConfig : public BaseConfig {
 class ScannWithDataViewRefinerConfig : public ScannConfig {
  public:
     DECLARE_DATA_VIEW_REFINER_MEMBERS()
-    KNOHWERE_DECLARE_CONFIG(ScannWithDataViewRefinerConfig){REGISTER_DATA_VIEW_REFINER_CONFIG()}
+    KNOWHERE_DECLARE_CONFIG(ScannWithDataViewRefinerConfig){REGISTER_DATA_VIEW_REFINER_CONFIG()}
 
     Status CheckAndAdjust(PARAM_TYPE param_type, std::string* err_msg) override {
         if (!faiss::cppcontrib::knowhere::support_pq_fast_scan) {

--- a/src/index/diskann/aisaq_config.h
+++ b/src/index/diskann/aisaq_config.h
@@ -28,7 +28,7 @@ class AisaqConfig : public DiskANNConfig {
     // number of entry points valid only with aisaq option.
     CFG_INT num_entry_points;
 
-    KNOHWERE_DECLARE_CONFIG(AisaqConfig) {
+    KNOWHERE_DECLARE_CONFIG(AisaqConfig) {
         // Block AiSAQ parameters
 
         KNOWHERE_CONFIG_DECLARE_FIELD(vectors_beamwidth)

--- a/src/index/diskann/diskann_config.h
+++ b/src/index/diskann/diskann_config.h
@@ -83,7 +83,7 @@ class DiskANNConfig : public BaseConfig {
     // value should be in range of [0.0, 1.0] which means when greater or equal to x% of the bits are set,
     // use PQ + Refine. Default to -1.0f, negative vlaues will use dynamic threshold calculator given topk.
     CFG_FLOAT filter_threshold;
-    KNOHWERE_DECLARE_CONFIG(DiskANNConfig) {
+    KNOWHERE_DECLARE_CONFIG(DiskANNConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(max_degree)
             .description("the degree of the graph index.")
             .set_default(48)

--- a/src/index/gpu/flat_gpu/flat_gpu_config.h
+++ b/src/index/gpu/flat_gpu/flat_gpu_config.h
@@ -19,7 +19,7 @@ namespace knowhere {
 class GpuFlatConfig : public FlatConfig {
  public:
     CFG_INT gpu_id;
-    KNOHWERE_DECLARE_CONFIG(GpuFlatConfig) {
+    KNOWHERE_DECLARE_CONFIG(GpuFlatConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(gpu_id).description("gpu device id").set_default(0).for_train();
     }
 };

--- a/src/index/gpu/ivf_gpu/ivf_gpu_config.h
+++ b/src/index/gpu/ivf_gpu/ivf_gpu_config.h
@@ -16,7 +16,7 @@ namespace knowhere {
 class GpuIvfFlatConfig : public IvfFlatConfig {
  public:
     CFG_INT gpu_id;
-    KNOHWERE_DECLARE_CONFIG(GpuIvfFlatConfig) {
+    KNOWHERE_DECLARE_CONFIG(GpuIvfFlatConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(gpu_id).description("gpu device id").set_default(0).for_train();
     }
 };
@@ -24,7 +24,7 @@ class GpuIvfFlatConfig : public IvfFlatConfig {
 class GpuIvfPqConfig : public IvfPqConfig {
  public:
     CFG_INT gpu_id;
-    KNOHWERE_DECLARE_CONFIG(GpuIvfPqConfig) {
+    KNOWHERE_DECLARE_CONFIG(GpuIvfPqConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(gpu_id).description("gpu device id").set_default(0).for_train();
     }
 };
@@ -32,7 +32,7 @@ class GpuIvfPqConfig : public IvfPqConfig {
 class GpuIvfSqConfig : public IvfSqConfig {
  public:
     CFG_INT gpu_id;
-    KNOHWERE_DECLARE_CONFIG(GpuIvfSqConfig) {
+    KNOWHERE_DECLARE_CONFIG(GpuIvfSqConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(gpu_id).description("gpu device id").set_default(0).for_train();
     }
 };

--- a/src/index/gpu_cuvs/gpu_cuvs_cagra_config.h
+++ b/src/index/gpu_cuvs/gpu_cuvs_cagra_config.h
@@ -52,7 +52,7 @@ struct GpuCuvsCagraConfig : public BaseConfig {
     CFG_INT ef;
     CFG_BOOL persistent;
 
-    KNOHWERE_DECLARE_CONFIG(GpuCuvsCagraConfig) {
+    KNOWHERE_DECLARE_CONFIG(GpuCuvsCagraConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(cache_dataset_on_device)
             .set_default(false)
             .description("cache dataset on device for refinement")

--- a/src/index/gpu_cuvs/gpu_cuvs_ivf_flat_config.h
+++ b/src/index/gpu_cuvs/gpu_cuvs_ivf_flat_config.h
@@ -30,7 +30,7 @@ struct GpuCuvsIvfFlatConfig : public IvfFlatConfig {
     CFG_INT kmeans_n_iters;
     CFG_FLOAT kmeans_trainset_fraction;
     CFG_BOOL adaptive_centers;
-    KNOHWERE_DECLARE_CONFIG(GpuCuvsIvfFlatConfig) {
+    KNOWHERE_DECLARE_CONFIG(GpuCuvsIvfFlatConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(cache_dataset_on_device)
             .set_default(false)
             .description("cache dataset on device for refinement")

--- a/src/index/gpu_cuvs/gpu_cuvs_ivf_pq_config.h
+++ b/src/index/gpu_cuvs/gpu_cuvs_ivf_pq_config.h
@@ -37,7 +37,7 @@ struct GpuCuvsIvfPqConfig : public IvfPqConfig {
     CFG_STRING internal_distance_dtype;
     CFG_FLOAT preferred_shmem_carveout;
 
-    KNOHWERE_DECLARE_CONFIG(GpuCuvsIvfPqConfig) {
+    KNOWHERE_DECLARE_CONFIG(GpuCuvsIvfPqConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(cache_dataset_on_device)
             .set_default(false)
             .description("cache dataset on device for refinement")

--- a/src/index/hnsw/base_hnsw_config.h
+++ b/src/index/hnsw/base_hnsw_config.h
@@ -33,7 +33,7 @@ class BaseHnswConfig : public BaseConfig {
     CFG_INT overview_levels;
     CFG_BOOL disable_fallback_brute_force;  // default is false, means we will use fallback brute force when hnsw search
                                             // does not get enough topk results
-    KNOHWERE_DECLARE_CONFIG(BaseHnswConfig) {
+    KNOWHERE_DECLARE_CONFIG(BaseHnswConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(M).description("hnsw M").set_default(30).set_range(2, 2048).for_train();
         KNOWHERE_CONFIG_DECLARE_FIELD(efConstruction)
             .description("hnsw efConstruction")

--- a/src/index/hnsw/faiss_hnsw_config.h
+++ b/src/index/hnsw/faiss_hnsw_config.h
@@ -30,7 +30,7 @@ class FaissHnswConfig : public BaseHnswConfig {
     // type of refine
     CFG_STRING refine_type;
 
-    KNOHWERE_DECLARE_CONFIG(FaissHnswConfig) {
+    KNOWHERE_DECLARE_CONFIG(FaissHnswConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(seed_ef)
             .description("hnsw seed_ef when using iterator")
             .set_default(kIteratorSeedEf)
@@ -97,7 +97,7 @@ class FaissHnswSqConfig : public FaissHnswConfig {
     // user can use quant_type to control quantizer type.
     // we have fp16, bf16, etc, so '8', '4' and '6' is insufficient
     CFG_STRING sq_type;
-    KNOHWERE_DECLARE_CONFIG(FaissHnswSqConfig) {
+    KNOWHERE_DECLARE_CONFIG(FaissHnswSqConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(sq_type)
             .set_default("SQ8")
             .description("scalar quantizer type")
@@ -157,7 +157,7 @@ class FaissHnswPqConfig : public FaissHnswConfig {
     // number of bits per subquantizer
     CFG_INT nbits;
 
-    KNOHWERE_DECLARE_CONFIG(FaissHnswPqConfig) {
+    KNOWHERE_DECLARE_CONFIG(FaissHnswPqConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(m).description("m").set_default(32).for_train().set_range(1, 65536);
         // FAISS rejects nbits > 24, because it is not practical
         KNOWHERE_CONFIG_DECLARE_FIELD(nbits).description("nbits").set_default(8).for_train().set_range(1, 24);
@@ -203,7 +203,7 @@ class FaissHnswPrqConfig : public FaissHnswConfig {
     CFG_INT nrq;
     // number of bits per subquantizer
     CFG_INT nbits;
-    KNOHWERE_DECLARE_CONFIG(FaissHnswPrqConfig) {
+    KNOWHERE_DECLARE_CONFIG(FaissHnswPrqConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(m).description("Number of splits").set_default(2).for_train().set_range(1, 65536);
         // I'm not sure whether nrq > 16 is practical
         KNOWHERE_CONFIG_DECLARE_FIELD(nrq)

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -51,7 +51,7 @@ Index<T>::BuildAsync(const DataSetPtr dataset, const Json& json, const std::chro
         auto res = this->node->BulidAsyncEmbListIfNeed(dataset, std::move(cfg), interrupt.get());
         auto time = rc.ElapseFromBegin("done");
         time *= 0.000001;  // convert to s
-        knowhere_build_latency.Observe(time);
+        this->node->GetBuildLatencyMetric().Observe(time);
 #else
         auto res = this->node->BulidAsyncEmbListIfNeed(dataset, std::move(cfg), Interrupt.get());
 #endif
@@ -81,7 +81,7 @@ Index<T>::Build(const DataSetPtr dataset, const Json& json, bool use_knowhere_bu
     auto res = this->node->BuildEmbListIfNeed(dataset, std::move(cfg), use_knowhere_build_pool);
     auto time = rc.ElapseFromBegin("done");
     time *= 0.000001;  // convert to s
-    knowhere_build_latency.Observe(time);
+    this->node->GetBuildLatencyMetric().Observe(time);
 #else
     auto res = this->node->BuildEmbListIfNeed(dataset, std::move(cfg), use_knowhere_build_pool);
 #endif
@@ -167,7 +167,7 @@ Index<T>::Search(const DataSetPtr dataset, const Json& json, const BitsetView& b
     auto res = this->node->SearchEmbListIfNeed(dataset, std::move(cfg), bitset, op_context);
     auto time = rc.ElapseFromBegin("done");
     time *= 0.001;  // convert to ms
-    knowhere_search_latency.Observe(time);
+    this->node->GetSearchLatencyMetric().Observe(time);
     knowhere_search_topk.Observe(k);
 
     // LCOV_EXCL_START
@@ -211,7 +211,7 @@ Index<T>::AnnIterator(const DataSetPtr dataset, const Json& json, const BitsetVi
         this->node->AnnIteratorEmbListIfNeed(dataset, std::move(cfg), bitset, use_knowhere_search_pool, op_context);
     auto time = rc.ElapseFromBegin("done");
     time *= 0.001;  // convert to ms
-    knowhere_search_latency.Observe(time);
+    this->node->GetSearchLatencyMetric().Observe(time);
 #else
     auto res =
         this->node->AnnIteratorEmbListIfNeed(dataset, std::move(cfg), bitset, use_knowhere_search_pool, op_context);
@@ -268,7 +268,7 @@ Index<T>::RangeSearch(const DataSetPtr dataset, const Json& json, const BitsetVi
     auto res = this->node->RangeSearchEmbListIfNeed(dataset, std::move(cfg), bitset, op_context);
     auto time = rc.ElapseFromBegin("done");
     time *= 0.001;  // convert to ms
-    knowhere_range_search_latency.Observe(time);
+    this->node->GetRangeSearchLatencyMetric().Observe(time);
 
     // LCOV_EXCL_START
     if (has_trace_id) {
@@ -359,7 +359,7 @@ Index<T>::Deserialize(const BinarySet& binset, const Json& json) {
     res = this->node->DeserializeEmbListIfNeed(binset, std::move(cfg));
     auto time = rc.ElapseFromBegin("done");
     time *= 0.001;  // convert to ms
-    knowhere_load_latency.Observe(time);
+    this->node->GetLoadLatencyMetric().Observe(time);
 #else
     res = this->node->DeserializeEmbListIfNeed(binset, std::move(cfg));
 #endif
@@ -388,7 +388,7 @@ Index<T>::DeserializeFromFile(const std::string& filename, const Json& json) {
     res = this->node->DeserializeFromFileIfNeed(filename, std::move(cfg));
     auto time = rc.ElapseFromBegin("done");
     time *= 0.001;  // convert to ms
-    knowhere_load_latency.Observe(time);
+    this->node->GetLoadLatencyMetric().Observe(time);
 #else
     res = this->node->DeserializeFromFileIfNeed(filename, std::move(cfg));
 #endif

--- a/src/index/ivf/ivf_config.h
+++ b/src/index/ivf/ivf_config.h
@@ -29,7 +29,7 @@ class IvfConfig : public BaseConfig {
     CFG_BOOL use_elkan;
     CFG_BOOL ensure_topk_full;  // internal config, used for temp index
     CFG_INT max_empty_result_buckets;
-    KNOHWERE_DECLARE_CONFIG(IvfConfig) {
+    KNOWHERE_DECLARE_CONFIG(IvfConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(nlist)
             .description("number of inverted lists.")
             .set_default(128)
@@ -92,7 +92,7 @@ class IvfFlatConfig : public IvfConfig {};
 class IvfFlatCcConfig : public IvfFlatConfig {
  public:
     CFG_INT ssize;
-    KNOHWERE_DECLARE_CONFIG(IvfFlatCcConfig) {
+    KNOWHERE_DECLARE_CONFIG(IvfFlatCcConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(ssize)
             .description("segment size")
             .set_default(48)
@@ -112,7 +112,7 @@ class IvfPqConfig : public IvfConfig {
     CFG_FLOAT refine_k;
     // type of refine
     CFG_STRING refine_type;
-    KNOHWERE_DECLARE_CONFIG(IvfPqConfig) {
+    KNOWHERE_DECLARE_CONFIG(IvfPqConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(m).description("m").for_train().set_range(1, 65536);
         // FAISS rejects nbits > 24, because it is not practical
         KNOWHERE_CONFIG_DECLARE_FIELD(nbits).description("nbits").set_default(8).for_train().set_range(1, 24);
@@ -174,7 +174,7 @@ class ScannConfig : public IvfFlatConfig {
     CFG_BOOL with_raw_data;
     CFG_INT sub_dim;
     CFG_BOOL ensure_topk_full;
-    KNOHWERE_DECLARE_CONFIG(ScannConfig) {
+    KNOWHERE_DECLARE_CONFIG(ScannConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(reorder_k)
             .description("reorder k used for refining")
             .allow_empty_without_default()
@@ -254,7 +254,7 @@ class IvfSqConfig : public IvfConfig {
     CFG_FLOAT refine_k;
     // type of refine
     CFG_STRING refine_type;
-    KNOHWERE_DECLARE_CONFIG(IvfSqConfig) {
+    KNOWHERE_DECLARE_CONFIG(IvfSqConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(sq_type)
             .description("the type of sq")
             .set_default("SQ8")
@@ -331,7 +331,7 @@ class IvfSqCcConfig : public IvfFlatCcConfig {
     // cc index is a just-in-time index, raw data is avaliable after training if raw_data_store_prefix has value.
     // ivf sq cc index will not keep raw data after using binaryset to create a new ivf sq cc index.
     CFG_STRING raw_data_store_prefix;
-    KNOHWERE_DECLARE_CONFIG(IvfSqCcConfig) {
+    KNOWHERE_DECLARE_CONFIG(IvfSqCcConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(code_size)
             .set_default(8)
             .description("code size, range in [4, 6, 8 and 16]")
@@ -370,7 +370,7 @@ class IvfRaBitQConfig : public IvfConfig {
     // the value `0` means that the query won't be quantized and will
     //   be processed as is.
     CFG_INT rbq_bits_query;
-    KNOHWERE_DECLARE_CONFIG(IvfRaBitQConfig) {
+    KNOWHERE_DECLARE_CONFIG(IvfRaBitQConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(rbq_bits_query)
             .description("rbq_bits_query")
             .set_default(0)
@@ -435,7 +435,7 @@ class IvfRaBitQFastScanConfig : public IvfConfig {
     // Declared so that passing rbq_bits_query > 0 is caught and rejected
     // rather than silently ignored. FastScan always uses qb=8 internally.
     CFG_INT rbq_bits_query;
-    KNOHWERE_DECLARE_CONFIG(IvfRaBitQFastScanConfig) {
+    KNOWHERE_DECLARE_CONFIG(IvfRaBitQFastScanConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(rbq_bits_query)
             .description("not supported on IVF_RABITQ_FASTSCAN; must be 0 or omitted")
             .set_default(0)

--- a/src/index/minhash/minhash_lsh_config.h
+++ b/src/index/minhash/minhash_lsh_config.h
@@ -25,7 +25,7 @@ class MinHashLSHConfig : public BaseConfig {
     CFG_BOOL with_raw_data;
     CFG_INT refine_k;
     CFG_BOOL mh_lsh_batch_search;
-    KNOHWERE_DECLARE_CONFIG(MinHashLSHConfig) {
+    KNOWHERE_DECLARE_CONFIG(MinHashLSHConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(mh_lsh_aligned_block_size)
             .description("decide the data format in file")
             .set_default(4096)

--- a/src/index/sparse/block_inverted_index.h
+++ b/src/index/sparse/block_inverted_index.h
@@ -705,7 +705,7 @@ BlockInvertedIndex<DType, QType, MetricType>::add(const SparseRow<DType>* data, 
     this->nr_rows_ = rows;
     this->max_dim_ = dim;
 
-#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOHWERE_WITH_LIGHT)
+#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
     this->build_stats_.dataset_nnz_stats_.resize(rows);
 #endif
 
@@ -722,12 +722,12 @@ BlockInvertedIndex<DType, QType, MetricType>::add(const SparseRow<DType>* data, 
             plist_cnts[this->dim_map_[dim]]++;
             ++total_nnz;
         }
-#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOHWERE_WITH_LIGHT)
+#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
         this->build_stats_.dataset_nnz_stats_[i] = data[i].size();
 #endif
     }
 
-#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOHWERE_WITH_LIGHT)
+#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
     this->build_stats_.posting_list_length_stats_.resize(this->nr_inner_dims_);
     for (size_t i = 0; i < this->nr_inner_dims_; ++i) {
         this->build_stats_.posting_list_length_stats_[i] = plist_cnts[i];

--- a/src/index/sparse/flatten_inverted_index.h
+++ b/src/index/sparse/flatten_inverted_index.h
@@ -465,7 +465,7 @@ FlattenInvertedIndex<DType, QType>::add(const SparseRow<DType>* data, size_t row
     this->nr_rows_ = rows;
     this->max_dim_ = dim;
 
-#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOHWERE_WITH_LIGHT)
+#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
     this->build_stats_.dataset_nnz_stats_.resize(rows);
 #endif
 
@@ -482,12 +482,12 @@ FlattenInvertedIndex<DType, QType>::add(const SparseRow<DType>* data, size_t row
             plist_cnts[this->dim_map_[dim]]++;
             ++total_nnz;
         }
-#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOHWERE_WITH_LIGHT)
+#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
         this->build_stats_.dataset_nnz_stats_[i] = data[i].size();
 #endif
     }
 
-#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOHWERE_WITH_LIGHT)
+#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
     this->build_stats_.posting_list_length_stats_.resize(this->nr_inner_dims_);
     for (size_t i = 0; i < this->nr_inner_dims_; ++i) {
         this->build_stats_.posting_list_length_stats_[i] = plist_cnts[i];
@@ -604,7 +604,7 @@ FlattenInvertedIndex<DType, QType>::serialize(MemoryIOWriter& writer) const {
     nr_sections += ((this->meta_data_.flags_ & InvertedIndexMetaData::FLAG_HAS_ROW_SUMS) != 0) +
                    ((this->meta_data_.flags_ & InvertedIndexMetaData::FLAG_HAS_MAX_SCORES_PER_DIM) != 0) +
                    ((this->meta_data_.flags_ & InvertedIndexMetaData::FLAG_HAS_BLOCK_MAX_SCORES) != 0);
-#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOHWERE_WITH_LIGHT)
+#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
     // use a section to store some build stats for prometheus
     nr_sections += 1;
 #endif
@@ -649,7 +649,7 @@ FlattenInvertedIndex<DType, QType>::serialize(MemoryIOWriter& writer) const {
         curr_section_idx++;
     }
 
-#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOHWERE_WITH_LIGHT)
+#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
     section_headers[curr_section_idx].type = InvertedIndexSectionType::PROMETHEUS_BUILD_STATS;
     section_headers[curr_section_idx].offset = used_offset;
     section_headers[curr_section_idx].size =
@@ -693,7 +693,7 @@ FlattenInvertedIndex<DType, QType>::serialize(MemoryIOWriter& writer) const {
     }
 
     // write prometheus build stats
-#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOHWERE_WITH_LIGHT)
+#if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
     writer.write(this->build_stats_.dataset_nnz_stats_.data(), sizeof(uint32_t), this->nr_rows_);
     writer.write(this->build_stats_.posting_list_length_stats_.data(), sizeof(uint32_t), this->nr_inner_dims_);
 #endif

--- a/src/index/sparse/sparse_index_config.h
+++ b/src/index/sparse/sparse_index_config.h
@@ -42,7 +42,7 @@ class SparseInvertedIndexConfig : public BaseConfig {
     CFG_STRING quant_type;
     CFG_INT sindi_window_size;
 
-    KNOHWERE_DECLARE_CONFIG(SparseInvertedIndexConfig) {
+    KNOWHERE_DECLARE_CONFIG(SparseInvertedIndexConfig) {
         // NOTE: drop_ratio_build has been deprecated, it won't change anything
         KNOWHERE_CONFIG_DECLARE_FIELD(drop_ratio_build)
             .description("drop ratio for build")

--- a/tests/ut/test_config.cc
+++ b/tests/ut/test_config.cc
@@ -661,7 +661,7 @@ TEST_CASE("Test config load", "[BOOL]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_BOOL bool_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(bool_val).description("bool field for test").for_train_and_search();
             }
         };
@@ -691,7 +691,7 @@ TEST_CASE("Test config load", "[BOOL]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_BOOL bool_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(bool_val)
                     .description("bool field for test")
                     .allow_empty_without_default()
@@ -724,7 +724,7 @@ TEST_CASE("Test config load", "[BOOL]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_BOOL bool_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(bool_val)
                     .description("bool field for test")
                     .set_default(true)
@@ -763,7 +763,7 @@ TEST_CASE("Test config load", "[INT]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_INT int_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(int_val).description("int field for test").for_train_and_search();
             }
         };
@@ -793,7 +793,7 @@ TEST_CASE("Test config load", "[INT]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_INT int_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(int_val)
                     .description("int field for test")
                     .allow_empty_without_default()
@@ -826,7 +826,7 @@ TEST_CASE("Test config load", "[INT]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_INT int_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(int_val)
                     .description("int field for test")
                     .set_default(2)
@@ -878,7 +878,7 @@ TEST_CASE("Test config load", "[FLOAT]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_FLOAT float_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(float_val).description("float field for test").for_train_and_search();
             }
         };
@@ -908,7 +908,7 @@ TEST_CASE("Test config load", "[FLOAT]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_FLOAT float_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(float_val)
                     .description("float field for test")
                     .allow_empty_without_default()
@@ -941,7 +941,7 @@ TEST_CASE("Test config load", "[FLOAT]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_FLOAT float_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(float_val)
                     .description("float field for test")
                     .set_default(2.0)
@@ -993,7 +993,7 @@ TEST_CASE("Test config load", "[STRING]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_STRING str_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(str_val).description("string field for test").for_train_and_search();
             }
         };
@@ -1023,7 +1023,7 @@ TEST_CASE("Test config load", "[STRING]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_STRING str_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(str_val)
                     .description("string field for test")
                     .allow_empty_without_default()
@@ -1056,7 +1056,7 @@ TEST_CASE("Test config load", "[STRING]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_STRING str_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(str_val)
                     .description("string field for test")
                     .set_default("knowhere")
@@ -1095,7 +1095,7 @@ TEST_CASE("Test config load", "[MATERIALIZED_VIEW_SEARCH_INFO]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_MATERIALIZED_VIEW_SEARCH_INFO_TYPE info_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(info_val).description("info field for test").for_train_and_search();
             }
         };
@@ -1118,7 +1118,7 @@ TEST_CASE("Test config load", "[MATERIALIZED_VIEW_SEARCH_INFO]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_MATERIALIZED_VIEW_SEARCH_INFO_TYPE info_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(info_val)
                     .description("info field for test")
                     .allow_empty_without_default()
@@ -1156,7 +1156,7 @@ TEST_CASE("Test config", "[FormatAndCheck]") {
             CFG_BOOL False_val;
             CFG_BOOL TRUE_val;
             CFG_BOOL FALSE_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(int_val).for_train_and_search();
                 KNOWHERE_CONFIG_DECLARE_FIELD(float_val).for_train_and_search();
                 KNOWHERE_CONFIG_DECLARE_FIELD(true_val).for_train_and_search();
@@ -1199,7 +1199,7 @@ TEST_CASE("Test config", "[FormatAndCheck]") {
         class TestConfig : public knowhere::Config {
          public:
             CFG_INT int_val;
-            KNOHWERE_DECLARE_CONFIG(TestConfig) {
+            KNOWHERE_DECLARE_CONFIG(TestConfig) {
                 KNOWHERE_CONFIG_DECLARE_FIELD(int_val).for_train_and_search();
             }
         };

--- a/tests/ut/test_prometheus.cc
+++ b/tests/ut/test_prometheus.cc
@@ -13,6 +13,7 @@
 #include <string>
 
 #include "catch2/catch_test_macros.hpp"
+#include "knowhere/comp/index_param.h"
 #include "knowhere/prometheus_client.h"
 
 TEST_CASE("Test prometheus client", "[prometheus client]") {
@@ -20,5 +21,16 @@ TEST_CASE("Test prometheus client", "[prometheus client]") {
         auto str = knowhere::prometheusClient->GetMetrics();
         std::cout << str << std::endl;
         CHECK(str.length() >= 0);
+    }
+
+    SECTION("check index type latency labels") {
+        knowhere::ObserveSearchLatencyByIndexType("knowhere", knowhere::IndexEnum::INDEX_FAISS_IDMAP, 12.0);
+        knowhere::ObserveBuildLatencyByIndexType("knowhere", knowhere::IndexEnum::INDEX_HNSW, 1.5);
+
+        auto str = knowhere::prometheusClient->GetMetrics();
+        CHECK(str.find("search_latency_bucket{index_type=\"FLAT\",module=\"knowhere\"") != std::string::npos);
+        CHECK(str.find("build_latency_bucket{index_type=\"HNSW\",module=\"knowhere\"") != std::string::npos);
+        CHECK(str.find("index_type=\"FLAT\"") != std::string::npos);
+        CHECK(str.find("index_type=\"HNSW\"") != std::string::npos);
     }
 }

--- a/tests/ut/test_prometheus.cc
+++ b/tests/ut/test_prometheus.cc
@@ -11,6 +11,9 @@
 
 #include <iostream>
 #include <string>
+#include <thread>
+#include <unordered_set>
+#include <vector>
 
 #include "catch2/catch_test_macros.hpp"
 #include "knowhere/comp/index_param.h"
@@ -32,5 +35,22 @@ TEST_CASE("Test prometheus client", "[prometheus client]") {
         CHECK(str.find("build_latency_bucket{index_type=\"HNSW\",module=\"knowhere\"") != std::string::npos);
         CHECK(str.find("index_type=\"FLAT\"") != std::string::npos);
         CHECK(str.find("index_type=\"HNSW\"") != std::string::npos);
+    }
+
+    SECTION("concurrent GetPrometheusHistogram returns a single instance") {
+        constexpr int kThreads = 16;
+        std::vector<std::thread> workers;
+        std::vector<prometheus::Histogram*> observed(kThreads, nullptr);
+        for (int i = 0; i < kThreads; ++i) {
+            workers.emplace_back([i, &observed] {
+                observed[i] = &knowhere::GetPrometheusHistogram(knowhere::search_latency_family, "knowhere",
+                                                                knowhere::IndexEnum::INDEX_HNSW);
+            });
+        }
+        for (auto& t : workers) {
+            t.join();
+        }
+        std::unordered_set<prometheus::Histogram*> unique(observed.begin(), observed.end());
+        CHECK(unique.size() == 1);
     }
 }


### PR DESCRIPTION
issue: #1579

- add Prometheus latency metrics labeled by index_type for Knowhere
- keep the metric names as build_latency, load_latency, search_latency, and range_search_latency
- preserve Cardinals existing metric compatibility and make the metric cache concurrency-safe
