### PR TITLE
Revert "ci: reduce ARM e2e pod resources to allow concurrent scheduling (#1569)"

### DIFF
--- a/ci/pod/e2e-arm-cpu.yaml
+++ b/ci/pod/e2e-arm-cpu.yaml
@@ -19,11 +19,11 @@ spec:
     args: ["cat"]
     resources:
       requests:
-        memory: "12Gi"
-        cpu: "3"
+        memory: "16Gi"
+        cpu: "4"
       limits:
-        memory: "12Gi"
-        cpu: "3"
+        memory: "16Gi"
+        cpu: "4"
     volumeMounts:
       - mountPath: /home/data
         name: db-data


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/1598

Reverts the changes from PR [#1569](https://github.com/zilliztech/knowhere/pull/1569), restoring ARM e2e pod resource requests to 4 CPU / 16Gi.

## Summary
- Revert of https://github.com/zilliztech/knowhere/pull/1569 (commit 767a86afe3828c109370da58921396d1cc85d1e3)
- Restores ARM e2e pod resource requests back to 4 CPU / 16Gi (from 3 CPU / 12Gi)
- At 12Gi, certain PRs' ARM e2e jobs were hitting OOM — see #1598

## Test plan
- [x] ARM e2e jobs run successfully with restored resource requests, verifed with https://github.com/zilliztech/knowhere/pull/1597