### PR TITLE
fix: use base scalar Similarity types in RVV SQ4U fallback path

### DIFF
--- a/thirdparty/faiss/faiss/cppcontrib/knowhere/impl/ScalarQuantizerCodec_rvv.h
+++ b/thirdparty/faiss/faiss/cppcontrib/knowhere/impl/ScalarQuantizerCodec_rvv.h
@@ -403,7 +403,6 @@ template <int SIMDWIDTH>
 struct SimilarityL2_rvv {};
 template <>
 struct SimilarityL2_rvv<0> {
-    static constexpr int simdwidth = 1;
     static constexpr MetricType metric_type = METRIC_L2;
 };
 
@@ -411,7 +410,6 @@ template <int SIMDWIDTH>
 struct SimilarityIP_rvv {};
 template <>
 struct SimilarityIP_rvv<0> {
-    static constexpr int simdwidth = 1;
     static constexpr MetricType metric_type = METRIC_INNER_PRODUCT;
 };
 
@@ -1175,7 +1173,17 @@ ScalarQuantizer::SQDistanceComputer* select_distance_computer_rvv(
             // distance computation.
             // TODO: Implement RVV-optimized DistanceComputerSQ4UByte_rvv
             // similar to AVX2 version
-            return select_distance_computer<Similarity>(qtype, dim, trained);
+            // Use base scalar Similarity types for fallback to avoid
+            // instantiating DCTemplate with RVV tag types that lack the
+            // full scalar Similarity interface (constructor, begin,
+            // add_component, etc.)
+            if constexpr (Similarity::metric_type == METRIC_L2) {
+                return select_distance_computer<SimilarityL2<1>>(
+                        qtype, dim, trained);
+            } else {
+                return select_distance_computer<SimilarityIP<1>>(
+                        qtype, dim, trained);
+            }
 
         case ScalarQuantizer::QT_6bit:
             return new DCTemplate_rvv<


### PR DESCRIPTION
Follow-up fix for #1586. The previous fix added `simdwidth` to the RVV Similarity tag types, but the `QT_4bit_uniform` fallback path in `select_distance_computer_rvv` still passed `SimilarityL2_rvv<0>` / `SimilarityIP_rvv<0>` directly to the base `select_distance_computer`, causing compilation failure on riscv64.

**Fix**:
1. Map RVV tag types to their base scalar equivalents before calling `select_distance_computer`:
   - `SimilarityL2_rvv<0>` (metric_type == METRIC_L2) → `SimilarityL2<1>`
   - `SimilarityIP_rvv<0>` (metric_type == METRIC_INNER_PRODUCT) → `SimilarityIP<1>`
2. Revert the incomplete fix from #1586 (remove `simdwidth` from RVV tag types), since the RVV code path never reads `Similarity::simdwidth` — keeping tag types minimal and consistent with their pure-tag design.

issue: https://github.com/zilliztech/knowhere/issues/1587

## Compilation errors before this fix (on riscv64 with v2.6.11 + #1586)

```
ScalarQuantizerCodec.h:659:20: error: no matching function for call to 'SimilarityIP_rvv<0>::SimilarityIP_rvv(std::nullptr_t)'
ScalarQuantizerCodec.h:660:13: error: 'struct SimilarityIP_rvv<0>' has no member named 'begin'
ScalarQuantizerCodec.h:664:17: error: 'struct SimilarityIP_rvv<0>' has no member named 'add_component_2'
ScalarQuantizerCodec.h:666:20: error: 'struct SimilarityIP_rvv<0>' has no member named 'result'
ScalarQuantizerCodec.h:648:20: error: no matching function for call to 'SimilarityL2_rvv<0>::SimilarityL2_rvv(const float*&)'
ScalarQuantizerCodec.h:649:13: error: 'struct SimilarityL2_rvv<0>' has no member named 'begin'
...
```