### PR TITLE
Fix Conan cache restore isolation

### DIFF
--- a/.github/actions/cache-restore/action.yaml
+++ b/.github/actions/cache-restore/action.yaml
@@ -21,9 +21,11 @@ runs:
         # Key must match cache-save/action.yaml exactly for exact-key hits.
         key: knowhere-${{ inputs.os }}-${{ github.job }}-ccache-${{ hashFiles('src/**/*.cpp', 'src/**/*.cc', 'src/**/*.c', 'src/**/*.h', 'src/**/*.hpp', 'include/**/*.h', 'include/**/*.hpp', 'tests/**/*.cpp', 'tests/**/*.cc', 'tests/**/*.h', 'benchmark/**/*.cpp', 'benchmark/**/*.cc', 'benchmark/**/*.h', 'cmake/**', 'CMakeLists.txt', 'Makefile', 'conanfile.py') }}
         restore-keys: knowhere-${{ inputs.os }}-${{ github.job }}-ccache-
+    - name: Reset Conan package cache
+      shell: bash
+      run: rm -rf ~/.conan2/p
     - name: Cache Conan Packages
       uses: actions/cache/restore@v4
       with:
         path: ~/.conan2
         key: knowhere-${{ inputs.os }}-${{ github.job }}-conan2-${{ hashFiles('conanfile.py') }}
-        restore-keys: knowhere-${{ inputs.os }}-${{ github.job }}-conan2-


### PR DESCRIPTION
## What

This PR makes the GitHub Actions Conan cache restore safer on self-hosted runners.

It was prompted by PR https://github.com/zilliztech/knowhere/pull/1609, whose Unit Test run restored a stale `main` Conan cache via the broad `restore-keys` prefix and then failed with a Conan package directory collision.

Changes:
- remove Conan `restore-keys` so a changed `conanfile.py` no longer falls back to an older Conan cache
- remove `~/.conan2/p` before restoring the Conan cache so persistent runner leftovers cannot collide with restored Conan metadata
- keep ccache restore behavior unchanged

## Verification

Ran locally:
- `git diff --check`
- structural check confirming the reset step exists and the Conan cache block has no `restore-keys`
- `python3` YAML parse of `.github/actions/cache-restore/action.yaml`

Note: full validation requires a GitHub Actions run on the self-hosted runner.