### PR TITLE
fix: rename remaining KNOHWERE_DECLARE_CONFIG sites in svs_config.h

### DIFF
--- a/src/index/svs/svs_config.h
+++ b/src/index/svs/svs_config.h
@@ -31,7 +31,7 @@ class SvsVamanaConfig : public BaseConfig {
     CFG_FLOAT svs_alpha;
     // Data storage format: "fp32", "fp16", "sqi8".
     CFG_STRING svs_storage_kind;
-    KNOHWERE_DECLARE_CONFIG(SvsVamanaConfig) {
+    KNOWHERE_DECLARE_CONFIG(SvsVamanaConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(svs_graph_max_degree)
             .description("maximum degree of the Vamana graph.")
             .set_default(32)
@@ -71,7 +71,7 @@ class SvsVamanaConfig : public BaseConfig {
 
 class SvsVamanaLvqConfig : public SvsVamanaConfig {
  public:
-    KNOHWERE_DECLARE_CONFIG(SvsVamanaLvqConfig) {
+    KNOWHERE_DECLARE_CONFIG(SvsVamanaLvqConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(svs_graph_max_degree)
             .description("maximum degree of the Vamana graph.")
             .set_range(4, 256)
@@ -113,7 +113,7 @@ class SvsVamanaLeanVecConfig : public SvsVamanaConfig {
  public:
     // Dimensionality for LeanVec compression. Default is d/2 (set to 0 to use default).
     CFG_INT svs_leanvec_dim;
-    KNOHWERE_DECLARE_CONFIG(SvsVamanaLeanVecConfig) {
+    KNOWHERE_DECLARE_CONFIG(SvsVamanaLeanVecConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(svs_graph_max_degree)
             .description("maximum degree of the Vamana graph.")
             .set_range(4, 256)


### PR DESCRIPTION
## What

Rename the three call sites of the typo'd macro `KNOHWERE_DECLARE_CONFIG` in `src/index/svs/svs_config.h` (`SvsVamanaConfig`, `SvsVamanaLvqConfig`, `SvsVamanaLeanVecConfig`) to the correct spelling `KNOWHERE_DECLARE_CONFIG`.

## Why

PR [#1577](https://github.com/zilliztech/knowhere/pull/1577) (commit c884fd87) renamed the macro definition in `include/knowhere/config.h`:

```diff
-#define KNOHWERE_DECLARE_CONFIG(CONFIG) CONFIG()
+#define KNOWHERE_DECLARE_CONFIG(CONFIG) CONFIG()
```

It updated most in-tree call sites but missed the three uses in `svs_config.h`. The breakage is silent today because [`CMakeLists.txt:37`](https://github.com/zilliztech/knowhere/blob/main/CMakeLists.txt#L37) defaults `WITH_SVS` to `OFF`, so PR-CI never compiles this file. It would surface as soon as anyone builds with `-DWITH_SVS=ON`.

The same typo also exists in the cardinal-side vendored headers (`know/cardinal_config.h`, `know/cardinal_cluster_config.h`); that already broke the [knowhere/nightly-2.0](https://jenkins.milvus.io:18080/job/knowhere/job/nightly-2.0/) Jenkins job from build #822 onward and is fixed in zilliztech/cardinal#823. This PR is just the matching cleanup on the knowhere side.

## Test

- `pre-commit run --files src/index/svs/svs_config.h` — passes (clang-format clean).
- Pure macro rename, no behavior change.