### PR TITLE
fix: add missing simdwidth to RVV Similarity classes for SQ4U fallback

### DIFF
--- a/thirdparty/faiss/faiss/cppcontrib/knowhere/impl/ScalarQuantizerCodec_rvv.h
+++ b/thirdparty/faiss/faiss/cppcontrib/knowhere/impl/ScalarQuantizerCodec_rvv.h
@@ -403,6 +403,7 @@ template <int SIMDWIDTH>
 struct SimilarityL2_rvv {};
 template <>
 struct SimilarityL2_rvv<0> {
+    static constexpr int simdwidth = 1;
     static constexpr MetricType metric_type = METRIC_L2;
 };
 
@@ -410,6 +411,7 @@ template <int SIMDWIDTH>
 struct SimilarityIP_rvv {};
 template <>
 struct SimilarityIP_rvv<0> {
+    static constexpr int simdwidth = 1;
     static constexpr MetricType metric_type = METRIC_INNER_PRODUCT;
 };
 


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/1587
/kind bug

- `SimilarityL2_rvv<0>` and `SimilarityIP_rvv<0>` are missing `static constexpr int simdwidth`, causing compilation failure on riscv64 when the `QT_4bit_uniform` case in `select_distance_computer_rvv` falls back to base `select_distance_computer` (which requires `Sim::simdwidth`)
- Added `simdwidth = 1` to both classes — value is 1 (scalar) because the fallback `DistanceComputerSQ4UByte` uses scalar quantization internally
- Issue introduced in 55c18bb ("Add fallback and uts for sq4u #1421")

## Compilation error (before fix)

```
ScalarQuantizerCodec.h:744:36: error: 'simdwidth' is not a member of 'faiss::SimilarityL2_rvv<0>'
  744 |     constexpr int SIMDWIDTH = Sim::simdwidth;
```