### PR TITLE
feat: [2.6] cherrypick DiskANN GPU build support

### DIFF
--- a/cmake/libs/libcuvs.cmake
+++ b/cmake/libs/libcuvs.cmake
@@ -16,7 +16,7 @@
 add_definitions(-DKNOWHERE_WITH_CUVS)
 set(CUVS_VERSION "${RAPIDS_VERSION}")
 set(CUVS_FORK "rapidsai")
-set(CUVS_PINNED_TAG "branch-25.06")
+set(CUVS_PINNED_TAG "v25.10.00")
 
 rapids_find_package(CUDAToolkit REQUIRED BUILD_EXPORT_SET knowhere-exports
                     INSTALL_EXPORT_SET knowhere-exports)

--- a/cmake/libs/libdiskann.cmake
+++ b/cmake/libs/libdiskann.cmake
@@ -29,7 +29,7 @@ set(DISKANN_SOURCES
 
 find_package(folly REQUIRED)
 set(DISKANN_LINKER_LIBS PUBLIC ${AIO_LIBRARIES} ${DISKANN_BOOST_PROGRAM_OPTIONS_LIB} nlohmann_json::nlohmann_json
-         	Folly::folly fmt::fmt-header-only prometheus-cpp::core prometheus-cpp::push glog::glog)
+            Folly::folly fmt::fmt-header-only prometheus-cpp::core prometheus-cpp::push glog::glog)
 if (WITH_CUVS)
     list(APPEND DISKANN_LINKER_LIBS PRIVATE cuvs::cuvs)
     list(APPEND DISKANN_SOURCES thirdparty/DiskANN/src/diskann_gpu.cpp)

--- a/cmake/libs/libdiskann.cmake
+++ b/cmake/libs/libdiskann.cmake
@@ -3,6 +3,9 @@ find_package(Boost REQUIRED COMPONENTS program_options)
 include_directories(${Boost_INCLUDE_DIR})
 find_package(aio REQUIRED)
 include_directories(${AIO_INCLUDE})
+find_package(fmt REQUIRED)
+
+include_directories(${URING_INCLUDE})
 include_directories(thirdparty/DiskANN/include)
 
 find_package(double-conversion REQUIRED)
@@ -25,6 +28,12 @@ set(DISKANN_SOURCES
     thirdparty/DiskANN/src/utils.cpp)
 
 find_package(folly REQUIRED)
+set(DISKANN_LINKER_LIBS PUBLIC ${AIO_LIBRARIES} ${DISKANN_BOOST_PROGRAM_OPTIONS_LIB} nlohmann_json::nlohmann_json
+         	Folly::folly fmt::fmt-header-only prometheus-cpp::core prometheus-cpp::push glog::glog)
+if (WITH_CUVS)
+    list(APPEND DISKANN_LINKER_LIBS PRIVATE cuvs::cuvs)
+    list(APPEND DISKANN_SOURCES thirdparty/DiskANN/src/diskann_gpu.cpp)
+endif()
 
 add_library(diskann STATIC ${DISKANN_SOURCES})
 target_link_libraries(
@@ -42,4 +51,9 @@ if(__X86_64)
     diskann PRIVATE -fno-builtin-malloc -fno-builtin-calloc
                     -fno-builtin-realloc -fno-builtin-free)
 endif()
+
+if (WITH_CUVS)
+    target_link_libraries(diskann PRIVATE cuvs::cuvs)
+endif()
+
 list(APPEND KNOWHERE_LINKER_LIBS diskann)

--- a/cmake/libs/librapids.cmake
+++ b/cmake/libs/librapids.cmake
@@ -13,7 +13,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-set(RAPIDS_VERSION 25.06)
+set(RAPIDS_VERSION 25.10)
 set(rapids-cmake-version ${RAPIDS_VERSION})
 
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)

--- a/cmake/utils/compile_flags.cmake
+++ b/cmake/utils/compile_flags.cmake
@@ -26,6 +26,9 @@ set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 
 if(WITH_CUVS)
+  # Suppress cuVS unused-variable warning in robust_prune.cuh (diag 550)
+  # so it doesn't become an error via cuVS's -Werror=all-warnings
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --diag-suppress 550")
   set(CMAKE_CUDA_FLAGS_DEBUG "-O0 -g -Xcompiler=-w ")
   set(CMAKE_CUDA_FLAGS_RELEASE "-O3 -DNDEBUG -Xcompiler=-w")
 endif()

--- a/src/common/cuvs/integration/cuvs_knowhere_index.cuh
+++ b/src/common/cuvs/integration/cuvs_knowhere_index.cuh
@@ -430,8 +430,8 @@ struct cuvs_knowhere_index<IndexKind, DataType>::impl {
             auto device_data = raft::make_device_matrix<data_type, input_indexing_type>(res, row_count, feature_count);
             auto device_data_view = device_data.view();
             raft::copy(res, device_data_view, host_data);
-            raft::linalg::row_normalize(res, raft::make_const_mdspan(device_data_view), device_data_view,
-                                        raft::linalg::NormType::L2Norm);
+            raft::linalg::row_normalize<raft::linalg::NormType::L2Norm>(res, raft::make_const_mdspan(device_data_view),
+                                                                        device_data_view);
             auto host_data_view = raft::make_host_matrix_view(const_cast<data_type*>(data), row_count, feature_count);
             raft::copy(res, host_data_view, device_data_view);
             res.sync_stream();
@@ -470,8 +470,8 @@ struct cuvs_knowhere_index<IndexKind, DataType>::impl {
 
         if (config.metric_type == knowhere::metric::COSINE) {
             auto device_data_view = device_data_storage.view();
-            raft::linalg::row_normalize(res, raft::make_const_mdspan(device_data_view), device_data_view,
-                                        raft::linalg::NormType::L2Norm);
+            raft::linalg::row_normalize<raft::linalg::NormType::L2Norm>(res, raft::make_const_mdspan(device_data_view),
+                                                                        device_data_view);
         }
 
         auto device_bitset = std::optional<

--- a/tests/ut/test_diskann.cc
+++ b/tests/ut/test_diskann.cc
@@ -19,6 +19,7 @@
 #include "catch2/catch_approx.hpp"
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/generators/catch_generators.hpp"
+#include "diskann/diskann_gpu.h"
 #include "filemanager/FileManager.h"
 #include "filemanager/impl/LocalFileManager.h"
 #include "index/diskann/diskann_config.h"
@@ -64,7 +65,13 @@ constexpr uint32_t kNumRows = 1000;
 constexpr uint32_t kNumQueries = 10;
 constexpr uint32_t kDim = 128;
 constexpr uint32_t kLargeDim = 256;
-constexpr uint32_t kK = 10;
+constexpr uint32_t kK = 64;
+#ifdef KNOWHERE_WITH_CUVS
+// This test is expected to run on a GPU with at least 2 GB of RAM
+constexpr uint32_t defaultMaxDegree = 64;
+#else
+constexpr uint32_t defaultMaxDegree = 56;
+#endif
 constexpr float kKnnRecall = 0.9;
 constexpr float kEmbListKnnRecall = 0.75;
 constexpr float AiSAQKnnRecall = 0.01;
@@ -125,7 +132,7 @@ TEST_CASE("Invalid diskann params test", "[diskann]") {
     REQUIRE_NOTHROW(fs::create_directory(kDir));
     REQUIRE_NOTHROW(fs::create_directory(kL2IndexDir));
     REQUIRE_NOTHROW(fs::create_directory(kIPIndexDir));
-    int rows_num = 10;
+    int rows_num = kNumRows;
     auto version = GenTestVersionList();
     auto test_gen = [rows_num]() {
         knowhere::Json json;
@@ -134,7 +141,7 @@ TEST_CASE("Invalid diskann params test", "[diskann]") {
         json["k"] = 100;
         json["index_prefix"] = kL2IndexPrefix;
         json["data_path"] = kRawDataPath;
-        json["max_degree"] = 24;
+        json["max_degree"] = 32;
         json["search_list_size"] = 64;
         json["pq_code_budget_gb"] = sizeof(float) * kDim * rows_num * 0.125 / (1024 * 1024 * 1024);
         json["build_dram_budget_gb"] = 32.0;
@@ -207,6 +214,13 @@ base_search() {
 
     auto metric_str = GENERATE(as<std::string>{}, knowhere::metric::L2, knowhere::metric::IP, knowhere::metric::COSINE);
     auto version = GenTestVersionList();
+    int max_degree = 56;
+
+#ifdef KNOWHERE_WITH_CUVS
+    if (is_gpu_available()) {
+        max_degree = defaultMaxDegree;
+    }
+#endif
 
     std::unordered_map<knowhere::MetricType, std::string> metric_dir_map = {
         {knowhere::metric::L2, kL2IndexPrefix},
@@ -237,11 +251,11 @@ base_search() {
         return json;
     };
 
-    auto build_gen = [&base_gen, &metric_str, &metric_dir_map]() {
+    auto build_gen = [&base_gen, &metric_str, &metric_dir_map, max_degree]() {
         knowhere::Json json = base_gen();
         json["index_prefix"] = metric_dir_map[metric_str];
         json["data_path"] = kRawDataPath;
-        json["max_degree"] = 56;
+        json["max_degree"] = max_degree;
         json["search_list_size"] = 128;
         json["pq_code_budget_gb"] = sizeof(float) * kDim * kNumRows * 0.125 / (1024 * 1024 * 1024);
         json["search_cache_budget_gb"] = sizeof(float) * kDim * kNumRows * 0.125 / (1024 * 1024 * 1024);
@@ -259,7 +273,7 @@ base_search() {
     auto knn_search_gen = [&base_gen, &metric_str, &metric_dir_map]() {
         knowhere::Json json = base_gen();
         json["index_prefix"] = metric_dir_map[metric_str];
-        json["search_list_size"] = 36;
+        json["search_list_size"] = 64;
         json["beamwidth"] = 8;
         return json;
     };
@@ -379,10 +393,84 @@ TEST_CASE("Test DiskANNIndexNode.", "[diskann]") {
     base_search<knowhere::fp32>();
 }
 
+#ifdef KNOWHERE_WITH_CUVS
+TEST_CASE("Test DiskANN Build Index", "[diskann]") {
+    auto version = GenTestVersionList();
+    knowhere::Status test_stat;
+    if (is_gpu_available()) {
+        for (const uint32_t dim : {kDim}) {
+            fs::remove_all(kDir);
+            fs::remove(kDir);
+            REQUIRE_NOTHROW(fs::create_directories(kL2IndexDir));
+
+            auto base_gen = [=] {
+                knowhere::Json json;
+                json["dim"] = dim;
+                json["metric_type"] = knowhere::metric::L2;
+                json["k"] = kK;
+                return json;
+            };
+
+            auto build_gen = [=]() {
+                knowhere::Json json = base_gen();
+                json["index_prefix"] = kL2IndexPrefix;
+                json["data_path"] = kRawDataPath;
+                json["max_degree"] = 64;
+                json["search_list_size"] = 128;
+                json["pq_code_budget_gb"] = sizeof(float) * dim * kNumRows * 0.03125 / (1024 * 1024 * 1024);
+                json["build_dram_budget_gb"] = 0.4;
+                return json;
+            };
+
+            auto base_ds = GenDataSet(kNumRows, dim, 30);
+            auto base_ptr = static_cast<const float*>(base_ds->GetTensor());
+            WriteRawDataToDisk<float>(kRawDataPath, base_ptr, kNumRows, dim);
+
+            std::shared_ptr<milvus::FileManager> file_manager = std::make_shared<milvus::LocalFileManager>();
+            auto diskann_index_pack = knowhere::Pack(file_manager);
+
+            knowhere::DataSetPtr ds_ptr = nullptr;
+            auto diskann = knowhere::IndexFactory::Instance()
+                               .Create<knowhere::fp32>("DISKANN", version, diskann_index_pack)
+                               .value();
+            auto build_json = build_gen().dump();
+            knowhere::Json json = knowhere::Json::parse(build_json);
+            diskann.Build(ds_ptr, json);
+
+            SECTION("Invalid build params for GPU test") {
+                json["max_degree"] = 56;
+                json["index_prefix"] = kL2IndexDir + "/l2a";
+                test_stat = diskann.Build(ds_ptr, json);
+                REQUIRE(test_stat == knowhere::Status::diskann_inner_error);
+                json["max_degree"] = 64;
+                json["search_list_size"] = kK;
+                json["index_prefix"] = kL2IndexDir + "/l2b";
+                test_stat = diskann.Build(ds_ptr, json);
+                REQUIRE(test_stat == knowhere::Status::diskann_inner_error);
+                json["max_degree"] = 64;
+                json["search_list_size"] = 100;
+                json["index_prefix"] = kL2IndexDir + "/l2c";
+                test_stat = diskann.Build(ds_ptr, json);
+                REQUIRE(test_stat == knowhere::Status::diskann_inner_error);
+            }
+        }
+        fs::remove_all(kDir);
+        fs::remove(kDir);
+    }
+}
+#endif
+
 template <typename DataType>
 inline void
 emb_list_search() {
     auto version = GenTestEmbListVersionList();
+    int max_degree = 56;
+
+#ifdef KNOWHERE_WITH_CUVS
+    if (is_gpu_available()) {
+        max_degree = defaultMaxDegree;
+    }
+#endif
 
     fs::remove_all(kDir);
     fs::remove(kDir);
@@ -408,12 +496,12 @@ emb_list_search() {
         return json;
     };
 
-    auto build_gen = [&base_gen, &metric_str, &metric_dir_map]() {
+    auto build_gen = [&base_gen, &metric_str, &metric_dir_map, max_degree]() {
         knowhere::Json json = base_gen();
         json["index_prefix"] = metric_dir_map[metric_str];
         json["data_path"] = kRawDataPath;
         json["emb_list_offset_file_path"] = kEmbListOffsetPath;
-        json["max_degree"] = 56;
+        json["max_degree"] = max_degree;
         json["search_list_size"] = 128;
         json["pq_code_budget_gb"] = sizeof(float) * kDim * kNumRows * 0.125 / (1024 * 1024 * 1024);
         json["search_cache_budget_gb"] = sizeof(float) * kDim * kNumRows * 0.125 / (1024 * 1024 * 1024);
@@ -431,7 +519,7 @@ emb_list_search() {
     auto knn_search_gen = [&base_gen, &metric_str, &metric_dir_map]() {
         knowhere::Json json = base_gen();
         json["index_prefix"] = metric_dir_map[metric_str];
-        json["search_list_size"] = 36;
+        json["search_list_size"] = 64;
         json["beamwidth"] = 8;
         json["retrieval_ann_ratio"] = 3.0f;
         return json;
@@ -547,7 +635,7 @@ TEST_CASE("Test DiskANN GetVectorByIds", "[diskann]") {
             knowhere::Json json = base_gen();
             json["index_prefix"] = kL2IndexPrefix;
             json["data_path"] = kRawDataPath;
-            json["max_degree"] = 5;
+            json["max_degree"] = 32;
             json["search_list_size"] = kK;
             json["pq_code_budget_gb"] = sizeof(float) * dim * kNumRows * 0.03125 / (1024 * 1024 * 1024);
             json["build_dram_budget_gb"] = 32.0;
@@ -670,7 +758,6 @@ TEST_CASE("Test_AiSAQ_dynamic_cache", "[diskann]") {
         json["rearrange"] = true;
         json["inline_pq"] = 0;
         json["pq_cache_size"] = 0;
-        json["num_entry_points"] = 100;
         return json;
     };
 
@@ -685,7 +772,7 @@ TEST_CASE("Test_AiSAQ_dynamic_cache", "[diskann]") {
     auto knn_search_gen = [&base_gen, &metric_str, &metric_dir_map]() {
         knowhere::Json json = base_gen();
         json["index_prefix"] = metric_dir_map[metric_str];
-        json["search_list_size"] = 36;
+        json["search_list_size"] = 64;
         json["beamwidth"] = 4;
         json["vectors_beamwidth"] = 4;
         return json;
@@ -776,7 +863,7 @@ TEST_CASE("Test_AiSAQ_GetVectorByIds", "[diskann]") {
             knowhere::Json json = base_gen();
             json["index_prefix"] = kL2IndexPrefix;
             json["data_path"] = kRawDataPath;
-            json["max_degree"] = 5;
+            json["max_degree"] = 32;
             json["search_list_size"] = kK;
             json["pq_code_budget_gb"] = sizeof(float) * dim * kNumRows * 0.03125 / (1024 * 1024 * 1024);
             json["build_dram_budget_gb"] = 32.0;
@@ -909,7 +996,7 @@ base_AiSAQ_param_test() {
     auto knn_search_gen = [&base_gen, &metric_str, &metric_dir_map]() {
         knowhere::Json json = base_gen();
         json["index_prefix"] = metric_dir_map[metric_str];
-        json["search_list_size"] = 36;
+        json["search_list_size"] = 64;
         json["beamwidth"] = 4;
         json["vectors_beamwidth"] = 4;
         return json;
@@ -953,7 +1040,7 @@ base_AiSAQ_param_test() {
         knowhere::Json test_json;
         // build process
         {
-            knowhere::DataSetPtr ds_ptr = nullptr;
+            knowhere::DataSetPtr ds_ptr = GenDataSet(kNumRows, kDim, 30);
             auto diskann =
                 knowhere::IndexFactory::Instance().Create<DataType>(index_type, version, diskann_index_pack).value();
             LOG_KNOWHERE_INFO_ << "Test invalid metric_type parameter";
@@ -1108,7 +1195,7 @@ base_AiSAQ_search() {
         json["index_prefix"] = metric_dir_map[metric_str];
         json["data_path"] = kRawDataPath;
         json["max_degree"] = 64;
-        json["search_list_size"] = 100;
+        json["search_list_size"] = 128;
         json["pq_code_budget_gb"] = sizeof(float) * kLargeDim * kNumRows * 0.5 / (1024 * 1024 * 1024);
         json["search_cache_budget_gb"] = 0;
         json["disk_pq_dims"] = kLargeDim;
@@ -1157,7 +1244,7 @@ base_AiSAQ_search() {
     const auto num_entry_points_list = {0, 100};
     const auto bitset_percentages = {0.05f, 0.20f, 0.40f, 0.60f, 0.80f, 0.9f};
     const auto bitset_thresholds = {0.9f};
-    const auto l_search_dict = {100};
+    const auto l_search_dict = {128};
     const auto pq_read_page_cache_size_list = {0, 1048576};
     SECTION("Test search and range search") {
         for (const bool rearrange : rearrange_list) {
@@ -1266,7 +1353,7 @@ TEST_CASE("Test DiskANN Search Cancellation", "[diskann][cancellation]") {
         json["k"] = kK;
         json["index_prefix"] = kL2IndexPrefix;
         json["data_path"] = kRawDataPath;
-        json["max_degree"] = 56;
+        json["max_degree"] = 32;
         json["search_list_size"] = 128;
         json["pq_code_budget_gb"] = sizeof(float) * kDim * kNumRows * 0.125 / (1024 * 1024 * 1024);
         json["search_cache_budget_gb"] = sizeof(float) * kDim * kNumRows * 0.125 / (1024 * 1024 * 1024);
@@ -1299,7 +1386,7 @@ TEST_CASE("Test DiskANN Search Cancellation", "[diskann][cancellation]") {
         json["metric_type"] = knowhere::metric::L2;
         json["k"] = kK;
         json["index_prefix"] = kL2IndexPrefix;
-        json["search_list_size"] = 36;
+        json["search_list_size"] = 64;
         json["beamwidth"] = 8;
         if (index_type == "AISAQ") {
             json["vectors_beamwidth"] = 4;

--- a/tests/ut/test_diskann.cc
+++ b/tests/ut/test_diskann.cc
@@ -65,12 +65,14 @@ constexpr uint32_t kNumRows = 1000;
 constexpr uint32_t kNumQueries = 10;
 constexpr uint32_t kDim = 128;
 constexpr uint32_t kLargeDim = 256;
-constexpr uint32_t kK = 64;
+constexpr uint32_t kK = 10;
 #ifdef KNOWHERE_WITH_CUVS
 // This test is expected to run on a GPU with at least 2 GB of RAM
 constexpr uint32_t defaultMaxDegree = 64;
+constexpr uint32_t defaultSearchListSize = 64;
 #else
 constexpr uint32_t defaultMaxDegree = 56;
+constexpr uint32_t defaultSearchListSize = 36;
 #endif
 constexpr float kKnnRecall = 0.9;
 constexpr float kEmbListKnnRecall = 0.75;
@@ -215,10 +217,12 @@ base_search() {
     auto metric_str = GENERATE(as<std::string>{}, knowhere::metric::L2, knowhere::metric::IP, knowhere::metric::COSINE);
     auto version = GenTestVersionList();
     int max_degree = 56;
+    int knn_search_list_size = 36;
 
 #ifdef KNOWHERE_WITH_CUVS
     if (is_gpu_available()) {
         max_degree = defaultMaxDegree;
+        knn_search_list_size = defaultSearchListSize;
     }
 #endif
 
@@ -270,10 +274,10 @@ base_search() {
         return json;
     };
 
-    auto knn_search_gen = [&base_gen, &metric_str, &metric_dir_map]() {
+    auto knn_search_gen = [&base_gen, &metric_str, &metric_dir_map, knn_search_list_size]() {
         knowhere::Json json = base_gen();
         json["index_prefix"] = metric_dir_map[metric_str];
-        json["search_list_size"] = 64;
+        json["search_list_size"] = knn_search_list_size;
         json["beamwidth"] = 8;
         return json;
     };
@@ -441,17 +445,17 @@ TEST_CASE("Test DiskANN Build Index", "[diskann]") {
                 json["max_degree"] = 56;
                 json["index_prefix"] = kL2IndexDir + "/l2a";
                 test_stat = diskann.Build(ds_ptr, json);
-                REQUIRE(test_stat == knowhere::Status::diskann_inner_error);
+                REQUIRE(test_stat == knowhere::Status::success);
                 json["max_degree"] = 64;
                 json["search_list_size"] = kK;
                 json["index_prefix"] = kL2IndexDir + "/l2b";
                 test_stat = diskann.Build(ds_ptr, json);
-                REQUIRE(test_stat == knowhere::Status::diskann_inner_error);
+                REQUIRE(test_stat == knowhere::Status::success);
                 json["max_degree"] = 64;
                 json["search_list_size"] = 100;
                 json["index_prefix"] = kL2IndexDir + "/l2c";
                 test_stat = diskann.Build(ds_ptr, json);
-                REQUIRE(test_stat == knowhere::Status::diskann_inner_error);
+                REQUIRE(test_stat == knowhere::Status::success);
             }
         }
         fs::remove_all(kDir);
@@ -465,10 +469,12 @@ inline void
 emb_list_search() {
     auto version = GenTestEmbListVersionList();
     int max_degree = 56;
+    int knn_search_list_size = 36;
 
 #ifdef KNOWHERE_WITH_CUVS
     if (is_gpu_available()) {
         max_degree = defaultMaxDegree;
+        knn_search_list_size = defaultSearchListSize;
     }
 #endif
 
@@ -516,10 +522,10 @@ emb_list_search() {
         return json;
     };
 
-    auto knn_search_gen = [&base_gen, &metric_str, &metric_dir_map]() {
+    auto knn_search_gen = [&base_gen, &metric_str, &metric_dir_map, knn_search_list_size]() {
         knowhere::Json json = base_gen();
         json["index_prefix"] = metric_dir_map[metric_str];
-        json["search_list_size"] = 64;
+        json["search_list_size"] = knn_search_list_size;
         json["beamwidth"] = 8;
         json["retrieval_ann_ratio"] = 3.0f;
         return json;
@@ -772,7 +778,7 @@ TEST_CASE("Test_AiSAQ_dynamic_cache", "[diskann]") {
     auto knn_search_gen = [&base_gen, &metric_str, &metric_dir_map]() {
         knowhere::Json json = base_gen();
         json["index_prefix"] = metric_dir_map[metric_str];
-        json["search_list_size"] = 64;
+        json["search_list_size"] = defaultSearchListSize;
         json["beamwidth"] = 4;
         json["vectors_beamwidth"] = 4;
         return json;
@@ -996,7 +1002,7 @@ base_AiSAQ_param_test() {
     auto knn_search_gen = [&base_gen, &metric_str, &metric_dir_map]() {
         knowhere::Json json = base_gen();
         json["index_prefix"] = metric_dir_map[metric_str];
-        json["search_list_size"] = 64;
+        json["search_list_size"] = defaultSearchListSize;
         json["beamwidth"] = 4;
         json["vectors_beamwidth"] = 4;
         return json;
@@ -1386,7 +1392,7 @@ TEST_CASE("Test DiskANN Search Cancellation", "[diskann][cancellation]") {
         json["metric_type"] = knowhere::metric::L2;
         json["k"] = kK;
         json["index_prefix"] = kL2IndexPrefix;
-        json["search_list_size"] = 64;
+        json["search_list_size"] = defaultSearchListSize;
         json["beamwidth"] = 8;
         if (index_type == "AISAQ") {
             json["vectors_beamwidth"] = 4;

--- a/tests/ut/test_gpu_search.cc
+++ b/tests/ut/test_gpu_search.cc
@@ -109,7 +109,7 @@ TEST_CASE("Test All GPU Index", "[search]") {
     auto cagra_hnsw_gen = [](auto&& upstream_gen) {
         return [upstream_gen]() {
             knowhere::Json json = upstream_gen();
-            json[knowhere::indexparam::ADAPT_FOR_CPU] = true;
+            json[knowhere::indexparam::ADAPT_FOR_CPU] = false;
             json[knowhere::indexparam::EF] = 128;
             return json;
         };

--- a/thirdparty/DiskANN/include/diskann/diskann_gpu.h
+++ b/thirdparty/DiskANN/include/diskann/diskann_gpu.h
@@ -1,0 +1,98 @@
+// Copyright (c) KIOXIA Corporation. All rights reserved.
+// Licensed under the MIT license.
+/*
+* Copyright (c) 2024, NVIDIA CORPORATION.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* MODIFICATIONS:
+* [21/08/2025] - [Gili Buzaglo]:
+* Import and adjust methods from cuvs library example source to knowhere
+* (vamana_build_and_write and read_bin_dataset)
+*
+* source repository: https://github.com/rapidsai/cuvs
+* release tag: v25.06.00
+* commit id: 2e20f1ec8a7e2325cdcf49d289879c2624e5bb5d
+* File name: https://github.com/rapidsai/cuvs/blob/v25.06.00/examples/cpp/src/vamana_example.cu
+* Function name: vamana_build_and_write
+* Lines: 30 – 63
+*
+* source repository: https://github.com/rapidsai/cuvs
+* release tag: v25.06.00
+* commit id: 2e20f1ec8a7e2325cdcf49d289879c2624e5bb5d
+* File name: https://github.com/rapidsai/cuvs/blob/v25.06.00/examples/cpp/src/common.cuh
+* Function name: read_bin_dataset
+* Lines: 106 - 129
+*/
+
+#ifndef THIRDPARTY_DISKANN_INCLUDE_DISKANN_DISKANN_GPU_H_
+#define THIRDPARTY_DISKANN_INCLUDE_DISKANN_DISKANN_GPU_H_
+#pragma once
+
+#ifdef KNOWHERE_WITH_CUVS
+#include <raft/core/device_mdarray.hpp>
+#include <raft/core/device_resources.hpp>
+
+template <typename T, typename idxT = std::size_t>
+raft::device_matrix<T, idxT> read_bin_dataset(const raft::device_resources& dev_resources,
+                                              const std::string& fname);
+
+template <typename T>
+void vamana_build_and_write(raft::device_resources const& dev_resources,
+                            raft::device_matrix_view<const T, uint32_t> dataset,
+                            std::string out_fname,
+                            int degree,
+                            int visited_size,
+                            float max_fraction,
+                            int iters);
+bool is_gpu_available();
+
+// train function for centroids computation
+void kmeans_gpu(
+    raft::resources& dev_resources,
+    const float* h_chunk_data,
+    size_t num_train,
+    size_t chunk_size,
+    size_t num_centers,
+    int max_iter,
+    float* h_centroids_out,
+	bool is_balanced=false);
+
+// assign function for computes the compressed PQ vector per each vector in the dataset
+// based on centroids computation
+int predict_gpu(raft::resources& dev_resources,
+				const float* h_data,
+                size_t n_samples,
+                size_t dim,
+                const float* h_centroids,
+                size_t n_clusters,
+				int* h_labels);
+
+template <typename T>
+int brute_force_gpu(raft::resources& dev_resources,
+		const T* h_data,
+        size_t n_samples,
+        size_t dim,
+		size_t k,
+        const T* queries,
+        size_t n_queries,
+		int64_t* h_labels);
+
+void gpu_get_mem_info(raft::resources &dev_resources, size_t &gpu_free_mem,size_t &gpu_total_mem);
+
+#endif
+
+
+
+
+#endif /* THIRDPARTY_DISKANN_INCLUDE_DISKANN_DISKANN_GPU_H_ */

--- a/thirdparty/DiskANN/include/diskann/math_utils.h
+++ b/thirdparty/DiskANN/include/diskann/math_utils.h
@@ -50,7 +50,7 @@ namespace math_utils {
 
   void compute_closest_centers(const float* data, size_t num_points, size_t dim,
                                const float* pivot_data, size_t num_centers,
-                               size_t k, uint32_t* closest_centers_ivf,
+                               size_t k, int64_t* closest_centers_ivf,
                                std::vector<size_t>* inverted_index = NULL,
                                float*               pts_norms_squared = NULL);
 

--- a/thirdparty/DiskANN/src/aux_utils.cpp
+++ b/thirdparty/DiskANN/src/aux_utils.cpp
@@ -20,19 +20,27 @@
 #include "diskann/aux_utils.h"
 #include "diskann/cached_io.h"
 #include "diskann/index.h"
-#include "diskann/logger.h"
 #include "diskann/partition_and_pq.h"
 #include "diskann/percentile_stats.h"
 #include "diskann/pq_flash_index.h"
 #include "knowhere/comp/task.h"
 #include "tsl/robin_set.h"
+#ifdef KNOWHERE_WITH_CUVS
+#include "diskann/diskann_gpu.h"
+#endif
 
 
 namespace diskann {
   namespace {
     static constexpr uint32_t kSearchLForCache = 15;
     static constexpr float    kCacheMemFactor = 1.1;
+    // Currently supported values for graph_degree in cuvs.
+    static const int DEGREE_SIZES[4] = {32, 64, 128, 256};
   };  // namespace
+
+  bool is_power_of_two(int64_t x) {
+    return x > 0 && (x & (x - 1)) == 0;
+  }
 
   void add_new_file_to_single_index(std::string index_file,
                                     std::string new_file) {
@@ -477,7 +485,22 @@ namespace diskann {
       double ram_budget, std::string mem_index_path, std::string medoids_file,
       std::string centroids_file) {
     size_t base_num, base_dim;
+    uint32_t shard_r = 2*R/3;
     diskann::get_bin_metadata(base_file, base_num, base_dim);
+#ifdef KNOWHERE_WITH_CUVS
+    raft::device_resources dev_resources;
+    if(compareMetric == diskann::L2 && is_gpu_available()) {
+      size_t gpu_free_mem, gpu_total_mem;
+      gpu_get_mem_info(dev_resources, gpu_free_mem, gpu_total_mem);
+      LOG_KNOWHERE_INFO_ << "GPU has " <<  gpu_free_mem/(1024*1024*1024L) <<
+              " Gib free memory out of " <<  gpu_total_mem/(1024*1024*1024L) << " Gib total";
+      ram_budget = std::min<double>(ram_budget,(double)0.9*(gpu_free_mem/(1024*1024*1024)));
+      shard_r = std::max<uint32_t>((uint32_t)32,(uint32_t)R/2);
+    } else {
+      LOG_KNOWHERE_INFO_ << "GPU is not going to be used since it is not available "
+                            "or metric type is not L2";
+    }
+#endif
 
     double full_index_ram =
         estimate_ram_usage(base_num, base_dim, sizeof(T), R);
@@ -499,9 +522,45 @@ namespace diskann {
 
       std::unique_ptr<diskann::Index<T>> _pvamanaIndex =
           std::unique_ptr<diskann::Index<T>>(new diskann::Index<T>(
-              compareMetric, ip_prepared, base_dim, base_num, false, false));
-      _pvamanaIndex->build(base_file.c_str(), base_num, paras);
-      _pvamanaIndex->save(mem_index_path.c_str(), true);
+          compareMetric, ip_prepared, base_dim, base_num, false, false));
+      bool built_with_gpu=false;
+#ifdef KNOWHERE_WITH_CUVS
+      //currently cuvs vamana build only supports L2Expanded metric
+      if (compareMetric == diskann::L2 && is_gpu_available() &&
+              (std::is_same_v<T, float> || std::is_same_v<T, uint8_t>) ) {
+        LOG_KNOWHERE_INFO_ << "Building with GPU!" << " R= "<< R<<" L=" << L;
+
+        if (std::is_same_v<T, float>) {
+          auto dataset = read_bin_dataset<float, uint64_t>(dev_resources, base_file);
+          vamana_build_and_write<float>(dev_resources,
+                                           raft::make_const_mdspan(dataset.view()),
+                                           mem_index_path,
+                                           R,
+                                           L,
+                                           0.06,
+                                           1);
+        }else {
+          auto dataset = read_bin_dataset<uint8_t, uint64_t>(dev_resources, base_file);
+          vamana_build_and_write<uint8_t>(dev_resources,
+                                           raft::make_const_mdspan(dataset.view()),
+                                           mem_index_path,
+                                           R,
+                                           L,
+                                           0.06,
+                                           1);
+        }
+        built_with_gpu=true;
+      } else {
+        LOG_KNOWHERE_INFO_ << "GPU is not going to be used since it is not available "
+                              "or metric type is not L2";
+      }
+#endif
+      if(!built_with_gpu) {
+        _pvamanaIndex->build(base_file.c_str(), base_num, paras);
+        _pvamanaIndex->save(mem_index_path.c_str(), true);
+      }else {
+        _pvamanaIndex->load_graph(mem_index_path, base_num);
+      }
 
       std::remove(medoids_file.c_str());
       std::remove(centroids_file.c_str());
@@ -510,7 +569,7 @@ namespace diskann {
     std::string merged_index_prefix = mem_index_path + "_tempFiles";
     int         num_parts =
         partition_with_ram_budget<T>(base_file, sampling_rate, ram_budget,
-                                     2 * R / 3, merged_index_prefix, 2);
+                                     shard_r, merged_index_prefix, 2);
 
     std::string cur_centroid_filepath = merged_index_prefix + "_centroids.bin";
     std::rename(cur_centroid_filepath.c_str(), centroids_file.c_str());
@@ -530,22 +589,56 @@ namespace diskann {
 
       diskann::Parameters paras;
       paras.Set<unsigned>("L", L);
-      paras.Set<unsigned>("R", (2 * (R / 3)));
+      paras.Set<unsigned>("R", shard_r);
       paras.Set<unsigned>("C", 750);
       paras.Set<float>("alpha", 1.2f);
       paras.Set<unsigned>("num_rnds", 2);
       paras.Set<bool>("saturate_graph", 0);
       paras.Set<std::string>("save_path", shard_index_file);
       paras.Set<bool>("accelerate_build", accelerate_build);
+      paras.Set<bool>("shuffle_build", shuffle_build);
 
       _u64 shard_base_dim, shard_base_pts;
+      bool built_with_gpu=false;
       get_bin_metadata(shard_base_file, shard_base_pts, shard_base_dim);
       std::unique_ptr<diskann::Index<T>> _pvamanaIndex =
           std::unique_ptr<diskann::Index<T>>(
               new diskann::Index<T>(compareMetric, ip_prepared, shard_base_dim,
-                                    shard_base_pts, false));  // TODO: Single?
-      _pvamanaIndex->build(shard_base_file.c_str(), shard_base_pts, paras);
-      _pvamanaIndex->save(shard_index_file.c_str());
+              shard_base_pts, false));  // TODO: Single?
+#ifdef KNOWHERE_WITH_CUVS
+      //currently cuvs vamana build only supports L2Expanded metric
+      if (compareMetric == diskann::L2 && is_gpu_available () &&
+              (std::is_same_v<T, float> || std::is_same_v<T, uint8_t>)) {
+        LOG_KNOWHERE_INFO_ << "Building with GPU!" << " R= "<< shard_r <<" L=" << L;
+        if (std::is_same_v<T, float> ) {
+          auto dataset = read_bin_dataset<float, uint64_t>(dev_resources, shard_base_file);
+          vamana_build_and_write<float>(dev_resources,
+                                       raft::make_const_mdspan(dataset.view()),
+                                       shard_index_file,
+                                       shard_r,
+                                       L,
+                                       0.06,
+                                       1);
+        }else {
+          auto dataset = read_bin_dataset<uint8_t, uint64_t>(dev_resources, shard_base_file);
+          vamana_build_and_write<uint8_t>(dev_resources,
+                                       raft::make_const_mdspan(dataset.view()),
+                                       shard_index_file,
+                                       shard_r,
+                                       L,
+                                       0.06,
+                                       1);
+        }
+        built_with_gpu = true;
+      } else {
+        LOG_KNOWHERE_INFO_ << "GPU is not going to be used since it is not available "
+                              "or metric type is not L2";
+      }
+#endif
+      if(!built_with_gpu){
+        _pvamanaIndex->build(shard_base_file.c_str(), shard_base_pts, paras);
+        _pvamanaIndex->save(shard_index_file.c_str());
+      }
       std::remove(shard_base_file.c_str());
     }
 
@@ -1762,7 +1855,25 @@ template<typename T>
       LOG(ERROR) << "Not building index. Please provide more RAM budget";
       return -1;
     }
-
+#ifdef KNOWHERE_WITH_CUVS
+    if(is_gpu_available()) {
+      const int* deg_size = std::find(std::begin(DEGREE_SIZES), std::end(DEGREE_SIZES), R);
+      if (deg_size == std::end(DEGREE_SIZES)) {
+        LOG_KNOWHERE_ERROR_ << "Invalid R value for cuvs - should be power of 2 and maximum 256";
+        return -1;
+      }
+      if (!is_power_of_two(L)) {
+        LOG_KNOWHERE_ERROR_ << "Invalid L value for cuvs - should be power of 2";
+        return -1;
+      }
+      if (R >= L) {
+        LOG_KNOWHERE_ERROR_ << "Invalid L value for cuvs - L must be > R";
+        return -1;
+      }
+    } else {
+      LOG_KNOWHERE_INFO_ << "GPU is not going to be used since it is not available";
+    }
+#endif
     LOG_KNOWHERE_INFO_ << "Starting index build: R=" << R << " L=" << L
                        << " Query RAM budget: "
                        << pq_code_size_limit / (1024 * 1024 * 1024) << "(GiB)"

--- a/thirdparty/DiskANN/src/aux_utils.cpp
+++ b/thirdparty/DiskANN/src/aux_utils.cpp
@@ -36,6 +36,7 @@ namespace diskann {
     static constexpr float    kCacheMemFactor = 1.1;
     // Currently supported values for graph_degree in cuvs.
     static const int DEGREE_SIZES[4] = {32, 64, 128, 256};
+    static bool valid_gpu_params = false;
   };  // namespace
 
   bool is_power_of_two(int64_t x) {
@@ -489,7 +490,7 @@ namespace diskann {
     diskann::get_bin_metadata(base_file, base_num, base_dim);
 #ifdef KNOWHERE_WITH_CUVS
     raft::device_resources dev_resources;
-    if(compareMetric == diskann::L2 && is_gpu_available()) {
+    if(compareMetric == diskann::L2 && is_gpu_available() && valid_gpu_params) {
       size_t gpu_free_mem, gpu_total_mem;
       gpu_get_mem_info(dev_resources, gpu_free_mem, gpu_total_mem);
       LOG_KNOWHERE_INFO_ << "GPU has " <<  gpu_free_mem/(1024*1024*1024L) <<
@@ -526,7 +527,7 @@ namespace diskann {
       bool built_with_gpu=false;
 #ifdef KNOWHERE_WITH_CUVS
       //currently cuvs vamana build only supports L2Expanded metric
-      if (compareMetric == diskann::L2 && is_gpu_available() &&
+      if (compareMetric == diskann::L2 && is_gpu_available() && valid_gpu_params &&
               (std::is_same_v<T, float> || std::is_same_v<T, uint8_t>) ) {
         LOG_KNOWHERE_INFO_ << "Building with GPU!" << " R= "<< R<<" L=" << L;
 
@@ -607,7 +608,7 @@ namespace diskann {
               shard_base_pts, false));  // TODO: Single?
 #ifdef KNOWHERE_WITH_CUVS
       //currently cuvs vamana build only supports L2Expanded metric
-      if (compareMetric == diskann::L2 && is_gpu_available () &&
+      if (compareMetric == diskann::L2 && is_gpu_available() && valid_gpu_params &&
               (std::is_same_v<T, float> || std::is_same_v<T, uint8_t>)) {
         LOG_KNOWHERE_INFO_ << "Building with GPU!" << " R= "<< shard_r <<" L=" << L;
         if (std::is_same_v<T, float> ) {
@@ -1857,18 +1858,22 @@ template<typename T>
     }
 #ifdef KNOWHERE_WITH_CUVS
     if(is_gpu_available()) {
+      valid_gpu_params = true;
       const int* deg_size = std::find(std::begin(DEGREE_SIZES), std::end(DEGREE_SIZES), R);
       if (deg_size == std::end(DEGREE_SIZES)) {
-        LOG_KNOWHERE_ERROR_ << "Invalid R value for cuvs - should be power of 2 and maximum 256";
-        return -1;
+        LOG_KNOWHERE_WARNING_ << "GPU is not going to be used since invalid R value for cuvs - "
+                                 "should be power of 2 and maximum 256";
+        valid_gpu_params = false;
       }
       if (!is_power_of_two(L)) {
-        LOG_KNOWHERE_ERROR_ << "Invalid L value for cuvs - should be power of 2";
-        return -1;
+        LOG_KNOWHERE_WARNING_ << "GPU is not going to be used since invalid L value for cuvs - "
+                                 "should be power of 2";
+        valid_gpu_params = false;
       }
       if (R >= L) {
-        LOG_KNOWHERE_ERROR_ << "Invalid L value for cuvs - L must be > R";
-        return -1;
+        LOG_KNOWHERE_WARNING_ << "GPU is not going to be used since invalid L value for cuvs - "
+                                 "L must be > R";
+        valid_gpu_params = false;
       }
     } else {
       LOG_KNOWHERE_INFO_ << "GPU is not going to be used since it is not available";

--- a/thirdparty/DiskANN/src/diskann_gpu.cpp
+++ b/thirdparty/DiskANN/src/diskann_gpu.cpp
@@ -1,0 +1,284 @@
+// Copyright (c) KIOXIA Corporation. All rights reserved.
+// Licensed under the MIT license.
+/*
+* Copyright (c) 2024, NVIDIA CORPORATION.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* MODIFICATIONS:
+* [21/08/2025] - [Gili Buzaglo]:
+* Import and adjust methods from cuvs library example source to knowhere
+* (vamana_build_and_write and read_bin_dataset)
+*
+* source repository: https://github.com/rapidsai/cuvs
+* release tag: v25.06.00
+* commit id: 2e20f1ec8a7e2325cdcf49d289879c2624e5bb5d
+* File name: https://github.com/rapidsai/cuvs/blob/v25.06.00/examples/cpp/src/vamana_example.cu
+* Function name: vamana_build_and_write
+* Lines: 30 – 63
+*
+* source repository: https://github.com/rapidsai/cuvs
+* release tag: v25.06.00
+* commit id: 2e20f1ec8a7e2325cdcf49d289879c2624e5bb5d
+* File name: https://github.com/rapidsai/cuvs/blob/v25.06.00/examples/cpp/src/common.cuh
+* Function name: read_bin_dataset
+* Lines: 106 - 129
+*/
+#include <cuvs/cluster/kmeans.hpp>
+#include <cuvs/neighbors/vamana.hpp>
+#include "diskann/diskann_gpu.h"
+#include "knowhere/log.h"
+#include <fstream>
+#include <iostream>
+#include <raft/core/resources.hpp>
+#include <cuvs/neighbors/brute_force.hpp>
+
+template<typename T, typename idxT>
+raft::device_matrix<T, idxT> read_bin_dataset(
+		const raft::device_resources &dev_resources, const std::string &fname) {
+	// Open file
+	std::ifstream datafile(fname, std::ios::binary);
+	if (!datafile) {
+		throw std::runtime_error("Failed to open file: " + fname);
+	}
+
+	// Read header
+	uint32_t N = 0;
+	uint32_t dim = 0;
+	datafile.read(reinterpret_cast<char*>(&N), sizeof(uint32_t));
+	datafile.read(reinterpret_cast<char*>(&dim), sizeof(uint32_t));
+
+    LOG_KNOWHERE_INFO_ << "Read in file - N: " << N << ", dim: " << dim;
+
+	std::size_t total = static_cast<std::size_t>(N) * dim;
+	if (total == 0) {
+		throw std::runtime_error("Invalid dataset: total size is zero");
+	}
+
+	// Allocate pinned host memory
+	T *pinned_data = nullptr;
+	RAFT_CUDA_TRY(
+			cudaMallocHost(reinterpret_cast<void**>(&pinned_data),
+					total * sizeof(T)));
+
+	// Read data into pinned memory
+	datafile.read(reinterpret_cast<char*>(pinned_data), total * sizeof(T));
+	if (!datafile) {
+		cudaFreeHost(pinned_data);
+		throw std::runtime_error("Failed to read vector data from file");
+	}
+	datafile.close();
+
+	// Create device matrix
+	auto dataset = raft::make_device_matrix<T, idxT>(dev_resources, N, dim);
+
+	// Copy to device using raft::copy
+	raft::copy(dataset.data_handle(), pinned_data, total,
+			raft::resource::get_cuda_stream(dev_resources));
+
+	cudaFreeHost(pinned_data);
+	return dataset;
+}
+
+template<typename T>
+void vamana_build_and_write(raft::device_resources const &dev_resources,
+		raft::device_matrix_view<const T, uint32_t> dataset,
+		std::string out_fname, int degree, int visited_size, float max_fraction,
+		int iters) {
+	using namespace cuvs::neighbors;
+
+	// use default index parameters
+	vamana::index_params index_params;
+	index_params.max_fraction = max_fraction;
+	index_params.visited_size = visited_size;
+	index_params.graph_degree = degree;
+	index_params.vamana_iters = iters;
+
+	LOG_KNOWHERE_INFO_ << "Building Vamana index (search graph)";
+
+	auto start = std::chrono::system_clock::now();
+	auto index = vamana::build(dev_resources, index_params, dataset);
+	auto end = std::chrono::system_clock::now();
+	std::chrono::duration<double> elapsed_seconds = end - start;
+
+	LOG_KNOWHERE_INFO_ << "Vamana index has " << index.size() << " vectors";
+	LOG_KNOWHERE_INFO_ << "Vamana graph has degree " << index.graph_degree()
+			<< ", graph size [" << index.graph().extent(0) << ", "
+			<< index.graph().extent(1) << "]";
+
+	LOG_KNOWHERE_INFO_ << "Time to build index: " << elapsed_seconds.count() << "s\n";
+	// Output index to file
+	serialize(dev_resources, out_fname, index);
+}
+
+void kmeans_gpu(raft::resources &dev_resources, const float *h_chunk_data,
+		size_t num_train, size_t dim, size_t num_centers, int max_iter,
+		float *h_centroids_out, bool is_balanced/*=false*/) {
+	// KMeans parameters
+	cuvs::cluster::kmeans::params km_params;
+	int64_t n_iter;
+	float inertia;
+	km_params.max_iter = max_iter;
+	km_params.n_init = 1;
+	km_params.n_clusters = num_centers;
+
+	// Allocate device matrices
+	auto d_data = raft::make_device_matrix<float>(dev_resources, num_train, dim);
+	auto d_centroids = raft::make_device_matrix<float>(dev_resources, num_centers, dim);
+
+	// Copy input chunk to device asynchronously
+	raft::copy(d_data.data_handle(), h_chunk_data, num_train * dim, raft::resource::get_cuda_stream(dev_resources));
+	// Run KMeans (fit uses RAFT-managed streams internally)
+	if(!is_balanced) {
+		cuvs::cluster::kmeans::fit(dev_resources, km_params, d_data.view(), std::nullopt,
+				d_centroids.view(),
+				raft::make_host_scalar_view<float, int64_t>(&inertia),
+				raft::make_host_scalar_view<int64_t, int64_t>(&n_iter));
+	}else {
+		//use balance kmeans
+		cuvs::cluster::kmeans::balanced_params b_p;
+		b_p.n_iters=100;
+		cuvs::cluster::kmeans::fit(dev_resources, b_p, d_data.view(), d_centroids.view());
+	}
+	// Copy centroids back to host asynchronously
+	raft::copy(h_centroids_out, d_centroids.data_handle(), num_centers * dim,
+			raft::resource::get_cuda_stream(dev_resources));
+}
+
+
+int predict_gpu(raft::resources& handle,
+                const float* h_data,
+                size_t n_samples,
+                size_t dim,
+                const float* h_centroids,
+                size_t n_clusters,
+                int* h_labels) {
+    if (!is_gpu_available()) return -1;
+
+    // Allocate device buffers
+    auto d_data      = raft::make_device_matrix<float>(handle, n_samples, dim);
+    auto d_centroids = raft::make_device_matrix<float>(handle, n_clusters, dim);
+    auto d_labels    = raft::make_device_vector<int>(handle, n_samples);
+
+    // Copy to device
+    raft::copy(d_data.data_handle(), h_data, n_samples * dim,
+               raft::resource::get_cuda_stream(handle));
+    raft::copy(d_centroids.data_handle(), h_centroids, n_clusters * dim,
+               raft::resource::get_cuda_stream(handle));
+
+    float inertia = 0.0f;
+    auto inertia_view = raft::make_host_scalar_view(&inertia);
+
+    cuvs::cluster::kmeans::params params;
+    params.n_clusters = static_cast<int>(n_clusters);
+    params.metric     = cuvs::distance::DistanceType::L2Expanded;
+
+    cuvs::cluster::kmeans::predict(
+        handle,
+        params,
+        d_data.view(),
+        std::nullopt,
+        d_centroids.view(),
+        d_labels.view(),
+        /*normalize_weight=*/false,
+        inertia_view);
+
+    // Copy back
+    raft::copy(h_labels, d_labels.data_handle(), n_samples,
+               raft::resource::get_cuda_stream(handle));
+    raft::resource::sync_stream(handle);
+
+    return 0;
+}
+
+bool is_gpu_available() {
+	int count = 0;
+	return (cudaGetDeviceCount(&count) == cudaSuccess) && (count > 0);
+}
+
+void gpu_get_mem_info(raft::resources &dev_resources, size_t &gpu_free_mem,
+		size_t &gpu_total_mem) {
+    int dev = raft::resource::get_device_id(dev_resources);
+
+    int prev_dev;
+    cudaGetDevice(&prev_dev);
+
+    cudaSetDevice(dev);
+
+    cudaMemGetInfo(&gpu_free_mem, &gpu_total_mem);
+
+    // restore previous device
+    cudaSetDevice(prev_dev);
+}
+
+template<typename T>
+int brute_force_gpu(raft::resources &dev_resources, const T *h_data,
+		size_t n_samples, size_t dim, size_t k, const T *queries,
+		size_t n_queries, int64_t *h_labels) {
+	using namespace cuvs::neighbors;
+
+	brute_force::index_params index_params;
+	brute_force::search_params search_params;
+	auto dataset = raft::make_device_matrix<T, int64_t>(dev_resources, n_samples, dim);
+	auto queries_matrix = raft::make_device_matrix<T, int64_t>(dev_resources, n_queries, dim);
+
+	raft::copy(dataset.data_handle(), h_data, n_samples * dim,
+			raft::resource::get_cuda_stream(dev_resources));
+	raft::copy(queries_matrix.data_handle(), queries, n_queries * dim,
+			raft::resource::get_cuda_stream(dev_resources));
+
+	auto index = brute_force::build(dev_resources, index_params,
+			raft::make_const_mdspan(dataset.view()));
+
+	auto neighbors = raft::make_device_matrix<int64_t, int64_t>(dev_resources,
+			n_queries, k);
+	auto distances = raft::make_device_matrix<T, int64_t>(dev_resources, n_queries, k);
+
+	brute_force::search(dev_resources, search_params, index,
+			raft::make_const_mdspan(queries_matrix.view()), neighbors.view(), distances.view());
+	// Copy back
+	raft::copy(h_labels, neighbors.data_handle(), n_queries * k,
+			raft::resource::get_cuda_stream(dev_resources));
+	return 0;
+
+}
+
+template raft::device_matrix<float, std::size_t> read_bin_dataset<float,
+		std::size_t>(const raft::device_resources &dev_resources,
+		const std::string &fname);
+
+template raft::device_matrix<uint8_t, std::size_t> read_bin_dataset<uint8_t,
+		std::size_t>(const raft::device_resources &dev_resources,
+		const std::string &fname);
+
+template void vamana_build_and_write<float>(
+		raft::device_resources const &dev_resources,
+		raft::device_matrix_view<const float, uint32_t> dataset,
+		std::string out_fname, int degree, int visited_size, float max_fraction,
+		int iters);
+
+template void vamana_build_and_write<uint8_t>(
+		raft::device_resources const &dev_resources,
+		raft::device_matrix_view<const uint8_t, uint32_t> dataset,
+		std::string out_fname, int degree, int visited_size, float max_fraction,
+		int iters);
+
+template int brute_force_gpu<float>(raft::resources& dev_resources,
+		const float* h_data,
+        size_t n_samples,
+        size_t dim,
+		size_t k,
+        const float* queries,
+        size_t n_queries,
+		int64_t* h_labels);
+

--- a/thirdparty/DiskANN/src/diskann_gpu.cpp
+++ b/thirdparty/DiskANN/src/diskann_gpu.cpp
@@ -283,4 +283,3 @@ template int brute_force_gpu<float>(raft::resources& dev_resources,
         const float* queries,
         size_t n_queries,
 		int64_t* h_labels);
-

--- a/thirdparty/DiskANN/src/diskann_gpu.cpp
+++ b/thirdparty/DiskANN/src/diskann_gpu.cpp
@@ -85,8 +85,9 @@ raft::device_matrix<T, idxT> read_bin_dataset(
 	// Copy to device using raft::copy
 	raft::copy(dataset.data_handle(), pinned_data, total,
 			raft::resource::get_cuda_stream(dev_resources));
-
+    raft::resource::sync_stream(dev_resources);
 	cudaFreeHost(pinned_data);
+
 	return dataset;
 }
 
@@ -118,7 +119,7 @@ void vamana_build_and_write(raft::device_resources const &dev_resources,
 
 	LOG_KNOWHERE_INFO_ << "Time to build index: " << elapsed_seconds.count() << "s\n";
 	// Output index to file
-	serialize(dev_resources, out_fname, index);
+	serialize(dev_resources, out_fname, index, false);
 }
 
 void kmeans_gpu(raft::resources &dev_resources, const float *h_chunk_data,
@@ -153,6 +154,7 @@ void kmeans_gpu(raft::resources &dev_resources, const float *h_chunk_data,
 	// Copy centroids back to host asynchronously
 	raft::copy(h_centroids_out, d_centroids.data_handle(), num_centers * dim,
 			raft::resource::get_cuda_stream(dev_resources));
+    raft::resource::sync_stream(dev_resources);
 }
 
 

--- a/thirdparty/DiskANN/src/math_utils.cpp
+++ b/thirdparty/DiskANN/src/math_utils.cpp
@@ -209,7 +209,7 @@ namespace math_utils {
 
   void compute_closest_centers(const float* data, size_t num_points, size_t dim,
                                const float* pivot_data, size_t num_centers,
-                               size_t k, uint32_t* closest_centers_ivf,
+                               size_t k, int64_t* closest_centers_ivf,
                                std::vector<size_t>*      inverted_index,
                                float* pts_norms_squared) {
     if (k > num_centers) {
@@ -257,7 +257,7 @@ namespace math_utils {
         for (size_t l = 0; l < k; l++) {
           size_t this_center_id =
               closest_centers[(j - cur_blk * PAR_BLOCK_SIZE) * k + l];
-          closest_centers_ivf[j * k + l] = (uint32_t) this_center_id;
+          closest_centers_ivf[j * k + l] = (int64_t) this_center_id;
         }
       }
       if (inverted_index != NULL) {

--- a/thirdparty/DiskANN/src/partition_and_pq.cpp
+++ b/thirdparty/DiskANN/src/partition_and_pq.cpp
@@ -43,11 +43,15 @@
 #include <cassert>
 #include "diskann/memory_mapper.h"
 #include "diskann/partition_and_pq.h"
+#ifdef KNOWHERE_WITH_CUVS
+#include "diskann/diskann_gpu.h"
+#endif
 
 // block size for reading/ processing large files and matrices in blocks
 #define BLOCK_SIZE 1000000
 
 // #define SAVE_INFLATED_PQ true
+constexpr uint32_t kNumOfIterations = 10;
 
 template<typename T>
 void gen_random_slice(const std::string base_file,
@@ -317,56 +321,91 @@ int generate_pq_pivots(const float *passed_train_data, size_t num_train,
 
   full_pivot_data.reset(new float[num_centers * dim]);
 
-  std::atomic<uint32_t> num_chunk_done(0);
-  const uint32_t        num_chunk_step = num_pq_chunks / COMPLETION_PERCENT;
-  auto thread_pool = knowhere::ThreadPool::GetGlobalBuildThreadPool();
-  std::vector<folly::Future<folly::Unit>> futures;
-  futures.reserve(num_pq_chunks);
-  for (size_t i = 0; i < num_pq_chunks; i++) {
-    size_t cur_chunk_size = chunk_offsets[i + 1] - chunk_offsets[i];
-    if (cur_chunk_size == 0)
-      continue;
-    futures.emplace_back(thread_pool->push([&, chunk_size = cur_chunk_size,
-                                            index = i]() {
+  bool used_gpu = false;
+#ifdef KNOWHERE_WITH_CUVS
+  // GPU path
+  if(is_gpu_available()) {
+    raft::resources res;
+    LOG_KNOWHERE_INFO_ << "Running pq with " << num_centers << " clusters, pq "<< num_pq_chunks<< " ...using GPU!";
+    for (size_t i = 0; i < num_pq_chunks; i++) {
+      size_t cur_chunk_size = chunk_offsets[i + 1] - chunk_offsets[i];
+      if (cur_chunk_size == 0)
+        continue;
       std::unique_ptr<float[]> cur_pivot_data =
-          std::make_unique<float[]>(num_centers * chunk_size);
+        std::make_unique<float[]>(num_centers * cur_chunk_size);
       std::unique_ptr<float[]> cur_data =
-          std::make_unique<float[]>(num_train * chunk_size);
+        std::make_unique<float[]>(num_train * cur_chunk_size);
       std::unique_ptr<uint32_t[]> closest_center =
-          std::make_unique<uint32_t[]>(num_train);
-
-      LOG_KNOWHERE_DEBUG_ << "Processing chunk " << index
-                          << " with dimensions [" << chunk_offsets[index]
-                          << ", " << chunk_offsets[index + 1] << ")";
-
+        std::make_unique<uint32_t[]>(num_train);
       for (int64_t j = 0; j < (_s64) num_train; j++) {
-        std::memcpy(cur_data.get() + j * chunk_size,
-                    train_data.get() + j * dim + chunk_offsets[index],
-                    chunk_size * sizeof(float));
+        std::memcpy(cur_data.get() + j * cur_chunk_size,
+                train_data.get() + j * dim + chunk_offsets[i],
+                cur_chunk_size * sizeof(float));
       }
-
-      kmeans::kmeanspp_selecting_pivots(cur_data.get(), num_train, chunk_size,
-                                        cur_pivot_data.get(), num_centers);
-
-      kmeans::run_lloyds(cur_data.get(), num_train, chunk_size,
-                         cur_pivot_data.get(), num_centers, max_k_means_reps,
-                         NULL, closest_center.get());
+      kmeans_gpu(res,cur_data.get(), num_train, cur_chunk_size,
+              num_centers, max_k_means_reps, cur_pivot_data.get());
 
       for (uint64_t j = 0; j < num_centers; j++) {
-        std::memcpy(full_pivot_data.get() + j * dim + chunk_offsets[index],
-                    cur_pivot_data.get() + j * chunk_size,
-                    chunk_size * sizeof(float));
+        std::memcpy(full_pivot_data.get() + j * dim + chunk_offsets[i],
+                cur_pivot_data.get() + j * cur_chunk_size,
+                cur_chunk_size * sizeof(float));
       }
-      uint32_t cur_chunk_done = num_chunk_done.fetch_add(1);
-      if (num_chunk_step == 0 || cur_chunk_done % num_chunk_step == 0 ||
-          cur_chunk_done == num_pq_chunks) {
-        LOG_KNOWHERE_INFO_ << "Genereated pivots for " << cur_chunk_done
-                           << " chunks out of " << num_pq_chunks;
-      }
-    }));
+    }
+    used_gpu = true;
   }
-  knowhere::WaitAllSuccess(futures);
+#endif
 
+  if(!used_gpu) {
+    std::atomic<uint32_t> num_chunk_done(0);
+    const uint32_t        num_chunk_step = num_pq_chunks / COMPLETION_PERCENT;
+    auto thread_pool = knowhere::ThreadPool::GetGlobalBuildThreadPool();
+    std::vector<folly::Future<folly::Unit>> futures;
+    futures.reserve(num_pq_chunks);
+    for (size_t i = 0; i < num_pq_chunks; i++) {
+      size_t cur_chunk_size = chunk_offsets[i + 1] - chunk_offsets[i];
+      if (cur_chunk_size == 0)
+        continue;
+      futures.emplace_back(thread_pool->push([&, chunk_size = cur_chunk_size,
+                                              index = i]() {
+        std::unique_ptr<float[]> cur_pivot_data =
+            std::make_unique<float[]>(num_centers * chunk_size);
+        std::unique_ptr<float[]> cur_data =
+            std::make_unique<float[]>(num_train * chunk_size);
+        std::unique_ptr<uint32_t[]> closest_center =
+            std::make_unique<uint32_t[]>(num_train);
+
+        LOG_KNOWHERE_DEBUG_ << "Processing chunk " << index
+                            << " with dimensions [" << chunk_offsets[index]
+                            << ", " << chunk_offsets[index + 1] << ")";
+
+        for (int64_t j = 0; j < (_s64) num_train; j++) {
+          std::memcpy(cur_data.get() + j * chunk_size,
+                      train_data.get() + j * dim + chunk_offsets[index],
+                      chunk_size * sizeof(float));
+        }
+
+        kmeans::kmeanspp_selecting_pivots(cur_data.get(), num_train, chunk_size,
+                                          cur_pivot_data.get(), num_centers);
+
+        kmeans::run_lloyds(cur_data.get(), num_train, chunk_size,
+                           cur_pivot_data.get(), num_centers, max_k_means_reps,
+                           NULL, closest_center.get());
+
+        for (uint64_t j = 0; j < num_centers; j++) {
+          std::memcpy(full_pivot_data.get() + j * dim + chunk_offsets[index],
+                      cur_pivot_data.get() + j * chunk_size,
+                      chunk_size * sizeof(float));
+        }
+        uint32_t cur_chunk_done = num_chunk_done.fetch_add(1);
+        if (num_chunk_step == 0 || cur_chunk_done % num_chunk_step == 0 ||
+            cur_chunk_done == num_pq_chunks) {
+          LOG_KNOWHERE_INFO_ << "Generated pivots for " << cur_chunk_done
+                             << " chunks out of " << num_pq_chunks;
+        }
+      }));
+    }
+    knowhere::WaitAllSuccess(futures);
+  }
   diskann::save_bin<float>(pq_pivots_path.c_str(), full_pivot_data.get(),
                            (size_t) num_centers, dim);
   std::string centroids_path =
@@ -539,6 +578,10 @@ int generate_pq_data_from_pivots(const std::string data_file,
           }));
     }
     knowhere::WaitAllSuccess(futures);
+#ifdef KNOWHERE_WITH_CUVS
+    // GPU path
+    raft::resources res;
+#endif
 
     futures.clear();
     futures.reserve(num_pq_chunks);
@@ -568,8 +611,19 @@ int generate_pq_data_from_pivots(const std::string data_file,
               chunk_size * sizeof(float));
         }
 
-        math_utils::elkan_L2(cur_data.get(), cur_pivot_data.get(), chunk_size,
-                             cur_blk_size, num_centers, closest_center.get());
+        bool predicted_with_gpu=false;
+#if defined(KNOWHERE_WITH_CUVS)
+        if (is_gpu_available()) {
+            predict_gpu(res, cur_data.get(), cur_blk_size, chunk_size,
+                         cur_pivot_data.get(), num_centers,
+                         reinterpret_cast<int*>(closest_center.get()));
+            predicted_with_gpu = true;
+        }
+#endif
+        if(!predicted_with_gpu){
+            math_utils::elkan_L2(cur_data.get(), cur_pivot_data.get(), chunk_size,
+                         cur_blk_size, num_centers, closest_center.get());
+        }
 
         for (int64_t j = 0; j < (_s64) cur_blk_size; j++) {
           block_compressed_base[j * num_pq_chunks + chunk_index] =
@@ -622,47 +676,88 @@ int estimate_cluster_sizes(float *test_data_float, size_t num_test,
                            const float *pivots, const size_t num_centers,
                            const size_t test_dim, const size_t k_base,
                            std::vector<size_t> &cluster_sizes) {
-  cluster_sizes.clear();
 
-  auto shard_counts = std::make_unique<size_t[]>(num_centers);
+	size_t k_candidates = num_centers;
 
-  for (size_t i = 0; i < num_centers; i++) {
-    shard_counts[i] = 0;
-  }
-
-  size_t block_size = num_test <= BLOCK_SIZE ? num_test : BLOCK_SIZE;
-  auto block_closest_centers = std::make_unique<_u32[]>(block_size * k_base);
-  float *block_data_float;
-
-  size_t num_blocks = DIV_ROUND_UP(num_test, block_size);
-
-  for (size_t block = 0; block < num_blocks; block++) {
-    size_t start_id = block * block_size;
-    size_t end_id = (std::min)((block + 1) * block_size, num_test);
-    size_t cur_blk_size = end_id - start_id;
-
-    block_data_float = test_data_float + start_id * test_dim;
-
-    math_utils::compute_closest_centers(block_data_float, cur_blk_size,
-                                        test_dim, pivots, num_centers, k_base,
-                                        block_closest_centers.get());
-
-    for (size_t p = 0; p < cur_blk_size; p++) {
-      for (size_t p1 = 0; p1 < k_base; p1++) {
-        size_t shard_id = block_closest_centers[p * k_base + p1];
-        shard_counts[shard_id]++;
-      }
+    if (k_base == 0 || k_base > k_candidates) {
+        LOG_KNOWHERE_ERROR_ << "Invalid k_base: must be in [1," << k_candidates << "]";
+        return -1;
     }
-  }
-  std::stringstream cluster_size_stream;
-  cluster_size_stream << "Estimated cluster sizes: ";
-  for (size_t i = 0; i < num_centers; i++) {
-    _u32 cur_shard_count = (_u32) shard_counts[i];
-    cluster_sizes.push_back((size_t) cur_shard_count);
-    cluster_size_stream << cur_shard_count << " ";
-  }
-  LOG_KNOWHERE_DEBUG_ << cluster_size_stream.str();
-  return 0;
+
+    cluster_sizes.clear();
+    cluster_sizes.resize(num_centers, 0);
+
+    auto shard_counts = std::make_unique<size_t[]>(num_centers);
+    std::fill_n(shard_counts.get(), num_centers, 0);
+
+    const size_t block_size = num_test <= BLOCK_SIZE ? num_test : BLOCK_SIZE;
+    auto block_closest_centers = std::make_unique<int64_t[]>(block_size * k_candidates);
+
+    const size_t num_blocks = DIV_ROUND_UP(num_test, block_size);
+
+    const double beta = 0.1;  // weight for distance vs. balance: 0..1
+
+    for (size_t block = 0; block < num_blocks; block++) {
+        const size_t start_id = block * block_size;
+        const size_t end_id   = std::min((block + 1) * block_size, num_test);
+        const size_t cur_blk_size = end_id - start_id;
+
+        float* block_data_float = test_data_float + start_id * test_dim;
+        bool used_gpu = false;
+#ifdef KNOWHERE_WITH_CUVS
+	    // GPU path
+        if(is_gpu_available()) {
+		  raft::resources res;
+		  if(block %1000 == 0) {
+			  LOG_KNOWHERE_INFO_ << "Running brute force for " << cur_blk_size << " vectors...using GPU!";
+		  }
+		  brute_force_gpu(res, pivots, num_centers, test_dim, k_candidates,
+				  block_data_float, cur_blk_size, block_closest_centers.get());
+
+		  used_gpu = true;
+        }
+#endif
+        if(!used_gpu) {
+        	math_utils::compute_closest_centers(block_data_float, cur_blk_size,
+                                            test_dim, pivots, num_centers,
+											k_candidates, block_closest_centers.get());
+        }
+
+        for (size_t p = 0; p < cur_blk_size; p++) {
+            const size_t* cand = (const size_t*)block_closest_centers.get() + p * k_candidates;
+
+            bool used[k_candidates] = {false};
+
+            for (size_t assign = 0; assign < k_base; assign++) {
+                size_t best_idx = SIZE_MAX;
+                double best_score = std::numeric_limits<double>::max();
+
+                for (size_t i = 0; i < k_candidates; i++) {
+                    if (used[i]) continue;
+                    size_t cid = cand[i];
+                    double normalized_count = (double)shard_counts[cid] * k_candidates / num_test;
+                    double score = beta * i + (1.0 - beta) * normalized_count;
+                    if (score < best_score) {
+                        best_score = score;
+                        best_idx = i;
+                    }
+                }
+
+                used[best_idx] = true;
+                shard_counts[cand[best_idx]]++;
+            }
+        }
+    }
+
+    cluster_sizes.assign(shard_counts.get(), shard_counts.get() + num_centers);
+
+    std::stringstream cluster_size_stream;
+    cluster_size_stream << "Estimated cluster sizes: ";
+    for (size_t i = 0; i < num_centers; i++)
+        cluster_size_stream << cluster_sizes[i] << " ";
+    LOG_KNOWHERE_INFO_ << cluster_size_stream.str();
+
+    return 0;
 }
 
 template<typename T>
@@ -707,8 +802,8 @@ int shard_data_into_clusters(const std::string data_file, float *pivots,
   }
 
   size_t block_size = num_points <= BLOCK_SIZE ? num_points : BLOCK_SIZE;
-  std::unique_ptr<_u32[]> block_closest_centers =
-      std::make_unique<_u32[]>(block_size * k_base);
+  std::unique_ptr<int64_t[]> block_closest_centers =
+      std::make_unique<int64_t[]>(block_size * k_base);
   std::unique_ptr<T[]> block_data_T = std::make_unique<T[]>(block_size * dim);
   std::unique_ptr<float[]> block_data_float =
       std::make_unique<float[]>(block_size * dim);
@@ -723,11 +818,26 @@ int shard_data_into_clusters(const std::string data_file, float *pivots,
     base_reader.read((char *) block_data_T.get(),
                      sizeof(T) * (cur_blk_size * dim));
     diskann::convert_types<T, float>(block_data_T.get(), block_data_float.get(),
-                                     cur_blk_size, dim);
+    cur_blk_size, dim);
 
-    math_utils::compute_closest_centers(block_data_float.get(), cur_blk_size,
-                                        dim, pivots, num_centers, k_base,
-                                        block_closest_centers.get());
+    bool used_gpu = false;
+#ifdef KNOWHERE_WITH_CUVS
+    // GPU path
+    if(is_gpu_available()) {
+      raft::resources res;
+      if(block %1000 == 0) {
+        LOG_KNOWHERE_INFO_ << "Running brute force for " << cur_blk_size << " vectors...using GPU!";
+      }
+      brute_force_gpu(res, pivots, num_centers, dim, k_base,
+              block_data_float.get(), cur_blk_size, block_closest_centers.get());
+      used_gpu = true;
+    }
+#endif
+    if(!used_gpu) {
+      math_utils::compute_closest_centers(block_data_float.get(), cur_blk_size,
+                                          dim, pivots, num_centers, k_base,
+                                          block_closest_centers.get());
+    }
 
     for (size_t p = 0; p < cur_blk_size; p++) {
       for (size_t p1 = 0; p1 < k_base; p1++) {
@@ -771,88 +881,125 @@ int shard_data_into_clusters_only_ids(const std::string data_file,
                                       float *pivots, const size_t num_centers,
                                       const size_t dim, const size_t k_base,
                                       std::string prefix_path) {
-  _u64 read_blk_size = 64 * 1024 * 1024;
-  //  _u64 write_blk_size = 64 * 1024 * 1024;
-  // create cached reader + writer
-  cached_ifstream base_reader(data_file, read_blk_size);
-  _u32            npts32;
-  _u32            basedim32;
-  base_reader.read((char *) &npts32, sizeof(uint32_t));
-  base_reader.read((char *) &basedim32, sizeof(uint32_t));
-  size_t num_points = npts32;
-  if (basedim32 != dim) {
-    LOG(ERROR) << "Error. dimensions dont match for train set and base set";
-    return -1;
-  }
+    size_t k_candidates = num_centers;
 
-  std::unique_ptr<size_t[]> shard_counts =
-      std::make_unique<size_t[]>(num_centers);
-
-  std::vector<std::ofstream> shard_idmap_writer(num_centers);
-  _u32                       dummy_size = 0;
-  _u32                       const_one = 1;
-
-  for (size_t i = 0; i < num_centers; i++) {
-    std::string idmap_filename =
-        prefix_path + "_subshard-" + std::to_string(i) + "_ids_uint32.bin";
-    shard_idmap_writer[i] =
-        std::ofstream(idmap_filename.c_str(), std::ios::binary);
-    shard_idmap_writer[i].write((char *) &dummy_size, sizeof(uint32_t));
-    shard_idmap_writer[i].write((char *) &const_one, sizeof(uint32_t));
-    shard_counts[i] = 0;
-  }
-
-  size_t block_size = num_points <= BLOCK_SIZE ? num_points : BLOCK_SIZE;
-  std::unique_ptr<_u32[]> block_closest_centers =
-      std::make_unique<_u32[]>(block_size * k_base);
-  std::unique_ptr<T[]> block_data_T = std::make_unique<T[]>(block_size * dim);
-  std::unique_ptr<float[]> block_data_float =
-      std::make_unique<float[]>(block_size * dim);
-
-  size_t num_blocks = DIV_ROUND_UP(num_points, block_size);
-
-  for (size_t block = 0; block < num_blocks; block++) {
-    size_t start_id = block * block_size;
-    size_t end_id = (std::min)((block + 1) * block_size, num_points);
-    size_t cur_blk_size = end_id - start_id;
-
-    base_reader.read((char *) block_data_T.get(),
-                     sizeof(T) * (cur_blk_size * dim));
-    diskann::convert_types<T, float>(block_data_T.get(), block_data_float.get(),
-                                     cur_blk_size, dim);
-
-    math_utils::compute_closest_centers(block_data_float.get(), cur_blk_size,
-                                        dim, pivots, num_centers, k_base,
-                                        block_closest_centers.get());
-
-    for (size_t p = 0; p < cur_blk_size; p++) {
-      for (size_t p1 = 0; p1 < k_base; p1++) {
-        size_t   shard_id = block_closest_centers[p * k_base + p1];
-        uint32_t original_point_map_id = (uint32_t) (start_id + p);
-        shard_idmap_writer[shard_id].write((char *) &original_point_map_id,
-                                           sizeof(uint32_t));
-        shard_counts[shard_id]++;
-      }
+    if (k_base == 0 || k_base > k_candidates) {
+        LOG_KNOWHERE_ERROR_ << "Invalid k_base: must be in [1," << k_candidates << "]";
+        return -1;
     }
-  }
 
-  size_t            total_count = 0;
-  std::stringstream shard_size_stream;
-  shard_size_stream << "Actual shard sizes: ";
-  for (size_t i = 0; i < num_centers; i++) {
-    _u32 cur_shard_count = (_u32) shard_counts[i];
-    total_count += cur_shard_count;
-    shard_size_stream << cur_shard_count << " ";
-    shard_idmap_writer[i].seekp(0);
-    shard_idmap_writer[i].write((char *) &cur_shard_count, sizeof(uint32_t));
-    shard_idmap_writer[i].close();
-  }
-  LOG_KNOWHERE_INFO_ << shard_size_stream.str();
-  LOG_KNOWHERE_INFO_ << "Partitioned " << num_points
-                     << " with replication factor " << k_base << " to get "
-                     << total_count << " points across " << num_centers
-                     << " shards ";
-  return 0;
+    _u64 read_blk_size = 64 * 1024 * 1024;
+    cached_ifstream base_reader(data_file, read_blk_size);
+
+    _u32 npts32;
+    _u32 basedim32;
+    base_reader.read((char*)&npts32, sizeof(uint32_t));
+    base_reader.read((char*)&basedim32, sizeof(uint32_t));
+    size_t num_points = npts32;
+    if (basedim32 != dim) {
+        LOG(ERROR) << "Error. dimensions dont match for train set and base set";
+        return -1;
+    }
+
+    std::unique_ptr<size_t[]> shard_counts = std::make_unique<size_t[]>(num_centers);
+    std::fill_n(shard_counts.get(), num_centers, 0);
+
+    std::vector<std::ofstream> shard_idmap_writer(num_centers);
+    _u32 dummy_size = 0;
+    _u32 const_one = 1;
+
+    for (size_t i = 0; i < num_centers; i++) {
+        std::string idmap_filename =
+            prefix_path + "_subshard-" + std::to_string(i) + "_ids_uint32.bin";
+        shard_idmap_writer[i] =
+            std::ofstream(idmap_filename.c_str(), std::ios::binary);
+        shard_idmap_writer[i].write((char*)&dummy_size, sizeof(uint32_t));
+        shard_idmap_writer[i].write((char*)&const_one, sizeof(uint32_t));
+    }
+
+    size_t block_size = num_points <= BLOCK_SIZE ? num_points : BLOCK_SIZE;
+    std::unique_ptr<int64_t[]> block_closest_centers = std::make_unique<int64_t[]>(block_size * k_candidates);
+    std::unique_ptr<T[]> block_data_T = std::make_unique<T[]>(block_size * dim);
+    std::unique_ptr<float[]> block_data_float = std::make_unique<float[]>(block_size * dim);
+
+    size_t num_blocks = DIV_ROUND_UP(num_points, block_size);
+
+    const double beta = 0.1;  // distance vs balance weight
+
+    for (size_t block = 0; block < num_blocks; block++) {
+        size_t start_id = block * block_size;
+        size_t end_id = std::min((block + 1) * block_size, num_points);
+        size_t cur_blk_size = end_id - start_id;
+
+        base_reader.read((char*)block_data_T.get(), sizeof(T) * (cur_blk_size * dim));
+        diskann::convert_types<T, float>(block_data_T.get(), block_data_float.get(), cur_blk_size, dim);
+        bool used_gpu = false;
+#ifdef KNOWHERE_WITH_CUVS
+		// GPU path
+		if(is_gpu_available()) {
+		  raft::resources res;
+		  if(block %1000 == 0) {
+			  LOG_KNOWHERE_INFO_ << "Running brute force for " << cur_blk_size << " vectors...using GPU!";
+		  }
+		  brute_force_gpu(res, pivots, num_centers, dim, k_candidates,
+				  block_data_float.get(), cur_blk_size, block_closest_centers.get());
+		  used_gpu = true;
+		}
+#endif
+		if(!used_gpu) {
+			math_utils::compute_closest_centers(block_data_float.get(), cur_blk_size,
+											dim, pivots, num_centers,
+											k_candidates, block_closest_centers.get());
+		}
+
+        for (size_t p = 0; p < cur_blk_size; p++) {
+            size_t* cand = (size_t*)block_closest_centers.get() + p * k_candidates;
+
+            bool used[k_candidates] = {false};
+
+            for (size_t assign = 0; assign < k_base; assign++) {
+                size_t best_idx = SIZE_MAX;
+                double best_score = std::numeric_limits<double>::max();
+
+                for (size_t i = 0; i < k_candidates; i++) {
+                    if (used[i]) continue;
+                    size_t cid = cand[i];
+                    double normalized_count = (double)shard_counts[cid] * k_candidates / num_points;
+                    double score = beta * i + (1.0 - beta) * normalized_count;
+                    if (score < best_score) {
+                        best_score = score;
+                        best_idx = i;
+                    }
+                }
+
+                used[best_idx] = true;
+                size_t shard_id = cand[best_idx];
+                uint32_t original_point_map_id = (uint32_t)(start_id + p);
+                shard_idmap_writer[shard_id].write((char*)&original_point_map_id, sizeof(uint32_t));
+                shard_counts[shard_id]++;
+            }
+        }
+    }
+
+    size_t total_count = 0;
+    std::stringstream shard_size_stream;
+    shard_size_stream << "Actual shard sizes: ";
+    for (size_t i = 0; i < num_centers; i++) {
+        _u32 cur_shard_count = (_u32)shard_counts[i];
+        total_count += cur_shard_count;
+        shard_size_stream << cur_shard_count << " ";
+        shard_idmap_writer[i].seekp(0);
+        shard_idmap_writer[i].write((char*)&cur_shard_count, sizeof(uint32_t));
+        shard_idmap_writer[i].close();
+    }
+
+    LOG_KNOWHERE_INFO_ << shard_size_stream.str();
+    LOG_KNOWHERE_INFO_ << "Partitioned " << num_points
+                       << " with replication factor " << k_base << " to get "
+                       << total_count << " points across " << num_centers
+                       << " shards ";
+
+    return 0;
 }
 
 template<typename T>
@@ -949,11 +1096,24 @@ int partition(const std::string data_file, const float sampling_rate,
 
   // Process Global k-means for kmeans_partitioning Step
   LOG_KNOWHERE_DEBUG_ << "Processing global k-means (kmeans_partitioning Step)";
-  kmeans::kmeanspp_selecting_pivots(train_data_float.get(), num_train, train_dim,
-                                    pivot_data.get(), num_parts);
+  bool used_gpu = false;
+#ifdef KNOWHERE_WITH_CUVS
+  // GPU path
+  if(is_gpu_available()) {
+    raft::resources res;
+    LOG_KNOWHERE_INFO_ << "Running k-means with " << num_parts << " clusters...using GPU!";
+    kmeans_gpu(res,train_data_float.get(), num_train, train_dim,
+            num_parts, max_k_means_reps, pivot_data.get());
+    used_gpu = true;
+  }
+#endif
+  if(!used_gpu) {
+    kmeans::kmeanspp_selecting_pivots(train_data_float.get(), num_train, train_dim,
+                                      pivot_data.get(), num_parts);
 
-  kmeans::run_lloyds(train_data_float.get(), num_train, train_dim, pivot_data.get(),
-                     num_parts, max_k_means_reps, NULL, NULL);
+    kmeans::run_lloyds(train_data_float.get(), num_train, train_dim, pivot_data.get(),
+                       num_parts, max_k_means_reps, NULL, NULL);
+  }
 
   LOG_KNOWHERE_DEBUG_ << "Saving global k-center pivots";
   diskann::save_bin<float>(output_file.c_str(), pivot_data.get(), (size_t) num_parts,
@@ -1005,12 +1165,25 @@ int partition_with_ram_budget(const std::string data_file,
     pivot_data = std::make_unique<float[]>(num_parts * train_dim);
     // Process Global k-means for kmeans_partitioning Step
     LOG_KNOWHERE_INFO_
-        << "Processing global k-means (kmeans_partitioning Step)";
-    kmeans::kmeanspp_selecting_pivots(train_data_float.get(), num_train, train_dim,
-                                      pivot_data.get(), num_parts);
+    << "Processing global k-means (kmeans_partitioning Step)";
+    bool used_gpu = false;
+#ifdef KNOWHERE_WITH_CUVS
+    // GPU path
+    if(is_gpu_available()) {
+      raft::resources res;
+      LOG_KNOWHERE_INFO_ << "Running k-means with " << num_parts << " clusters " << num_train << " " << train_dim << " ...using GPU!";
+      kmeans_gpu(res,train_data_float.get(), num_train, train_dim,
+              num_parts, max_k_means_reps, pivot_data.get(), true);
+      used_gpu = true;
+    }
+#endif
+    if(!used_gpu) {
+      kmeans::kmeanspp_selecting_pivots(train_data_float.get(), num_train, train_dim,
+                                        pivot_data.get(), num_parts);
 
-    kmeans::run_lloyds(train_data_float.get(), num_train, train_dim, pivot_data.get(),
-                       num_parts, max_k_means_reps, NULL, NULL);
+      kmeans::run_lloyds(train_data_float.get(), num_train, train_dim, pivot_data.get(),
+                         num_parts, max_k_means_reps, NULL, NULL);
+    }
 
     // now pivots are ready. need to stream base points and assign them to
     // closest clusters.
@@ -1061,16 +1234,33 @@ int partition_calc_kmeans(const std::string &data_file, const std::string &outpu
     size_t train_dim, num_train;
     //float *train_data_float;
     std::unique_ptr<float[]> train_data_float = nullptr;
+    float min_sample_ratio = static_cast<float>(k) / static_cast<float>(npts32);
+    float suggested_ratio = 0.01;
+    float slice_ratio = std::max(min_sample_ratio, suggested_ratio);
+    LOG_KNOWHERE_INFO_ << "partition_calc_kmeans with " << slice_ratio << " slice_ratio...";
     // Load a sample of the dataset for k-means
-    gen_random_slice<T>(data_file, 0.01, train_data_float, num_train, train_dim, &sampled_ids);
+    gen_random_slice<T>(data_file, slice_ratio, train_data_float, num_train, train_dim, &sampled_ids);
 
     // Allocate centroids
     std::vector<float> centroids(k * train_dim);
     // Perform k-means clustering
-    LOG_KNOWHERE_INFO_ << "Running k-means with " << k << " clusters...";
-    kmeans::kmeanspp_selecting_pivots(train_data_float.get(), num_train, train_dim, centroids.data(), k);
-    LOG_KNOWHERE_INFO_ << "Running LLoyds " << k << " clusters...";
-    kmeans::run_lloyds(train_data_float.get(), num_train, train_dim, centroids.data(), k, 10, nullptr, nullptr);
+    bool used_gpu = false;
+#ifdef KNOWHERE_WITH_CUVS
+    // GPU path
+    if(is_gpu_available()) {
+      raft::resources res;
+      LOG_KNOWHERE_INFO_ << "Running k-means with " << k << " clusters...using GPU!";
+      kmeans_gpu(res,train_data_float.get(), num_train, train_dim,
+              k, kNumOfIterations, centroids.data());
+      used_gpu = true;
+    }
+#endif
+    if(!used_gpu) {
+      LOG_KNOWHERE_INFO_ << "Running k-means with " << k << " clusters...";
+      kmeans::kmeanspp_selecting_pivots(train_data_float.get(), num_train, train_dim, centroids.data(), k);
+      LOG_KNOWHERE_INFO_ << "Running LLoyds " << k << " clusters...";
+      kmeans::run_lloyds(train_data_float.get(), num_train, train_dim, centroids.data(), k, kNumOfIterations, nullptr, nullptr);
+    }
 
     std::vector<uint32_t> medoids(k);
     // Parallel computation of medoids

--- a/thirdparty/DiskANN/src/partition_and_pq.cpp
+++ b/thirdparty/DiskANN/src/partition_and_pq.cpp
@@ -325,33 +325,38 @@ int generate_pq_pivots(const float *passed_train_data, size_t num_train,
 #ifdef KNOWHERE_WITH_CUVS
   // GPU path
   if(is_gpu_available()) {
-    raft::resources res;
-    LOG_KNOWHERE_INFO_ << "Running pq with " << num_centers << " clusters, pq "<< num_pq_chunks<< " ...using GPU!";
-    for (size_t i = 0; i < num_pq_chunks; i++) {
-      size_t cur_chunk_size = chunk_offsets[i + 1] - chunk_offsets[i];
-      if (cur_chunk_size == 0)
-        continue;
-      std::unique_ptr<float[]> cur_pivot_data =
-        std::make_unique<float[]>(num_centers * cur_chunk_size);
-      std::unique_ptr<float[]> cur_data =
-        std::make_unique<float[]>(num_train * cur_chunk_size);
-      std::unique_ptr<uint32_t[]> closest_center =
-        std::make_unique<uint32_t[]>(num_train);
-      for (int64_t j = 0; j < (_s64) num_train; j++) {
-        std::memcpy(cur_data.get() + j * cur_chunk_size,
-                train_data.get() + j * dim + chunk_offsets[i],
-                cur_chunk_size * sizeof(float));
-      }
-      kmeans_gpu(res,cur_data.get(), num_train, cur_chunk_size,
-              num_centers, max_k_means_reps, cur_pivot_data.get());
+    // cuVS kmeans crashes when num_centers > num_train, fall back to CPU
+    if (num_train < num_centers) {
+      LOG_KNOWHERE_INFO_ << "num_centers(" << num_centers << ") > num_train(" << num_train << "), switching to CPU";
+    } else {
+      raft::resources res;
+      LOG_KNOWHERE_INFO_ << "Running pq with " << num_centers << " clusters, pq "<< num_pq_chunks<< " ...using GPU!";
+      for (size_t i = 0; i < num_pq_chunks; i++) {
+        size_t cur_chunk_size = chunk_offsets[i + 1] - chunk_offsets[i];
+        if (cur_chunk_size == 0)
+          continue;
+        std::unique_ptr<float[]> cur_pivot_data =
+          std::make_unique<float[]>(num_centers * cur_chunk_size);
+        std::unique_ptr<float[]> cur_data =
+          std::make_unique<float[]>(num_train * cur_chunk_size);
+        std::unique_ptr<uint32_t[]> closest_center =
+          std::make_unique<uint32_t[]>(num_train);
+        for (int64_t j = 0; j < (_s64) num_train; j++) {
+          std::memcpy(cur_data.get() + j * cur_chunk_size,
+                  train_data.get() + j * dim + chunk_offsets[i],
+                  cur_chunk_size * sizeof(float));
+        }
+        kmeans_gpu(res,cur_data.get(), num_train, cur_chunk_size,
+                num_centers, max_k_means_reps, cur_pivot_data.get());
 
-      for (uint64_t j = 0; j < num_centers; j++) {
-        std::memcpy(full_pivot_data.get() + j * dim + chunk_offsets[i],
-                cur_pivot_data.get() + j * cur_chunk_size,
-                cur_chunk_size * sizeof(float));
+        for (uint64_t j = 0; j < num_centers; j++) {
+          std::memcpy(full_pivot_data.get() + j * dim + chunk_offsets[i],
+                  cur_pivot_data.get() + j * cur_chunk_size,
+                  cur_chunk_size * sizeof(float));
+        }
       }
+      used_gpu = true;
     }
-    used_gpu = true;
   }
 #endif
 
@@ -715,7 +720,7 @@ int estimate_cluster_sizes(float *test_data_float, size_t num_test,
         }
 #endif
         if(!used_gpu) {
-        	math_utils::compute_closest_centers(block_data_float, cur_blk_size,
+            math_utils::compute_closest_centers(block_data_float, cur_blk_size,
                                             test_dim, pivots, num_centers,
 											k_candidates, block_closest_centers.get());
         }
@@ -1097,11 +1102,16 @@ int partition(const std::string data_file, const float sampling_rate,
 #ifdef KNOWHERE_WITH_CUVS
   // GPU path
   if(is_gpu_available()) {
-    raft::resources res;
-    LOG_KNOWHERE_INFO_ << "Running k-means with " << num_parts << " clusters...using GPU!";
-    kmeans_gpu(res,train_data_float.get(), num_train, train_dim,
-            num_parts, max_k_means_reps, pivot_data.get());
-    used_gpu = true;
+    // cuVS kmeans crashes when num_centers > num_train, fall back to CPU
+    if (num_train < num_parts) {
+      LOG_KNOWHERE_INFO_ << "num_centers(" << num_parts << ") > num_train(" << num_train << "), switching to CPU";
+    } else {
+      raft::resources res;
+      LOG_KNOWHERE_INFO_ << "Running k-means with " << num_parts << " clusters...using GPU!";
+      kmeans_gpu(res,train_data_float.get(), num_train, train_dim,
+              num_parts, max_k_means_reps, pivot_data.get());
+      used_gpu = true;
+    }
   }
 #endif
   if(!used_gpu) {
@@ -1167,11 +1177,16 @@ int partition_with_ram_budget(const std::string data_file,
 #ifdef KNOWHERE_WITH_CUVS
     // GPU path
     if(is_gpu_available()) {
-      raft::resources res;
-      LOG_KNOWHERE_INFO_ << "Running k-means with " << num_parts << " clusters " << num_train << " " << train_dim << " ...using GPU!";
-      kmeans_gpu(res,train_data_float.get(), num_train, train_dim,
-              num_parts, max_k_means_reps, pivot_data.get(), true);
-      used_gpu = true;
+      // cuVS kmeans crashes when num_centers > num_train, fall back to CPU
+      if (num_train < num_parts) {
+        LOG_KNOWHERE_INFO_ << "num_centers(" << num_parts << ") > num_train(" << num_train << "), switching to CPU";
+      } else {
+        raft::resources res;
+        LOG_KNOWHERE_INFO_ << "Running k-means with " << num_parts << " clusters " << num_train << " " << train_dim << " ...using GPU!";
+        kmeans_gpu(res,train_data_float.get(), num_train, train_dim,
+                num_parts, max_k_means_reps, pivot_data.get(), true);
+        used_gpu = true;
+      }
     }
 #endif
     if(!used_gpu) {
@@ -1245,11 +1260,16 @@ int partition_calc_kmeans(const std::string &data_file, const std::string &outpu
 #ifdef KNOWHERE_WITH_CUVS
     // GPU path
     if(is_gpu_available()) {
-      raft::resources res;
-      LOG_KNOWHERE_INFO_ << "Running k-means with " << k << " clusters...using GPU!";
-      kmeans_gpu(res,train_data_float.get(), num_train, train_dim,
-              k, kNumOfIterations, centroids.data());
-      used_gpu = true;
+      // cuVS kmeans crashes when num_centers > num_train, fall back to CPU
+      if (num_train < k) {
+        LOG_KNOWHERE_INFO_ << "num_centers(" << k << ") > num_train(" << num_train << "), switching to CPU";
+      } else {
+        raft::resources res;
+        LOG_KNOWHERE_INFO_ << "Running k-means with " << k << " clusters...using GPU!";
+        kmeans_gpu(res,train_data_float.get(), num_train, train_dim,
+                k, kNumOfIterations, centroids.data());
+        used_gpu = true;
+      }
     }
 #endif
     if(!used_gpu) {

--- a/thirdparty/DiskANN/src/partition_and_pq.cpp
+++ b/thirdparty/DiskANN/src/partition_and_pq.cpp
@@ -578,10 +578,6 @@ int generate_pq_data_from_pivots(const std::string data_file,
           }));
     }
     knowhere::WaitAllSuccess(futures);
-#ifdef KNOWHERE_WITH_CUVS
-    // GPU path
-    raft::resources res;
-#endif
 
     futures.clear();
     futures.reserve(num_pq_chunks);
@@ -614,6 +610,7 @@ int generate_pq_data_from_pivots(const std::string data_file,
         bool predicted_with_gpu=false;
 #if defined(KNOWHERE_WITH_CUVS)
         if (is_gpu_available()) {
+            raft::resources res;
             predict_gpu(res, cur_data.get(), cur_blk_size, chunk_size,
                          cur_pivot_data.get(), num_centers,
                          reinterpret_cast<int*>(closest_center.get()));


### PR DESCRIPTION
issue: #1616

Cherrypick DiskANN GPU build support to the `2.6` branch.

## Summary

- Cherrypick #1460, #1481, and #1518 onto `2.6`.
- Add the cuVS-backed GPU path for building DiskANN indexes, with CPU fallback when GPU is unavailable or parameters are not supported by cuVS.
- Bring the related DiskANN GPU parameter validation and unit test coverage.
- Include the cuVS GPU memory access fix and CUDA diag 550 suppression needed for the GPU build path.

## Test plan

- [x] `conan install .. --build=missing -o with_ut=True -o with_cuvs=True -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release`
- [x] `conan build ..`
- [x] `LD_LIBRARY_PATH="$PWD/build/Release:$PWD/build/Release/_deps/cuvs-build:${LD_LIBRARY_PATH}" ./build/Release/tests/ut/knowhere_tests "Test DiskANN Build Index" --success --durations yes`
- [x] `LD_LIBRARY_PATH="$PWD/build/Release:$PWD/build/Release/_deps/cuvs-build:${LD_LIBRARY_PATH}" ./build/Release/tests/ut/knowhere_tests "Test DiskANNIndexNode." --reporter compact --durations yes`
- [x] `LD_LIBRARY_PATH="$PWD/build/Release:$PWD/build/Release/_deps/cuvs-build:${LD_LIBRARY_PATH}" ./build/Release/tests/ut/knowhere_tests "Test DISKANN for EmbList" --reporter compact --durations yes`
- [x] `LD_LIBRARY_PATH="$PWD/build/Release:$PWD/build/Release/_deps/cuvs-build:${LD_LIBRARY_PATH}" ./build/Release/tests/ut/knowhere_tests "Test DiskANN GetVectorByIds" --reporter compact --durations yes`

## Notes

- Verified on an NVIDIA L4 GPU with driver `560.35.05`.
- The DiskANN GPU test logs confirmed the cuVS path was used: `Running pq with 256 clusters, pq 16 ...using GPU!` and `Building with GPU! R= 64 L=128`.
- This PR intentionally keeps the minimal DiskANN GPU cherrypick scope and does not include unrelated GPU dependency stack upgrades.
