### PR TITLE
bump: cardinal pins to v2.5.105 (v1) and v3.0.1 (v2)

### DIFF
--- a/cmake/libs/cardinal/v1/CMakeLists.txt
+++ b/cmake/libs/cardinal/v1/CMakeLists.txt
@@ -3,7 +3,7 @@ project(knowhere CXX C)
 
 # Use short SHA1 as version
 # v2.5 tag is used for cardinal v1
-set(CARDINAL_VERSION v2.5.104)
+set(CARDINAL_VERSION v2.5.105)
 set(CARDINAL_REPO_URL "https://github.com/zilliztech/cardinal.git")
 
 set(CARDINAL_ROOT  "${KNOWHERE_THRID_ROOT}/cardinalv1")

--- a/cmake/libs/cardinal/v2/CMakeLists.txt
+++ b/cmake/libs/cardinal/v2/CMakeLists.txt
@@ -3,7 +3,7 @@ project(knowhere CXX C)
 
 # Use short SHA1 as version
 # v2.6 tag is used for cardinal v2
-set(CARDINAL_VERSION v3.0.0)
+set(CARDINAL_VERSION v3.0.1)
 set(CARDINAL_REPO_URL "https://github.com/zilliztech/cardinal.git")
 
 set(CARDINAL_ROOT  "${KNOWHERE_THRID_ROOT}/cardinalv2")


### PR DESCRIPTION
## What

Bump the two `CARDINAL_VERSION` pins to the new tags cut from the post-typo-fix tips of cardinal:

| File | Old tag | New tag | Includes |
|---|---|---|---|
| `cmake/libs/cardinal/v1/CMakeLists.txt` | `v2.5.104` | `v2.5.105` | zilliztech/cardinal#824 + #825 (rename on v1) |
| `cmake/libs/cardinal/v2/CMakeLists.txt` | `v3.0.0` | `v3.0.1` | zilliztech/cardinal#823 (rename on master) + #809 (Conan 2.x migration, already required by knowhere main since #1495) |

## Why

[#1577](https://github.com/zilliztech/knowhere/pull/1577) (commit c884fd87) renamed the macro definition in `include/knowhere/config.h`:

```diff
-#define KNOHWERE_DECLARE_CONFIG(CONFIG) CONFIG()
+#define KNOWHERE_DECLARE_CONFIG(CONFIG) CONFIG()
```

The two cardinal vendored copies were pinned at tags cut before the corresponding cardinal-side renames landed, so every `WITH_CARDINAL=ON` build fails:

```
thirdparty/cardinalv{1,2}/know/cardinal_config.h:33:5: error: ISO C++ forbids
declaration of 'KNOHWERE_DECLARE_CONFIG' with no type [-fpermissive]
```

Observed in:
- [`knowhere/nightly-2.0`](https://jenkins.milvus.io:18080/job/knowhere/job/nightly-2.0/) (x86) from build #822 onward
- [`knowhere/cardinal e2e (arm)`](https://jenkins-3.zilliz.cc/blue/organizations/jenkins/knowhere%2Fcardinal%20e2e%20(arm)/) on PR-823

This bump consumes the corresponding fix releases on the cardinal side and unblocks both pipelines.

## Notes

- `v3.0.1` also pulls in cardinal's Conan 2.x migration (#809). Knowhere main already requires Conan 2.x since [#1495](https://github.com/zilliztech/knowhere/pull/1495), so this is a non-issue here, but worth noting for any downstream consumer that pins by tag.
- Anyone with primed cardinal workspaces (Jenkins agents, Conan caches) should `git fetch --tags --force` after this lands so the new tag refs are visible locally.

## Test

- `pre-commit run --files cmake/libs/cardinal/v1/CMakeLists.txt cmake/libs/cardinal/v2/CMakeLists.txt` — clean.
- Pure version-string bump; no behavior change in this repo.