### PR TITLE
ci: prevent SSE e2e pod zombies blocking the SSE node

### DIFF
--- a/ci/E2E2-SSE.groovy
+++ b/ci/E2E2-SSE.groovy
@@ -1,4 +1,4 @@
-// int total_timeout_minutes = 120
+int total_timeout_minutes = 480
 def knowhere_wheel=''
 pipeline {
     agent {
@@ -7,11 +7,13 @@ pipeline {
             inheritFrom 'default'
             yamlFile 'ci/pod/e2e-cpu.yaml'
             defaultContainer 'main'
+            podRetention never()
+            idleMinutes 0
         }
     }
 
     options {
-        // timeout(time: total_timeout_minutes, unit: 'MINUTES')
+        timeout(time: total_timeout_minutes, unit: 'MINUTES')
         buildDiscarder logRotator(artifactDaysToKeepStr: '30')
         parallelsAlwaysFailFast()
         disableConcurrentBuilds(abortPrevious: true)
@@ -49,6 +51,8 @@ pipeline {
                     inheritFrom 'default'
                     yamlFile 'ci/pod/e2e-sse.yaml'
                     defaultContainer 'main'
+                    podRetention never()
+                    idleMinutes 0
                 }
             }
             steps {

--- a/ci/pod/e2e-sse.yaml
+++ b/ci/pod/e2e-sse.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: knowhere-ci
 spec:
   enableServiceLinks: false
+  restartPolicy: Never
+  activeDeadlineSeconds: 36000
+  terminationGracePeriodSeconds: 30
   nodeSelector:
     node.kubernetes.io/cpu-feature.sse: true
   tolerations:


### PR DESCRIPTION
## Problem

The SSE e2e pipeline occasionally leaves pods in \`1/2 NotReady\` state for days after the \`main\` container exits successfully. In the recent real incident, pod \`knowhere-kn2-sse--pr-1584-3-grlk2-j07vb-dsqc7\` sat on node \`k8s-ci-node11\` for 7+ days — the \`main\` container had exited \`Completed\` with \`exitCode=0\`, but the \`jnlp\` sidecar stayed \`Running\` — which kept the Pod phase at \`Running\`, so the Pod's full memory reservation (dominated by \`main\`'s \`3Gi\` request) stayed held on the node even though \`main\`'s process was already gone.

The CI cluster only has **one** node labeled \`node.kubernetes.io/cpu-feature.sse=true\` (\`k8s-ci-node11\`, 8 CPU / ~3.9Gi). A single zombie consumes >99% of its allocatable memory, which in turn causes every subsequent SSE build (PR 1588, 1590, 1591, 1592, 1593, 1594, 1595, 1596 were all affected at observation time) to stay \`Pending\` with:

\`\`\`
FailedScheduling: 0/7 nodes are available: 1 Insufficient cpu, 1 Insufficient memory,
  2 node(s) didn't match Pod's node affinity/selector, ...
\`\`\`

## Root cause

The Kubernetes Plugin cannot always guarantee pod deletion after build termination (Jenkins master restart, network blip between master and agent, or the plugin losing the agent session). Without additional safeguards, the \`jnlp\` sidecar keeps its TCP connection to an already-torn-down build and the pod is never cleaned up. Compounding this, the timeout in \`ci/E2E2-SSE.groovy\` was commented out, so nothing bounded hung builds either.

## Fix — three layers of defense

| Layer | Mechanism | Triggers when |
|---|---|---|
| 1 | \`podRetention never()\` + \`idleMinutes 0\` on both agent blocks | Build reaches any terminal state (success / failure / abort) — plugin deletes pod immediately |
| 2 | Restored Jenkins \`timeout(480 min)\` | Build genuinely hangs; 480 min picked to safely exceed legitimate 5–6h SSE test runs |
| 3 | Pod-level \`activeDeadlineSeconds: 36000\` (10h) + \`restartPolicy: Never\` | Jenkins loses the agent entirely — kubelet enforces the wall independently |

The ordering is intentional: Jenkins timeout (8h) < k8s hard wall (10h), so under normal degradation Jenkins gets to finalize and clean up first, and k8s only fires as the last line of defense.

Note on layer 3: when \`activeDeadlineSeconds\` fires, k8s marks the Pod \`Failed\` and kills its containers. That releases the node memory reservation immediately, which is the property we need here. The Pod object itself lingers until GC, but that's an object-count concern, not the resource-hold problem this PR solves.

## Scope

Only touches the SSE pipeline:

- \`ci/E2E2-SSE.groovy\` — 6 lines added, 2 uncommented
- \`ci/pod/e2e-sse.yaml\` — 3 lines added

Other pipelines (CPU / GPU / ARM) are not modified — SSE is the singleton-node bottleneck and the only one where this has caused outages. The same pattern can be applied later to the rest if we see the problem spread.

## Verification

- Ran \`groovy -v\` / syntactic eyeball — all three \`podRetention\`, \`idleMinutes\`, and \`timeout\` invocations are standard Jenkins Kubernetes Plugin DSL.
- \`activeDeadlineSeconds\` is valid on bare Pods per the k8s pod lifecycle docs.
- Diff kept to the minimum needed; no refactor of surrounding code.

Will monitor node11 over the next few SSE builds after merge to confirm pods are deleted on build completion and the memory allocation drops back to baseline.
