### PR TITLE
Update build scripts

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,7 +26,8 @@ Checks: >
     performance-trivially-destructible, performance-inefficient-vector-operation,
     performance-move-const-arg, performance-move-constructor-init,
     performance-noexcept-move-constructor, performance-no-automatic-move,
-    performance-type-promotion-in-math-fn, -clang-analyzer-optin.core.EnumCastOutOfRange
+    performance-type-promotion-in-math-fn, -clang-analyzer-optin.core.EnumCastOutOfRange,
+    -modernize-use-ranges
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '^(?:.*\/knowhere\/include\/.+\.h)|(?:.*\/knowhere\/src\/.+\.h)$'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,7 +26,7 @@ Checks: >
     performance-trivially-destructible, performance-inefficient-vector-operation,
     performance-move-const-arg, performance-move-constructor-init,
     performance-noexcept-move-constructor, performance-no-automatic-move,
-    performance-type-promotion-in-math-fn
+    performance-type-promotion-in-math-fn, -clang-analyzer-optin.core.EnumCastOutOfRange
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '^(?:.*\/knowhere\/include\/.+\.h)|(?:.*\/knowhere\/src\/.+\.h)$'

--- a/.claude/skills/building/SKILL.md
+++ b/.claude/skills/building/SKILL.md
@@ -10,7 +10,7 @@ description: Use when building knowhere from source, configuring build options (
 ```bash
 # Ubuntu/Debian
 sudo apt install build-essential libopenblas-openmp-dev libaio-dev python3-dev python3-pip
-pip3 install conan==2.25.1 --user
+pip3 install conan==2.28.1 --user
 conan profile detect --force
 conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2
 export PATH=$PATH:$HOME/.local/bin

--- a/.github/workflows/analyzer.yaml
+++ b/.github/workflows/analyzer.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Build & Analyzer
         run: |
           make WITH_UT=True \
-          && find src -type f | grep -E "\.cc$" | xargs /usr/bin/run-clang-tidy-14.py -quiet -p=./build/Release
+          && find src -type f | grep -E "\.cc$" | xargs /usr/bin/run-clang-tidy-22.py -quiet -p=./build/Release
       - name: Save Cache
         uses: ./.github/actions/cache-save
         with:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -20,8 +20,6 @@ jobs:
         include:
           - os: ubuntu-22.04
             arch: x86_64
-          # - os: ubuntu-20.04
-          #   arch: aarch64
           # - os: macos-11
           #   arch: x86_64
           # - os: macos-11
@@ -37,20 +35,21 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: pypa/cibuildwheel@v2.12.1
+      - uses: pypa/cibuildwheel@v3.4.1
         env:
-          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311*"
-          CIBW_SKIP: "*musllinux*" # faiss-cpu fails to build on musllinux
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+          CIBW_SKIP: "*musllinux* cp31?t-*" # faiss-cpu fails to build on musllinux; skip free-threaded CPython.
           CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
+          CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
           CIBW_BEFORE_ALL_LINUX: "bash scripts/install_deps.sh && make"
-          # Use portable wheel build script instead of plain setup.py
-          CIBW_BEFORE_BUILD: "pip3 install pytest numpy faiss-cpu bfloat16 auditwheel"
+          CIBW_BEFORE_BUILD: "python -m pip install wheel pytest 'numpy>=2,<3' ml-dtypes faiss-cpu auditwheel"
           # Custom build command using our portable wheel builder
           CIBW_BUILD_FRONTEND: "build"
           # Note: cibuildwheel will use our build_portable_wheel.sh via setup.py
           # The script automatically handles auditwheel repair
-          CIBW_TEST_REQUIRES: "pytest numpy<2 faiss-cpu bfloat16"
-          CIBW_TEST_COMMAND: "pytest {project}/tests/python/test_index_with_random.py"
+          CIBW_TEST_REQUIRES: "wheel pytest numpy>=2,<3 ml-dtypes faiss-cpu"
+          CIBW_TEST_COMMAND: "python -m pytest {project}/tests/python/test_index_with_random.py"
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.tag }}"
         with:
           package-dir: python
@@ -61,7 +60,7 @@ jobs:
 
   upload:
     needs: [build_wheels]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -103,17 +103,15 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Install Dependency
         run: |
           bash scripts/install_deps.sh
-          pip3 install pytest faiss-cpu
+          python -m pip install wheel pytest 'numpy>=2,<3' ml-dtypes faiss-cpu
       - name: Install GCC 12
         # GCC 11 (ubuntu-22.04 default) has incomplete C++20 support:
         # std::partial_ordering, std::strong_ordering, std::weak_ordering
         # from <compare> are not available, causing abseil build failures.
-        # Installed after install_deps.sh so bfloat16 builds with GCC 11
-        # (bfloat16 fails on GCC 12 due to missing #include <memory>).
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-12 g++-12
@@ -139,4 +137,4 @@ jobs:
           cd python && pip3 install dist/*-manylinux*.whl
       - name: Test
         run: |
-          pytest tests/python/test_index_with_random.py
+          python -m pytest tests/python/test_index_with_random.py

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ coverage/
 
 # virtualenv
 venv/
+**/.venv/
 **/dist/
 **/knowhere.egg-info/
 **/knowhere/knowhere_wrap.cpp

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ CARDINAL_VERSION_FORCE_CHECKOUT ?=
 WITH_DEBUG ?=
 CONAN_PROFILE ?=
 
+# CMake 4.x removed compatibility with cmake_minimum_required versions below
+# 3.5. Export this so Conan-built third-party packages inherit it too.
+export CMAKE_POLICY_VERSION_MINIMUM ?= 3.5
+
 # Prevent build-flag variables from leaking into the environment of child
 # processes (conan / cmake).  Without this, GNU Make exports command-line
 # variables such as WITH_ASAN to every sub-process, which causes the custom
@@ -104,7 +108,7 @@ ifneq ($(CARDINAL_VERSION_FORCE_CHECKOUT),)
 endif
 
 ifdef CONAN_PROFILE
-    CONAN_SETTINGS += -pr $(CONAN_PROFILE)
+    CONAN_SETTINGS += -pr:h $(CONAN_PROFILE) -pr:b $(CONAN_PROFILE)
 endif
 
 .PHONY: build test \
@@ -173,7 +177,7 @@ help: ## Show available targets
 	@echo "  WITH_CARDINAL=True Enable Cardinal build"
 	@echo "  CARDINAL_VERSION_FORCE_CHECKOUT=True Force Cardinal checkout to configured version"
 	@echo "  WITH_DEBUG=True    Debug build (default: Release)"
-	@echo "  CONAN_PROFILE=<p>  Use a custom Conan profile (e.g. clang, gcc-15)"
+	@echo "  CONAN_PROFILE=<p>  Use one custom Conan profile for host and build"
 	@echo "  LIBCXX=<lib>       Override compiler.libcxx (auto-detected from OS)"
 	@echo ""
 	@echo "Examples:"
@@ -183,5 +187,5 @@ help: ## Show available targets
 	@echo "  make WITH_GPU=True WITH_UT=True   # GPU UT"
 	@echo "  make WITH_DEBUG=True WITH_UT=True # CPU debug + UT"
 	@echo "  make LIBCXX=libc++                # override compiler.libcxx"
-	@echo "  make CONAN_PROFILE=gcc15          # CPU with custom profile"
+	@echo "  make CONAN_PROFILE=/path/to/profile # CPU with custom profile"
 	@echo ""

--- a/ci/docker/builder/cpu/ubuntu20.04/Dockerfile
+++ b/ci/docker/builder/cpu/ubuntu20.04/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3 \
 # install knowhere dependancies
 RUN apt update \
     && apt install -y libopenblas-openmp-dev libcurl4-openssl-dev libaio-dev libevent-dev lcov \
-    && pip3 install conan==2.25.1 \
+    && pip3 install conan==2.28.1 \
     && conan profile detect --force \
     && conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2 \
     && export PATH=$PATH:$HOME/.local/bin

--- a/ci/docker/builder/cpu/ubuntu22.04/Dockerfile
+++ b/ci/docker/builder/cpu/ubuntu22.04/Dockerfile
@@ -6,7 +6,6 @@ ENV CMAKE_TAR="cmake-3.28.5-linux-x86_64.tar.gz"
 ENV CCACHE_VERSION="v4.9.1"
 ENV CCACHE_DIR="ccache-4.9.1-linux-x86_64"
 ENV CCACHE_TAR="ccache-4.9.1-linux-x86_64.tar.xz"
-ENV BFLOAT16_WHL="bfloat16-1.4.0-cp311-cp311-linux_x86_64.whl"
 
 RUN apt update \
     && apt install -y ca-certificates apt-transport-https software-properties-common lsb-release \
@@ -26,7 +25,7 @@ RUN apt update \
     && apt remove --purge -y \
     && rm -rf /var/lib/apt/lists/*
 
-# install cmake, ccache and bfloat16
+# install cmake, ccache and Python BF16 dtype support
 RUN cd /tmp \
     && wget https://github.com/Kitware/CMake/releases/download/${CMAKE_VERSION}/${CMAKE_TAR} \
     && tar --strip-components=1 -xz -C /usr/local -f ${CMAKE_TAR} \
@@ -35,14 +34,12 @@ RUN cd /tmp \
     && tar -xf ${CCACHE_TAR} \
     && cp ${CCACHE_DIR}/ccache /usr/local/bin \
     && rm -f ${CCACHE_TAR} \
-    && wget https://github.com/zilliztech/knowhere/releases/download/v2.3.1/${BFLOAT16_WHL} \
-    && pip3 install ${BFLOAT16_WHL} \
-    && rm -f ${BFLOAT16_WHL}
+    && pip3 install 'numpy>=2,<3' ml-dtypes
 
 # install knowhere dependancies
 RUN apt update \
     && apt install -y libopenblas-openmp-dev libcurl4-openssl-dev libaio-dev libevent-dev lcov \
-    && pip3 install conan==2.25.1 \
+    && pip3 install conan==2.28.1 \
     && conan profile detect --force \
     && conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2
 # clone knowhere repo and build to update .conan2

--- a/ci/docker/builder/cpu/ubuntu22.04/arm64/Dockerfile
+++ b/ci/docker/builder/cpu/ubuntu22.04/arm64/Dockerfile
@@ -5,7 +5,6 @@ ENV CMAKE_VERSION="v3.30.5"
 ENV CMAKE_TAR="cmake-3.30.5-linux-aarch64.tar.gz"
 ENV CCACHE_DIR="ccache-4.9.1"
 ENV CCACHE_SRC_TAR="v4.9.1.tar.gz"
-ENV BFLOAT16_WHL="bfloat16-1.4.0-cp311-cp311-linux_aarch64.whl"
 
 RUN apt update \
     && apt install -y ca-certificates apt-transport-https software-properties-common lsb-release \
@@ -25,7 +24,7 @@ RUN apt update \
     && apt remove --purge -y \
     && rm -rf /var/lib/apt/lists/*
 
-# install cmake, ccache and bfloat16
+# install cmake, ccache and Python BF16 dtype support
 RUN cd /tmp \
     && wget https://github.com/Kitware/CMake/releases/download/${CMAKE_VERSION}/${CMAKE_TAR} \
     && tar --strip-components=1 -xz -C /usr/local -f ${CMAKE_TAR} \
@@ -37,14 +36,12 @@ RUN cd /tmp \
     && cmake -D CMAKE_BUILD_TYPE=Release .. \
     && make -j3 && make install \
     && cd ../.. && rm -rf ${CCACHE_DIR} ${CCACHE_SRC_TAR} \
-    && wget https://github.com/zilliztech/knowhere/releases/download/v2.3.1/${BFLOAT16_WHL} \
-    && pip3 install ${BFLOAT16_WHL} \
-    && rm -f ${BFLOAT16_WHL}
+    && pip3 install 'numpy>=2,<3' ml-dtypes
 
 # install knowhere dependancies
 RUN apt update \
     && apt install -y libopenblas-openmp-dev libcurl4-openssl-dev libaio-dev libevent-dev lcov \
-    && pip3 install conan==2.25.1 \
+    && pip3 install conan==2.28.1 \
     && conan profile detect --force \
     && conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2
 # clone knowhere repo and build to update .conan2

--- a/ci/docker/builder/gpu/ubuntu20.04/Dockerfile
+++ b/ci/docker/builder/gpu/ubuntu20.04/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3 \
 # install knowhere dependancies
 RUN apt update \
     && apt install -y libopenblas-openmp-dev libcurl4-openssl-dev libaio-dev libevent-dev lcov \
-    && pip3 install conan==2.25.1 \
+    && pip3 install conan==2.28.1 \
     && conan profile detect --force \
     && conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2 \
     && export PATH=$PATH:$HOME/.local/bin

--- a/ci/docker/builder/gpu/ubuntu22.04/Dockerfile
+++ b/ci/docker/builder/gpu/ubuntu22.04/Dockerfile
@@ -6,7 +6,6 @@ ENV CMAKE_TAR="cmake-3.30.5-linux-x86_64.tar.gz"
 ENV CCACHE_VERSION="v4.9.1"
 ENV CCACHE_DIR="ccache-4.9.1-linux-x86_64"
 ENV CCACHE_TAR="ccache-4.9.1-linux-x86_64.tar.xz"
-ENV BFLOAT16_WHL="bfloat16-1.4.0-cp311-cp311-linux_x86_64.whl"
 
 RUN apt update \
     && apt install -y ca-certificates apt-transport-https software-properties-common lsb-release \
@@ -26,7 +25,7 @@ RUN apt update \
     && apt remove --purge -y \
     && rm -rf /var/lib/apt/lists/*
 
-# install cmake, ccache and bfloat16
+# install cmake, ccache and Python BF16 dtype support
 RUN cd /tmp \
     && wget https://github.com/Kitware/CMake/releases/download/${CMAKE_VERSION}/${CMAKE_TAR} \
     && tar --strip-components=1 -xz -C /usr/local -f ${CMAKE_TAR} \
@@ -35,14 +34,12 @@ RUN cd /tmp \
     && tar -xf ${CCACHE_TAR} \
     && cp ${CCACHE_DIR}/ccache /usr/local/bin \
     && rm -f ${CCACHE_TAR} \
-    && wget https://github.com/zilliztech/knowhere/releases/download/v2.3.1/${BFLOAT16_WHL} \
-    && pip3 install ${BFLOAT16_WHL} \
-    && rm -f ${BFLOAT16_WHL}
+    && pip3 install 'numpy>=2,<3' ml-dtypes
 
 # install knowhere dependancies
 RUN apt update \
     && apt install -y libopenblas-openmp-dev libcurl4-openssl-dev libaio-dev libevent-dev lcov \
-    && pip3 install conan==2.25.1 \
+    && pip3 install conan==2.28.1 \
     && conan profile detect --force \
     && conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2
 # clone knowhere repo and build to update .conan2

--- a/include/knowhere/utils.h
+++ b/include/knowhere/utils.h
@@ -59,7 +59,7 @@ CopyAndNormalizeVecs(const DataType* x, size_t rows, int32_t dim);
 
 template <typename DataType>
 extern void
-NormalizeDataset(const DataSetPtr dataset);
+NormalizeDataset(DataSetPtr dataset);
 
 template <typename DataType>
 extern std::tuple<DataSetPtr, std::vector<float>>

--- a/python/build_portable_wheel.sh
+++ b/python/build_portable_wheel.sh
@@ -7,7 +7,19 @@ set -euo pipefail
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="${SCRIPT_DIR}/../build/Release"
-PYTHON="${PYTHON:-python3}"
+VENV_DIR="${KNOWHERE_PYTHON_VENV:-${SCRIPT_DIR}/.venv}"
+
+# Prefer the project-local uv venv for standalone builds, but still honor an
+# explicit PYTHON from cibuildwheel or a workflow-specific interpreter.
+if [ -z "${PYTHON:-}" ] && [ -x "${VENV_DIR}/bin/python" ]; then
+    PYTHON="${VENV_DIR}/bin/python"
+    export PATH="${VENV_DIR}/bin:${PATH}"
+else
+    PYTHON="${PYTHON:-python3}"
+    if [ -d "${VENV_DIR}/bin" ]; then
+        export PATH="${VENV_DIR}/bin:${PATH}"
+    fi
+fi
 
 # Color output (optional)
 if [ -t 1 ]; then
@@ -66,15 +78,21 @@ check_deps() {
         fi
     done
 
-    command -v auditwheel >/dev/null || {
-        log_warn "auditwheel not found, installing..."
-        pip3 install -q auditwheel
-    }
-
     command -v "$PYTHON" >/dev/null || { log_error "Python not found: $PYTHON"; exit 1; }
 
+    if ! command -v auditwheel >/dev/null; then
+        if command -v uv >/dev/null; then
+            log_warn "auditwheel not found, installing into $PYTHON environment with uv..."
+            uv pip install --python "$PYTHON" auditwheel
+            export PATH="$(dirname "$PYTHON"):${PATH}"
+        else
+            log_error "auditwheel not found. Run scripts/install_deps.sh to create the uv-managed Python environment."
+            exit 1
+        fi
+    fi
+
     $PYTHON -c "import numpy" 2>/dev/null || {
-        log_error "numpy not found. Install with: pip3 install 'numpy<2'"
+        log_error "numpy not found. Install with: uv pip install --python '$PYTHON' 'numpy>=2,<3'"
         exit 1
     }
 
@@ -115,8 +133,9 @@ detect_platform() {
     local major=$(echo "$glibc_ver" | cut -d. -f1)
     local minor=$(echo "$glibc_ver" | cut -d. -f2)
 
-    # Map GLIBC version to manylinux tag with detected architecture
-    if   [ "$major" -eq 2 ] && [ "$minor" -ge 35 ]; then echo "manylinux_2_35_${arch}"
+    # PEP 600 tags are glibc-versioned. Do not cap newer distros at 2.35:
+    # auditwheel rejects that when binaries contain newer versioned symbols.
+    if   [ "$major" -eq 2 ] && [ "$minor" -ge 35 ]; then echo "manylinux_2_${minor}_${arch}"
     elif [ "$major" -eq 2 ] && [ "$minor" -ge 31 ]; then echo "manylinux_2_31_${arch}"
     elif [ "$major" -eq 2 ] && [ "$minor" -ge 28 ]; then echo "manylinux_2_28_${arch}"
     elif [ "$major" -eq 2 ] && [ "$minor" -ge 24 ]; then echo "manylinux_2_24_${arch}"
@@ -152,10 +171,18 @@ repair_wheel() {
                 sed 's/.*\[\(.*\)\]/\1/' | \
                 tr ':' '\n' | grep -v '^$' | tr '\n' ':')
 
-    export LD_LIBRARY_PATH="${lib_paths}:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu"
+    local multiarch
+    multiarch=$(gcc -print-multiarch 2>/dev/null || true)
+
+    local system_lib_paths="/lib:/usr/lib"
+    if [ -n "$multiarch" ]; then
+        system_lib_paths="${system_lib_paths}:/lib/${multiarch}:/usr/lib/${multiarch}"
+    fi
+
+    export LD_LIBRARY_PATH="${lib_paths}:${system_lib_paths}:${LD_LIBRARY_PATH:-}"
 
     # Run auditwheel repair (all output to stderr so it doesn't leak into command substitution)
-    if ! auditwheel repair "$wheel" -w dist/ --plat "$platform" 2>&1 >&2; then
+    if ! auditwheel repair "$wheel" -w dist/ --plat "$platform" >&2; then
         log_error "auditwheel repair failed" >&2
         exit 1
     fi

--- a/python/knowhere/__init__.py
+++ b/python/knowhere/__init__.py
@@ -8,7 +8,7 @@ from .swigknowhere import BruteForceSearchInt8, BruteForceRangeSearchInt8
 from .swigknowhere import BruteForceSearchBin, BruteForceRangeSearchBin
 
 import numpy as np
-from bfloat16 import bfloat16
+from ml_dtypes import bfloat16
 
 
 def CreateIndex(name, version, type=np.float32):

--- a/python/knowhere/knowhere.i
+++ b/python/knowhere/knowhere.i
@@ -41,6 +41,12 @@ typedef uint64_t size_t;
 #include <fstream>
 #include <string>
 using namespace knowhere;
+
+#if SWIG_VERSION >= 0x040300
+#define KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT(result, obj, is_void) SWIG_Python_AppendOutput(result, obj, is_void)
+#else
+#define KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT(result, obj, is_void) SWIG_Python_AppendOutput(result, obj)
+#endif
 %}
 
 %{
@@ -97,7 +103,7 @@ import_array();
 %typemap(argout) knowhere::Status& status %{
     PyObject *o;
     o = PyInt_FromLong(long(*$1));
-    $result = SWIG_Python_AppendOutput($result, o);
+    $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result, o, 0);
 %}
 
 %pythoncode %{

--- a/python/knowhere/numpy.i
+++ b/python/knowhere/numpy.i
@@ -1991,7 +1991,7 @@
 %typemap(argout)
   (DATA_TYPE ARGOUT_ARRAY1[ANY])
 {
-  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,(PyObject*)array$argnum, 1);
 }
 
 /* Typemap suite for (DATA_TYPE* ARGOUT_ARRAY1, DIM_TYPE DIM1)
@@ -2020,7 +2020,7 @@
 %typemap(argout)
   (DATA_TYPE* ARGOUT_ARRAY1, DIM_TYPE DIM1)
 {
-  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,(PyObject*)array$argnum, 1);
 }
 
 /* Typemap suite for (DIM_TYPE DIM1, DATA_TYPE* ARGOUT_ARRAY1)
@@ -2049,7 +2049,7 @@
 %typemap(argout)
   (DIM_TYPE DIM1, DATA_TYPE* ARGOUT_ARRAY1)
 {
-  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,(PyObject*)array$argnum, 1);
 }
 
 /* Typemap suite for (DATA_TYPE ARGOUT_ARRAY2[ANY][ANY])
@@ -2067,7 +2067,7 @@
 %typemap(argout)
   (DATA_TYPE ARGOUT_ARRAY2[ANY][ANY])
 {
-  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,(PyObject*)array$argnum, 1);
 }
 
 /* Typemap suite for (DATA_TYPE ARGOUT_ARRAY3[ANY][ANY][ANY])
@@ -2085,7 +2085,7 @@
 %typemap(argout)
   (DATA_TYPE ARGOUT_ARRAY3[ANY][ANY][ANY])
 {
-  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,(PyObject*)array$argnum, 1);
 }
 
 /* Typemap suite for (DATA_TYPE ARGOUT_ARRAY4[ANY][ANY][ANY][ANY])
@@ -2103,7 +2103,7 @@
 %typemap(argout)
   (DATA_TYPE ARGOUT_ARRAY4[ANY][ANY][ANY][ANY])
 {
-  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,(PyObject*)array$argnum, 1);
 }
 
 /*****************************/
@@ -2128,7 +2128,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DATA_TYPE** ARGOUTVIEW_ARRAY1)
@@ -2149,7 +2149,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEW_ARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
@@ -2171,7 +2171,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEW_ARRAY2)
@@ -2193,7 +2193,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEW_FARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
@@ -2215,7 +2215,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array || !require_fortran(array)) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEW_FARRAY2)
@@ -2237,7 +2237,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array || !require_fortran(array)) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEW_ARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2261,7 +2261,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3,
@@ -2285,7 +2285,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEW_FARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2309,7 +2309,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array || !require_fortran(array)) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3,
@@ -2333,7 +2333,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array || !require_fortran(array)) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEW_ARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2358,7 +2358,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
@@ -2383,7 +2383,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEW_FARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2408,7 +2408,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array || !require_fortran(array)) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
@@ -2433,7 +2433,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array || !require_fortran(array)) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /*************************************/
@@ -2471,7 +2471,7 @@
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DATA_TYPE** ARGOUTVIEWM_ARRAY1)
@@ -2505,7 +2505,7 @@
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_ARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
@@ -2540,7 +2540,7 @@
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEWM_ARRAY2)
@@ -2575,7 +2575,7 @@
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_FARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
@@ -2610,7 +2610,7 @@
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEWM_FARRAY2)
@@ -2645,7 +2645,7 @@
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_ARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2682,7 +2682,7 @@
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3,
@@ -2719,7 +2719,7 @@
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_FARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2756,7 +2756,7 @@
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3,
@@ -2793,7 +2793,7 @@
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_ARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2831,7 +2831,7 @@
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
@@ -2869,7 +2869,7 @@
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_FARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2907,7 +2907,7 @@
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
@@ -2945,7 +2945,7 @@
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = KNOWHERE_SWIG_PYTHON_APPEND_OUTPUT($result,obj, 1);
 }
 
 /**************************************/

--- a/python/setup.py
+++ b/python/setup.py
@@ -107,7 +107,10 @@ setup(
     author_email="milvus-team@zilliz.com",
     license='Apache License 2.0',
     keywords="search nearest neighbors",
-    # numpy must be pre-installed (install_deps.sh handles this).
+
+    # numpy must be pre-installed in the active Python environment. Standalone
+    # wheel builds use the uv-managed python/.venv from install_deps.sh; CI
+    # jobs such as cibuildwheel install numpy into their own active interpreter.
     # Do NOT use setup_requires — it triggers the deprecated fetch_build_eggs
     # which makes network calls to PyPI and fails intermittently in CI.
     #use_scm_version={'root': '..', 'local_scheme': 'no-local-version', 'version_scheme': 'release-branch-semver'},
@@ -116,7 +119,11 @@ setup(
     packages=["knowhere"],
     include_package_data=True,
     package_data={"knowhere": ["libknowhere.so"]},
-    python_requires=">=3.8",
+    python_requires=">=3.10",
+    install_requires=[
+        "numpy>=2,<3",
+        "ml-dtypes",
+    ],
     ext_modules=[_swigknowhere],
     cmdclass={"build_py": CustomBuildPy},
     classifiers=[
@@ -125,10 +132,11 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
 )

--- a/scripts/conan_profiles/clang_22_arm
+++ b/scripts/conan_profiles/clang_22_arm
@@ -1,0 +1,36 @@
+# ARM clang-22 profile used by the Ubuntu multiversion validation.
+# Boost.Build maps Conan armv8 to arm64-pc-linux, which breaks clang's
+# libstdc++ discovery on Ubuntu aarch64. Build boost and libunwind with GCC 12
+# and keep the rest of Knowhere on clang-22 with the GNU aarch64 target.
+
+[settings]
+arch=armv8
+build_type=Release
+compiler=clang
+compiler.cppstd=20
+compiler.libcxx=libstdc++11
+compiler.version=22
+os=Linux
+boost/*:compiler=gcc
+boost/*:compiler.cppstd=20
+boost/*:compiler.libcxx=libstdc++11
+boost/*:compiler.version=12
+libunwind/*:compiler=gcc
+libunwind/*:compiler.version=12
+
+[conf]
+tools.build:compiler_executables={"c": "clang-22", "cpp": "clang++-22"}
+tools.build:cflags=["--target=aarch64-linux-gnu"]
+tools.build:cxxflags=["--target=aarch64-linux-gnu"]
+tools.build:sharedlinkflags=["--target=aarch64-linux-gnu"]
+tools.build:exelinkflags=["--target=aarch64-linux-gnu"]
+boost/*:tools.build:compiler_executables={"c": "gcc-12", "cpp": "g++-12"}
+boost/*:tools.build:cflags=[]
+boost/*:tools.build:cxxflags=[]
+boost/*:tools.build:sharedlinkflags=[]
+boost/*:tools.build:exelinkflags=[]
+libunwind/*:tools.build:compiler_executables={"c": "gcc-12", "cpp": "g++-12"}
+libunwind/*:tools.build:cflags=[]
+libunwind/*:tools.build:cxxflags=[]
+libunwind/*:tools.build:sharedlinkflags=[]
+libunwind/*:tools.build:exelinkflags=[]

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -27,8 +27,12 @@
 
 set -euo pipefail
 
-CONAN_VERSION="2.25.1"
+CONAN_VERSION="2.28.1"
 CONAN_REMOTE_URL="https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2"
+CMAKE_MIN_VERSION="${CMAKE_MIN_VERSION:-3.28.1}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+KNOWHERE_PYTHON_VENV="${KNOWHERE_PYTHON_VENV:-${REPO_ROOT}/python/.venv}"
 
 UNAME="$(uname -s)"
 case "${UNAME}" in
@@ -39,27 +43,230 @@ esac
 
 echo "[install_deps] Installing dependencies..."
 
+version_ge() {
+    local actual="$1"
+    local required="$2"
+    [[ "$(printf '%s\n%s\n' "${required}" "${actual}" | sort -V | head -n1)" == "${required}" ]]
+}
+
+cmake_version() {
+    command -v cmake >/dev/null 2>&1 || return 1
+    cmake --version | awk 'NR == 1 { print $3 }'
+}
+
+cmake_satisfies_minimum() {
+    local current
+    current="$(cmake_version 2>/dev/null || true)"
+    [[ -n "${current}" ]] && version_ge "${current}" "${CMAKE_MIN_VERSION}"
+}
+
+pip3_install() {
+    if pip3 install "$@"; then
+        return
+    fi
+
+    echo "[install_deps] pip3 install failed; retrying with --break-system-packages for PEP 668 environments."
+    pip3 install --break-system-packages "$@"
+}
+
+python_user_bin() {
+    local user_base
+    user_base="$(python3 -m site --user-base 2>/dev/null || true)"
+    if [[ -n "${user_base}" ]]; then
+        printf '%s/bin\n' "${user_base}"
+    fi
+}
+
+install_uv() {
+    if ! command -v pip3 >/dev/null 2>&1; then
+        echo "[install_deps] pip3 is required to bootstrap uv."
+        exit 1
+    fi
+
+    local user_bin
+    user_bin="$(python_user_bin)"
+    export PATH="${user_bin:+${user_bin}:}$HOME/.local/bin:$PATH"
+
+    if ! command -v uv >/dev/null 2>&1; then
+        echo "[install_deps] Installing uv with pip3..."
+        pip3_install --user uv
+    fi
+
+    if ! command -v uv >/dev/null 2>&1; then
+        echo "[install_deps] uv was installed, but the uv executable is not on PATH."
+        echo "[install_deps] Checked Python user bin: ${user_bin:-unavailable}; fallback bin: $HOME/.local/bin."
+        exit 1
+    fi
+}
+
+configure_uv_tool_path() {
+    if [[ -z "${UV_TOOL_BIN_DIR:-}" ]]; then
+        if [[ -w /usr/local/bin ]]; then
+            export UV_TOOL_BIN_DIR="/usr/local/bin"
+        else
+            export UV_TOOL_BIN_DIR="$HOME/.local/bin"
+        fi
+    fi
+    mkdir -p "${UV_TOOL_BIN_DIR}"
+    export PATH="${UV_TOOL_BIN_DIR}:$HOME/.local/bin:$PATH"
+}
+
+persist_path_for_ci() {
+    [[ -n "${GITHUB_PATH:-}" ]] || return 0
+
+    local user_bin
+    user_bin="$(python_user_bin)"
+
+    printf '%s\n' "${UV_TOOL_BIN_DIR}" >> "${GITHUB_PATH}"
+    if [[ -n "${user_bin}" ]]; then
+        printf '%s\n' "${user_bin}" >> "${GITHUB_PATH}"
+    fi
+    printf '%s\n' "$HOME/.local/bin" >> "${GITHUB_PATH}"
+}
+
+install_python_tools() {
+    install_uv
+    configure_uv_tool_path
+
+    echo "[install_deps] Installing Conan ${CONAN_VERSION} with uv..."
+    uv tool install --force "conan==${CONAN_VERSION}"
+
+    if [[ "${OS}" == "Linux" ]]; then
+        echo "[install_deps] Preparing Python wheel environment with uv at ${KNOWHERE_PYTHON_VENV}..."
+        if [[ ! -x "${KNOWHERE_PYTHON_VENV}/bin/python" ]]; then
+            uv venv --python python3 "${KNOWHERE_PYTHON_VENV}"
+        fi
+        uv pip install --python "${KNOWHERE_PYTHON_VENV}/bin/python" -U setuptools wheel 'numpy>=2,<3' ml-dtypes auditwheel
+    fi
+
+    if [[ -x "${KNOWHERE_PYTHON_VENV}/bin/python" ]]; then
+        export PATH="${KNOWHERE_PYTHON_VENV}/bin:${PATH}"
+        export PYTHON="${KNOWHERE_PYTHON_VENV}/bin/python"
+    fi
+
+    persist_path_for_ci
+}
+
 if [[ "${OS}" == "Linux" ]]; then
     # Use sudo for package manager commands when not running as root.
     if [ "$(id -u)" -ne 0 ]; then
-        SUDO="sudo"
+        if ! command -v sudo >/dev/null 2>&1; then
+            echo "[install_deps] Need root privileges or sudo to install packages."
+            exit 1
+        fi
+        SUDO=(sudo)
     else
-        SUDO=""
+        SUDO=()
     fi
 
+    run_privileged() {
+        "${SUDO[@]}" "$@"
+    }
+
+    apt_get() {
+        run_privileged env DEBIAN_FRONTEND=noninteractive apt-get "$@"
+    }
+
+    yum_cmd() {
+        run_privileged yum "$@"
+    }
+
+    ubuntu_codename() {
+        local codename=""
+        if [[ -r /etc/os-release ]]; then
+            # shellcheck disable=SC1091
+            . /etc/os-release
+            codename="${VERSION_CODENAME:-${UBUNTU_CODENAME:-}}"
+        fi
+        printf '%s\n' "${codename}"
+    }
+
+    install_llvm22_apt_repo() {
+        local codename
+        codename="$(ubuntu_codename)"
+
+        case "${codename}" in
+            jammy|noble)
+                if apt-cache policy clang-tidy-22 2>/dev/null | awk '/Candidate:/ { found=1; ok=($2 != "(none)") } END { exit !(found && ok) }'; then
+                    return
+                fi
+
+                # Equivalent to the repository setup in https://apt.llvm.org/llvm.sh,
+                # but without invoking add-apt-repository or installing the full clang
+                # toolchain. CI only needs the packages listed below.
+                echo "[install_deps] Installing LLVM 22 apt repository for ${codename}..."
+                apt_get install -y wget ca-certificates gnupg
+
+                local key_tmp
+                key_tmp="$(mktemp)"
+                wget -O "${key_tmp}.asc" https://apt.llvm.org/llvm-snapshot.gpg.key
+                gpg --dearmor -o "${key_tmp}.gpg" "${key_tmp}.asc"
+                run_privileged install -D -m 0644 "${key_tmp}.gpg" /usr/share/keyrings/apt.llvm.org.gpg
+                rm -f "${key_tmp}" "${key_tmp}.asc" "${key_tmp}.gpg"
+
+                printf 'deb [signed-by=/usr/share/keyrings/apt.llvm.org.gpg] https://apt.llvm.org/%s/ llvm-toolchain-%s-22 main\n' "${codename}" "${codename}" \
+                    | run_privileged tee /etc/apt/sources.list.d/llvm-toolchain-"${codename}"-22.list >/dev/null
+                apt_get update
+                ;;
+            *)
+                echo "[install_deps] Using distribution LLVM 22 packages for ${codename:-unknown Ubuntu release}."
+                ;;
+        esac
+    }
+
+    install_recent_cmake_apt() {
+        if cmake_satisfies_minimum; then
+            echo "[install_deps] CMake $(cmake_version) satisfies >= ${CMAKE_MIN_VERSION}."
+            return
+        fi
+
+        local ubuntu_codename
+        ubuntu_codename="$(ubuntu_codename)"
+
+        case "${ubuntu_codename}" in
+            jammy|noble)
+                echo "[install_deps] Installing CMake >= ${CMAKE_MIN_VERSION} from Kitware for ${ubuntu_codename}..."
+                apt_get install -y ca-certificates gnupg wget
+
+                local key_tmp
+                key_tmp="$(mktemp)"
+                wget -O "${key_tmp}.asc" https://apt.kitware.com/keys/kitware-archive-latest.asc
+                gpg --dearmor -o "${key_tmp}.gpg" "${key_tmp}.asc"
+                run_privileged install -D -m 0644 "${key_tmp}.gpg" /usr/share/keyrings/kitware-archive-keyring.gpg
+                rm -f "${key_tmp}" "${key_tmp}.asc" "${key_tmp}.gpg"
+
+                printf 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ %s main\n' "${ubuntu_codename}" \
+                    | run_privileged tee /etc/apt/sources.list.d/kitware.list >/dev/null
+                apt_get update
+                ;;
+            *)
+                echo "[install_deps] Using distribution CMake package for ${ubuntu_codename:-unknown Ubuntu release}."
+                ;;
+        esac
+
+        apt_get install -y cmake
+        if ! cmake_satisfies_minimum; then
+            echo "[install_deps] CMake >= ${CMAKE_MIN_VERSION} is required, but installed $(cmake_version 2>/dev/null || echo none)."
+            exit 1
+        fi
+        echo "[install_deps] Installed CMake $(cmake_version)."
+    }
+
     if command -v apt-get >/dev/null 2>&1; then
-        ${SUDO} apt-get update || true
+        apt_get update || true
+        install_llvm22_apt_repo
 
         packages=(
-            g++ gcc make cmake ccache
+            g++ gcc make ccache
             libaio-dev                 # DiskANN async I/O
             libcurl4-openssl-dev       # folly dependency
             libdouble-conversion-dev   # folly dependency
             libevent-dev               # gRPC dependency
             libgflags-dev              # folly / glog dependency
-            libomp-dev                 # OpenMP parallelization
             python3 python3-pip
-            clang-tidy-14              # CI: static analysis (analyzer CI)
+            python3-venv                # uv-managed wheel environment
+            clang-tidy-22              # CI: static analysis (analyzer CI)
+            libomp-22-dev              # CI analysis/builds: version-matched OpenMP headers (omp.h)
             lcov                       # CI: code coverage reports
             binutils                   # wheel: readelf wheel RPATH inspection
             patchelf                   # wheel: RPATH rewriting
@@ -67,10 +274,11 @@ if [[ "${OS}" == "Linux" ]]; then
             swig                       # wheel: C++ → Python binding generator
             unzip                      # wheel: readelf wheel RPATH inspection
         )
-        ${SUDO} apt-get install -y "${packages[@]}"
+        apt_get install -y "${packages[@]}"
+        install_recent_cmake_apt
 
     elif command -v yum >/dev/null 2>&1; then
-        ${SUDO} yum makecache || true
+        yum_cmd makecache || true
 
         packages=(
             gcc-c++ gcc make cmake ccache
@@ -78,8 +286,8 @@ if [[ "${OS}" == "Linux" ]]; then
             libcurl-devel            # folly dependency
             double-conversion-devel  # folly dependency
             libevent-devel           # gRPC dependency
+            libomp-devel             # OpenMP parallelism
             gflags-devel             # folly / glog dependency
-            libomp-devel             # OpenMP parallelization
             python3 python3-pip
             clang-tools-extra        # CI: static analysis (provides clang-tidy)
             lcov                     # CI: code coverage reports
@@ -89,7 +297,7 @@ if [[ "${OS}" == "Linux" ]]; then
             swig                     # wheel: C++ → Python binding generator
             unzip                    # wheel: readelf wheel RPATH inspection
         )
-        ${SUDO} yum install -y "${packages[@]}"
+        yum_cmd install -y "${packages[@]}"
 
     else
         echo "[install_deps] Unsupported Linux package manager. Expected apt-get or yum."
@@ -107,31 +315,7 @@ else
     exit 1
 fi
 
-if [[ "${OS}" == "Mac" ]]; then
-    # macOS Homebrew Python (PEP 668) blocks system-wide pip install;
-    # use pipx for conan. Wheel-building packages (setuptools, wheel,
-    # bfloat16, auditwheel) are Linux-only for the swig-build job.
-    brew install pipx
-    pipx ensurepath
-    pipx install conan==${CONAN_VERSION}
-    export PATH="$HOME/.local/bin:$PATH"
-    # In GitHub Actions each step spawns a new shell, so the PATH export above
-    # only affects install_deps.sh itself. Persist ~/.local/bin to GITHUB_PATH
-    # so subsequent steps (Build, Test) can find the conan command.
-    if [[ -n "${GITHUB_PATH:-}" ]]; then
-        echo "$HOME/.local/bin" >> "${GITHUB_PATH}"
-    fi
-else
-    pip3 install conan==${CONAN_VERSION}  # C/C++ package manager
-
-    pip3 install -U setuptools
-    # wheel must be installed before bfloat16: bfloat16 has no pre-built wheel
-    # for Python 3.8, so pip builds from source. Without the wheel package, pip
-    # uses PEP 517 build isolation which can't see the installed numpy.
-    pip3 install wheel 'numpy<2'
-    pip3 install bfloat16   # wheel: bfloat16 dtype support for PyKnowhere
-    pip3 install auditwheel  # wheel: manylinux wheel repair
-fi
+install_python_tools
 
 echo "[install_deps] Configuring conan profile and remote..."
 conan profile detect --force || true

--- a/src/cluster/cluster_factory.cc
+++ b/src/cluster/cluster_factory.cc
@@ -26,7 +26,7 @@ ClusterFactory::Create(const std::string& name, const Object& object) {
         return expected<Cluster<ClusterNode>>::Err(Status::invalid_cluster_error, "cluster type not supported");
     }
     LOG_KNOWHERE_INFO_ << "use key " << key << " to create knowhere cluster worker " << name;
-    auto fun_map_v = (FunMapValue<Cluster<ClusterNode>>*)(func_mapping_[key].get());
+    auto fun_map_v = static_cast<FunMapValue<Cluster<ClusterNode>>*>(func_mapping_[key].get());
 
     return fun_map_v->fun_value(object);
 }

--- a/src/common/comp/brute_force.cc
+++ b/src/common/comp/brute_force.cc
@@ -1482,7 +1482,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
 
     auto num_chunk = base_dataset->GetNumChunk();
     auto num_total_vectors = base_dataset->GetRows();
-    if (num_total_vectors != static_cast<int64_t>(chunk_lims[num_chunk]))) {
+    if (num_total_vectors != static_cast<int64_t>(chunk_lims[num_chunk])) {
         LOG_KNOWHERE_ERROR_ << "the num_rows should be equal to the last element of chunk_lims";
         return expected<std::vector<IndexNode::IteratorPtr>>::Err(
             Status::invalid_args, "the num_rows should be equal to the last element of chunk_lims");

--- a/src/common/comp/brute_force.cc
+++ b/src/common/comp/brute_force.cc
@@ -97,7 +97,7 @@ GetInverseVecNorms(const DataSetPtr& base) {
         auto chunk_lims = base->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
         auto nb = base->GetRows();
         auto inv_norms = std::make_unique<float[]>(nb);
-        auto base_tensor = (const DataType**)base->GetTensor();
+        auto base_tensor = static_cast<const DataType* const*>(base->GetTensor());
 
         // use search thread pool to compute inverse norms
         auto pool = ThreadPool::GetGlobalSearchThreadPool();
@@ -116,7 +116,7 @@ GetInverseVecNorms(const DataSetPtr& base) {
         WaitAllSuccess(futs);
         return inv_norms;
     } else {
-        auto xb = (DataType*)base->GetTensor();
+        auto xb = static_cast<const DataType*>(base->GetTensor());
         auto nb = base->GetRows();
         auto dim = base->GetDim();
         auto inv_norms = std::make_unique<float[]>(nb);
@@ -195,12 +195,12 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
     faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
     switch (faiss_metric_type) {
         case faiss::METRIC_L2: {
-            auto cur_query = (const DataType*)xq + dim * query_idx;
+            auto cur_query = static_cast<const DataType*>(xq) + dim * query_idx;
             if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                 faiss::cppcontrib::knowhere::knn_L2sqr(cur_query, static_cast<const float*>(xb), dim, 1, nb, topk,
                                                        cur_distances, cur_labels, nullptr, id_selector);
             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
-                faiss::cppcontrib::knowhere::knn_L2sqr_typed(cur_query, (const DataType*)xb, dim, 1, nb, topk,
+                faiss::cppcontrib::knowhere::knn_L2sqr_typed(cur_query, static_cast<const DataType*>(xb), dim, 1, nb, topk,
                                                              cur_distances, cur_labels, nullptr, id_selector);
             } else {
                 LOG_KNOWHERE_ERROR_ << "Metric L2 not supported for current vector type";
@@ -209,7 +209,7 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
             break;
         }
         case faiss::METRIC_INNER_PRODUCT: {
-            auto cur_query = (const DataType*)xq + dim * query_idx;
+            auto cur_query = static_cast<const DataType*>(xq) + dim * query_idx;
             if (is_cosine) {
                 if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                     auto copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
@@ -219,7 +219,7 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
                 } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                     // normalize query vector may cause precision loss, so div query norms in apply
                     // function
-                    faiss::cppcontrib::knowhere::knn_cosine_typed(cur_query, (const DataType*)xb, inv_norms, dim, 1, nb,
+                    faiss::cppcontrib::knowhere::knn_cosine_typed(cur_query, static_cast<const DataType*>(xb), inv_norms, dim, 1, nb,
                                                                   topk, cur_distances, cur_labels, id_selector);
                 } else {
                     LOG_KNOWHERE_ERROR_ << "Metric COSINE not supported for current vector type";
@@ -230,7 +230,7 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
                     faiss::cppcontrib::knowhere::knn_inner_product(cur_query, static_cast<const float*>(xb), dim, 1, nb,
                                                                    topk, cur_distances, cur_labels, id_selector);
                 } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
-                    faiss::cppcontrib::knowhere::knn_inner_product_typed(cur_query, (const DataType*)xb, dim, 1, nb,
+                    faiss::cppcontrib::knowhere::knn_inner_product_typed(cur_query, static_cast<const DataType*>(xb), dim, 1, nb,
                                                                          topk, cur_distances, cur_labels, id_selector);
                 } else {
                     LOG_KNOWHERE_ERROR_ << "Metric IP not supported for current vector type";
@@ -340,8 +340,8 @@ brute_force_emb_list_impl(const void* xq, size_t query_el_idx, const void* xb, i
             if constexpr (std::is_same_v<DataType, knowhere::bin1>) {
                 code_size = (dim + 7) / 8;
             }
-            auto cur_query = (const DataType*)xq + query_el_offset.offset[query_el_idx] * code_size;
-            auto cur_base = (const DataType*)xb + base_el_offset.offset[base_el_idx] * code_size;
+            auto cur_query = static_cast<const DataType*>(xq) + query_el_offset.offset[query_el_idx] * code_size;
+            auto cur_base = static_cast<const DataType*>(xb) + base_el_offset.offset[base_el_idx] * code_size;
 
             if (IsMetricType(el_sub_metric_type, metric::COSINE)) {
                 if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
@@ -493,8 +493,8 @@ BruteForce::SearchWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID = (uint8_t*)trace_id_str.c_str(),
-                                        .spanID = (uint8_t*)span_id_str.c_str(),
+        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()),
+                                        .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
                                         .traceFlags = static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf search with buf", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
@@ -657,8 +657,8 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID = (uint8_t*)trace_id_str.c_str(),
-                                        .spanID = (uint8_t*)span_id_str.c_str(),
+        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()),
+                                        .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
                                         .traceFlags = static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf search [on chunk] with buf", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
@@ -701,7 +701,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                 std::priority_queue<DistId, std::vector<DistId>, std::less<>> maxheap;
 
                 for (int chunk_idx = 0; chunk_idx < num_chunk; chunk_idx++) {
-                    const DataType* xb = ((const DataType**)base_tensor)[chunk_idx];
+                    const DataType* xb = (static_cast<const DataType* const*>(base_tensor))[chunk_idx];
                     auto num_base_vectors = chunk_lims[chunk_idx + 1] - chunk_lims[chunk_idx];
                     // reset tmp buffers for this chunk (faiss may not fully overwrite when nb < k)
                     std::fill(tmp_labels.begin(), tmp_labels.end(), -1);
@@ -836,7 +836,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                     std::vector<size_t> tmp_base_lims = {0, num_base_vectors};
                     auto tmp_base_el_offset = EmbListOffset(tmp_base_lims);
 
-                    auto cur_base = ((const DataType**)base_tensor)[chunk_idx];
+                    auto cur_base = (static_cast<const DataType* const*>(base_tensor))[chunk_idx];
 
                     RETURN_IF_ERROR(brute_force_emb_list_impl<DataType>(
                         xq, query_el_idx, cur_base, tmp_labels.data(), tmp_distances.data(), k, dim, tmp_base_el_offset,
@@ -935,8 +935,8 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID = (uint8_t*)trace_id_str.c_str(),
-                                        .spanID = (uint8_t*)span_id_str.c_str(),
+        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()),
+                                        .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
                                         .traceFlags = static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf range search", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
@@ -1030,12 +1030,12 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                 faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
                 switch (faiss_metric_type) {
                     case faiss::METRIC_L2: {
-                        [[maybe_unused]] auto cur_query = (const DataType*)xq + dim * index;
+                        [[maybe_unused]] auto cur_query = static_cast<const DataType*>(xq) + dim * index;
                         if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                             faiss::cppcontrib::knowhere::range_search_L2sqr(cur_query, static_cast<const float*>(xb),
                                                                             dim, 1, nb, radius, &res, id_selector);
                         } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
-                            faiss::cppcontrib::knowhere::range_search_L2sqr_typed(cur_query, (const DataType*)xb, dim,
+                            faiss::cppcontrib::knowhere::range_search_L2sqr_typed(cur_query, static_cast<const DataType*>(xb), dim,
                                                                                   1, nb, radius, &res, id_selector);
                         } else {
                             LOG_KNOWHERE_ERROR_ << "Metric L2 not supported for current vector type";
@@ -1044,7 +1044,7 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                         break;
                     }
                     case faiss::METRIC_INNER_PRODUCT: {
-                        [[maybe_unused]] auto cur_query = (const DataType*)xq + dim * index;
+                        [[maybe_unused]] auto cur_query = static_cast<const DataType*>(xq) + dim * index;
                         if (is_cosine) {
                             if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                                 auto copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
@@ -1053,7 +1053,7 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                                     radius, &res, id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                 // normalize query vector may cause precision loss, so div query norms in apply function
-                                faiss::cppcontrib::knowhere::range_search_cosine_typed(cur_query, (const DataType*)xb,
+                                faiss::cppcontrib::knowhere::range_search_cosine_typed(cur_query, static_cast<const DataType*>(xb),
                                                                                        inv_norms.get(), dim, 1, nb,
                                                                                        radius, &res, id_selector);
                             } else {
@@ -1063,10 +1063,10 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                         } else {
                             if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                                 faiss::cppcontrib::knowhere::range_search_inner_product(
-                                    cur_query, (const DataType*)xb, dim, 1, nb, radius, &res, id_selector);
+                                    cur_query, static_cast<const DataType*>(xb), dim, 1, nb, radius, &res, id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                 faiss::cppcontrib::knowhere::range_search_inner_product_typed(
-                                    cur_query, (const DataType*)xb, dim, 1, nb, radius, &res, id_selector);
+                                    cur_query, static_cast<const DataType*>(xb), dim, 1, nb, radius, &res, id_selector);
                             } else {
                                 LOG_KNOWHERE_ERROR_ << "Metric IP not supported for current vector type";
                                 return Status::faiss_inner_error;
@@ -1155,8 +1155,8 @@ BruteForce::SearchSparseWithBuf(const DataSetPtr base_dataset, const DataSetPtr 
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID = (uint8_t*)trace_id_str.c_str(),
-                                        .spanID = (uint8_t*)span_id_str.c_str(),
+        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()),
+                                        .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
                                         .traceFlags = static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf search sparse with buf", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
@@ -1287,8 +1287,8 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID = (uint8_t*)trace_id_str.c_str(),
-                                        .spanID = (uint8_t*)span_id_str.c_str(),
+        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()),
+                                        .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
                                         .traceFlags = static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf ann iterator initialization", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
@@ -1326,14 +1326,14 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                 if constexpr (std::is_same_v<DataType, knowhere::bin1>) {
                     code_size = (dim + 7) / 8;
                 }
-                [[maybe_unused]] auto cur_query = (const DataType*)xq + code_size * i;
+                [[maybe_unused]] auto cur_query = static_cast<const DataType*>(xq) + code_size * i;
                 switch (faiss_metric_type) {
                     case faiss::METRIC_L2: {
                         if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                             faiss::cppcontrib::knowhere::all_L2sqr(cur_query, static_cast<const float*>(xb), dim, 1, nb,
                                                                    distances_ids, nullptr, id_selector);
                         } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
-                            faiss::cppcontrib::knowhere::all_L2sqr_typed(cur_query, (const DataType*)xb, dim, 1, nb,
+                            faiss::cppcontrib::knowhere::all_L2sqr_typed(cur_query, static_cast<const DataType*>(xb), dim, 1, nb,
                                                                          distances_ids, nullptr, id_selector);
                         } else {
                             std::string err_msg = "Metric L2 not supported for current vector type";
@@ -1351,7 +1351,7 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                                                                         dim, 1, nb, distances_ids, id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                 // normalize query vector may cause precision loss, so div query norms in apply function
-                                faiss::cppcontrib::knowhere::all_cosine_typed(cur_query, (const DataType*)xb,
+                                faiss::cppcontrib::knowhere::all_cosine_typed(cur_query, static_cast<const DataType*>(xb),
                                                                               inv_norms.get(), dim, 1, nb,
                                                                               distances_ids, id_selector);
                             } else {
@@ -1365,7 +1365,7 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                                                                                dim, 1, nb, distances_ids, id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                 faiss::cppcontrib::knowhere::all_inner_product_typed(
-                                    cur_query, (const DataType*)xb, dim, 1, nb, distances_ids, id_selector);
+                                    cur_query, static_cast<const DataType*>(xb), dim, 1, nb, distances_ids, id_selector);
                             } else {
                                 std::string err_msg = "Metric IP not supported for current vector type";
                                 LOG_KNOWHERE_ERROR_ << err_msg;
@@ -1378,7 +1378,7 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                         if constexpr (std::is_same_v<DataType, knowhere::bin1>) {
                             std::vector<int32_t> distances(nb, std::numeric_limits<int32_t>::max());
                             faiss::cppcontrib::knowhere::all_hamming_distances(
-                                cur_query, (const DataType*)xb, code_size, 1, nb, distances.data(), id_selector);
+                                cur_query, static_cast<const DataType*>(xb), code_size, 1, nb, distances.data(), id_selector);
                             for (int j = 0; j < nb; ++j) {
                                 if (distances[j] == std::numeric_limits<int32_t>::max()) {
                                     distances_ids[j] = {-1, max_dis};
@@ -1397,7 +1397,7 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                         if constexpr (std::is_same_v<DataType, knowhere::bin1>) {
                             std::vector<float> distances(nb, max_dis);
                             faiss::cppcontrib::knowhere::all_jaccard_distances(
-                                cur_query, (const DataType*)xb, code_size, 1, nb, distances.data(), id_selector);
+                                cur_query, static_cast<const DataType*>(xb), code_size, 1, nb, distances.data(), id_selector);
                             for (int j = 0; j < nb; ++j) {
                                 if (distances[j] == std::numeric_limits<float>::infinity()) {
                                     distances_ids[j] = {-1, max_dis};
@@ -1491,7 +1491,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
 
     auto num_chunk = base_dataset->GetNumChunk();
     auto num_total_vectors = base_dataset->GetRows();
-    if (num_total_vectors != static_cast<int64_t>(chunk_lims[num_chunk])) {
+    if (std::cmp_not_equal(num_total_vectors, chunk_lims[num_chunk])) {
         LOG_KNOWHERE_ERROR_ << "the num_rows should be equal to the last element of chunk_lims";
         return expected<std::vector<IndexNode::IteratorPtr>>::Err(
             Status::invalid_args, "the num_rows should be equal to the last element of chunk_lims");
@@ -1516,8 +1516,8 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID = (uint8_t*)trace_id_str.c_str(),
-                                        .spanID = (uint8_t*)span_id_str.c_str(),
+        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()),
+                                        .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
                                         .traceFlags = static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf ann iterator initialization", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
@@ -1532,7 +1532,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
         for (int i = 0; i < nq; ++i) {
             // Heavy computations with `compute_dist_func` will be deferred until the first call to 'Iterator->Next()'.
             auto compute_dist_func = [=]() -> std::vector<DistId> {
-                auto chunk_tensor = (const DataType**)base_dataset->GetTensor();
+                auto chunk_tensor = static_cast<const DataType* const*>(base_dataset->GetTensor());
                 auto xq = query_dataset->GetTensor();
                 auto xb_id_offset = base_dataset->GetTensorBeginId();
 
@@ -1543,7 +1543,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                 if constexpr (std::is_same_v<DataType, knowhere::bin1>) {
                     code_size = (dim + 7) / 8;
                 }
-                [[maybe_unused]] auto cur_query = (const DataType*)xq + code_size * i;
+                [[maybe_unused]] auto cur_query = static_cast<const DataType*>(xq) + code_size * i;
 
                 for (int chunk_idx = 0; chunk_idx < num_chunk; chunk_idx++) {
                     const size_t num_base_vectors = chunk_lims[chunk_idx + 1] - chunk_lims[chunk_idx];
@@ -1558,11 +1558,11 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                     switch (faiss_metric_type) {
                         case faiss::METRIC_L2: {
                             if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
-                                faiss::cppcontrib::knowhere::all_L2sqr(cur_query, (const float*)xb, dim, 1,
+                                faiss::cppcontrib::knowhere::all_L2sqr(cur_query, static_cast<const float*>(xb), dim, 1,
                                                                        num_base_vectors, chunk_distances_ids, nullptr,
                                                                        id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
-                                faiss::cppcontrib::knowhere::all_L2sqr_typed(cur_query, (const DataType*)xb, dim, 1,
+                                faiss::cppcontrib::knowhere::all_L2sqr_typed(cur_query, static_cast<const DataType*>(xb), dim, 1,
                                                                              num_base_vectors, chunk_distances_ids,
                                                                              nullptr, id_selector);
                             } else {
@@ -1585,14 +1585,14 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                                 auto chunk_inv_norms = inv_norms ? inv_norms.get() + chunk_lims[chunk_idx] : nullptr;
                                 if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                                     auto copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
-                                    faiss::cppcontrib::knowhere::all_cosine(copied_query.get(), (const float*)xb,
+                                    faiss::cppcontrib::knowhere::all_cosine(copied_query.get(), static_cast<const float*>(xb),
                                                                             chunk_inv_norms, dim, 1, num_base_vectors,
                                                                             chunk_distances_ids, id_selector);
                                 } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                     // normalize query vector may cause precision loss, so div query norms in apply
                                     // function
                                     faiss::cppcontrib::knowhere::all_cosine_typed(
-                                        cur_query, (const DataType*)xb, chunk_inv_norms, dim, 1, num_base_vectors,
+                                        cur_query, static_cast<const DataType*>(xb), chunk_inv_norms, dim, 1, num_base_vectors,
                                         chunk_distances_ids, id_selector);
                                 } else {
                                     std::string err_msg = "Metric COSINE not supported for current vector type";
@@ -1609,12 +1609,12 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                                 }
                             } else {
                                 if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
-                                    faiss::cppcontrib::knowhere::all_inner_product(cur_query, (const float*)xb, dim, 1,
+                                    faiss::cppcontrib::knowhere::all_inner_product(cur_query, static_cast<const float*>(xb), dim, 1,
                                                                                    num_base_vectors,
                                                                                    chunk_distances_ids, id_selector);
                                 } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                     faiss::cppcontrib::knowhere::all_inner_product_typed(
-                                        cur_query, (const DataType*)xb, dim, 1, num_base_vectors, chunk_distances_ids,
+                                        cur_query, static_cast<const DataType*>(xb), dim, 1, num_base_vectors, chunk_distances_ids,
                                         id_selector);
                                 } else {
                                     std::string err_msg = "Metric IP not supported for current vector type";
@@ -1635,7 +1635,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                         case faiss::METRIC_Hamming: {
                             if constexpr (std::is_same_v<DataType, knowhere::bin1>) {
                                 std::vector<int32_t> distances(num_base_vectors, max_dis);
-                                faiss::cppcontrib::knowhere::all_hamming_distances(cur_query, (const DataType*)xb,
+                                faiss::cppcontrib::knowhere::all_hamming_distances(cur_query, static_cast<const DataType*>(xb),
                                                                                    code_size, 1, num_base_vectors,
                                                                                    distances.data(), id_selector);
                                 for (size_t j = 0; j < num_base_vectors; ++j) {
@@ -1658,7 +1658,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                         case faiss::METRIC_Jaccard: {
                             if constexpr (std::is_same_v<DataType, knowhere::bin1>) {
                                 std::vector<float> distances(num_base_vectors, max_dis);
-                                faiss::cppcontrib::knowhere::all_jaccard_distances(cur_query, (const DataType*)xb,
+                                faiss::cppcontrib::knowhere::all_jaccard_distances(cur_query, static_cast<const DataType*>(xb),
                                                                                    code_size, 1, num_base_vectors,
                                                                                    distances.data(), id_selector);
                                 for (size_t j = 0; j < num_base_vectors; ++j) {
@@ -1725,8 +1725,8 @@ BruteForce::AnnIterator<knowhere::sparse::SparseRow<float>>(const DataSetPtr bas
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID = (uint8_t*)trace_id_str.c_str(),
-                                        .spanID = (uint8_t*)span_id_str.c_str(),
+        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()),
+                                        .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
                                         .traceFlags = static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf iterator sparse", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, metric_str);

--- a/src/common/comp/brute_force.cc
+++ b/src/common/comp/brute_force.cc
@@ -13,6 +13,7 @@
 
 #include <faiss/cppcontrib/knowhere/utils/binary_distances.h>
 
+#include <utility>
 #include <vector>
 
 #include "common/metric.h"
@@ -104,9 +105,10 @@ GetInverseVecNorms(const DataSetPtr& base) {
         futs.reserve(num_chunk_dataset);
         for (auto i = 0; i < num_chunk_dataset; i++) {
             futs.emplace_back(pool->push([&, chunk_idx = i] {
-                auto num_vectors = chunk_lims[chunk_idx + 1] - chunk_lims[chunk_idx];
+                const size_t num_vectors = chunk_lims[chunk_idx + 1] - chunk_lims[chunk_idx];
                 auto xb = base_tensor[chunk_idx];
-                for (auto j = 0; j < num_vectors; j++) {
+
+                for (size_t j = 0; j < num_vectors; j++) {
                     inv_norms[chunk_lims[chunk_idx] + j] = compute_inv_norm(xb + j * dim, dim);
                 }
             }));
@@ -125,10 +127,11 @@ GetInverseVecNorms(const DataSetPtr& base) {
         constexpr int64_t chunk_size = 8192;
         auto chunk_num = (nb + chunk_size - 1) / chunk_size;
         futs.reserve(chunk_num);
-        for (auto i = 0; i < nb; i += chunk_size) {
-            auto last = std::min(i + chunk_size, nb);
+
+        for (int64_t i = 0; i < nb; i += chunk_size) {
+            int64_t last = std::min(i + chunk_size, nb);
             futs.emplace_back(pool->push([&, beg_id = i, end_id = last] {
-                for (auto j = beg_id; j < end_id; j++) {
+                for (int64_t j = beg_id; j < end_id; j++) {
                     inv_norms[j] = compute_inv_norm(xb + j * dim, dim);
                 }
             }));
@@ -194,7 +197,7 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
         case faiss::METRIC_L2: {
             auto cur_query = (const DataType*)xq + dim * query_idx;
             if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
-                faiss::cppcontrib::knowhere::knn_L2sqr(cur_query, (const float*)xb, dim, 1, nb, topk, cur_distances,
+                faiss::cppcontrib::knowhere::knn_L2sqr(cur_query, static_cast<const float*>(xb), dim, 1, nb, topk, cur_distances,
                                                        cur_labels, nullptr, id_selector);
             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                 faiss::cppcontrib::knowhere::knn_L2sqr_typed(cur_query, (const DataType*)xb, dim, 1, nb, topk,
@@ -210,7 +213,7 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
             if (is_cosine) {
                 if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                     auto copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
-                    faiss::cppcontrib::knowhere::knn_cosine(copied_query.get(), (const float*)xb, inv_norms, dim, 1, nb,
+                    faiss::cppcontrib::knowhere::knn_cosine(copied_query.get(), static_cast<const float*>(xb), inv_norms, dim, 1, nb,
                                                             topk, cur_distances, cur_labels, id_selector);
                 } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                     // normalize query vector may cause precision loss, so div query norms in apply
@@ -223,7 +226,7 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
                 }
             } else {
                 if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
-                    faiss::cppcontrib::knowhere::knn_inner_product(cur_query, (const float*)xb, dim, 1, nb, topk,
+                    faiss::cppcontrib::knowhere::knn_inner_product(cur_query, static_cast<const float*>(xb), dim, 1, nb, topk,
                                                                    cur_distances, cur_labels, id_selector);
                 } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                     faiss::cppcontrib::knowhere::knn_inner_product_typed(cur_query, (const DataType*)xb, dim, 1, nb,
@@ -236,19 +239,19 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
             break;
         }
         case faiss::METRIC_Jaccard: {
-            auto cur_query = (const uint8_t*)xq + (dim / 8) * query_idx;
-            faiss::float_maxheap_array_t res = {size_t(1), size_t(topk), cur_labels, cur_distances};
-            faiss::cppcontrib::knowhere::binary_knn_hc(faiss::METRIC_Jaccard, &res, cur_query, (const uint8_t*)xb, nb,
+            auto cur_query = static_cast<const uint8_t*>(xq) + (dim / 8) * query_idx;
+            faiss::float_maxheap_array_t res = {.nh=static_cast<size_t>(1), .k=(topk), .ids=cur_labels, .val=cur_distances};
+            faiss::cppcontrib::knowhere::binary_knn_hc(faiss::METRIC_Jaccard, &res, cur_query, static_cast<const uint8_t*>(xb), nb,
                                                        dim / 8, id_selector);
             break;
         }
         case faiss::METRIC_Hamming: {
-            auto cur_query = (const uint8_t*)xq + (dim / 8) * query_idx;
+            auto cur_query = static_cast<const uint8_t*>(xq) + (dim / 8) * query_idx;
             std::vector<int32_t> int_distances(topk);
-            faiss::int_maxheap_array_t res = {size_t(1), size_t(topk), cur_labels, int_distances.data()};
-            faiss::cppcontrib::knowhere::binary_knn_hc(faiss::METRIC_Hamming, &res, (const uint8_t*)cur_query,
-                                                       (const uint8_t*)xb, nb, dim / 8, id_selector);
-            for (int i = 0; i < topk; ++i) {
+            faiss::int_maxheap_array_t res = {.nh=static_cast<size_t>(1), .k=(topk), .ids=cur_labels, .val=int_distances.data()};
+            faiss::cppcontrib::knowhere::binary_knn_hc(faiss::METRIC_Hamming, &res, static_cast<const uint8_t*>(cur_query),
+                                                       static_cast<const uint8_t*>(xb), nb, dim / 8, id_selector);
+            for (size_t i = 0; i < topk; ++i) {
                 cur_distances[i] = static_cast<float>(int_distances[i]);
             }
             break;
@@ -256,8 +259,8 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
         case faiss::METRIC_Substructure:
         case faiss::METRIC_Superstructure: {
             // only matched ids will be chosen, not to use heap
-            auto cur_query = (const uint8_t*)xq + (dim / 8) * query_idx;
-            faiss::cppcontrib::knowhere::binary_knn_mc(faiss_metric_type, cur_query, (const uint8_t*)xb, 1, nb, topk,
+            auto cur_query = static_cast<const uint8_t*>(xq) + (dim / 8) * query_idx;
+            faiss::cppcontrib::knowhere::binary_knn_mc(faiss_metric_type, cur_query, static_cast<const uint8_t*>(xb), 1, nb, topk,
                                                        dim / 8, cur_distances, cur_labels, id_selector);
             break;
         }
@@ -288,7 +291,7 @@ brute_force_minhash_impl(const void* xq, const void* xb, int64_t* labels, float*
     if (mh_valid_stat != Status::success) {
         return mh_valid_stat;
     }
-    auto search_status = minhash::MinHashVecSearch((const char*)xq, (const char*)xb, mh_vec_size_in_bytes,
+    auto search_status = minhash::MinHashVecSearch(static_cast<const char*>(xq), static_cast<const char*>(xb), mh_vec_size_in_bytes,
                                                    mh_vec_element_size_in_bytes, mh_lsh_band, mh_lsh_r, nq, nb, topk,
                                                    mh_search_with_jaccard, bitset, distances, labels);
     if (search_status != Status::success) {
@@ -408,21 +411,21 @@ brute_force_emb_list_impl(const void* xq, size_t query_el_idx, const void* xb, i
             }
             auto score = score_or.value();
             if (larger_is_closer) {
-                if (minheap.size() < (size_t)topk) {
-                    minheap.emplace((int64_t)base_el_idx + xb_id_offset, score);
+                if (minheap.size() < topk) {
+                    minheap.emplace(static_cast<int64_t>(base_el_idx) + xb_id_offset, score);
                 } else {
                     if (score > minheap.top().val) {
                         minheap.pop();
-                        minheap.emplace((int64_t)base_el_idx + xb_id_offset, score);
+                        minheap.emplace(static_cast<int64_t>(base_el_idx) + xb_id_offset, score);
                     }
                 }
             } else {
-                if (maxheap.size() < (size_t)topk) {
-                    maxheap.emplace((int64_t)base_el_idx + xb_id_offset, score);
+                if (maxheap.size() < topk) {
+                    maxheap.emplace(static_cast<int64_t>(base_el_idx) + xb_id_offset, score);
                 } else {
                     if (score < maxheap.top().val) {
                         maxheap.pop();
-                        maxheap.emplace((int64_t)base_el_idx + xb_id_offset, score);
+                        maxheap.emplace(static_cast<int64_t>(base_el_idx) + xb_id_offset, score);
                     }
                 }
             }
@@ -437,7 +440,7 @@ brute_force_emb_list_impl(const void* xq, size_t query_el_idx, const void* xb, i
             dis[query_el_idx * topk + real_el_k - j - 1] = a.val;
             minheap.pop();
         }
-        for (size_t j = real_el_k; j < (size_t)topk; j++) {
+        for (size_t j = real_el_k; j < topk; j++) {
             ids[query_el_idx * topk + j] = -1;
             dis[query_el_idx * topk + j] = std::numeric_limits<float>::min();
         }
@@ -449,7 +452,7 @@ brute_force_emb_list_impl(const void* xq, size_t query_el_idx, const void* xb, i
             dis[query_el_idx * topk + real_el_k - j - 1] = a.val;
             maxheap.pop();
         }
-        for (size_t j = real_el_k; j < (size_t)topk; j++) {
+        for (size_t j = real_el_k; j < topk; j++) {
             ids[query_el_idx * topk + j] = -1;
             dis[query_el_idx * topk + j] = std::numeric_limits<float>::max();
         }
@@ -486,8 +489,8 @@ BruteForce::SearchWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{(uint8_t*)trace_id_str.c_str(), (uint8_t*)span_id_str.c_str(),
-                                        (uint8_t)cfg.trace_flags.value()};
+        auto ctx = tracer::TraceContext{.traceID=(uint8_t*)trace_id_str.c_str(), .spanID=(uint8_t*)span_id_str.c_str(),
+                                        .traceFlags=static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf search with buf", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
         span->SetAttribute(meta::TOPK, cfg.k.value());
@@ -637,7 +640,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
     auto base_tensor = base_dataset->GetTensor();
     auto num_chunk = base_dataset->GetNumChunk();
     auto num_total_vectors = base_dataset->GetRows();
-    if (num_total_vectors != chunk_lims[num_chunk]) {
+    if (std::cmp_not_equal(num_total_vectors ,chunk_lims[num_chunk])) {
         LOG_KNOWHERE_ERROR_ << "the num_rows should be equal to the last element of chunk_lims";
         return Status::invalid_args;
     }
@@ -649,8 +652,8 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{(uint8_t*)trace_id_str.c_str(), (uint8_t*)span_id_str.c_str(),
-                                        (uint8_t)cfg.trace_flags.value()};
+        auto ctx = tracer::TraceContext{.traceID=(uint8_t*)trace_id_str.c_str(), .spanID=(uint8_t*)span_id_str.c_str(),
+                                        .traceFlags=static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf search [on chunk] with buf", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
         span->SetAttribute(meta::TOPK, cfg.k.value());
@@ -717,7 +720,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                         auto global_id = static_cast<int64_t>(id) + static_cast<int64_t>(chunk_lims[chunk_idx]);
                         auto distance = tmp_distances[j];
                         if (larger_is_closer) {
-                            if (minheap.size() < (size_t)k) {
+                            if (minheap.size() < static_cast<size_t>(k)) {
                                 minheap.emplace(global_id, distance);
                             } else {
                                 if (distance > minheap.top().val) {
@@ -726,7 +729,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                                 }
                             }
                         } else {
-                            if (maxheap.size() < (size_t)k) {
+                            if (maxheap.size() < static_cast<size_t>(k)) {
                                 maxheap.emplace(global_id, distance);
                             } else {
                                 if (distance < maxheap.top().val) {
@@ -746,7 +749,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                         dis[k * query_idx + real_el_k - j - 1] = a.val;
                         minheap.pop();
                     }
-                    for (size_t j = real_el_k; j < (size_t)k; j++) {
+                    for (size_t j = real_el_k; std::cmp_less(j ,k); j++) {
                         ids[k * query_idx + j] = -1;
                         dis[k * query_idx + j] = std::numeric_limits<float>::min();
                     }
@@ -758,7 +761,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                         dis[k * query_idx + real_el_k - j - 1] = a.val;
                         maxheap.pop();
                     }
-                    for (size_t j = real_el_k; j < (size_t)k; j++) {
+                    for (size_t j = real_el_k; std::cmp_less(j ,k); j++) {
                         ids[k * query_idx + j] = -1;
                         dis[k * query_idx + j] = std::numeric_limits<float>::max();
                     }
@@ -800,7 +803,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
         auto pool = ThreadPool::GetGlobalSearchThreadPool();
         std::vector<folly::Future<Status>> futs;
         futs.reserve(num_query_el);
-        for (auto query_el_i = 0; query_el_i < num_query_el; query_el_i++) {
+        for (auto query_el_i = 0; std::cmp_less(query_el_i , num_query_el); query_el_i++) {
             auto num_query_vectors = query_el_offset.get_el_len(query_el_i);
             if (num_query_vectors == 0) {
                 continue;
@@ -842,7 +845,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                         }
                         auto distance = tmp_distances[j];
                         if (larger_is_closer) {
-                            if (minheap.size() < (size_t)k) {
+                            if (minheap.size() < static_cast<size_t>(k)) {
                                 minheap.emplace(id, distance);
                             } else {
                                 if (distance > minheap.top().val) {
@@ -851,7 +854,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                                 }
                             }
                         } else {
-                            if (maxheap.size() < (size_t)k) {
+                            if (maxheap.size() < static_cast<size_t>(k)) {
                                 maxheap.emplace(id, distance);
                             } else {
                                 if (distance < maxheap.top().val) {
@@ -871,7 +874,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                         dis[k * query_el_idx + real_el_k - j - 1] = a.val;
                         minheap.pop();
                     }
-                    for (size_t j = real_el_k; j < (size_t)k; j++) {
+                    for (size_t j = real_el_k; std::cmp_less(j ,k); j++) {
                         ids[k * query_el_idx + j] = -1;
                         dis[k * query_el_idx + j] = std::numeric_limits<float>::min();
                     }
@@ -883,7 +886,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                         dis[k * query_el_idx + real_el_k - j - 1] = a.val;
                         maxheap.pop();
                     }
-                    for (size_t j = real_el_k; j < (size_t)k; j++) {
+                    for (size_t j = real_el_k; std::cmp_less(j ,k); j++) {
                         ids[k * query_el_idx + j] = -1;
                         dis[k * query_el_idx + j] = std::numeric_limits<float>::max();
                     }
@@ -926,8 +929,8 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{(uint8_t*)trace_id_str.c_str(), (uint8_t*)span_id_str.c_str(),
-                                        (uint8_t)cfg.trace_flags.value()};
+        auto ctx = tracer::TraceContext{.traceID=(uint8_t*)trace_id_str.c_str(), .spanID=(uint8_t*)span_id_str.c_str(),
+                                        .traceFlags=static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf range search", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
         span->SetAttribute(meta::RADIUS, cfg.radius.value());
@@ -983,8 +986,8 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
     for (int i = 0; i < nq; ++i) {
         futs.emplace_back(pool->push([&, index = i] {
             if constexpr (std::is_same_v<DataType, knowhere::sparse::SparseRow<float>>) {
-                auto cur_query = (const sparse::SparseRow<float>*)xq + index;
-                auto xb_sparse = (const sparse::SparseRow<float>*)xb;
+                auto cur_query = static_cast<const sparse::SparseRow<float>*>(xq) + index;
+                auto xb_sparse = static_cast<const sparse::SparseRow<float>*>(xb);
                 std::set<std::pair<float, int64_t>, std::greater<>> result;
                 for (int j = 0; j < nb; ++j) {
                     auto xid = xb_id_offset + j;
@@ -1022,7 +1025,7 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                     case faiss::METRIC_L2: {
                         [[maybe_unused]] auto cur_query = (const DataType*)xq + dim * index;
                         if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
-                            faiss::cppcontrib::knowhere::range_search_L2sqr(cur_query, (const float*)xb, dim, 1, nb,
+                            faiss::cppcontrib::knowhere::range_search_L2sqr(cur_query, static_cast<const float*>(xb), dim, 1, nb,
                                                                             radius, &res, id_selector);
                         } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                             faiss::cppcontrib::knowhere::range_search_L2sqr_typed(cur_query, (const DataType*)xb, dim,
@@ -1038,7 +1041,7 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                         if (is_cosine) {
                             if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                                 auto copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
-                                faiss::cppcontrib::knowhere::range_search_cosine(copied_query.get(), (const float*)xb,
+                                faiss::cppcontrib::knowhere::range_search_cosine(copied_query.get(), static_cast<const float*>(xb),
                                                                                  inv_norms.get(), dim, 1, nb, radius,
                                                                                  &res, id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
@@ -1065,16 +1068,16 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                         break;
                     }
                     case faiss::METRIC_Jaccard: {
-                        auto cur_query = (const uint8_t*)xq + (dim / 8) * index;
+                        auto cur_query = static_cast<const uint8_t*>(xq) + (dim / 8) * index;
                         faiss::cppcontrib::knowhere::binary_range_search<faiss::CMin<float, int64_t>, float>(
-                            faiss::METRIC_Jaccard, cur_query, (const uint8_t*)xb, 1, nb, radius, dim / 8, &res,
+                            faiss::METRIC_Jaccard, cur_query, static_cast<const uint8_t*>(xb), 1, nb, radius, dim / 8, &res,
                             id_selector);
                         break;
                     }
                     case faiss::METRIC_Hamming: {
-                        auto cur_query = (const uint8_t*)xq + (dim / 8) * index;
+                        auto cur_query = static_cast<const uint8_t*>(xq) + (dim / 8) * index;
                         faiss::cppcontrib::knowhere::binary_range_search<faiss::CMin<int, int64_t>, int>(
-                            faiss::METRIC_Hamming, cur_query, (const uint8_t*)xb, 1, nb, (int)radius, dim / 8, &res,
+                            faiss::METRIC_Hamming, cur_query, static_cast<const uint8_t*>(xb), 1, nb, static_cast<int>(radius), dim / 8, &res,
                             id_selector);
                         break;
                     }
@@ -1145,8 +1148,8 @@ BruteForce::SearchSparseWithBuf(const DataSetPtr base_dataset, const DataSetPtr 
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{(uint8_t*)trace_id_str.c_str(), (uint8_t*)span_id_str.c_str(),
-                                        (uint8_t)cfg.trace_flags.value()};
+        auto ctx = tracer::TraceContext{.traceID=(uint8_t*)trace_id_str.c_str(), .spanID=(uint8_t*)span_id_str.c_str(),
+                                        .traceFlags=static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf search sparse with buf", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
         span->SetAttribute(meta::TOPK, cfg.k.value());
@@ -1276,8 +1279,8 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{(uint8_t*)trace_id_str.c_str(), (uint8_t*)span_id_str.c_str(),
-                                        (uint8_t)cfg.trace_flags.value()};
+        auto ctx = tracer::TraceContext{.traceID=(uint8_t*)trace_id_str.c_str(), .spanID=(uint8_t*)span_id_str.c_str(),
+                                        .traceFlags=static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf ann iterator initialization", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
         span->SetAttribute(meta::ROWS, nb);
@@ -1318,7 +1321,7 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                 switch (faiss_metric_type) {
                     case faiss::METRIC_L2: {
                         if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
-                            faiss::cppcontrib::knowhere::all_L2sqr(cur_query, (const float*)xb, dim, 1, nb,
+                            faiss::cppcontrib::knowhere::all_L2sqr(cur_query, static_cast<const float*>(xb), dim, 1, nb,
                                                                    distances_ids, nullptr, id_selector);
                         } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                             faiss::cppcontrib::knowhere::all_L2sqr_typed(cur_query, (const DataType*)xb, dim, 1, nb,
@@ -1334,7 +1337,7 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                         if (is_cosine) {
                             if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                                 auto copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
-                                faiss::cppcontrib::knowhere::all_cosine(copied_query.get(), (const float*)xb,
+                                faiss::cppcontrib::knowhere::all_cosine(copied_query.get(), static_cast<const float*>(xb),
                                                                         inv_norms.get(), dim, 1, nb, distances_ids,
                                                                         id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
@@ -1349,7 +1352,7 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                             }
                         } else {
                             if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
-                                faiss::cppcontrib::knowhere::all_inner_product(cur_query, (const float*)xb, dim, 1, nb,
+                                faiss::cppcontrib::knowhere::all_inner_product(cur_query, static_cast<const float*>(xb), dim, 1, nb,
                                                                                distances_ids, id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                 faiss::cppcontrib::knowhere::all_inner_product_typed(
@@ -1479,7 +1482,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
 
     auto num_chunk = base_dataset->GetNumChunk();
     auto num_total_vectors = base_dataset->GetRows();
-    if (num_total_vectors != chunk_lims[num_chunk]) {
+    if (num_total_vectors != static_cast<int64_t>(chunk_lims[num_chunk]))) {
         LOG_KNOWHERE_ERROR_ << "the num_rows should be equal to the last element of chunk_lims";
         return expected<std::vector<IndexNode::IteratorPtr>>::Err(
             Status::invalid_args, "the num_rows should be equal to the last element of chunk_lims");
@@ -1504,8 +1507,8 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{(uint8_t*)trace_id_str.c_str(), (uint8_t*)span_id_str.c_str(),
-                                        (uint8_t)cfg.trace_flags.value()};
+        auto ctx = tracer::TraceContext{.traceID=(uint8_t*)trace_id_str.c_str(), .spanID=(uint8_t*)span_id_str.c_str(),
+                                        .traceFlags=static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf ann iterator initialization", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
         span->SetAttribute(meta::ROWS, num_total_vectors);
@@ -1533,8 +1536,9 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                 [[maybe_unused]] auto cur_query = (const DataType*)xq + code_size * i;
 
                 for (int chunk_idx = 0; chunk_idx < num_chunk; chunk_idx++) {
-                    auto num_base_vectors = chunk_lims[chunk_idx + 1] - chunk_lims[chunk_idx];
+                    const size_t num_base_vectors = chunk_lims[chunk_idx + 1] - chunk_lims[chunk_idx];
                     auto xb = chunk_tensor[chunk_idx];
+
                     BitsetView bitset = bitset_;
                     bitset.set_id_offset(xb_id_offset + chunk_lims[chunk_idx]);
                     BitsetViewIDSelector bw_idselector(bitset);
@@ -1557,7 +1561,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                                 KNOWHERE_THROW_MSG(err_msg);
                             }
                             // copy chunk_distances_ids to distances_ids
-                            for (int j = 0; j < num_base_vectors; ++j) {
+                            for (size_t j = 0; j < num_base_vectors; ++j) {
                                 distances_ids[chunk_lims[chunk_idx] + j].id =
                                     chunk_distances_ids[j].id == -1
                                         ? -1
@@ -1586,7 +1590,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                                     KNOWHERE_THROW_MSG(err_msg);
                                 }
                                 // copy chunk_distances_ids to distances_ids
-                                for (int j = 0; j < num_base_vectors; ++j) {
+                                for (size_t j = 0; j < num_base_vectors; ++j) {
                                     distances_ids[chunk_lims[chunk_idx] + j].id =
                                         chunk_distances_ids[j].id == -1
                                             ? -1
@@ -1608,7 +1612,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                                     KNOWHERE_THROW_MSG(err_msg);
                                 }
                                 // copy chunk_distances_ids to distances_ids
-                                for (int j = 0; j < num_base_vectors; ++j) {
+                                for (size_t j = 0; j < num_base_vectors; ++j) {
                                     distances_ids[chunk_lims[chunk_idx] + j].id =
                                         chunk_distances_ids[j].id == -1
                                             ? -1
@@ -1624,7 +1628,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                                 faiss::cppcontrib::knowhere::all_hamming_distances(cur_query, (const DataType*)xb,
                                                                                    code_size, 1, num_base_vectors,
                                                                                    distances.data(), id_selector);
-                                for (int j = 0; j < num_base_vectors; ++j) {
+                                for (size_t j = 0; j < num_base_vectors; ++j) {
                                     if (distances[j] == std::numeric_limits<int32_t>::max()) {
                                         distances_ids[chunk_lims[chunk_idx] + j].id = -1;
                                         distances_ids[chunk_lims[chunk_idx] + j].val = max_dis;
@@ -1647,7 +1651,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                                 faiss::cppcontrib::knowhere::all_jaccard_distances(cur_query, (const DataType*)xb,
                                                                                    code_size, 1, num_base_vectors,
                                                                                    distances.data(), id_selector);
-                                for (int j = 0; j < num_base_vectors; ++j) {
+                                for (size_t j = 0; j < num_base_vectors; ++j) {
                                     if (distances[j] == std::numeric_limits<float>::infinity()) {
                                         distances_ids[chunk_lims[chunk_idx] + j].id = -1;
                                         distances_ids[chunk_lims[chunk_idx] + j].val = max_dis;
@@ -1711,8 +1715,8 @@ BruteForce::AnnIterator<knowhere::sparse::SparseRow<float>>(const DataSetPtr bas
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{(uint8_t*)trace_id_str.c_str(), (uint8_t*)span_id_str.c_str(),
-                                        (uint8_t)cfg.trace_flags.value()};
+        auto ctx = tracer::TraceContext{.traceID=(uint8_t*)trace_id_str.c_str(), .spanID=(uint8_t*)span_id_str.c_str(),
+                                        .traceFlags=static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf iterator sparse", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, metric_str);
         span->SetAttribute(meta::ROWS, rows);

--- a/src/common/comp/brute_force.cc
+++ b/src/common/comp/brute_force.cc
@@ -197,8 +197,8 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
         case faiss::METRIC_L2: {
             auto cur_query = (const DataType*)xq + dim * query_idx;
             if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
-                faiss::cppcontrib::knowhere::knn_L2sqr(cur_query, static_cast<const float*>(xb), dim, 1, nb, topk, cur_distances,
-                                                       cur_labels, nullptr, id_selector);
+                faiss::cppcontrib::knowhere::knn_L2sqr(cur_query, static_cast<const float*>(xb), dim, 1, nb, topk,
+                                                       cur_distances, cur_labels, nullptr, id_selector);
             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                 faiss::cppcontrib::knowhere::knn_L2sqr_typed(cur_query, (const DataType*)xb, dim, 1, nb, topk,
                                                              cur_distances, cur_labels, nullptr, id_selector);
@@ -213,8 +213,9 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
             if (is_cosine) {
                 if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                     auto copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
-                    faiss::cppcontrib::knowhere::knn_cosine(copied_query.get(), static_cast<const float*>(xb), inv_norms, dim, 1, nb,
-                                                            topk, cur_distances, cur_labels, id_selector);
+                    faiss::cppcontrib::knowhere::knn_cosine(copied_query.get(), static_cast<const float*>(xb),
+                                                            inv_norms, dim, 1, nb, topk, cur_distances, cur_labels,
+                                                            id_selector);
                 } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                     // normalize query vector may cause precision loss, so div query norms in apply
                     // function
@@ -226,8 +227,8 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
                 }
             } else {
                 if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
-                    faiss::cppcontrib::knowhere::knn_inner_product(cur_query, static_cast<const float*>(xb), dim, 1, nb, topk,
-                                                                   cur_distances, cur_labels, id_selector);
+                    faiss::cppcontrib::knowhere::knn_inner_product(cur_query, static_cast<const float*>(xb), dim, 1, nb,
+                                                                   topk, cur_distances, cur_labels, id_selector);
                 } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                     faiss::cppcontrib::knowhere::knn_inner_product_typed(cur_query, (const DataType*)xb, dim, 1, nb,
                                                                          topk, cur_distances, cur_labels, id_selector);
@@ -240,16 +241,19 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
         }
         case faiss::METRIC_Jaccard: {
             auto cur_query = static_cast<const uint8_t*>(xq) + (dim / 8) * query_idx;
-            faiss::float_maxheap_array_t res = {.nh=static_cast<size_t>(1), .k=(topk), .ids=cur_labels, .val=cur_distances};
-            faiss::cppcontrib::knowhere::binary_knn_hc(faiss::METRIC_Jaccard, &res, cur_query, static_cast<const uint8_t*>(xb), nb,
-                                                       dim / 8, id_selector);
+            faiss::float_maxheap_array_t res = {
+                .nh = static_cast<size_t>(1), .k = (topk), .ids = cur_labels, .val = cur_distances};
+            faiss::cppcontrib::knowhere::binary_knn_hc(faiss::METRIC_Jaccard, &res, cur_query,
+                                                       static_cast<const uint8_t*>(xb), nb, dim / 8, id_selector);
             break;
         }
         case faiss::METRIC_Hamming: {
             auto cur_query = static_cast<const uint8_t*>(xq) + (dim / 8) * query_idx;
             std::vector<int32_t> int_distances(topk);
-            faiss::int_maxheap_array_t res = {.nh=static_cast<size_t>(1), .k=(topk), .ids=cur_labels, .val=int_distances.data()};
-            faiss::cppcontrib::knowhere::binary_knn_hc(faiss::METRIC_Hamming, &res, static_cast<const uint8_t*>(cur_query),
+            faiss::int_maxheap_array_t res = {
+                .nh = static_cast<size_t>(1), .k = (topk), .ids = cur_labels, .val = int_distances.data()};
+            faiss::cppcontrib::knowhere::binary_knn_hc(faiss::METRIC_Hamming, &res,
+                                                       static_cast<const uint8_t*>(cur_query),
                                                        static_cast<const uint8_t*>(xb), nb, dim / 8, id_selector);
             for (size_t i = 0; i < topk; ++i) {
                 cur_distances[i] = static_cast<float>(int_distances[i]);
@@ -260,8 +264,8 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
         case faiss::METRIC_Superstructure: {
             // only matched ids will be chosen, not to use heap
             auto cur_query = static_cast<const uint8_t*>(xq) + (dim / 8) * query_idx;
-            faiss::cppcontrib::knowhere::binary_knn_mc(faiss_metric_type, cur_query, static_cast<const uint8_t*>(xb), 1, nb, topk,
-                                                       dim / 8, cur_distances, cur_labels, id_selector);
+            faiss::cppcontrib::knowhere::binary_knn_mc(faiss_metric_type, cur_query, static_cast<const uint8_t*>(xb), 1,
+                                                       nb, topk, dim / 8, cur_distances, cur_labels, id_selector);
             break;
         }
         default: {
@@ -291,9 +295,9 @@ brute_force_minhash_impl(const void* xq, const void* xb, int64_t* labels, float*
     if (mh_valid_stat != Status::success) {
         return mh_valid_stat;
     }
-    auto search_status = minhash::MinHashVecSearch(static_cast<const char*>(xq), static_cast<const char*>(xb), mh_vec_size_in_bytes,
-                                                   mh_vec_element_size_in_bytes, mh_lsh_band, mh_lsh_r, nq, nb, topk,
-                                                   mh_search_with_jaccard, bitset, distances, labels);
+    auto search_status = minhash::MinHashVecSearch(
+        static_cast<const char*>(xq), static_cast<const char*>(xb), mh_vec_size_in_bytes, mh_vec_element_size_in_bytes,
+        mh_lsh_band, mh_lsh_r, nq, nb, topk, mh_search_with_jaccard, bitset, distances, labels);
     if (search_status != Status::success) {
         return search_status;
     }
@@ -489,8 +493,9 @@ BruteForce::SearchWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID=(uint8_t*)trace_id_str.c_str(), .spanID=(uint8_t*)span_id_str.c_str(),
-                                        .traceFlags=static_cast<uint8_t>(cfg.trace_flags.value())};
+        auto ctx = tracer::TraceContext{.traceID = (uint8_t*)trace_id_str.c_str(),
+                                        .spanID = (uint8_t*)span_id_str.c_str(),
+                                        .traceFlags = static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf search with buf", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
         span->SetAttribute(meta::TOPK, cfg.k.value());
@@ -640,7 +645,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
     auto base_tensor = base_dataset->GetTensor();
     auto num_chunk = base_dataset->GetNumChunk();
     auto num_total_vectors = base_dataset->GetRows();
-    if (std::cmp_not_equal(num_total_vectors ,chunk_lims[num_chunk])) {
+    if (std::cmp_not_equal(num_total_vectors, chunk_lims[num_chunk])) {
         LOG_KNOWHERE_ERROR_ << "the num_rows should be equal to the last element of chunk_lims";
         return Status::invalid_args;
     }
@@ -652,8 +657,9 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID=(uint8_t*)trace_id_str.c_str(), .spanID=(uint8_t*)span_id_str.c_str(),
-                                        .traceFlags=static_cast<uint8_t>(cfg.trace_flags.value())};
+        auto ctx = tracer::TraceContext{.traceID = (uint8_t*)trace_id_str.c_str(),
+                                        .spanID = (uint8_t*)span_id_str.c_str(),
+                                        .traceFlags = static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf search [on chunk] with buf", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
         span->SetAttribute(meta::TOPK, cfg.k.value());
@@ -749,7 +755,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                         dis[k * query_idx + real_el_k - j - 1] = a.val;
                         minheap.pop();
                     }
-                    for (size_t j = real_el_k; std::cmp_less(j ,k); j++) {
+                    for (size_t j = real_el_k; std::cmp_less(j, k); j++) {
                         ids[k * query_idx + j] = -1;
                         dis[k * query_idx + j] = std::numeric_limits<float>::min();
                     }
@@ -761,7 +767,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                         dis[k * query_idx + real_el_k - j - 1] = a.val;
                         maxheap.pop();
                     }
-                    for (size_t j = real_el_k; std::cmp_less(j ,k); j++) {
+                    for (size_t j = real_el_k; std::cmp_less(j, k); j++) {
                         ids[k * query_idx + j] = -1;
                         dis[k * query_idx + j] = std::numeric_limits<float>::max();
                     }
@@ -803,7 +809,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
         auto pool = ThreadPool::GetGlobalSearchThreadPool();
         std::vector<folly::Future<Status>> futs;
         futs.reserve(num_query_el);
-        for (auto query_el_i = 0; std::cmp_less(query_el_i , num_query_el); query_el_i++) {
+        for (auto query_el_i = 0; std::cmp_less(query_el_i, num_query_el); query_el_i++) {
             auto num_query_vectors = query_el_offset.get_el_len(query_el_i);
             if (num_query_vectors == 0) {
                 continue;
@@ -874,7 +880,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                         dis[k * query_el_idx + real_el_k - j - 1] = a.val;
                         minheap.pop();
                     }
-                    for (size_t j = real_el_k; std::cmp_less(j ,k); j++) {
+                    for (size_t j = real_el_k; std::cmp_less(j, k); j++) {
                         ids[k * query_el_idx + j] = -1;
                         dis[k * query_el_idx + j] = std::numeric_limits<float>::min();
                     }
@@ -886,7 +892,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                         dis[k * query_el_idx + real_el_k - j - 1] = a.val;
                         maxheap.pop();
                     }
-                    for (size_t j = real_el_k; std::cmp_less(j ,k); j++) {
+                    for (size_t j = real_el_k; std::cmp_less(j, k); j++) {
                         ids[k * query_el_idx + j] = -1;
                         dis[k * query_el_idx + j] = std::numeric_limits<float>::max();
                     }
@@ -929,8 +935,9 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID=(uint8_t*)trace_id_str.c_str(), .spanID=(uint8_t*)span_id_str.c_str(),
-                                        .traceFlags=static_cast<uint8_t>(cfg.trace_flags.value())};
+        auto ctx = tracer::TraceContext{.traceID = (uint8_t*)trace_id_str.c_str(),
+                                        .spanID = (uint8_t*)span_id_str.c_str(),
+                                        .traceFlags = static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf range search", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
         span->SetAttribute(meta::RADIUS, cfg.radius.value());
@@ -1025,8 +1032,8 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                     case faiss::METRIC_L2: {
                         [[maybe_unused]] auto cur_query = (const DataType*)xq + dim * index;
                         if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
-                            faiss::cppcontrib::knowhere::range_search_L2sqr(cur_query, static_cast<const float*>(xb), dim, 1, nb,
-                                                                            radius, &res, id_selector);
+                            faiss::cppcontrib::knowhere::range_search_L2sqr(cur_query, static_cast<const float*>(xb),
+                                                                            dim, 1, nb, radius, &res, id_selector);
                         } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                             faiss::cppcontrib::knowhere::range_search_L2sqr_typed(cur_query, (const DataType*)xb, dim,
                                                                                   1, nb, radius, &res, id_selector);
@@ -1041,9 +1048,9 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                         if (is_cosine) {
                             if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                                 auto copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
-                                faiss::cppcontrib::knowhere::range_search_cosine(copied_query.get(), static_cast<const float*>(xb),
-                                                                                 inv_norms.get(), dim, 1, nb, radius,
-                                                                                 &res, id_selector);
+                                faiss::cppcontrib::knowhere::range_search_cosine(
+                                    copied_query.get(), static_cast<const float*>(xb), inv_norms.get(), dim, 1, nb,
+                                    radius, &res, id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                 // normalize query vector may cause precision loss, so div query norms in apply function
                                 faiss::cppcontrib::knowhere::range_search_cosine_typed(cur_query, (const DataType*)xb,
@@ -1070,15 +1077,15 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                     case faiss::METRIC_Jaccard: {
                         auto cur_query = static_cast<const uint8_t*>(xq) + (dim / 8) * index;
                         faiss::cppcontrib::knowhere::binary_range_search<faiss::CMin<float, int64_t>, float>(
-                            faiss::METRIC_Jaccard, cur_query, static_cast<const uint8_t*>(xb), 1, nb, radius, dim / 8, &res,
-                            id_selector);
+                            faiss::METRIC_Jaccard, cur_query, static_cast<const uint8_t*>(xb), 1, nb, radius, dim / 8,
+                            &res, id_selector);
                         break;
                     }
                     case faiss::METRIC_Hamming: {
                         auto cur_query = static_cast<const uint8_t*>(xq) + (dim / 8) * index;
                         faiss::cppcontrib::knowhere::binary_range_search<faiss::CMin<int, int64_t>, int>(
-                            faiss::METRIC_Hamming, cur_query, static_cast<const uint8_t*>(xb), 1, nb, static_cast<int>(radius), dim / 8, &res,
-                            id_selector);
+                            faiss::METRIC_Hamming, cur_query, static_cast<const uint8_t*>(xb), 1, nb,
+                            static_cast<int>(radius), dim / 8, &res, id_selector);
                         break;
                     }
                     default: {
@@ -1148,8 +1155,9 @@ BruteForce::SearchSparseWithBuf(const DataSetPtr base_dataset, const DataSetPtr 
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID=(uint8_t*)trace_id_str.c_str(), .spanID=(uint8_t*)span_id_str.c_str(),
-                                        .traceFlags=static_cast<uint8_t>(cfg.trace_flags.value())};
+        auto ctx = tracer::TraceContext{.traceID = (uint8_t*)trace_id_str.c_str(),
+                                        .spanID = (uint8_t*)span_id_str.c_str(),
+                                        .traceFlags = static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf search sparse with buf", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
         span->SetAttribute(meta::TOPK, cfg.k.value());
@@ -1279,8 +1287,9 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID=(uint8_t*)trace_id_str.c_str(), .spanID=(uint8_t*)span_id_str.c_str(),
-                                        .traceFlags=static_cast<uint8_t>(cfg.trace_flags.value())};
+        auto ctx = tracer::TraceContext{.traceID = (uint8_t*)trace_id_str.c_str(),
+                                        .spanID = (uint8_t*)span_id_str.c_str(),
+                                        .traceFlags = static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf ann iterator initialization", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
         span->SetAttribute(meta::ROWS, nb);
@@ -1337,9 +1346,9 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                         if (is_cosine) {
                             if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                                 auto copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
-                                faiss::cppcontrib::knowhere::all_cosine(copied_query.get(), static_cast<const float*>(xb),
-                                                                        inv_norms.get(), dim, 1, nb, distances_ids,
-                                                                        id_selector);
+                                faiss::cppcontrib::knowhere::all_cosine(copied_query.get(),
+                                                                        static_cast<const float*>(xb), inv_norms.get(),
+                                                                        dim, 1, nb, distances_ids, id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                 // normalize query vector may cause precision loss, so div query norms in apply function
                                 faiss::cppcontrib::knowhere::all_cosine_typed(cur_query, (const DataType*)xb,
@@ -1352,8 +1361,8 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                             }
                         } else {
                             if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
-                                faiss::cppcontrib::knowhere::all_inner_product(cur_query, static_cast<const float*>(xb), dim, 1, nb,
-                                                                               distances_ids, id_selector);
+                                faiss::cppcontrib::knowhere::all_inner_product(cur_query, static_cast<const float*>(xb),
+                                                                               dim, 1, nb, distances_ids, id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                 faiss::cppcontrib::knowhere::all_inner_product_typed(
                                     cur_query, (const DataType*)xb, dim, 1, nb, distances_ids, id_selector);
@@ -1507,8 +1516,9 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID=(uint8_t*)trace_id_str.c_str(), .spanID=(uint8_t*)span_id_str.c_str(),
-                                        .traceFlags=static_cast<uint8_t>(cfg.trace_flags.value())};
+        auto ctx = tracer::TraceContext{.traceID = (uint8_t*)trace_id_str.c_str(),
+                                        .spanID = (uint8_t*)span_id_str.c_str(),
+                                        .traceFlags = static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf ann iterator initialization", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, cfg.metric_type.value());
         span->SetAttribute(meta::ROWS, num_total_vectors);
@@ -1715,8 +1725,9 @@ BruteForce::AnnIterator<knowhere::sparse::SparseRow<float>>(const DataSetPtr bas
     if (cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID=(uint8_t*)trace_id_str.c_str(), .spanID=(uint8_t*)span_id_str.c_str(),
-                                        .traceFlags=static_cast<uint8_t>(cfg.trace_flags.value())};
+        auto ctx = tracer::TraceContext{.traceID = (uint8_t*)trace_id_str.c_str(),
+                                        .spanID = (uint8_t*)span_id_str.c_str(),
+                                        .traceFlags = static_cast<uint8_t>(cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere bf iterator sparse", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, metric_str);
         span->SetAttribute(meta::ROWS, rows);

--- a/src/common/comp/brute_force.cc
+++ b/src/common/comp/brute_force.cc
@@ -200,8 +200,8 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
                 faiss::cppcontrib::knowhere::knn_L2sqr(cur_query, static_cast<const float*>(xb), dim, 1, nb, topk,
                                                        cur_distances, cur_labels, nullptr, id_selector);
             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
-                faiss::cppcontrib::knowhere::knn_L2sqr_typed(cur_query, static_cast<const DataType*>(xb), dim, 1, nb, topk,
-                                                             cur_distances, cur_labels, nullptr, id_selector);
+                faiss::cppcontrib::knowhere::knn_L2sqr_typed(cur_query, static_cast<const DataType*>(xb), dim, 1, nb,
+                                                             topk, cur_distances, cur_labels, nullptr, id_selector);
             } else {
                 LOG_KNOWHERE_ERROR_ << "Metric L2 not supported for current vector type";
                 return Status::faiss_inner_error;
@@ -219,8 +219,9 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
                 } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                     // normalize query vector may cause precision loss, so div query norms in apply
                     // function
-                    faiss::cppcontrib::knowhere::knn_cosine_typed(cur_query, static_cast<const DataType*>(xb), inv_norms, dim, 1, nb,
-                                                                  topk, cur_distances, cur_labels, id_selector);
+                    faiss::cppcontrib::knowhere::knn_cosine_typed(cur_query, static_cast<const DataType*>(xb),
+                                                                  inv_norms, dim, 1, nb, topk, cur_distances,
+                                                                  cur_labels, id_selector);
                 } else {
                     LOG_KNOWHERE_ERROR_ << "Metric COSINE not supported for current vector type";
                     return Status::faiss_inner_error;
@@ -230,8 +231,9 @@ brute_force_dense_impl(const void* xq, size_t query_idx, const void* xb, const f
                     faiss::cppcontrib::knowhere::knn_inner_product(cur_query, static_cast<const float*>(xb), dim, 1, nb,
                                                                    topk, cur_distances, cur_labels, id_selector);
                 } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
-                    faiss::cppcontrib::knowhere::knn_inner_product_typed(cur_query, static_cast<const DataType*>(xb), dim, 1, nb,
-                                                                         topk, cur_distances, cur_labels, id_selector);
+                    faiss::cppcontrib::knowhere::knn_inner_product_typed(cur_query, static_cast<const DataType*>(xb),
+                                                                         dim, 1, nb, topk, cur_distances, cur_labels,
+                                                                         id_selector);
                 } else {
                     LOG_KNOWHERE_ERROR_ << "Metric IP not supported for current vector type";
                     return Status::faiss_inner_error;
@@ -1035,8 +1037,8 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                             faiss::cppcontrib::knowhere::range_search_L2sqr(cur_query, static_cast<const float*>(xb),
                                                                             dim, 1, nb, radius, &res, id_selector);
                         } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
-                            faiss::cppcontrib::knowhere::range_search_L2sqr_typed(cur_query, static_cast<const DataType*>(xb), dim,
-                                                                                  1, nb, radius, &res, id_selector);
+                            faiss::cppcontrib::knowhere::range_search_L2sqr_typed(
+                                cur_query, static_cast<const DataType*>(xb), dim, 1, nb, radius, &res, id_selector);
                         } else {
                             LOG_KNOWHERE_ERROR_ << "Metric L2 not supported for current vector type";
                             return Status::faiss_inner_error;
@@ -1053,9 +1055,9 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                                     radius, &res, id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                 // normalize query vector may cause precision loss, so div query norms in apply function
-                                faiss::cppcontrib::knowhere::range_search_cosine_typed(cur_query, static_cast<const DataType*>(xb),
-                                                                                       inv_norms.get(), dim, 1, nb,
-                                                                                       radius, &res, id_selector);
+                                faiss::cppcontrib::knowhere::range_search_cosine_typed(
+                                    cur_query, static_cast<const DataType*>(xb), inv_norms.get(), dim, 1, nb, radius,
+                                    &res, id_selector);
                             } else {
                                 LOG_KNOWHERE_ERROR_ << "Metric COSINE not supported for current vector type";
                                 return Status::faiss_inner_error;
@@ -1333,8 +1335,9 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                             faiss::cppcontrib::knowhere::all_L2sqr(cur_query, static_cast<const float*>(xb), dim, 1, nb,
                                                                    distances_ids, nullptr, id_selector);
                         } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
-                            faiss::cppcontrib::knowhere::all_L2sqr_typed(cur_query, static_cast<const DataType*>(xb), dim, 1, nb,
-                                                                         distances_ids, nullptr, id_selector);
+                            faiss::cppcontrib::knowhere::all_L2sqr_typed(cur_query, static_cast<const DataType*>(xb),
+                                                                         dim, 1, nb, distances_ids, nullptr,
+                                                                         id_selector);
                         } else {
                             std::string err_msg = "Metric L2 not supported for current vector type";
                             LOG_KNOWHERE_ERROR_ << err_msg;
@@ -1351,9 +1354,9 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                                                                         dim, 1, nb, distances_ids, id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                 // normalize query vector may cause precision loss, so div query norms in apply function
-                                faiss::cppcontrib::knowhere::all_cosine_typed(cur_query, static_cast<const DataType*>(xb),
-                                                                              inv_norms.get(), dim, 1, nb,
-                                                                              distances_ids, id_selector);
+                                faiss::cppcontrib::knowhere::all_cosine_typed(
+                                    cur_query, static_cast<const DataType*>(xb), inv_norms.get(), dim, 1, nb,
+                                    distances_ids, id_selector);
                             } else {
                                 std::string err_msg = "Metric COSINE not supported for current vector type";
                                 LOG_KNOWHERE_ERROR_ << err_msg;
@@ -1365,7 +1368,8 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                                                                                dim, 1, nb, distances_ids, id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                 faiss::cppcontrib::knowhere::all_inner_product_typed(
-                                    cur_query, static_cast<const DataType*>(xb), dim, 1, nb, distances_ids, id_selector);
+                                    cur_query, static_cast<const DataType*>(xb), dim, 1, nb, distances_ids,
+                                    id_selector);
                             } else {
                                 std::string err_msg = "Metric IP not supported for current vector type";
                                 LOG_KNOWHERE_ERROR_ << err_msg;
@@ -1378,7 +1382,8 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                         if constexpr (std::is_same_v<DataType, knowhere::bin1>) {
                             std::vector<int32_t> distances(nb, std::numeric_limits<int32_t>::max());
                             faiss::cppcontrib::knowhere::all_hamming_distances(
-                                cur_query, static_cast<const DataType*>(xb), code_size, 1, nb, distances.data(), id_selector);
+                                cur_query, static_cast<const DataType*>(xb), code_size, 1, nb, distances.data(),
+                                id_selector);
                             for (int j = 0; j < nb; ++j) {
                                 if (distances[j] == std::numeric_limits<int32_t>::max()) {
                                     distances_ids[j] = {-1, max_dis};
@@ -1397,7 +1402,8 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                         if constexpr (std::is_same_v<DataType, knowhere::bin1>) {
                             std::vector<float> distances(nb, max_dis);
                             faiss::cppcontrib::knowhere::all_jaccard_distances(
-                                cur_query, static_cast<const DataType*>(xb), code_size, 1, nb, distances.data(), id_selector);
+                                cur_query, static_cast<const DataType*>(xb), code_size, 1, nb, distances.data(),
+                                id_selector);
                             for (int j = 0; j < nb; ++j) {
                                 if (distances[j] == std::numeric_limits<float>::infinity()) {
                                     distances_ids[j] = {-1, max_dis};
@@ -1562,9 +1568,9 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                                                                        num_base_vectors, chunk_distances_ids, nullptr,
                                                                        id_selector);
                             } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
-                                faiss::cppcontrib::knowhere::all_L2sqr_typed(cur_query, static_cast<const DataType*>(xb), dim, 1,
-                                                                             num_base_vectors, chunk_distances_ids,
-                                                                             nullptr, id_selector);
+                                faiss::cppcontrib::knowhere::all_L2sqr_typed(
+                                    cur_query, static_cast<const DataType*>(xb), dim, 1, num_base_vectors,
+                                    chunk_distances_ids, nullptr, id_selector);
                             } else {
                                 std::string err_msg = "Metric L2 not supported for current vector type";
                                 LOG_KNOWHERE_ERROR_ << err_msg;
@@ -1585,15 +1591,15 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                                 auto chunk_inv_norms = inv_norms ? inv_norms.get() + chunk_lims[chunk_idx] : nullptr;
                                 if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                                     auto copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
-                                    faiss::cppcontrib::knowhere::all_cosine(copied_query.get(), static_cast<const float*>(xb),
-                                                                            chunk_inv_norms, dim, 1, num_base_vectors,
-                                                                            chunk_distances_ids, id_selector);
+                                    faiss::cppcontrib::knowhere::all_cosine(
+                                        copied_query.get(), static_cast<const float*>(xb), chunk_inv_norms, dim, 1,
+                                        num_base_vectors, chunk_distances_ids, id_selector);
                                 } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                     // normalize query vector may cause precision loss, so div query norms in apply
                                     // function
                                     faiss::cppcontrib::knowhere::all_cosine_typed(
-                                        cur_query, static_cast<const DataType*>(xb), chunk_inv_norms, dim, 1, num_base_vectors,
-                                        chunk_distances_ids, id_selector);
+                                        cur_query, static_cast<const DataType*>(xb), chunk_inv_norms, dim, 1,
+                                        num_base_vectors, chunk_distances_ids, id_selector);
                                 } else {
                                     std::string err_msg = "Metric COSINE not supported for current vector type";
                                     LOG_KNOWHERE_ERROR_ << err_msg;
@@ -1609,13 +1615,13 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                                 }
                             } else {
                                 if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
-                                    faiss::cppcontrib::knowhere::all_inner_product(cur_query, static_cast<const float*>(xb), dim, 1,
-                                                                                   num_base_vectors,
-                                                                                   chunk_distances_ids, id_selector);
+                                    faiss::cppcontrib::knowhere::all_inner_product(
+                                        cur_query, static_cast<const float*>(xb), dim, 1, num_base_vectors,
+                                        chunk_distances_ids, id_selector);
                                 } else if constexpr (KnowhereLowPrecisionTypeCheck<DataType>::value) {
                                     faiss::cppcontrib::knowhere::all_inner_product_typed(
-                                        cur_query, static_cast<const DataType*>(xb), dim, 1, num_base_vectors, chunk_distances_ids,
-                                        id_selector);
+                                        cur_query, static_cast<const DataType*>(xb), dim, 1, num_base_vectors,
+                                        chunk_distances_ids, id_selector);
                                 } else {
                                     std::string err_msg = "Metric IP not supported for current vector type";
                                     LOG_KNOWHERE_ERROR_ << err_msg;
@@ -1635,9 +1641,9 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                         case faiss::METRIC_Hamming: {
                             if constexpr (std::is_same_v<DataType, knowhere::bin1>) {
                                 std::vector<int32_t> distances(num_base_vectors, max_dis);
-                                faiss::cppcontrib::knowhere::all_hamming_distances(cur_query, static_cast<const DataType*>(xb),
-                                                                                   code_size, 1, num_base_vectors,
-                                                                                   distances.data(), id_selector);
+                                faiss::cppcontrib::knowhere::all_hamming_distances(
+                                    cur_query, static_cast<const DataType*>(xb), code_size, 1, num_base_vectors,
+                                    distances.data(), id_selector);
                                 for (size_t j = 0; j < num_base_vectors; ++j) {
                                     if (distances[j] == std::numeric_limits<int32_t>::max()) {
                                         distances_ids[chunk_lims[chunk_idx] + j].id = -1;
@@ -1658,9 +1664,9 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                         case faiss::METRIC_Jaccard: {
                             if constexpr (std::is_same_v<DataType, knowhere::bin1>) {
                                 std::vector<float> distances(num_base_vectors, max_dis);
-                                faiss::cppcontrib::knowhere::all_jaccard_distances(cur_query, static_cast<const DataType*>(xb),
-                                                                                   code_size, 1, num_base_vectors,
-                                                                                   distances.data(), id_selector);
+                                faiss::cppcontrib::knowhere::all_jaccard_distances(
+                                    cur_query, static_cast<const DataType*>(xb), code_size, 1, num_base_vectors,
+                                    distances.data(), id_selector);
                                 for (size_t j = 0; j < num_base_vectors; ++j) {
                                     if (distances[j] == std::numeric_limits<float>::infinity()) {
                                         distances_ids[chunk_lims[chunk_idx] + j].id = -1;

--- a/src/common/prometheus_client.cc
+++ b/src/common/prometheus_client.cc
@@ -74,7 +74,7 @@ void
 PrometheusHistogramCache::RegisterMetrics(prometheus::Family<prometheus::Histogram>& family, const std::string& module,
                                           const std::vector<std::string>& index_types,
                                           const prometheus::Histogram::BucketBoundaries& buckets) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     for (const auto& index_type : index_types) {
         const auto key = module + '\n' + index_type + '\n' + std::to_string(reinterpret_cast<uintptr_t>(&family));
         if (metrics_.find(key) != metrics_.end()) {
@@ -90,7 +90,7 @@ PrometheusHistogramCache::GetMetric(prometheus::Family<prometheus::Histogram>& f
                                     const std::string& index_type,
                                     const prometheus::Histogram::BucketBoundaries& buckets) {
     const auto key = module + '\n' + index_type + '\n' + std::to_string(reinterpret_cast<uintptr_t>(&family));
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     auto it = metrics_.find(key);
     if (it != metrics_.end()) {
         return *(it->second);

--- a/src/common/utils.cc
+++ b/src/common/utils.cc
@@ -74,7 +74,7 @@ NormalizeVec(DataType* x, int32_t d) {
     if (norm_l2_sqr > 0 && std::abs(1.0f - norm_l2_sqr) > FloatAccuracy) {
         float norm_l2 = std::sqrt(norm_l2_sqr);
         for (int32_t i = 0; i < d; i++) {
-            x[i] = (DataType)((float)x[i] / norm_l2);
+            x[i] = static_cast<DataType>(static_cast<float>(x[i]) / norm_l2);
         }
         return norm_l2;
     }
@@ -104,10 +104,10 @@ CopyAndNormalizeVecs(const DataType* x, size_t rows, int32_t dim) {
 
 template <typename DataType>
 void
-NormalizeDataset(const DataSetPtr dataset) {
+NormalizeDataset(DataSetPtr dataset) {
     auto rows = dataset->GetRows();
     auto dim = dataset->GetDim();
-    auto data = (DataType*)dataset->GetTensor();
+    auto data = const_cast<DataType*>(static_cast<const DataType*>(dataset->GetTensor()));
 
     LOG_KNOWHERE_DEBUG_ << "vector normalize, rows " << rows << ", dim " << dim;
     NormalizeVecs<DataType>(data, rows, dim);
@@ -118,7 +118,7 @@ std::tuple<DataSetPtr, std::vector<float>>
 CopyAndNormalizeDataset(const DataSetPtr dataset) {
     auto rows = dataset->GetRows();
     auto dim = dataset->GetDim();
-    auto data = (DataType*)dataset->GetTensor();
+    auto data = static_cast<const DataType*>(dataset->GetTensor());
 
     LOG_KNOWHERE_DEBUG_ << "vector normalize, rows " << rows << ", dim " << dim;
 

--- a/src/index/diskann/diskann.cc
+++ b/src/index/diskann/diskann.cc
@@ -828,7 +828,7 @@ DiskANNIndexNode<DataType>::AnnIterator(const DataSetPtr dataset, std::unique_pt
 
     try {
         for (int i = 0; i < nq; i++) {
-            auto single_query = (DataType*)xq + i * dim;
+            auto single_query = static_cast<const DataType*>(xq) + i * dim;
             auto it = std::make_shared<iterator>(transform, single_query, lsearch, beamwidth, filter_ratio, bitset,
                                                  pq_flash_index_.get(), use_knowhere_search_pool);
             vec[i] = it;

--- a/src/index/diskann/diskann.cc
+++ b/src/index/diskann/diskann.cc
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <fstream>
 #include <limits>
+#include <memory>
 #include <unordered_set>
 
 #include "diskann/aux_utils.h"
@@ -143,7 +144,7 @@ class DiskANNIndexNode : public IndexNode {
     static expected<Resource>
     StaticEstimateLoadResource(const uint64_t file_size_in_bytes, const int64_t num_rows, const int64_t dim,
                                const knowhere::BaseConfig& config, const IndexVersion& version) {
-        return Resource{file_size_in_bytes / 4, file_size_in_bytes};
+        return Resource{.memoryCost=file_size_in_bytes / 4, .diskCost=file_size_in_bytes};
     }
 
     Status
@@ -502,7 +503,7 @@ Status
 DiskANNIndexNode<DataType>::BuildEmbListIfNeed(const DataSetPtr dataset, std::shared_ptr<Config> cfg,
                                                bool use_knowhere_build_pool) {
     assert(file_manager_ != nullptr);
-    std::lock_guard<std::mutex> lock(preparation_lock_);
+    std::scoped_lock lock(preparation_lock_);
     auto& config = static_cast<BaseConfig&>(*cfg);
     auto el_metric_type_or = get_el_metric_type(config.metric_type.value());
     if (!el_metric_type_or.has_value()) {
@@ -614,7 +615,7 @@ DiskANNIndexNode<DataType>::Deserialize(const BinarySet& binset, std::shared_ptr
     // load diskann pq code and meta info
     std::shared_ptr<AlignedFileReader> reader = nullptr;
 
-    reader.reset(new LinuxAlignedFileReader());
+    reader = std::make_shared<LinuxAlignedFileReader>();
 
     pq_flash_index_ = std::make_unique<diskann::PQFlashIndex<DataType>>(reader, diskann_metric);
     auto disk_ann_call = [&]() {
@@ -704,7 +705,7 @@ DiskANNIndexNode<DataType>::Deserialize(const BinarySet& binset, std::shared_ptr
 
         std::vector<folly::Future<folly::Unit>> futures;
         futures.reserve(warmup_num);
-        for (_s64 i = 0; i < (int64_t)warmup_num; ++i) {
+        for (uint64_t i = 0; i < warmup_num; ++i) {
             futures.emplace_back(search_pool_->push([&, index = i]() {
                 pq_flash_index_->cached_beam_search(warmup + (index * warmup_aligned_dim), 1, warmup_L,
                                                     warmup_result_ids_64.data() + (index * 1),
@@ -732,7 +733,7 @@ DiskANNIndexNode<DataType>::Deserialize(const BinarySet& binset, std::shared_ptr
 template <typename DataType>
 Status
 DiskANNIndexNode<DataType>::DeserializeEmbListIfNeed(const BinarySet& binset, std::shared_ptr<Config> cfg) {
-    std::lock_guard<std::mutex> lock(preparation_lock_);
+    std::scoped_lock lock(preparation_lock_);
     auto& config = static_cast<BaseConfig&>(*cfg);
     auto el_metric_type_or = get_el_metric_type(config.metric_type.value());
     if (!el_metric_type_or.has_value()) {
@@ -1010,7 +1011,8 @@ template <typename DataType>
 expected<DataSetPtr>
 DiskANNIndexNode<DataType>::GetIndexMeta(std::unique_ptr<Config> cfg) const {
     std::vector<int64_t> entry_points;
-    for (size_t i = 0; i < pq_flash_index_->get_num_medoids(); i++) {
+    entry_points.reserve(pq_flash_index_->get_num_medoids());
+for (size_t i = 0; i < pq_flash_index_->get_num_medoids(); i++) {
         entry_points.push_back(pq_flash_index_->get_medoids()[i]);
     }
     auto diskann_conf = static_cast<const DiskANNConfig&>(*cfg);

--- a/src/index/diskann/diskann.cc
+++ b/src/index/diskann/diskann.cc
@@ -144,7 +144,7 @@ class DiskANNIndexNode : public IndexNode {
     static expected<Resource>
     StaticEstimateLoadResource(const uint64_t file_size_in_bytes, const int64_t num_rows, const int64_t dim,
                                const knowhere::BaseConfig& config, const IndexVersion& version) {
-        return Resource{.memoryCost=file_size_in_bytes / 4, .diskCost=file_size_in_bytes};
+        return Resource{.memoryCost = file_size_in_bytes / 4, .diskCost = file_size_in_bytes};
     }
 
     Status
@@ -1012,7 +1012,7 @@ expected<DataSetPtr>
 DiskANNIndexNode<DataType>::GetIndexMeta(std::unique_ptr<Config> cfg) const {
     std::vector<int64_t> entry_points;
     entry_points.reserve(pq_flash_index_->get_num_medoids());
-for (size_t i = 0; i < pq_flash_index_->get_num_medoids(); i++) {
+    for (size_t i = 0; i < pq_flash_index_->get_num_medoids(); i++) {
         entry_points.push_back(pq_flash_index_->get_medoids()[i]);
     }
     auto diskann_conf = static_cast<const DiskANNConfig&>(*cfg);

--- a/src/index/diskann/diskann_aisaq.cc
+++ b/src/index/diskann/diskann_aisaq.cc
@@ -375,7 +375,7 @@ AisaqIndexNode<DataType>::Build(const DataSetPtr dataset, std::shared_ptr<Config
                                                      static_cast<uint32_t>(build_conf.disk_pq_dims.value()),
                                                      false,
                                                      build_conf.accelerate_build.value(),
-                                                     (uint32_t)num_nodes_to_cache, /* num_nodes_to_cache */
+                                                     static_cast<uint32_t>(num_nodes_to_cache), /* num_nodes_to_cache */
                                                      build_conf.shuffle_build.value(),
                                                      true,
                                                      static_cast<uint32_t>(build_conf.inline_pq.value()),

--- a/src/index/diskann/diskann_aisaq.cc
+++ b/src/index/diskann/diskann_aisaq.cc
@@ -85,7 +85,7 @@ class AisaqIndexNode : public IndexNode {
     StaticEstimateLoadResource(const uint64_t file_size_in_bytes, const int64_t num_rows, const int64_t dim,
                                const knowhere::BaseConfig& config, const IndexVersion& version) {
         uint64_t s = file_size_in_bytes / 1024;
-        return Resource{.memoryCost=s, .diskCost=file_size_in_bytes};
+        return Resource{.memoryCost = s, .diskCost = file_size_in_bytes};
     }
 
     Status
@@ -640,7 +640,8 @@ AisaqIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
     if (!search_conf.vectors_beamwidth.has_value()) {
         search_conf.vectors_beamwidth.value() = diskann::defaults::DEFAULT_AISAQ_VECTORS_BEAMWIDTH;
     } else {
-        const int32_t max_aisaq_vectors_beamwidth = static_cast<int32_t>(diskann::defaults::MAX_AISAQ_VECTORS_BEAMWIDTH);
+        const int32_t max_aisaq_vectors_beamwidth =
+            static_cast<int32_t>(diskann::defaults::MAX_AISAQ_VECTORS_BEAMWIDTH);
         if (search_conf.vectors_beamwidth.value() > max_aisaq_vectors_beamwidth) {
             LOG_KNOWHERE_ERROR_ << "Error. Vector beam width more than max value";
             return expected<DataSetPtr>::Err(Status::aisaq_error, "vector beam width more than maximal");

--- a/src/index/diskann/diskann_aisaq.cc
+++ b/src/index/diskann/diskann_aisaq.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #include <cstdint>
+#include <memory>
 
 #include "diskann/aisaq.h"
 #include "diskann/aux_utils.h"
@@ -84,7 +85,7 @@ class AisaqIndexNode : public IndexNode {
     StaticEstimateLoadResource(const uint64_t file_size_in_bytes, const int64_t num_rows, const int64_t dim,
                                const knowhere::BaseConfig& config, const IndexVersion& version) {
         uint64_t s = file_size_in_bytes / 1024;
-        return Resource{s, file_size_in_bytes};
+        return Resource{.memoryCost=s, .diskCost=file_size_in_bytes};
     }
 
     Status
@@ -296,15 +297,20 @@ AisaqIndexNode<DataType>::Build(const DataSetPtr dataset, std::shared_ptr<Config
         LOG_KNOWHERE_ERROR_ << "inline pq more than max degree value";
         return Status::aisaq_error;
     }
-    if (build_conf.max_degree.value() > (int)diskann::defaults::MAX_AISAQ_MAX_DEGREE) {
+
+    const int32_t max_degree = static_cast<int32_t>(diskann::defaults::MAX_AISAQ_MAX_DEGREE);
+    if (build_conf.max_degree.value() > max_degree) {
         LOG_KNOWHERE_ERROR_ << "max degree more than maximum allowed max degree value";
         return Status::aisaq_error;
     }
+
     if (build_conf.disk_pq_dims.value() < 0 || build_conf.disk_pq_dims.value() > build_conf.dim.value()) {
         LOG_KNOWHERE_ERROR_ << "disk PQ badget more than dimension value";
         return Status::aisaq_error;
     }
-    if (build_conf.search_list_size.value() > (int)diskann::defaults::MAX_AISAQ_SEARCH_LIST_SIZE) {
+
+    const int32_t max_aisaq_search_list_size = static_cast<int32_t>(diskann::defaults::MAX_AISAQ_SEARCH_LIST_SIZE);
+    if (build_conf.search_list_size.value() > max_aisaq_search_list_size) {
         LOG_KNOWHERE_ERROR_ << "search list size value more than maximum allowed value";
         return Status::aisaq_error;
     }
@@ -321,7 +327,7 @@ AisaqIndexNode<DataType>::Build(const DataSetPtr dataset, std::shared_ptr<Config
                        << " search_cache_budget_gb: " << build_conf.search_cache_budget_gb.value()
                        << " disk PQ budget: " << build_conf.disk_pq_dims.value();
 
-    std::lock_guard<std::mutex> lock(preparation_lock_);
+    std::scoped_lock lock(preparation_lock_);
     if (!CheckMetric(build_conf.metric_type.value())) {
         LOG_KNOWHERE_ERROR_ << "Invalid metric type: " << build_conf.metric_type.value();
         return Status::invalid_metric_type;
@@ -372,7 +378,7 @@ AisaqIndexNode<DataType>::Build(const DataSetPtr dataset, std::shared_ptr<Config
                                                      (uint32_t)num_nodes_to_cache, /* num_nodes_to_cache */
                                                      build_conf.shuffle_build.value(),
                                                      true,
-                                                     (uint32_t)build_conf.inline_pq.value(),
+                                                     static_cast<uint32_t>(build_conf.inline_pq.value()),
                                                      build_conf.rearrange.value(),
                                                      build_conf.num_entry_points.value()};
     RETURN_IF_ERROR(TryDiskANNCall([&]() {
@@ -417,7 +423,7 @@ AisaqIndexNode<DataType>::Deserialize(const BinarySet& binset, std::shared_ptr<C
 
     diskann::aisaq_pq_io_engine pq_read_io_engine = diskann::aisaq_pq_io_engine_default;
 
-    std::lock_guard<std::mutex> lock(preparation_lock_);
+    std::scoped_lock lock(preparation_lock_);
     if (!CheckMetric(prep_conf.metric_type.value())) {
         return Status::invalid_metric_type;
     }
@@ -471,7 +477,7 @@ AisaqIndexNode<DataType>::Deserialize(const BinarySet& binset, std::shared_ptr<C
     // load diskann pq code and meta info
     std::shared_ptr<AlignedFileReader> reader = nullptr;
 
-    reader.reset(new LinuxAlignedFileReader());
+    reader = std::make_shared<LinuxAlignedFileReader>();
 
     pq_flash_index_ = std::make_unique<diskann::PQFlashAisaqIndex<DataType>>(reader, diskann_metric);
 
@@ -575,7 +581,7 @@ AisaqIndexNode<DataType>::Deserialize(const BinarySet& binset, std::shared_ptr<C
 
         std::vector<folly::Future<folly::Unit>> futures;
         futures.reserve(warmup_num);
-        for (_s64 i = 0; i < (int64_t)warmup_num; ++i) {
+        for (uint64_t i = 0; i < warmup_num; ++i) {
             futures.emplace_back(search_pool_->push([&, index = i]() {
                 pq_flash_index_->aisaq_cached_beam_search(warmup + (index * warmup_aligned_dim), 1, warmup_L,
                                                           warmup_result_ids_64.data() + (index * 1),
@@ -624,7 +630,8 @@ AisaqIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
     if (!search_conf.beamwidth.has_value()) {
         search_conf.beamwidth.value() = diskann::defaults::DEFAULT_AISAQ_BEAMWIDTH;
     } else {
-        if (search_conf.beamwidth.value() > (int)diskann::defaults::MAX_AISAQ_BEAMWIDTH) {
+        const int32_t max_aisaq_beamwidth = static_cast<int32_t>(diskann::defaults::MAX_AISAQ_BEAMWIDTH);
+        if (search_conf.beamwidth.value() > max_aisaq_beamwidth) {
             LOG_KNOWHERE_ERROR_ << "Error. Beam width more than max value";
             return expected<DataSetPtr>::Err(Status::aisaq_error, "beam width more than maximal");
         }
@@ -633,7 +640,8 @@ AisaqIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
     if (!search_conf.vectors_beamwidth.has_value()) {
         search_conf.vectors_beamwidth.value() = diskann::defaults::DEFAULT_AISAQ_VECTORS_BEAMWIDTH;
     } else {
-        if (search_conf.vectors_beamwidth.value() > (int)diskann::defaults::MAX_AISAQ_VECTORS_BEAMWIDTH) {
+        const int32_t max_aisaq_vectors_beamwidth = static_cast<int32_t>(diskann::defaults::MAX_AISAQ_VECTORS_BEAMWIDTH);
+        if (search_conf.vectors_beamwidth.value() > max_aisaq_vectors_beamwidth) {
             LOG_KNOWHERE_ERROR_ << "Error. Vector beam width more than max value";
             return expected<DataSetPtr>::Err(Status::aisaq_error, "vector beam width more than maximal");
         }
@@ -649,7 +657,7 @@ AisaqIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
         aisaq_search_config.pq_read_page_cache_size = search_conf.pq_read_page_cache_size.value();
     }
 
-    auto nq = (uint64_t)dataset->GetRows();
+    auto nq = static_cast<uint64_t>(dataset->GetRows());
     auto dim = dataset->GetDim();
     auto xq = static_cast<const DataType*>(dataset->GetTensor());
 
@@ -737,6 +745,8 @@ template <typename DataType>
 expected<DataSetPtr>
 AisaqIndexNode<DataType>::GetIndexMeta(std::unique_ptr<Config> cfg) const {
     std::vector<int64_t> entry_points;
+    entry_points.reserve(pq_flash_index_->get_num_medoids());
+
     for (size_t i = 0; i < pq_flash_index_->get_num_medoids(); i++) {
         entry_points.push_back(pq_flash_index_->get_medoids()[i]);
     }

--- a/src/index/emb_list/emb_list_strategy.cc
+++ b/src/index/emb_list/emb_list_strategy.cc
@@ -52,7 +52,7 @@ RerankByCalcDistByIDs(const std::vector<int64_t>& candidate_docs, const DataSetP
     std::priority_queue<DistId, std::vector<DistId>, std::less<>> maxheap;
 
     for (int64_t doc_id : candidate_docs) {
-        auto vids = emb_list_offset->get_vids((size_t)doc_id);
+        auto vids = emb_list_offset->get_vids(static_cast<size_t>(doc_id));
         if (vids.empty()) {
             // Empty embedding lists (0 vectors) can appear as rerank candidates because some strategies
             // (e.g., MUVERA) encode every doc into the ANN index regardless of whether it has vectors.
@@ -76,14 +76,14 @@ RerankByCalcDistByIDs(const std::vector<int64_t>& candidate_docs, const DataSetP
         }
 
         if (larger_is_closer) {
-            if (minheap.size() < (size_t)k) {
+            if (minheap.size() < static_cast<size_t>(k)) {
                 minheap.emplace(doc_id, score.value());
             } else if (score.value() > minheap.top().val) {
                 minheap.pop();
                 minheap.emplace(doc_id, score.value());
             }
         } else {
-            if (maxheap.size() < (size_t)k) {
+            if (maxheap.size() < static_cast<size_t>(k)) {
                 maxheap.emplace(doc_id, score.value());
             } else if (score.value() < maxheap.top().val) {
                 maxheap.pop();

--- a/src/index/emb_list/emb_list_strategy_lemur.cc
+++ b/src/index/emb_list/emb_list_strategy_lemur.cc
@@ -775,7 +775,10 @@ class LemurEmbListStrategy : public EmbListStrategy {
                         break;
                     }
                 }
-                chunks.push_back({.doc_start=chunk_doc_start, .doc_end=cur_doc, .vec_start=chunk_vec_start, .vec_end=chunk_vec_end});
+                chunks.push_back({.doc_start = chunk_doc_start,
+                                  .doc_end = cur_doc,
+                                  .vec_start = chunk_vec_start,
+                                  .vec_end = chunk_vec_end});
             }
         }
 

--- a/src/index/emb_list/emb_list_strategy_lemur.cc
+++ b/src/index/emb_list/emb_list_strategy_lemur.cc
@@ -117,7 +117,7 @@ class LemurEmbListStrategy : public EmbListStrategy {
 
         // 3. Sample training vectors (reservoir sampling: O(actual_samples) memory).
         std::mt19937 rng(seed_);
-        int32_t actual_samples = std::min(num_train_samples_, static_cast<int32_t>(total_vectors));
+        size_t actual_samples = static_cast<size_t>(std::min(num_train_samples_, static_cast<int32_t>(total_vectors)));
         // Memory check: peak usage is ~2 × actual_samples × num_docs × 4B (y_train + y_train_raw)
         // plus actual_samples × original_dim × 4B (X_train). Cap at 4GB to avoid OOM.
         constexpr size_t kMaxTrainingMemoryBytes = 4ULL * 1024 * 1024 * 1024;  // 4GB
@@ -144,7 +144,7 @@ class LemurEmbListStrategy : public EmbListStrategy {
         }
 
         std::vector<float> X_train(actual_samples * original_dim_);
-        for (int64_t i = 0; i < actual_samples; ++i) {
+        for (size_t i = 0; i < actual_samples; ++i) {
             std::memcpy(X_train.data() + i * original_dim_, raw_data + sample_indices[i] * original_dim_,
                         original_dim_ * sizeof(float));
         }
@@ -560,8 +560,8 @@ class LemurEmbListStrategy : public EmbListStrategy {
         const uint8_t* end = data + size;
 
         // 1. Read magic and version
-        constexpr size_t kMinConfigSize = 6 * sizeof(int32_t) + sizeof(int64_t);  // must match Serialize
-        if (size < static_cast<int64_t>(kMinConfigSize)) {
+        constexpr int64_t kMinConfigSize = 6 * sizeof(int32_t) + sizeof(int64_t);  // must match Serialize
+        if (size < kMinConfigSize) {
             LOG_KNOWHERE_ERROR_ << "LEMUR: blob too small: " << size << " < " << kMinConfigSize;
             return Status::emb_list_inner_error;
         }
@@ -775,7 +775,7 @@ class LemurEmbListStrategy : public EmbListStrategy {
                         break;
                     }
                 }
-                chunks.push_back({chunk_doc_start, cur_doc, chunk_vec_start, chunk_vec_end});
+                chunks.push_back({.doc_start=chunk_doc_start, .doc_end=cur_doc, .vec_start=chunk_vec_start, .vec_end=chunk_vec_end});
             }
         }
 

--- a/src/index/emb_list/emb_list_strategy_muvera.cc
+++ b/src/index/emb_list/emb_list_strategy_muvera.cc
@@ -337,7 +337,7 @@ class MuveraEmbListStrategy : public EmbListStrategy {
     Status
     Deserialize(const uint8_t* data, int64_t size, const BaseConfig& config) override {
         // 1. Deserialize config parameters
-        constexpr size_t kExpectedConfigSize = 2 * sizeof(int32_t) + 4 * sizeof(int32_t) + sizeof(int64_t);
+        constexpr int64_t kExpectedConfigSize = 2 * sizeof(int32_t) + 4 * sizeof(int32_t) + sizeof(int64_t);
         if (size < static_cast<int64_t>(kExpectedConfigSize)) {
             LOG_KNOWHERE_ERROR_ << "MUVERA: blob too small: " << size << " < " << kExpectedConfigSize;
             return Status::emb_list_inner_error;

--- a/src/index/emb_list/emb_list_strategy_token_ann.cc
+++ b/src/index/emb_list/emb_list_strategy_token_ann.cc
@@ -81,8 +81,8 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
             LOG_KNOWHERE_WARNING_ << err_msg;
             return expected<DataSetPtr>::Err(Status::emb_list_inner_error, err_msg);
         }
-        int32_t vec_topk =
-            std::min(std::max((int32_t)(k * retrieval_ann_ratio), 1), (int32_t)emb_list_offset_->offset.back());
+        int32_t vec_topk = std::min(std::max(static_cast<int32_t>(k * retrieval_ann_ratio), 1),
+                                    static_cast<int32_t>(emb_list_offset_->offset.back()));
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
         knowhere_search_emb_list_retrieval_ann_ratio.Observe(retrieval_ann_ratio);
@@ -133,7 +133,7 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
                 if (stage1_ids[j] < 0) {
                     continue;
                 }
-                el_ids_set.emplace(emb_list_offset_->get_el_id((size_t)stage1_ids[j]));
+                el_ids_set.emplace(emb_list_offset_->get_el_id(static_cast<size_t>(stage1_ids[j])));
             }
 
             // Convert to vector for RerankByCalcDistByIDs
@@ -143,12 +143,12 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
                     LOG_KNOWHERE_ERROR_ << "Invalid el_id: " << el_id;
                     return expected<DataSetPtr>::Err(Status::emb_list_inner_error, "invalid emb_list id");
                 }
-                candidate_docs.push_back((int64_t)el_id);
+                candidate_docs.push_back(static_cast<int64_t>(el_id));
             }
             total_candidates += candidate_docs.size();
 
             // Compute aggregated score for each candidate
-            auto tensor = (const char*)query_dataset->GetTensor();
+            auto tensor = static_cast<const char*>(query_dataset->GetTensor());
             size_t tensor_offset = start_offset * query_code_size;
             auto bf_query_dataset = GenDataSet(nq, dim, tensor + tensor_offset);
 
@@ -169,12 +169,13 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
 #endif
 
         LOG_KNOWHERE_DEBUG_ << "[TokenANN] Stage2 Rerank"
-                            << ", total_candidates=" << total_candidates
-                            << ", avg_candidates_per_query=" << (num_q_el > 0 ? (double)total_candidates / num_q_el : 0)
+                            << ", total_candidates=" << total_candidates << ", avg_candidates_per_query="
+                            << (num_q_el > 0 ? static_cast<double>(total_candidates) / num_q_el : 0)
                             << ", total_dist_comps=" << total_distance_computations << ", avg_dist_comps_per_query="
-                            << (num_q_el > 0 ? (double)total_distance_computations / num_q_el : 0);
+                            << (num_q_el > 0 ? static_cast<double>(total_distance_computations) / num_q_el : 0);
 
-        return GenResultDataSet((int64_t)num_q_el, (int64_t)k, std::move(ids), std::move(dists));
+        return GenResultDataSet(static_cast<int64_t>(num_q_el), static_cast<int64_t>(k), std::move(ids),
+                                std::move(dists));
     }
 
     Status

--- a/src/index/flat/flat.cc
+++ b/src/index/flat/flat.cc
@@ -68,7 +68,7 @@ class FlatIndexNode : public IndexNode {
     Add(const DataSetPtr dataset, std::shared_ptr<Config> cfg, bool use_knowhere_build_pool) override {
         auto x = dataset->GetTensor();
         auto n = dataset->GetRows();
-        index_->add(n, (const DataType*)x);
+        index_->add(n, static_cast<const DataType*>(x));
         return Status::success;
     }
 
@@ -109,7 +109,7 @@ class FlatIndexNode : public IndexNode {
                     faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
 
                     if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
-                        auto cur_query = (const DataType*)x + dim * index;
+                        auto cur_query = static_cast<const DataType*>(x) + dim * index;
                         std::unique_ptr<DataType[]> copied_query = nullptr;
                         if (is_cosine) {
                             copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
@@ -185,7 +185,7 @@ class FlatIndexNode : public IndexNode {
                     faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
 
                     if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
-                        auto cur_query = (const DataType*)xq + dim * index;
+                        auto cur_query = static_cast<const DataType*>(xq) + dim * index;
                         std::unique_ptr<DataType[]> copied_query = nullptr;
                         if (is_cosine) {
                             copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);

--- a/src/index/flat/flat.cc
+++ b/src/index/flat/flat.cc
@@ -127,8 +127,8 @@ class FlatIndexNode : public IndexNode {
                         faiss::SearchParameters search_params;
                         search_params.sel = id_selector;
 
-                        index_->search(1, static_cast<const uint8_t*>(x) + index * ((dim + 7) / 8), k, cur_i_dis, cur_ids,
-                                       &search_params);
+                        index_->search(1, static_cast<const uint8_t*>(x) + index * ((dim + 7) / 8), k, cur_i_dis,
+                                       cur_ids, &search_params);
 
                         if (index_->metric_type == faiss::METRIC_Hamming) {
                             for (int64_t j = 0; j < k; j++) {

--- a/src/index/flat/flat.cc
+++ b/src/index/flat/flat.cc
@@ -33,8 +33,8 @@ template <typename DataType, typename IndexType>
 class FlatIndexNode : public IndexNode {
  public:
     FlatIndexNode(const int32_t version, const Object& object) : IndexNode(version), index_(nullptr) {
-        static_assert(std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexFlat>::value ||
-                          std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>::value,
+        static_assert(std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat> ||
+                          std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>,
                       "not support");
         static_assert(std::is_same_v<DataType, fp32> || std::is_same_v<DataType, bin1>,
                       "FlatIndexNode only support float/binary");
@@ -50,10 +50,10 @@ class FlatIndexNode : public IndexNode {
             LOG_KNOWHERE_ERROR_ << "unsupported metric type: " << f_cfg.metric_type.value();
             return metric.error();
         }
-        if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexBinaryFlat, IndexType>::value) {
+        if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexBinaryFlat, IndexType>) {
             index_ = std::make_unique<faiss::cppcontrib::knowhere::IndexBinaryFlat>(dataset->GetDim(), metric.value());
         }
-        if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexFlat, IndexType>::value) {
+        if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexFlat, IndexType>) {
             bool is_cosine = IsMetricType(f_cfg.metric_type.value(), knowhere::metric::COSINE);
             if (is_cosine) {
                 index_ = std::make_unique<faiss::cppcontrib::knowhere::IndexFlatCosine>(dataset->GetDim());
@@ -108,7 +108,7 @@ class FlatIndexNode : public IndexNode {
                     BitsetViewIDSelector bw_idselector(bitset);
                     faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
 
-                    if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexFlat>::value) {
+                    if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
                         auto cur_query = (const DataType*)x + dim * index;
                         std::unique_ptr<DataType[]> copied_query = nullptr;
                         if (is_cosine) {
@@ -121,13 +121,13 @@ class FlatIndexNode : public IndexNode {
 
                         index_->search(1, cur_query, k, cur_dis, cur_ids, &search_params);
                     }
-                    if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>::value) {
+                    if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>) {
                         auto cur_i_dis = reinterpret_cast<int32_t*>(cur_dis);
 
                         faiss::SearchParameters search_params;
                         search_params.sel = id_selector;
 
-                        index_->search(1, (const uint8_t*)x + index * ((dim + 7) / 8), k, cur_i_dis, cur_ids,
+                        index_->search(1, static_cast<const uint8_t*>(x) + index * ((dim + 7) / 8), k, cur_i_dis, cur_ids,
                                        &search_params);
 
                         if (index_->metric_type == faiss::METRIC_Hamming) {
@@ -184,7 +184,7 @@ class FlatIndexNode : public IndexNode {
                     BitsetViewIDSelector bw_idselector(bitset);
                     faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
 
-                    if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexFlat>::value) {
+                    if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
                         auto cur_query = (const DataType*)xq + dim * index;
                         std::unique_ptr<DataType[]> copied_query = nullptr;
                         if (is_cosine) {
@@ -197,11 +197,11 @@ class FlatIndexNode : public IndexNode {
 
                         index_->range_search(1, cur_query, radius, &res, &search_params);
                     }
-                    if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>::value) {
+                    if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>) {
                         faiss::SearchParameters search_params;
                         search_params.sel = id_selector;
 
-                        index_->range_search(1, (const uint8_t*)xq + index * ((dim + 7) / 8), radius, &res,
+                        index_->range_search(1, static_cast<const uint8_t*>(xq) + index * ((dim + 7) / 8), radius, &res,
                                              &search_params);
                     }
                     auto elem_cnt = res.lims[1];
@@ -234,7 +234,7 @@ class FlatIndexNode : public IndexNode {
         auto dim = Dim();
         auto rows = dataset->GetRows();
         auto ids = dataset->GetIds();
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexFlat>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
             DataType* data = nullptr;
             try {
                 data = new DataType[rows * dim];
@@ -248,7 +248,7 @@ class FlatIndexNode : public IndexNode {
                 return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
             }
         }
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>) {
             uint8_t* data = nullptr;
             try {
                 data = new uint8_t[rows * ((dim + 7) / 8)];
@@ -266,7 +266,7 @@ class FlatIndexNode : public IndexNode {
 
     static bool
     StaticHasRawData(const knowhere::BaseConfig& config, const IndexVersion& version) {
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexFlat>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
             const FlatConfig& f_cfg = static_cast<const FlatConfig&>(config);
             if (knowhere::Version(version) <= Version::GetMinimalVersion()) {
                 return !IsMetricType(f_cfg.metric_type.value(), metric::COSINE);
@@ -275,21 +275,21 @@ class FlatIndexNode : public IndexNode {
             }
         }
 
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>) {
             return true;
         }
     }
 
     bool
     HasRawData(const std::string& metric_type) const override {
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexFlat>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
             if (this->version_ <= Version::GetMinimalVersion()) {
                 return !IsMetricType(metric_type, metric::COSINE);
             } else {
                 return true;
             }
         }
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>) {
             return true;
         }
     }
@@ -307,10 +307,10 @@ class FlatIndexNode : public IndexNode {
         }
         try {
             MemoryIOWriter writer;
-            if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexFlat>::value) {
+            if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
                 faiss::cppcontrib::knowhere::write_index(index_.get(), &writer);
             }
-            if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>::value) {
+            if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>) {
                 faiss::cppcontrib::knowhere::write_index_binary(index_.get(), &writer);
             }
             std::shared_ptr<uint8_t[]> data(writer.data());
@@ -334,11 +334,11 @@ class FlatIndexNode : public IndexNode {
         }
 
         MemoryIOReader reader(binary->data.get(), binary->size);
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexFlat>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
             faiss::Index* index = faiss::cppcontrib::knowhere::read_index(&reader);
             index_.reset(static_cast<IndexType*>(index));
         }
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>) {
             faiss::cppcontrib::knowhere::IndexBinary* index = faiss::cppcontrib::knowhere::read_index_binary(&reader);
             index_.reset(static_cast<IndexType*>(index));
         }
@@ -354,11 +354,11 @@ class FlatIndexNode : public IndexNode {
             io_flags |= faiss::cppcontrib::knowhere::IO_FLAG_MMAP_IFC;
         }
 
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexFlat>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
             faiss::Index* index = faiss::cppcontrib::knowhere::read_index(filename.data(), io_flags);
             index_.reset(static_cast<IndexType*>(index));
         }
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>) {
             faiss::cppcontrib::knowhere::IndexBinary* index =
                 faiss::cppcontrib::knowhere::read_index_binary(filename.data(), io_flags);
             index_.reset(static_cast<IndexType*>(index));
@@ -393,10 +393,10 @@ class FlatIndexNode : public IndexNode {
 
     std::string
     Type() const override {
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexFlat>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
             return knowhere::IndexEnum::INDEX_FAISS_IDMAP;
         }
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryFlat>) {
             return knowhere::IndexEnum::INDEX_FAISS_BIN_IDMAP;
         }
     }

--- a/src/index/hnsw/faiss_hnsw.cc
+++ b/src/index/hnsw/faiss_hnsw.cc
@@ -30,6 +30,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include "common/metric.h"
 #include "faiss/cppcontrib/knowhere/IndexHNSW.h"
@@ -228,7 +229,7 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
                 uint32_t v = readHeader(&reader);
                 indexes.resize(v);
                 LOG_KNOWHERE_INFO_ << "read " << v << " mvs";
-                for (auto i = 0; i < v; ++i) {
+                for (uint32_t i = 0; i < v; ++i) {
                     auto read_index = std::unique_ptr<faiss::Index>(faiss::cppcontrib::knowhere::read_index(&reader));
                     indexes[i].reset(read_index.release());
                 }
@@ -270,7 +271,7 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
                     uint32_t v = readHeader(r);
                     LOG_KNOWHERE_INFO_ << "read " << v << " mvs";
                     indexes.resize(v);
-                    for (auto i = 0; i < v; ++i) {
+                    for (uint32_t i = 0; i < v; ++i) {
                         auto read_index =
                             std::unique_ptr<faiss::Index>(faiss::cppcontrib::knowhere::read_index(r, io_flags));
                         indexes[i].reset(read_index.release());
@@ -435,10 +436,11 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
     uint32_t
     readHeader(faiss::IOReader* f) {
         [[maybe_unused]] uint32_t version = faiss::cppcontrib::knowhere::read_value(f);
-        uint32_t size = faiss::cppcontrib::knowhere::read_value(f);
-        uint32_t cluster_size = faiss::cppcontrib::knowhere::read_value(f);
+        const uint32_t size = faiss::cppcontrib::knowhere::read_value(f);
+        const uint32_t cluster_size = faiss::cppcontrib::knowhere::read_value(f);
         labels.resize(cluster_size);
-        for (auto j = 0; j < cluster_size; ++j) {
+
+        for (uint32_t j = 0; j < cluster_size; ++j) {
             labels[j] = std::make_shared<std::vector<uint32_t>>();
             faiss::cppcontrib::knowhere::read_vector(*labels[j], f);
         }
@@ -471,7 +473,7 @@ convert_rows_to_fp32(const void* const __restrict src_in, float* const __restric
         const knowhere::fp16* const src = reinterpret_cast<const knowhere::fp16*>(src_in);
         for (size_t i = 0; i < nrows; i++) {
             for (size_t j = 0; j < dim; ++j) {
-                dst[i * dim + j] = (float)(src[offsets[i] * dim + j]);
+                dst[i * dim + j] = static_cast<float>(src[offsets[i] * dim + j]);
             }
         }
         return true;
@@ -479,7 +481,7 @@ convert_rows_to_fp32(const void* const __restrict src_in, float* const __restric
         const knowhere::bf16* const src = reinterpret_cast<const knowhere::bf16*>(src_in);
         for (size_t i = 0; i < nrows; i++) {
             for (size_t j = 0; j < dim; ++j) {
-                dst[i * dim + j] = (float)(src[offsets[i] * dim + j]);
+                dst[i * dim + j] = static_cast<float>(src[offsets[i] * dim + j]);
             }
         }
         return true;
@@ -487,7 +489,7 @@ convert_rows_to_fp32(const void* const __restrict src_in, float* const __restric
         const knowhere::fp32* const src = reinterpret_cast<const knowhere::fp32*>(src_in);
         for (size_t i = 0; i < nrows; i++) {
             for (size_t j = 0; j < dim; ++j) {
-                dst[i * dim + j] = (float)(src[offsets[i] * dim + j]);
+                dst[i * dim + j] = src[offsets[i] * dim + j];
             }
         }
         return true;
@@ -495,7 +497,7 @@ convert_rows_to_fp32(const void* const __restrict src_in, float* const __restric
         const knowhere::int8* const src = reinterpret_cast<const knowhere::int8*>(src_in);
         for (size_t i = 0; i < nrows; i++) {
             for (size_t j = 0; j < dim; ++j) {
-                dst[i * dim + j] = (float)(src[offsets[i] * dim + j]);
+                dst[i * dim + j] = static_cast<float>(src[offsets[i] * dim + j]);
             }
         }
         return true;
@@ -504,7 +506,7 @@ convert_rows_to_fp32(const void* const __restrict src_in, float* const __restric
         auto uint8_dim = (dim + 7) / 8;
         for (size_t i = 0; i < nrows; i++) {
             for (size_t j = 0; j < uint8_dim; ++j) {
-                dst[i * dim + j] = (float)(src[offsets[i] * uint8_dim + j]);
+                dst[i * dim + j] = static_cast<float>(src[offsets[i] * uint8_dim + j]);
             }
         }
         return true;
@@ -521,13 +523,13 @@ convert_rows_to_fp32(const void* const __restrict src_in, float* const __restric
     if (src_data_format == DataFormatEnum::fp16) {
         const knowhere::fp16* const src = reinterpret_cast<const knowhere::fp16*>(src_in);
         for (size_t i = 0; i < nrows * dim; i++) {
-            dst[i] = (float)(src[i + start_row * dim]);
+            dst[i] = static_cast<float>(src[i + start_row * dim]);
         }
         return true;
     } else if (src_data_format == DataFormatEnum::bf16) {
         const knowhere::bf16* const src = reinterpret_cast<const knowhere::bf16*>(src_in);
         for (size_t i = 0; i < nrows * dim; i++) {
-            dst[i] = (float)(src[i + start_row * dim]);
+            dst[i] = static_cast<float>(src[i + start_row * dim]);
         }
         return true;
     } else if (src_data_format == DataFormatEnum::fp32) {
@@ -539,7 +541,7 @@ convert_rows_to_fp32(const void* const __restrict src_in, float* const __restric
     } else if (src_data_format == DataFormatEnum::int8) {
         const knowhere::int8* const src = reinterpret_cast<const knowhere::int8*>(src_in);
         for (size_t i = 0; i < nrows * dim; i++) {
-            dst[i] = (float)(src[i + start_row * dim]);
+            dst[i] = static_cast<float>(src[i + start_row * dim]);
         }
         return true;
     } else if (src_data_format == DataFormatEnum::bin1) {
@@ -555,7 +557,7 @@ convert_rows_to_fp32(const void* const __restrict src_in, float* const __restric
         auto uint8_dim = (dim + 7) / 8;
         for (size_t i = 0; i < nrows; i++) {
             for (size_t j = 0; j < uint8_dim; j++) {
-                dst[i * dim + j] = (float)(src[(start_row + i) * uint8_dim + j]);
+                dst[i * dim + j] = static_cast<float>(src[(start_row + i) * uint8_dim + j]);
             }
         }
         return true;
@@ -572,13 +574,13 @@ convert_rows_from_fp32(const float* const __restrict src, void* const __restrict
     if (dst_data_format == DataFormatEnum::fp16) {
         knowhere::fp16* const dst = reinterpret_cast<knowhere::fp16*>(dst_in);
         for (size_t i = 0; i < nrows * dim; i++) {
-            dst[i + start_row * dim] = (knowhere::fp16)src[i];
+            dst[i + start_row * dim] = static_cast<knowhere::fp16>(src[i]);
         }
         return true;
     } else if (dst_data_format == DataFormatEnum::bf16) {
         knowhere::bf16* const dst = reinterpret_cast<knowhere::bf16*>(dst_in);
         for (size_t i = 0; i < nrows * dim; i++) {
-            dst[i + start_row * dim] = (knowhere::bf16)src[i];
+            dst[i + start_row * dim] = static_cast<knowhere::bf16>(src[i]);
         }
         return true;
     } else if (dst_data_format == DataFormatEnum::fp32) {
@@ -593,7 +595,7 @@ convert_rows_from_fp32(const float* const __restrict src, void* const __restrict
             KNOWHERE_THROW_IF_NOT_MSG(src[i] >= std::numeric_limits<knowhere::int8>::min() &&
                                           src[i] <= std::numeric_limits<knowhere::int8>::max(),
                                       "convert float to int8_t overflow");
-            dst[i + start_row * dim] = (knowhere::int8)src[i];
+            dst[i + start_row * dim] = static_cast<knowhere::int8>(src[i]);
         }
         return true;
     } else if (dst_data_format == DataFormatEnum::bin1) {
@@ -603,7 +605,7 @@ convert_rows_from_fp32(const float* const __restrict src, void* const __restrict
             KNOWHERE_THROW_IF_NOT_MSG(src[i] >= std::numeric_limits<knowhere::bin1>::min() &&
                                           src[i] <= std::numeric_limits<knowhere::bin1>::max(),
                                       "convert float to bin1(uint8_t) overflow");
-            dst[i + start_row * uint8_dim] = (knowhere::bin1)src[i];
+            dst[i + start_row * uint8_dim] = static_cast<knowhere::bin1>(src[i]);
         }
         return true;
     } else {
@@ -1405,7 +1407,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
                     std::vector<float> cur_query_tmp(dim);
                     if (data_format == DataFormatEnum::fp32) {
-                        cur_query = (const float*)data + idx * dim;
+                        cur_query = static_cast<const float*>(data) + idx * dim;
                     } else {
                         convert_rows_to_fp32(data, cur_query_tmp.data(), data_format, idx, 1, dim);
                         cur_query = cur_query_tmp.data();
@@ -1418,13 +1420,13 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                     // check if we need to perform a brute-force search bcz of the lack of results
                     auto bf_search_needed = [&]() -> bool {
                         size_t real_topk = 0;
-                        for (auto j = 0; j < k; ++j) {
+                        for (int j = 0; j < k; ++j) {
                             if (local_ids[j] < 0) {
                                 continue;
                             }
                             real_topk++;
                         }
-                        if (real_topk < k && real_topk < bitset.size() - bitset.count() &&
+                        if (std::cmp_less(real_topk, k) && real_topk < bitset.size() - bitset.count() &&
                             bf_index_wrapper_ptr != nullptr && !hnsw_cfg.disable_fallback_brute_force.value()) {
                             LOG_KNOWHERE_WARNING_ << "required topk: " << k
                                                   << ", but the actual num of results got from hnsw: " << real_topk
@@ -1455,7 +1457,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                     }
 
                     if (!labels.empty()) {
-                        for (auto j = 0; j < k; ++j) {
+                        for (int j = 0; j < k; ++j) {
                             local_ids[j] = local_ids[j] < 0 ? local_ids[j] : labels[index_id]->operator[](local_ids[j]);
                         }
                     }
@@ -1523,7 +1525,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         }
         const auto dim = dataset->GetDim();
         const auto rows = dataset->GetRows();
-        const float* data = (const float*)dataset->GetTensor();
+        const float* data = static_cast<const float*>(dataset->GetTensor());
         auto distances = std::make_unique<float[]>(rows * labels_len);
 
         BitsetView bitset(bitset_);
@@ -1559,14 +1561,14 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                     const float* cur_query = nullptr;
                     std::vector<float> cur_query_tmp(dim);
                     if (data_format == DataFormatEnum::fp32) {
-                        cur_query = (const float*)data + idx * dim;
+                        cur_query = data + idx * dim;
                     } else {
                         convert_rows_to_fp32(data, cur_query_tmp.data(), data_format, idx, 1, dim);
                         cur_query = cur_query_tmp.data();
                     }
 
                     dist_computer->set_query(cur_query);
-                    for (auto j = 0; j < labels_len; j++) {
+                    for (size_t j = 0; j < labels_len; j++) {
                         auto id = labels[j];
                         if (indexes.size() > 1) {
                             id = label_to_internal_offset[labels[j]] - index_rows_sum[index_id];
@@ -1719,7 +1721,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
                         std::vector<float> cur_query_tmp(dim);
                         if (data_format == DataFormatEnum::fp32) {
-                            cur_query = (const float*)data + idx * dim;
+                            cur_query = static_cast<const float*>(data) + idx * dim;
                         } else {
                             convert_rows_to_fp32(data, cur_query_tmp.data(), data_format, idx, 1, dim);
                             cur_query = cur_query_tmp.data();
@@ -1917,7 +1919,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                 cur_size += scalar_info[scalar_id].size();
             }
 
-            Status s = train_index((const float*)(tmp_data.get()), i, partition_size);
+            Status s = train_index(tmp_data.get(), i, partition_size);
             if (s != Status::success) {
                 return s;
             }
@@ -2150,7 +2152,7 @@ class BaseFaissRegularIndexHNSWFlatNode : public BaseFaissRegularIndexHNSWNode {
 
         // no scalar info or just one partition(after possible combination), build index on whole data
         if (scalar_info_map.empty() || tmp_combined_scalar_ids.size() <= 1) {
-            return train_index((const float*)(data), 0, rows);
+            return train_index(static_cast<const float*>(data), 0, rows);
         }
 
         LOG_KNOWHERE_INFO_ << "Train HNSW index with Scalar Info";
@@ -2803,7 +2805,7 @@ class BaseFaissRegularIndexHNSWPQNode : public BaseFaissRegularIndexHNSWNode {
                 LOG_KNOWHERE_ERROR_ << "Unsupported data format";
                 return Status::invalid_args;
             }
-            return train_index((const float*)(float_ds_ptr->GetTensor()), 0, rows);
+            return train_index(static_cast<const float*>(float_ds_ptr->GetTensor()), 0, rows);
         }
 
         LOG_KNOWHERE_INFO_ << "Train HNSWPQ Index with Scalar Info";
@@ -3089,7 +3091,7 @@ class BaseFaissRegularIndexHNSWPRQNode : public BaseFaissRegularIndexHNSWNode {
                 LOG_KNOWHERE_ERROR_ << "Unsupported data format";
                 return Status::invalid_args;
             }
-            return train_index((const float*)(float_ds_ptr->GetTensor()), 0, rows);
+            return train_index(static_cast<const float*>(float_ds_ptr->GetTensor()), 0, rows);
         }
 
         LOG_KNOWHERE_INFO_ << "Train HNSWPRQ Index with Scalar Info";

--- a/src/index/hnsw/impl/IndexConditionalWrapper.cc
+++ b/src/index/hnsw/impl/IndexConditionalWrapper.cc
@@ -49,7 +49,7 @@ WhetherPerformBruteForceSearch(const faiss::Index* index, const BaseConfig& cfg,
     if (!bitset.empty()) {
         const size_t filtered_out_num = bitset.count();
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
-        double ratio = ((double)filtered_out_num) / bitset.size();
+        double ratio = (static_cast<double>(filtered_out_num)) / bitset.size();
         knowhere::knowhere_hnsw_bitset_ratio.Observe(ratio);
 #endif
         if (filtered_out_num >= (bitset.size() * HnswSearchThresholds::kHnswSearchKnnBFFilterThreshold) ||
@@ -82,7 +82,7 @@ WhetherPerformBruteForceRangeSearch(const faiss::Index* index, const FaissHnswCo
     if (!bitset.empty()) {
         const size_t filtered_out_num = bitset.count();
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
-        double ratio = ((double)filtered_out_num) / bitset.size();
+        double ratio = (static_cast<double>(filtered_out_num)) / bitset.size();
         knowhere::knowhere_hnsw_bitset_ratio.Observe(ratio);
 #endif
         if (filtered_out_num >= (bitset.size() * HnswSearchThresholds::kHnswSearchRangeBFFilterThreshold) ||

--- a/src/index/hnsw/impl/IndexHNSWWrapper.cc
+++ b/src/index/hnsw/impl/IndexHNSWWrapper.cc
@@ -217,7 +217,7 @@ IndexHNSWWrapper::search(idx_t n, const float* __restrict x, idx_t k, float* __r
 
     // update stats if possible
     if (hnsw_stats != nullptr) {
-        hnsw_stats->combine({n1, n2, ndis, nhops});
+        hnsw_stats->combine({.n1 = n1, .n2 = n2, .ndis = ndis, .nhops = nhops});
     }
 
     // done, update the results, if needed

--- a/src/index/hnsw/impl/IndexHNSWWrapper.cc
+++ b/src/index/hnsw/impl/IndexHNSWWrapper.cc
@@ -387,7 +387,7 @@ IndexHNSWWrapper::range_search(idx_t n, const float* __restrict x, float radius_
 
     // update stats if possible
     if (hnsw_stats != nullptr) {
-        hnsw_stats->combine({n1, n2, ndis, nhops});
+        hnsw_stats->combine({.n1 = n1, .n2 = n2, .ndis = ndis, .nhops = nhops});
     }
 
     // done, update the results, if needed

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -127,7 +127,7 @@ Index<T>::Search(const DataSetPtr dataset, const Json& json, const BitsetView& b
     // when index is mutable, it could happen that data count larger than bitset size, see
     // https://github.com/zilliztech/knowhere/issues/70
     // so something must be wrong at caller side when passed bitset size larger than data count
-    if (bitset_.size() > (size_t)this->Count()) {
+    if (bitset_.size() > static_cast<size_t>(this->Count())) {
         msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
                           bitset_.size(), this->Count());
         LOG_KNOWHERE_ERROR_ << msg;
@@ -151,8 +151,9 @@ Index<T>::Search(const DataSetPtr dataset, const Json& json, const BitsetView& b
     if (b_cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(b_cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(b_cfg.span_id.value());
-        auto ctx = tracer::TraceContext{(uint8_t*)trace_id_str.c_str(), (uint8_t*)span_id_str.c_str(),
-                                        (uint8_t)b_cfg.trace_flags.value()};
+        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()), 
+                                        .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
+                                        .traceFlags = static_cast<uint8_t>(b_cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere search", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, b_cfg.metric_type.value());
         span->SetAttribute(meta::TOPK, b_cfg.k.value());
@@ -196,7 +197,7 @@ Index<T>::AnnIterator(const DataSetPtr dataset, const Json& json, const BitsetVi
     // when index is mutable, it could happen that data count larger than bitset size, see
     // https://github.com/zilliztech/knowhere/issues/70
     // so something must be wrong at caller side when passed bitset size larger than data count
-    if (bitset_.size() > (size_t)this->Count()) {
+    if (bitset_.size() > static_cast<size_t>(this->Count())) {
         msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
                           bitset_.size(), this->Count());
         LOG_KNOWHERE_ERROR_ << msg;
@@ -234,7 +235,7 @@ Index<T>::RangeSearch(const DataSetPtr dataset, const Json& json, const BitsetVi
     // when index is mutable, it could happen that data count larger than bitset size, see
     // https://github.com/zilliztech/knowhere/issues/70
     // so something must be wrong at caller side when passed bitset size larger than data count
-    if (bitset_.size() > (size_t)this->Count()) {
+    if (bitset_.size() > static_cast<size_t>(this->Count())) {
         msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
                           bitset_.size(), this->Count());
         LOG_KNOWHERE_ERROR_ << msg;
@@ -250,8 +251,9 @@ Index<T>::RangeSearch(const DataSetPtr dataset, const Json& json, const BitsetVi
     if (b_cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(b_cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(b_cfg.span_id.value());
-        auto ctx = tracer::TraceContext{(uint8_t*)trace_id_str.c_str(), (uint8_t*)span_id_str.c_str(),
-                                        (uint8_t)b_cfg.trace_flags.value()};
+        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()), 
+                                        .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
+                                        .traceFlags = static_cast<uint8_t>(b_cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere range search", &ctx);
         span->SetAttribute(meta::METRIC_TYPE, b_cfg.metric_type.value());
         span->SetAttribute(meta::RADIUS, b_cfg.radius.value());

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -151,7 +151,7 @@ Index<T>::Search(const DataSetPtr dataset, const Json& json, const BitsetView& b
     if (b_cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(b_cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(b_cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()), 
+        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()),
                                         .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
                                         .traceFlags = static_cast<uint8_t>(b_cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere search", &ctx);
@@ -251,7 +251,7 @@ Index<T>::RangeSearch(const DataSetPtr dataset, const Json& json, const BitsetVi
     if (b_cfg.trace_id.has_value()) {
         auto trace_id_str = tracer::GetIDFromHexStr(b_cfg.trace_id.value());
         auto span_id_str = tracer::GetIDFromHexStr(b_cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()), 
+        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()),
                                         .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
                                         .traceFlags = static_cast<uint8_t>(b_cfg.trace_flags.value())};
         span = tracer::StartSpan("knowhere range search", &ctx);

--- a/src/index/index_factory.cc
+++ b/src/index/index_factory.cc
@@ -57,7 +57,7 @@ IndexFactory::Create(const std::string& name, const int32_t& version, const Obje
         return expected<Index<IndexNode>>::Err(Status::invalid_index_error, "index not supported");
     }
     LOG_KNOWHERE_INFO_ << "use key " << key << " to create knowhere index " << name << " with version " << version;
-    auto fun_map_v = (FunMapValue<Index<IndexNode>>*)(func_mapping_[key].get());
+    auto fun_map_v = static_cast<FunMapValue<Index<IndexNode>>*>(func_mapping_[key].get());
 
 #ifdef KNOWHERE_WITH_CUVS
     if (!checkGpuAvailable(name)) {

--- a/src/index/index_node.cc
+++ b/src/index/index_node.cc
@@ -466,9 +466,11 @@ IndexNode::ParseEmbListMetaHeader(const uint8_t* data, int64_t size) {
         readBinaryPOD(reader, type_len);
         std::string strategy_type(reinterpret_cast<const char*>(data + reader.tellg()), type_len);
         reader.advance(type_len);
-        return {.strategy_type=std::move(strategy_type), .strategy_blob=data + reader.tellg(), .strategy_blob_size=static_cast<int64_t>(reader.remaining())};
+        return {.strategy_type = std::move(strategy_type),
+                .strategy_blob = data + reader.tellg(),
+                .strategy_blob_size = static_cast<int64_t>(reader.remaining())};
     }
-    return {.strategy_type=meta::EMB_LIST_STRATEGY_TOKENANN, .strategy_blob=data, .strategy_blob_size=size};
+    return {.strategy_type = meta::EMB_LIST_STRATEGY_TOKENANN, .strategy_blob = data, .strategy_blob_size = size};
 }
 
 Status

--- a/src/index/index_node.cc
+++ b/src/index/index_node.cc
@@ -108,7 +108,7 @@ IndexNode::RangeSearch(const DataSetPtr dataset, std::unique_ptr<Config> cfg, co
             }
             result_id_array[idx].push_back(id);
             result_dist_array[idx].push_back(dist);
-            
+
             if (range_search_k >= 0 && result_id_array[idx].size() >= static_cast<size_t>(range_search_k)) {
                 break;
             }

--- a/src/index/index_node.cc
+++ b/src/index/index_node.cc
@@ -108,7 +108,8 @@ IndexNode::RangeSearch(const DataSetPtr dataset, std::unique_ptr<Config> cfg, co
             }
             result_id_array[idx].push_back(id);
             result_dist_array[idx].push_back(dist);
-            if (range_search_k >= 0 && static_cast<int32_t>(result_id_array[idx].size()) >= range_search_k) {
+            
+            if (range_search_k >= 0 && result_id_array[idx].size() >= static_cast<size_t>(range_search_k)) {
                 break;
             }
         }
@@ -153,7 +154,7 @@ IndexNode::RangeSearch(const DataSetPtr dataset, std::unique_ptr<Config> cfg, co
                 continue;
             }
             if (range_search_k > 0) {
-                if (static_cast<int32_t>(early_stop_further_bounds.size()) < range_search_k) {
+                if (early_stop_further_bounds.size() < static_cast<size_t>(range_search_k)) {
                     early_stop_further_bounds.emplace(dist);
                 } else {
                     early_stop_further_bounds.pop();
@@ -321,7 +322,7 @@ IndexNode::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_t
 
     if (total_vecs == 0) {
         // all emblist are empty list
-        auto result = GenResultDataSet(num_el_ids, dim, (const void*)nullptr);
+        auto result = GenResultDataSet(num_el_ids, dim, nullptr);
         auto* offsets_ptr = new size_t[out_offsets.size()];
         std::memcpy(offsets_ptr, out_offsets.data(), out_offsets.size() * sizeof(size_t));
         result->Set(meta::EMB_LIST_OFFSET, static_cast<const size_t*>(offsets_ptr));
@@ -465,9 +466,9 @@ IndexNode::ParseEmbListMetaHeader(const uint8_t* data, int64_t size) {
         readBinaryPOD(reader, type_len);
         std::string strategy_type(reinterpret_cast<const char*>(data + reader.tellg()), type_len);
         reader.advance(type_len);
-        return {std::move(strategy_type), data + reader.tellg(), static_cast<int64_t>(reader.remaining())};
+        return {.strategy_type=std::move(strategy_type), .strategy_blob=data + reader.tellg(), .strategy_blob_size=static_cast<int64_t>(reader.remaining())};
     }
-    return {meta::EMB_LIST_STRATEGY_TOKENANN, data, size};
+    return {.strategy_type=meta::EMB_LIST_STRATEGY_TOKENANN, .strategy_blob=data, .strategy_blob_size=size};
 }
 
 Status
@@ -618,7 +619,7 @@ IndexNode::DeserializeEmbListFromFile(const std::string& filename, std::shared_p
         }
     }
 
-    if (file_size < static_cast<int64_t>(sizeof(int32_t))) {
+    if (file_size < sizeof(int32_t)) {
         LOG_KNOWHERE_WARNING_ << "emb_list meta file too small: " << file_size;
         return Status::emb_list_inner_error;
     }
@@ -696,7 +697,7 @@ IndexNode::CalcDistByRawIndex(const DataSetPtr dataset, const int64_t* labels, s
                 knowhere::checkCancellation(op_context);
                 std::unique_ptr<faiss::DistanceComputer> dist_computer(emb_list_raw_index_->get_distance_computer());
 
-                const float* cur_query = (const float*)query_data + idx * dim;
+                const float* cur_query = static_cast<const float*>(query_data) + idx * dim;
                 std::unique_ptr<float[]> copied_query = nullptr;
                 if (is_cosine) {
                     copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -678,7 +678,8 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
         // create scann index, which does not base_index by default,
         //    but owns the refine index by default omg
         if (scann_cfg.with_raw_data.value()) {
-            index = std::make_unique<faiss::cppcontrib::knowhere::IndexScaNN>(base_index.get(), static_cast<const float*>(data));
+            index = std::make_unique<faiss::cppcontrib::knowhere::IndexScaNN>(base_index.get(),
+                                                                              static_cast<const float*>(data));
         } else {
             index = std::make_unique<faiss::cppcontrib::knowhere::IndexScaNN>(base_index.get(), nullptr);
         }
@@ -984,7 +985,7 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, std::unique_
                     }
                 } else if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlatCC> ||
                                      std::is_same_v<IndexType,
-                                                  faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC>) {
+                                                    faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC>) {
                     auto cur_query = static_cast<const float*>(data) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -68,15 +68,15 @@ template <typename DataType, typename IndexType>
 class IvfIndexNode : public IndexNode {
  public:
     IvfIndexNode(const int32_t version, const Object& object) : IndexNode(version), index_(nullptr) {
-        static_assert(std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlat>::value ||
-                          std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlatCC>::value ||
-                          std::is_same<IndexType, IndexIVFPQWrapper>::value ||
-                          std::is_same<IndexType, IndexIVFSQWrapper>::value ||
-                          std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>::value ||
-                          std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexScaNN>::value ||
-                          std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC>::value ||
-                          std::is_same<IndexType, IndexIVFRaBitQWrapper>::value ||
-                          std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value,
+        static_assert(std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlat> ||
+                          std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlatCC> ||
+                          std::is_same_v<IndexType, IndexIVFPQWrapper> ||
+                          std::is_same_v<IndexType, IndexIVFSQWrapper> ||
+                          std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF> ||
+                          std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexScaNN> ||
+                          std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC> ||
+                          std::is_same_v<IndexType, IndexIVFRaBitQWrapper> ||
+                          std::is_same_v<IndexType, IndexIVFRaBitQFastScanWrapper>,
                       "not support");
         static_assert(std::is_same_v<DataType, fp32> || std::is_same_v<DataType, bin1>,
                       "IvfIndexNode only support float/binary");
@@ -113,12 +113,12 @@ class IvfIndexNode : public IndexNode {
                 milvus::OpContext* op_context) const override;
     static constexpr bool
     is_ann_iterator_supported() {
-        return (std::is_same<faiss::cppcontrib::knowhere::IndexIVFFlatCC, IndexType>::value ||
-                std::is_same<faiss::cppcontrib::knowhere::IndexIVFFlat, IndexType>::value ||
-                std::is_same<IndexIVFSQWrapper, IndexType>::value ||
-                std::is_same<faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC, IndexType>::value ||
-                std::is_same<faiss::cppcontrib::knowhere::IndexScaNN, IndexType>::value ||
-                std::is_same<IndexIVFRaBitQWrapper, IndexType>::value);
+        return (std::is_same_v<faiss::cppcontrib::knowhere::IndexIVFFlatCC, IndexType> ||
+                std::is_same_v<faiss::cppcontrib::knowhere::IndexIVFFlat, IndexType> ||
+                std::is_same_v<IndexIVFSQWrapper, IndexType> ||
+                std::is_same_v<faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC, IndexType> ||
+                std::is_same_v<faiss::cppcontrib::knowhere::IndexScaNN, IndexType> ||
+                std::is_same_v<IndexIVFRaBitQWrapper, IndexType>);
     }
     expected<std::vector<IndexNode::IteratorPtr>>
     AnnIterator(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset,
@@ -176,23 +176,23 @@ class IvfIndexNode : public IndexNode {
 
     static bool
     CommonHasRawData() {
-        if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexIVFFlat, IndexType>::value) {
+        if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexIVFFlat, IndexType>) {
             return true;
         }
-        if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexIVFFlatCC, IndexType>::value) {
+        if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexIVFFlatCC, IndexType>) {
             return true;
         }
-        if constexpr (std::is_same<IndexIVFPQWrapper, IndexType>::value) {
+        if constexpr (std::is_same_v<IndexIVFPQWrapper, IndexType>) {
             return false;
         }
-        if constexpr (std::is_same<IndexIVFSQWrapper, IndexType>::value) {
+        if constexpr (std::is_same_v<IndexIVFSQWrapper, IndexType>) {
             return false;
         }
-        if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexBinaryIVF, IndexType>::value) {
+        if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexBinaryIVF, IndexType>) {
             return true;
         }
-        if constexpr (std::is_same<IndexIVFRaBitQWrapper, IndexType>::value ||
-                      std::is_same<IndexIVFRaBitQFastScanWrapper, IndexType>::value) {
+        if constexpr (std::is_same_v<IndexIVFRaBitQWrapper, IndexType> ||
+                      std::is_same_v<IndexIVFRaBitQFastScanWrapper, IndexType>) {
             return false;
         }
         return false;
@@ -207,11 +207,11 @@ class IvfIndexNode : public IndexNode {
 
     static bool
     StaticHasRawData(const knowhere::BaseConfig& config, const IndexVersion& version) {
-        if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexScaNN, IndexType>::value) {
+        if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexScaNN, IndexType>) {
             const ScannConfig& scann_cfg = static_cast<const ScannConfig&>(config);
             return scann_cfg.with_raw_data.has_value() && scann_cfg.with_raw_data.value();
         }
-        if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC, IndexType>::value) {
+        if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC, IndexType>) {
             const IvfSqCcConfig& ivfsqcc_cfg = static_cast<const IvfSqCcConfig&>(config);
             return ivfsqcc_cfg.raw_data_store_prefix.has_value();
         }
@@ -223,10 +223,10 @@ class IvfIndexNode : public IndexNode {
         if (!index_) {
             return false;
         }
-        if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexScaNN, IndexType>::value) {
+        if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexScaNN, IndexType>) {
             return index_->with_raw_data();
         }
-        if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC, IndexType>::value) {
+        if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC, IndexType>) {
             return index_->with_raw_data();
         }
         return CommonHasRawData();
@@ -246,31 +246,31 @@ class IvfIndexNode : public IndexNode {
 
     static std::unique_ptr<BaseConfig>
     StaticCreateConfig() {
-        if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexIVFFlat, IndexType>::value) {
+        if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexIVFFlat, IndexType>) {
             return std::make_unique<IvfFlatConfig>();
         }
-        if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexIVFFlatCC, IndexType>::value) {
+        if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexIVFFlatCC, IndexType>) {
             return std::make_unique<IvfFlatCcConfig>();
         }
-        if constexpr (std::is_same<IndexIVFPQWrapper, IndexType>::value) {
+        if constexpr (std::is_same_v<IndexIVFPQWrapper, IndexType>) {
             return std::make_unique<IvfPqConfig>();
         }
-        if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexScaNN, IndexType>::value) {
+        if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexScaNN, IndexType>) {
             return std::make_unique<ScannConfig>();
         }
-        if constexpr (std::is_same<IndexIVFSQWrapper, IndexType>::value) {
+        if constexpr (std::is_same_v<IndexIVFSQWrapper, IndexType>) {
             return std::make_unique<IvfSqConfig>();
         }
-        if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexBinaryIVF, IndexType>::value) {
+        if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexBinaryIVF, IndexType>) {
             return std::make_unique<IvfBinConfig>();
         }
-        if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC, IndexType>::value) {
+        if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC, IndexType>) {
             return std::make_unique<IvfSqCcConfig>();
         }
-        if constexpr (std::is_same<IndexIVFRaBitQWrapper, IndexType>::value) {
+        if constexpr (std::is_same_v<IndexIVFRaBitQWrapper, IndexType>) {
             return std::make_unique<IvfRaBitQConfig>();
         }
-        if constexpr (std::is_same<IndexIVFRaBitQFastScanWrapper, IndexType>::value) {
+        if constexpr (std::is_same_v<IndexIVFRaBitQFastScanWrapper, IndexType>) {
             return std::make_unique<IvfRaBitQFastScanConfig>();
         }
     };
@@ -292,43 +292,43 @@ class IvfIndexNode : public IndexNode {
         if (!index_) {
             return 0;
         }
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlat>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlat>) {
             auto nb = index_->invlists->compute_ntotal();
             auto nlist = index_->nlist;
             auto code_size = index_->code_size;
             return ((nb + nlist) * (code_size + sizeof(int64_t)));
         }
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlatCC>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlatCC>) {
             auto nb = index_->invlists->compute_ntotal();
             auto nlist = index_->nlist;
             auto code_size = index_->code_size;
             return (nb * code_size + nb * sizeof(int64_t) + nlist * code_size);
         }
-        if constexpr (std::is_same<IndexType, IndexIVFPQWrapper>::value) {
+        if constexpr (std::is_same_v<IndexType, IndexIVFPQWrapper>) {
             return index_->size();
         }
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexScaNN>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexScaNN>) {
             return index_->size();
         }
-        if constexpr (std::is_same<IndexType, IndexIVFSQWrapper>::value) {
+        if constexpr (std::is_same_v<IndexType, IndexIVFSQWrapper>) {
             return index_->size();
         }
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>) {
             auto nb = index_->invlists->compute_ntotal();
             auto nlist = index_->nlist;
             auto code_size = index_->code_size;
             return (nb * code_size + nb * sizeof(int64_t) + nlist * code_size);
         }
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC>) {
             auto nb = index_->invlists->compute_ntotal();
             auto code_size = index_->code_size;
             auto nlist = index_->nlist;
             return (nb * code_size + nb * sizeof(int64_t) + 2 * code_size + nlist * sizeof(float));
         }
-        if constexpr (std::is_same<IndexType, IndexIVFRaBitQWrapper>::value) {
+        if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQWrapper>) {
             return index_->size();
         }
-        if constexpr (std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value) {
+        if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQFastScanWrapper>) {
             return index_->size();
         }
     };
@@ -341,31 +341,31 @@ class IvfIndexNode : public IndexNode {
     };
     std::string
     Type() const override {
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlat>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlat>) {
             return knowhere::IndexEnum::INDEX_FAISS_IVFFLAT;
         }
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlatCC>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlatCC>) {
             return knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC;
         }
-        if constexpr (std::is_same<IndexType, IndexIVFPQWrapper>::value) {
+        if constexpr (std::is_same_v<IndexType, IndexIVFPQWrapper>) {
             return knowhere::IndexEnum::INDEX_FAISS_IVFPQ;
         }
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexScaNN>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexScaNN>) {
             return knowhere::IndexEnum::INDEX_FAISS_SCANN;
         }
-        if constexpr (std::is_same<IndexType, IndexIVFSQWrapper>::value) {
+        if constexpr (std::is_same_v<IndexType, IndexIVFSQWrapper>) {
             return knowhere::IndexEnum::INDEX_FAISS_IVFSQ8;
         }
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>) {
             return knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT;
         }
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC>) {
             return knowhere::IndexEnum::INDEX_FAISS_IVFSQ_CC;
         }
-        if constexpr (std::is_same<IndexType, IndexIVFRaBitQWrapper>::value) {
+        if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQWrapper>) {
             return knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ;
         }
-        if constexpr (std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value) {
+        if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQFastScanWrapper>) {
             return knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ_FASTSCAN;
         }
     };
@@ -573,7 +573,7 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
 
     // faiss scann needs at least 16 rows since nbits=4
     constexpr int64_t SCANN_MIN_ROWS = 16;
-    if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexScaNN, IndexType>::value) {
+    if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexScaNN, IndexType>) {
         if (rows < SCANN_MIN_ROWS) {
             LOG_KNOWHERE_ERROR_ << rows << " rows is not enough, scann needs at least 16 rows to build index";
             return Status::faiss_inner_error;
@@ -581,7 +581,7 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
     }
 
     std::unique_ptr<IndexType> index;
-    if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexIVFFlat, IndexType>::value) {
+    if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexIVFFlat, IndexType>) {
         const IvfFlatConfig& ivf_flat_cfg = static_cast<const IvfFlatConfig&>(*cfg);
         auto nlist = MatchNlist(rows, ivf_flat_cfg.nlist.value());
 
@@ -597,12 +597,12 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
         // apply clustering config
         ApplyClusteringConfig(index->cp);
         // train
-        index->train(rows, (const float*)data);
+        index->train(rows, static_cast<const float*>(data));
         // transfer ownership of qzr to index
         index->quantizer = qzr.release();
         index->own_fields = true;
     }
-    if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexIVFFlatCC, IndexType>::value) {
+    if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexIVFFlatCC, IndexType>) {
         const IvfFlatCcConfig& ivf_flat_cc_cfg = static_cast<const IvfFlatCcConfig&>(*cfg);
         auto nlist = MatchNlist(rows, ivf_flat_cc_cfg.nlist.value());
 
@@ -619,7 +619,7 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
         // apply clustering config
         ApplyClusteringConfig(index->cp);
         // train
-        index->train(rows, (const float*)data);
+        index->train(rows, static_cast<const float*>(data));
         // transfer ownership of qzr to index
         index->quantizer = qzr.release();
         index->own_fields = true;
@@ -629,7 +629,7 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
         // populated directly in `add_core`. Fork `direct_map` stays at
         // NoMap for CC indexes; nothing reads from it for these types.
     }
-    if constexpr (std::is_same<IndexIVFPQWrapper, IndexType>::value) {
+    if constexpr (std::is_same_v<IndexIVFPQWrapper, IndexType>) {
         const IvfPqConfig& ivf_pq_cfg = static_cast<const IvfPqConfig&>(*cfg);
         auto nlist = MatchNlist(rows, ivf_pq_cfg.nlist.value());
         auto nbits = MatchNbits(rows, ivf_pq_cfg.nbits.value());
@@ -650,13 +650,13 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
         // apply clustering config
         ApplyClusteringConfig(index->get_base_ivf_index()->cp);
         // train
-        index->train(rows, (const float*)data);
+        index->train(rows, static_cast<const float*>(data));
         // transfer ownership of qzr to index
         faiss::cppcontrib::knowhere::IndexIVFPQ* uindex = index->get_base_ivf_index();
         uindex->quantizer = qzr.release();
         uindex->own_fields = true;
     }
-    if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexScaNN, IndexType>::value) {
+    if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexScaNN, IndexType>) {
         const ScannConfig& scann_cfg = static_cast<const ScannConfig&>(*cfg);
         auto nlist = MatchNlist(rows, scann_cfg.nlist.value());
         bool is_cosine = base_cfg.metric_type.value() == metric::COSINE;
@@ -678,12 +678,12 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
         // create scann index, which does not base_index by default,
         //    but owns the refine index by default omg
         if (scann_cfg.with_raw_data.value()) {
-            index = std::make_unique<faiss::cppcontrib::knowhere::IndexScaNN>(base_index.get(), (const float*)data);
+            index = std::make_unique<faiss::cppcontrib::knowhere::IndexScaNN>(base_index.get(), static_cast<const float*>(data));
         } else {
             index = std::make_unique<faiss::cppcontrib::knowhere::IndexScaNN>(base_index.get(), nullptr);
         }
         // train
-        index->train(rows, (const float*)data);
+        index->train(rows, static_cast<const float*>(data));
         // at this moment, we still own qzr. Transfer ownership to base_index.
         base_index->quantizer = qzr.release();
         base_index->own_fields = true;
@@ -691,7 +691,7 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
         base_index.release();
         index->own_fields = true;
     }
-    if constexpr (std::is_same<IndexIVFSQWrapper, IndexType>::value) {
+    if constexpr (std::is_same_v<IndexIVFSQWrapper, IndexType>) {
         const IvfSqConfig& ivf_sq_cfg = static_cast<const IvfSqConfig&>(*cfg);
         auto nlist = MatchNlist(rows, ivf_sq_cfg.nlist.value());
 
@@ -710,13 +710,13 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
         // apply clustering config
         ApplyClusteringConfig(index->get_base_ivf_index()->cp);
         // train
-        index->train(rows, (const float*)data);
+        index->train(rows, static_cast<const float*>(data));
         // transfer ownership of qzr to index
         faiss::cppcontrib::knowhere::IndexIVFScalarQuantizer* uindex = index->get_base_ivf_index();
         uindex->quantizer = qzr.release();
         uindex->own_fields = true;
     }
-    if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexBinaryIVF, IndexType>::value) {
+    if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexBinaryIVF, IndexType>) {
         const IvfBinConfig& ivf_bin_cfg = static_cast<const IvfBinConfig&>(*cfg);
         auto nlist = MatchNlist(rows, ivf_bin_cfg.nlist.value());
 
@@ -727,12 +727,12 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
         // apply clustering config
         ApplyClusteringConfig(index->cp);
         // train
-        index->train(rows, (const uint8_t*)data);
+        index->train(rows, static_cast<const uint8_t*>(data));
         // transfer ownership of qzr to index
         qzr.release();
         index->own_fields = true;
     }
-    if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC, IndexType>::value) {
+    if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC, IndexType>) {
         const IvfSqCcConfig& ivf_sq_cc_cfg = static_cast<const IvfSqCcConfig&>(*cfg);
         auto nlist = MatchNlist(rows, ivf_sq_cc_cfg.nlist.value());
         auto ssize = ivf_sq_cc_cfg.ssize.value();
@@ -757,14 +757,14 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
         // apply clustering config
         ApplyClusteringConfig(index->cp);
         // train
-        index->train(rows, (const float*)data);
+        index->train(rows, static_cast<const float*>(data));
         // transfer ownership of qzr to index
         index->quantizer = qzr.release();
         index->own_fields = true;
         // Path-D step 10.9: CC leaves use their own `cc_direct_map`
         // (ConcurrentDirectMap). Fork `direct_map` stays at NoMap.
     }
-    if constexpr (std::is_same<IndexIVFRaBitQWrapper, IndexType>::value) {
+    if constexpr (std::is_same_v<IndexIVFRaBitQWrapper, IndexType>) {
         const IvfRaBitQConfig& ivf_rabitq_cfg = static_cast<const IvfRaBitQConfig&>(*cfg);
         auto nlist = MatchNlist(rows, ivf_rabitq_cfg.nlist.value());
 
@@ -779,9 +779,9 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
         // apply clustering config
         ApplyClusteringConfig(index->get_ivfrabitq_index()->cp);
         // train
-        index->train(rows, (const float*)data);
+        index->train(rows, static_cast<const float*>(data));
     }
-    if constexpr (std::is_same<IndexIVFRaBitQFastScanWrapper, IndexType>::value) {
+    if constexpr (std::is_same_v<IndexIVFRaBitQFastScanWrapper, IndexType>) {
         const IvfRaBitQFastScanConfig& fs_cfg = static_cast<const IvfRaBitQFastScanConfig&>(*cfg);
         auto nlist = MatchNlist(rows, fs_cfg.nlist.value());
         auto result = IndexIVFRaBitQFastScanWrapper::create(dim, nlist, fs_cfg, metric.value());
@@ -795,7 +795,7 @@ IvfIndexNode<DataType, IndexType>::TrainInternal(const DataSetPtr dataset, std::
         if (fs_idx) {
             ApplyClusteringConfig(fs_idx->cp);
         }
-        index->train(rows, (const float*)data);
+        index->train(rows, static_cast<const float*>(data));
     }
     index_ = std::move(index);
 
@@ -825,10 +825,10 @@ IvfIndexNode<DataType, IndexType>::Add(const DataSetPtr dataset, std::shared_ptr
                           } else {
                               setter = std::make_unique<ThreadPool::ScopedBuildOmpSetter>();
                           }
-                          if constexpr (std::is_same<faiss::cppcontrib::knowhere::IndexBinaryIVF, IndexType>::value) {
-                              index_->add(rows, (const uint8_t*)data);
+                          if constexpr (std::is_same_v<faiss::cppcontrib::knowhere::IndexBinaryIVF, IndexType>) {
+                              index_->add(rows, static_cast<const uint8_t*>(data));
                           } else {
-                              index_->add(rows, (const float*)data);
+                              index_->add(rows, static_cast<const float*>(data));
                           }
                       })
                       .getTry();
@@ -966,8 +966,8 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, std::unique_
                 BitsetViewIDSelector bw_idselector(bitset);
                 faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
 
-                if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>::value) {
-                    auto cur_data = (const uint8_t*)data + index * ((dim + 7) / 8);
+                if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>) {
+                    auto cur_data = static_cast<const uint8_t*>(data) + index * ((dim + 7) / 8);
 
                     int32_t* i_distances = reinterpret_cast<int32_t*>(distances.get());
 
@@ -982,10 +982,10 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, std::unique_
                             distances[i + offset] = static_cast<float>(i_distances[i + offset]);
                         }
                     }
-                } else if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlatCC>::value ||
-                                     std::is_same<IndexType,
-                                                  faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC>::value) {
-                    auto cur_query = (const float*)data + index * dim;
+                } else if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlatCC> ||
+                                     std::is_same_v<IndexType,
+                                                  faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC>) {
+                    auto cur_query = static_cast<const float*>(data) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
                         cur_query = copied_query.get();
@@ -1006,8 +1006,8 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, std::unique_
                     }
 
                     index_->search(1, cur_query, k, distances.get() + offset, ids.get() + offset, &ivf_search_params);
-                } else if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexScaNN>::value) {
-                    auto cur_query = (const float*)data + index * dim;
+                } else if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexScaNN>) {
+                    auto cur_query = static_cast<const float*>(data) + index * dim;
                     const ScannConfig& scann_cfg = static_cast<const ScannConfig&>(*cfg);
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
@@ -1039,8 +1039,8 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, std::unique_
                     scann_search_params.reorder_k = scann_cfg.reorder_k.value();
 
                     index_->search(1, cur_query, k, distances.get() + offset, ids.get() + offset, &scann_search_params);
-                } else if constexpr (std::is_same<IndexType, IndexIVFRaBitQWrapper>::value) {
-                    auto cur_query = (const float*)data + index * dim;
+                } else if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQWrapper>) {
+                    auto cur_query = static_cast<const float*>(data) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
                         cur_query = copied_query.get();
@@ -1079,8 +1079,8 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, std::unique_
                         index_->search(1, cur_query, k, distances.get() + offset, ids.get() + offset,
                                        &ivf_search_params);
                     }
-                } else if constexpr (std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value) {
-                    auto cur_query = (const float*)data + index * dim;
+                } else if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQFastScanWrapper>) {
+                    auto cur_query = static_cast<const float*>(data) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
                         cur_query = copied_query.get();
@@ -1105,8 +1105,8 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, std::unique_
                     } else {
                         index_->search(1, cur_query, k, distances.get() + offset, ids.get() + offset, &fs_base_params);
                     }
-                } else if constexpr (std::is_same<IndexType, IndexIVFPQWrapper>::value) {
-                    auto cur_query = (const float*)data + index * dim;
+                } else if constexpr (std::is_same_v<IndexType, IndexIVFPQWrapper>) {
+                    auto cur_query = static_cast<const float*>(data) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
                         cur_query = copied_query.get();
@@ -1143,8 +1143,8 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, std::unique_
                         index_->search(1, cur_query, k, distances.get() + offset, ids.get() + offset,
                                        &ivf_search_params);
                     }
-                } else if constexpr (std::is_same<IndexType, IndexIVFSQWrapper>::value) {
-                    auto cur_query = (const float*)data + index * dim;
+                } else if constexpr (std::is_same_v<IndexType, IndexIVFSQWrapper>) {
+                    auto cur_query = static_cast<const float*>(data) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
                         cur_query = copied_query.get();
@@ -1182,7 +1182,7 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, std::unique_
                                        &ivf_search_params);
                     }
                 } else {
-                    auto cur_query = (const float*)data + index * dim;
+                    auto cur_query = static_cast<const float*>(data) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
                         cur_query = copied_query.get();
@@ -1241,7 +1241,7 @@ IvfIndexNode<DataType, IndexType>::CalcDistByIDs(const DataSetPtr dataset, const
                 futs.emplace_back(search_pool_->push([&, index = i] {
                     ThreadPool::ScopedSearchOmpSetter setter(1);
                     std::unique_ptr<float[]> copied_query = nullptr;
-                    auto query = (const float*)query_data + index * dim;
+                    auto query = static_cast<const float*>(query_data) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(query, 1, dim);
                         query = copied_query.get();
@@ -1318,8 +1318,8 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, std::un
                 BitsetViewIDSelector bw_idselector(bitset);
                 faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
 
-                if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>::value) {
-                    auto cur_data = (const uint8_t*)xq + index * ((dim + 7) / 8);
+                if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>) {
+                    auto cur_data = static_cast<const uint8_t*>(xq) + index * ((dim + 7) / 8);
 
                     faiss::cppcontrib::knowhere::IVFSearchParameters ivf_search_params;
                     ivf_search_params.nprobe = index_->nlist;
@@ -1327,8 +1327,8 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, std::un
                     ivf_search_params.sel = id_selector;
 
                     index_->range_search(1, cur_data, radius, &res, &ivf_search_params);
-                } else if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlat>::value) {
-                    auto cur_query = (const float*)xq + index * dim;
+                } else if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlat>) {
+                    auto cur_query = static_cast<const float*>(xq) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
                         cur_query = copied_query.get();
@@ -1341,8 +1341,8 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, std::un
                     ivf_search_params.sel = id_selector;
 
                     index_->range_search(1, cur_query, radius, &res, &ivf_search_params);
-                } else if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexScaNN>::value) {
-                    auto cur_query = (const float*)xq + index * dim;
+                } else if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexScaNN>) {
+                    auto cur_query = static_cast<const float*>(xq) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
                         cur_query = copied_query.get();
@@ -1354,8 +1354,8 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, std::un
                     search_params.sel = id_selector;
 
                     index_->range_search(1, cur_query, radius, &res, &search_params);
-                } else if constexpr (std::is_same<IndexType, IndexIVFRaBitQWrapper>::value) {
-                    auto cur_query = (const float*)xq + index * dim;
+                } else if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQWrapper>) {
+                    auto cur_query = static_cast<const float*>(xq) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
                         cur_query = copied_query.get();
@@ -1394,8 +1394,8 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, std::un
                     } else {
                         index_->range_search(1, cur_query, radius, &res, &ivf_search_params);
                     }
-                } else if constexpr (std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value) {
-                    auto cur_query = (const float*)xq + index * dim;
+                } else if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQFastScanWrapper>) {
+                    auto cur_query = static_cast<const float*>(xq) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
                         cur_query = copied_query.get();
@@ -1417,8 +1417,8 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, std::un
                     } else {
                         index_->range_search(1, cur_query, radius, &res, &fs_base_params);
                     }
-                } else if constexpr (std::is_same<IndexType, IndexIVFPQWrapper>::value) {
-                    auto cur_query = (const float*)xq + index * dim;
+                } else if constexpr (std::is_same_v<IndexType, IndexIVFPQWrapper>) {
+                    auto cur_query = static_cast<const float*>(xq) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
                         cur_query = copied_query.get();
@@ -1456,8 +1456,8 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, std::un
                     } else {
                         index_->range_search(1, cur_query, radius, &res, &ivf_search_params);
                     }
-                } else if constexpr (std::is_same<IndexType, IndexIVFSQWrapper>::value) {
-                    auto cur_query = (const float*)xq + index * dim;
+                } else if constexpr (std::is_same_v<IndexType, IndexIVFSQWrapper>) {
+                    auto cur_query = static_cast<const float*>(xq) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
                         cur_query = copied_query.get();
@@ -1496,7 +1496,7 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, std::un
                         index_->range_search(1, cur_query, radius, &res, &ivf_search_params);
                     }
                 } else {
-                    auto cur_query = (const float*)xq + index * dim;
+                    auto cur_query = static_cast<const float*>(xq) + index * dim;
                     if (is_cosine) {
                         copied_query = CopyAndNormalizeVecs(cur_query, 1, dim);
                         cur_query = copied_query.get();
@@ -1581,7 +1581,7 @@ IvfIndexNode<DataType, IndexType>::AnnIterator(const DataSetPtr dataset, std::un
         }
         try {
             for (int i = 0; i < rows; ++i) {
-                auto cur_query = (const float*)data + i * dim;
+                auto cur_query = static_cast<const float*>(data) + i * dim;
                 // if cosine, need normalize
                 std::unique_ptr<float[]> copied_query = nullptr;
                 if (is_cosine) {
@@ -1614,7 +1614,7 @@ IvfIndexNode<DataType, IndexType>::GetVectorByIds(const DataSetPtr dataset, milv
     if (!this->index_->is_trained) {
         return expected<DataSetPtr>::Err(Status::index_not_trained, "index not trained");
     }
-    if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>::value) {
+    if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>) {
         auto dim = Dim();
         auto rows = dataset->GetRows();
         auto ids = dataset->GetIds();
@@ -1631,8 +1631,8 @@ IvfIndexNode<DataType, IndexType>::GetVectorByIds(const DataSetPtr dataset, milv
             LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
         }
-    } else if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlat>::value ||
-                         std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlatCC>::value) {
+    } else if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlat> ||
+                         std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlatCC>) {
         auto dim = Dim();
         auto rows = dataset->GetRows();
         auto ids = dataset->GetIds();
@@ -1649,8 +1649,8 @@ IvfIndexNode<DataType, IndexType>::GetVectorByIds(const DataSetPtr dataset, milv
             LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
         }
-    } else if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexScaNN>::value ||
-                         std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC>::value) {
+    } else if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexScaNN> ||
+                         std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFScalarQuantizerCC>) {
         // we should never go here since we should call HasRawData() first
         if (!index_->with_raw_data()) {
             return expected<DataSetPtr>::Err(Status::not_implemented, "GetVectorByIds not implemented");
@@ -1728,17 +1728,17 @@ IvfIndexNode<DataType, IndexType>::SerializeImpl(BinarySet& binset) const {
             return Status::empty_index;
         }
         MemoryIOWriter writer;
-        if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>::value) {
+        if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>) {
             faiss::cppcontrib::knowhere::write_index_binary(index_.get(), &writer);
-        } else if constexpr (std::is_same<IndexType, IndexIVFRaBitQWrapper>::value) {
+        } else if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQWrapper>) {
             // Legacy IVFRaBitQ stays on knowhere cppcontrib IO.
             faiss::cppcontrib::knowhere::write_index(index_->index.get(), &writer);
-        } else if constexpr (std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value) {
+        } else if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQFastScanWrapper>) {
             // FastScan uses core Faiss types end-to-end, so serialize with core IO.
             faiss::write_index(index_->index.get(), &writer);
-        } else if constexpr (std::is_same<IndexType, IndexIVFPQWrapper>::value) {
+        } else if constexpr (std::is_same_v<IndexType, IndexIVFPQWrapper>) {
             faiss::cppcontrib::knowhere::write_index(index_->index.get(), &writer);
-        } else if constexpr (std::is_same<IndexType, IndexIVFSQWrapper>::value) {
+        } else if constexpr (std::is_same_v<IndexType, IndexIVFSQWrapper>) {
             faiss::cppcontrib::knowhere::write_index(index_->index.get(), &writer);
         } else {
             faiss::cppcontrib::knowhere::write_index(index_.get(), &writer);
@@ -1766,7 +1766,7 @@ IvfIndexNode<DataType, IndexType>::Deserialize(const BinarySet& binset, std::sha
 
     MemoryIOReader reader(binary->data.get(), binary->size);
     try {
-        if constexpr (std::is_same<IndexType, IndexIVFRaBitQWrapper>::value) {
+        if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQWrapper>) {
             // a special case for IVFRaBitQ, bcz a wrapper is involved.
 
             // deserialize
@@ -1779,7 +1779,7 @@ IvfIndexNode<DataType, IndexType>::Deserialize(const BinarySet& binset, std::sha
 
             // use the wrapper
             index_ = std::move(index_wr);
-        } else if constexpr (std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value) {
+        } else if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQFastScanWrapper>) {
             // FastScan stays on the core Faiss IO path end-to-end.
             auto index_raw = std::unique_ptr<faiss::Index>(faiss::read_index(&reader));
             auto index_wr = IndexIVFRaBitQFastScanWrapper::from_deserialized(std::move(index_raw));
@@ -1788,7 +1788,7 @@ IvfIndexNode<DataType, IndexType>::Deserialize(const BinarySet& binset, std::sha
                 return Status::invalid_serialized_index_type;
             }
             index_ = std::move(index_wr);
-        } else if constexpr (std::is_same<IndexType, IndexIVFPQWrapper>::value) {
+        } else if constexpr (std::is_same_v<IndexType, IndexIVFPQWrapper>) {
             // deserialize
             auto index_raw = std::unique_ptr<faiss::Index>(faiss::cppcontrib::knowhere::read_index(&reader));
             auto index_wr = IndexIVFPQWrapper::from_deserialized(std::move(index_raw));
@@ -1799,7 +1799,7 @@ IvfIndexNode<DataType, IndexType>::Deserialize(const BinarySet& binset, std::sha
 
             // use the wrapper
             index_ = std::move(index_wr);
-        } else if constexpr (std::is_same<IndexType, IndexIVFSQWrapper>::value) {
+        } else if constexpr (std::is_same_v<IndexType, IndexIVFSQWrapper>) {
             // deserialize
             auto index_raw = std::unique_ptr<faiss::Index>(faiss::cppcontrib::knowhere::read_index(&reader));
             auto index_wr = IndexIVFSQWrapper::from_deserialized(std::move(index_raw));
@@ -1812,7 +1812,7 @@ IvfIndexNode<DataType, IndexType>::Deserialize(const BinarySet& binset, std::sha
             index_ = std::move(index_wr);
         } else {
             // the default case for a regular index
-            if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>::value) {
+            if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>) {
                 index_.reset(static_cast<IndexType*>(faiss::cppcontrib::knowhere::read_index_binary(&reader)));
             } else {
                 index_.reset(static_cast<IndexType*>(faiss::cppcontrib::knowhere::read_index(&reader)));
@@ -1850,7 +1850,7 @@ IvfIndexNode<DataType, IndexType>::DeserializeFromFile(const std::string& filena
         io_flags |= faiss::cppcontrib::knowhere::IO_FLAG_MMAP;
     }
     try {
-        if constexpr (std::is_same<IndexType, IndexIVFRaBitQWrapper>::value) {
+        if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQWrapper>) {
             // a special case for IVFRaBitQ, bcz a wrapper is involved.
 
             // deserialize into a wrapper
@@ -1864,7 +1864,7 @@ IvfIndexNode<DataType, IndexType>::DeserializeFromFile(const std::string& filena
 
             // use the wrapper
             index_ = std::move(index_wr);
-        } else if constexpr (std::is_same<IndexType, IndexIVFRaBitQFastScanWrapper>::value) {
+        } else if constexpr (std::is_same_v<IndexType, IndexIVFRaBitQFastScanWrapper>) {
             // File deserialization mirrors the in-memory BinarySet path above:
             // use core Faiss IO and then validate the wrapper shape.
             auto index_raw = std::unique_ptr<faiss::Index>(faiss::read_index(filename.data(), io_flags));
@@ -1874,7 +1874,7 @@ IvfIndexNode<DataType, IndexType>::DeserializeFromFile(const std::string& filena
                 return Status::invalid_serialized_index_type;
             }
             index_ = std::move(index_wr);
-        } else if constexpr (std::is_same<IndexType, IndexIVFPQWrapper>::value) {
+        } else if constexpr (std::is_same_v<IndexType, IndexIVFPQWrapper>) {
             // deserialize into a wrapper
             auto index_raw =
                 std::unique_ptr<faiss::Index>(faiss::cppcontrib::knowhere::read_index(filename.data(), io_flags));
@@ -1886,7 +1886,7 @@ IvfIndexNode<DataType, IndexType>::DeserializeFromFile(const std::string& filena
 
             // use the wrapper
             index_ = std::move(index_wr);
-        } else if constexpr (std::is_same<IndexType, IndexIVFSQWrapper>::value) {
+        } else if constexpr (std::is_same_v<IndexType, IndexIVFSQWrapper>) {
             // deserialize into a wrapper
             auto index_raw =
                 std::unique_ptr<faiss::Index>(faiss::cppcontrib::knowhere::read_index(filename.data(), io_flags));
@@ -1900,7 +1900,7 @@ IvfIndexNode<DataType, IndexType>::DeserializeFromFile(const std::string& filena
             index_ = std::move(index_wr);
         } else {
             // the default case for a regular index
-            if constexpr (std::is_same<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>::value) {
+            if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>) {
                 index_.reset(
                     static_cast<IndexType*>(faiss::cppcontrib::knowhere::read_index_binary(filename.data(), io_flags)));
             } else {

--- a/src/index/minhash/minhash_index_node.cc
+++ b/src/index/minhash/minhash_index_node.cc
@@ -99,9 +99,9 @@ class MinHashLSHNode : public IndexNode {
         if (code_in_mem) {
             // TODO: more precise estimation to resolve the following comments
             // unknown dim and rows number, incorrect mem size if code_in_mem == true.
-            return Resource{.memoryCost=file_size_in_bytes, .diskCost=file_size_in_bytes};
+            return Resource{.memoryCost = file_size_in_bytes, .diskCost = file_size_in_bytes};
         } else {
-            return Resource{.memoryCost=0, .diskCost=file_size_in_bytes};
+            return Resource{.memoryCost = 0, .diskCost = file_size_in_bytes};
         }
     }
 
@@ -316,9 +316,9 @@ MinHashLSHNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
             size_t run_times = (nq + batch_size - 1) / batch_size;
             futures.reserve(run_times);
             for (size_t row = 0; row < run_times; ++row) {
-                futures.emplace_back(
-                    search_pool_->push([&, beg = row * batch_size, end = std::min(static_cast<int64_t>((row + 1) * batch_size), nq),
-                                        p_id_ptr = p_id.get(), p_dist_ptr = p_dist.get()]() {
+                futures.emplace_back(search_pool_->push(
+                    [&, beg = row * batch_size, end = std::min(static_cast<int64_t>((row + 1) * batch_size), nq),
+                     p_id_ptr = p_id.get(), p_dist_ptr = p_dist.get()]() {
                         for (size_t index = beg; std::cmp_less(index, end); index++) {
                             minhash_lsh_->Search(xq + (index * dim), p_dist_ptr + index * topk, p_id_ptr + index * topk,
                                                  &search_params);

--- a/src/index/minhash/minhash_index_node.cc
+++ b/src/index/minhash/minhash_index_node.cc
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
 #include <cstdint>
+#include <utility>
 
 #include "filemanager/FileManager.h"
 #include "index/minhash/minhash_lsh.h"
@@ -98,9 +99,9 @@ class MinHashLSHNode : public IndexNode {
         if (code_in_mem) {
             // TODO: more precise estimation to resolve the following comments
             // unknown dim and rows number, incorrect mem size if code_in_mem == true.
-            return Resource{file_size_in_bytes, file_size_in_bytes};
+            return Resource{.memoryCost=file_size_in_bytes, .diskCost=file_size_in_bytes};
         } else {
-            return Resource{0, file_size_in_bytes};
+            return Resource{.memoryCost=0, .diskCost=file_size_in_bytes};
         }
     }
 
@@ -227,13 +228,13 @@ MinHashLSHNode<DataType>::Build(const DataSetPtr dataset, std::shared_ptr<Config
             LOG_KNOWHERE_ERROR_ << "Expecting (dim % 8 == 0) and (mh_element_bit_width % 8 == 0)";
             return Status::invalid_args;
         }
-        size_t mh_vec_element_size = size_t(build_conf.mh_element_bit_width.value() / 8);
-        size_t mh_vec_length = size_t(dim / build_conf.mh_element_bit_width.value());
+        size_t mh_vec_element_size = static_cast<size_t>(build_conf.mh_element_bit_width.value() / 8);
+        size_t mh_vec_length = (dim / build_conf.mh_element_bit_width.value());
         minhash::MinHashLSHBuildParams index_params = {
             .data_path = build_conf.data_path.value(),
             .index_file_path = build_conf.index_prefix.value() + fname_,
-            .band = size_t(build_conf.mh_lsh_band.value()),
-            .block_size = size_t(build_conf.mh_lsh_aligned_block_size.value()),
+            .band = static_cast<size_t>(build_conf.mh_lsh_band.value()),
+            .block_size = static_cast<size_t>(build_conf.mh_lsh_aligned_block_size.value()),
             .with_raw_data = build_conf.with_raw_data.value(),
             .mh_vec_element_size = mh_vec_element_size,
             .mh_vec_length = mh_vec_length};
@@ -316,9 +317,9 @@ MinHashLSHNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
             futures.reserve(run_times);
             for (size_t row = 0; row < run_times; ++row) {
                 futures.emplace_back(
-                    search_pool_->push([&, beg = row * batch_size, end = std::min(int64_t((row + 1) * batch_size), nq),
+                    search_pool_->push([&, beg = row * batch_size, end = std::min(static_cast<int64_t>((row + 1) * batch_size), nq),
                                         p_id_ptr = p_id.get(), p_dist_ptr = p_dist.get()]() {
-                        for (size_t index = beg; index < (size_t)end; index++) {
+                        for (size_t index = beg; std::cmp_less(index, end); index++) {
                             minhash_lsh_->Search(xq + (index * dim), p_dist_ptr + index * topk, p_id_ptr + index * topk,
                                                  &search_params);
                         }

--- a/src/index/minhash/minhash_util.cc
+++ b/src/index/minhash/minhash_util.cc
@@ -117,8 +117,7 @@ minhash_lsh_hit_with_topk1_opt_search(const char* x, const char* y, size_t size_
     base_hash_k.reserve(ny * mh_lsh_band);
     base_hash_v.reserve(ny * mh_lsh_band);
     {
-        auto base_kv = minhash::GenTransposedHashKV(y, ny, size_in_bytes, element_size_in_bytes,
-                                                    mh_lsh_band, mh_lsh_r);
+        auto base_kv = minhash::GenTransposedHashKV(y, ny, size_in_bytes, element_size_in_bytes, mh_lsh_band, mh_lsh_r);
         minhash::SortHashKV(base_kv, ny, mh_lsh_band);
         for (size_t i = 0; i < ny * mh_lsh_band; i++) {
             base_hash_k.emplace_back(base_kv[i].Key);
@@ -128,8 +127,7 @@ minhash_lsh_hit_with_topk1_opt_search(const char* x, const char* y, size_t size_
     std::vector<minhash::KeyType> query_hash_k;
     query_hash_k.reserve(nx * mh_lsh_band);
     {
-        auto query_kv =
-            minhash::GenHashKV(x, nx, size_in_bytes, element_size_in_bytes, mh_lsh_band, mh_lsh_r);
+        auto query_kv = minhash::GenHashKV(x, nx, size_in_bytes, element_size_in_bytes, mh_lsh_band, mh_lsh_r);
         for (size_t i = 0; i < nx * mh_lsh_band; i++) {
             query_hash_k.emplace_back(query_kv[i].Key);
         }
@@ -145,28 +143,28 @@ minhash_lsh_hit_with_topk1_opt_search(const char* x, const char* y, size_t size_
     size_t run_times = (nx + kQueryBatch - 1) / kQueryBatch;
     futs.reserve(run_times);
     for (size_t row = 0; row < run_times; ++row) {
-        futs.emplace_back(pool->push([&query_hash_k, &base_hash_k, &base_hash_v, &all_res, mh_lsh_band, ny,
-                                      query_beg = row * kQueryBatch,
-                                      query_end = std::min(((row + 1) * kQueryBatch), nx)]() {
-            for (size_t query_id = query_beg; query_id < query_end; query_id++) {
-                auto query_key = query_hash_k.data() + mh_lsh_band * query_id;
-                for (size_t i = 0; i < mh_lsh_band; i++) {
-                    auto hit_id = faiss::cppcontrib::knowhere::u64_binary_search_eq(base_hash_k.data() + i * ny, ny,
-                                                                                    query_key[i]);
-                    if (hit_id != -1) {
-                        all_res[query_id].push(base_hash_v[hit_id], 1.0f);
-                        while (!all_res[query_id].full() && std::cmp_less(hit_id , mh_lsh_band) &&
-                               base_hash_k[i * mh_lsh_band + hit_id] == query_key[i]) {
+        futs.emplace_back(
+            pool->push([&query_hash_k, &base_hash_k, &base_hash_v, &all_res, mh_lsh_band, ny,
+                        query_beg = row * kQueryBatch, query_end = std::min(((row + 1) * kQueryBatch), nx)]() {
+                for (size_t query_id = query_beg; query_id < query_end; query_id++) {
+                    auto query_key = query_hash_k.data() + mh_lsh_band * query_id;
+                    for (size_t i = 0; i < mh_lsh_band; i++) {
+                        auto hit_id = faiss::cppcontrib::knowhere::u64_binary_search_eq(base_hash_k.data() + i * ny, ny,
+                                                                                        query_key[i]);
+                        if (hit_id != -1) {
                             all_res[query_id].push(base_hash_v[hit_id], 1.0f);
-                            hit_id++;
-                        }
-                        if (all_res[query_id].full()) {
-                            break;
+                            while (!all_res[query_id].full() && std::cmp_less(hit_id, mh_lsh_band) &&
+                                   base_hash_k[i * mh_lsh_band + hit_id] == query_key[i]) {
+                                all_res[query_id].push(base_hash_v[hit_id], 1.0f);
+                                hit_id++;
+                            }
+                            if (all_res[query_id].full()) {
+                                break;
+                            }
                         }
                     }
                 }
-            }
-        }));
+            }));
     }
     RETURN_IF_ERROR(WaitAllSuccess(futs));
     return Status::success;
@@ -201,12 +199,12 @@ minhash_ny_batch_search(const char* x, const char* y, size_t size_in_bytes, size
                 if (mh_search_with_jaccard) {
                     size_t mh_length = size_in_bytes / element_size_in_bytes;
                     auto cur_query = x + size_in_bytes * i;
-                    MinHashJaccardKNNSearchByNy(cur_query, y, mh_length, element_size_in_bytes, ny, topk,
-                                                bitset, cur_distances, cur_labels);
+                    MinHashJaccardKNNSearchByNy(cur_query, y, mh_length, element_size_in_bytes, ny, topk, bitset,
+                                                cur_distances, cur_labels);
                 } else {
                     auto cur_query = x + size_in_bytes * i;
-                    MinHashLSHHitByNy(cur_query, y, size_in_bytes, element_size_in_bytes, mh_lsh_band,
-                                      mh_lsh_r, ny, topk, bitset, cur_distances, cur_labels);
+                    MinHashLSHHitByNy(cur_query, y, size_in_bytes, element_size_in_bytes, mh_lsh_band, mh_lsh_r, ny,
+                                      topk, bitset, cur_distances, cur_labels);
                 }
             }
             return Status::success;
@@ -254,17 +252,21 @@ GenHashKV(const char* data, size_t rows, size_t data_size, size_t data_element_s
                 const char* data_j = data + data_size * j;
                 size_t b = 0;
                 for (; b + 4 <= band_num; b += 4) {
-                    res_kv.get()[j * band_num + b] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b),
-                                                      .Value=static_cast<minhash::ValueType>(j)};
-                    res_kv.get()[j * band_num + b + 1] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b + 1),
-                                                          .Value=static_cast<minhash::ValueType>(j)};
-                    res_kv.get()[j * band_num + b + 2] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b + 2),
-                                                          .Value=static_cast<minhash::ValueType>(j)};
-                    res_kv.get()[j * band_num + b + 3] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b + 3),
-                                                          .Value=static_cast<minhash::ValueType>(j)};
+                    res_kv.get()[j * band_num + b] = {.Key = GetHashKey(data_j, truncated_data_size, band_num, b),
+                                                      .Value = static_cast<minhash::ValueType>(j)};
+                    res_kv.get()[j * band_num + b + 1] = {
+                        .Key = GetHashKey(data_j, truncated_data_size, band_num, b + 1),
+                        .Value = static_cast<minhash::ValueType>(j)};
+                    res_kv.get()[j * band_num + b + 2] = {
+                        .Key = GetHashKey(data_j, truncated_data_size, band_num, b + 2),
+                        .Value = static_cast<minhash::ValueType>(j)};
+                    res_kv.get()[j * band_num + b + 3] = {
+                        .Key = GetHashKey(data_j, truncated_data_size, band_num, b + 3),
+                        .Value = static_cast<minhash::ValueType>(j)};
                 }
                 for (; b < band_num; b++) {
-                    minhash::KVPair kv = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b), .Value=static_cast<minhash::ValueType>(j)};
+                    minhash::KVPair kv = {.Key = GetHashKey(data_j, truncated_data_size, band_num, b),
+                                          .Value = static_cast<minhash::ValueType>(j)};
                     res_kv.get()[j * band_num + b] = kv;
                 }
             }
@@ -293,17 +295,18 @@ GenTransposedHashKV(const char* data, size_t rows, size_t data_size, size_t data
                 const char* data_j = data + data_size * j;
                 size_t b = 0;
                 for (; b + 4 <= band_num; b += 4) {
-                    res_kv.get()[b * rows + j] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b),
-                                                  .Value=static_cast<minhash::ValueType>(j)};
-                    res_kv.get()[(b + 1) * rows + j] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b + 1),
-                                                        .Value=static_cast<minhash::ValueType>(j)};
-                    res_kv.get()[(b + 2) * rows + j] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b + 2),
-                                                        .Value=static_cast<minhash::ValueType>(j)};
-                    res_kv.get()[(b + 3) * rows + j] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b + 3),
-                                                        .Value=static_cast<minhash::ValueType>(j)};
+                    res_kv.get()[b * rows + j] = {.Key = GetHashKey(data_j, truncated_data_size, band_num, b),
+                                                  .Value = static_cast<minhash::ValueType>(j)};
+                    res_kv.get()[(b + 1) * rows + j] = {.Key = GetHashKey(data_j, truncated_data_size, band_num, b + 1),
+                                                        .Value = static_cast<minhash::ValueType>(j)};
+                    res_kv.get()[(b + 2) * rows + j] = {.Key = GetHashKey(data_j, truncated_data_size, band_num, b + 2),
+                                                        .Value = static_cast<minhash::ValueType>(j)};
+                    res_kv.get()[(b + 3) * rows + j] = {.Key = GetHashKey(data_j, truncated_data_size, band_num, b + 3),
+                                                        .Value = static_cast<minhash::ValueType>(j)};
                 }
                 for (; b < band_num; b++) {
-                    minhash::KVPair kv = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b), .Value=static_cast<minhash::ValueType>(j)};
+                    minhash::KVPair kv = {.Key = GetHashKey(data_j, truncated_data_size, band_num, b),
+                                          .Value = static_cast<minhash::ValueType>(j)};
                     res_kv.get()[b * rows + j] = kv;
                 }
             }

--- a/src/index/minhash/minhash_util.cc
+++ b/src/index/minhash/minhash_util.cc
@@ -10,6 +10,8 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 #include "index/minhash/minhash_util.h"
 
+#include <utility>
+
 namespace knowhere::minhash {
 
 namespace {
@@ -25,7 +27,7 @@ minhash_jaccard_native(const char* x, const char* y, size_t element_length, size
         const char* y_b = y + element_size * i;
         res += (std::memcmp(x_b, y_b, element_size) == 0) ? 1.0f : 0.0f;
     }
-    return float(res) / float(element_length);
+    return (res) / static_cast<float>(element_length);
 }
 
 inline void
@@ -79,7 +81,7 @@ struct MinHashJaccardComputer : faiss::DistanceComputer {
     }
     float
     distance_to_code(const void* x) {
-        return dist1(q, (const char*)x, element_length, element_size);
+        return dist1(q, static_cast<const char*>(x), element_length, element_size);
     }
     float
     operator()(idx_t i) override {
@@ -115,7 +117,7 @@ minhash_lsh_hit_with_topk1_opt_search(const char* x, const char* y, size_t size_
     base_hash_k.reserve(ny * mh_lsh_band);
     base_hash_v.reserve(ny * mh_lsh_band);
     {
-        auto base_kv = minhash::GenTransposedHashKV((const char*)y, ny, size_in_bytes, element_size_in_bytes,
+        auto base_kv = minhash::GenTransposedHashKV(y, ny, size_in_bytes, element_size_in_bytes,
                                                     mh_lsh_band, mh_lsh_r);
         minhash::SortHashKV(base_kv, ny, mh_lsh_band);
         for (size_t i = 0; i < ny * mh_lsh_band; i++) {
@@ -127,7 +129,7 @@ minhash_lsh_hit_with_topk1_opt_search(const char* x, const char* y, size_t size_
     query_hash_k.reserve(nx * mh_lsh_band);
     {
         auto query_kv =
-            minhash::GenHashKV((const char*)x, nx, size_in_bytes, element_size_in_bytes, mh_lsh_band, mh_lsh_r);
+            minhash::GenHashKV(x, nx, size_in_bytes, element_size_in_bytes, mh_lsh_band, mh_lsh_r);
         for (size_t i = 0; i < nx * mh_lsh_band; i++) {
             query_hash_k.emplace_back(query_kv[i].Key);
         }
@@ -145,7 +147,7 @@ minhash_lsh_hit_with_topk1_opt_search(const char* x, const char* y, size_t size_
     for (size_t row = 0; row < run_times; ++row) {
         futs.emplace_back(pool->push([&query_hash_k, &base_hash_k, &base_hash_v, &all_res, mh_lsh_band, ny,
                                       query_beg = row * kQueryBatch,
-                                      query_end = std::min((size_t)((row + 1) * kQueryBatch), (size_t)nx)]() {
+                                      query_end = std::min(((row + 1) * kQueryBatch), nx)]() {
             for (size_t query_id = query_beg; query_id < query_end; query_id++) {
                 auto query_key = query_hash_k.data() + mh_lsh_band * query_id;
                 for (size_t i = 0; i < mh_lsh_band; i++) {
@@ -153,7 +155,7 @@ minhash_lsh_hit_with_topk1_opt_search(const char* x, const char* y, size_t size_
                                                                                     query_key[i]);
                     if (hit_id != -1) {
                         all_res[query_id].push(base_hash_v[hit_id], 1.0f);
-                        while (!all_res[query_id].full() && hit_id < mh_lsh_band &&
+                        while (!all_res[query_id].full() && std::cmp_less(hit_id , mh_lsh_band) &&
                                base_hash_k[i * mh_lsh_band + hit_id] == query_key[i]) {
                             all_res[query_id].push(base_hash_v[hit_id], 1.0f);
                             hit_id++;
@@ -190,7 +192,7 @@ minhash_ny_batch_search(const char* x, const char* y, size_t size_in_bytes, size
         futs.emplace_back(pool->push([&, batch_idx] {
             ThreadPool::ScopedSearchOmpSetter setter(1);
             int start_query = batch_idx * batch_size;
-            int end_query = std::min(size_t(start_query + batch_size), nx);
+            int end_query = std::min(static_cast<size_t>(start_query + batch_size), nx);
 
             for (int i = start_query; i < end_query; ++i) {
                 auto cur_labels = labels + topk * i;
@@ -198,12 +200,12 @@ minhash_ny_batch_search(const char* x, const char* y, size_t size_in_bytes, size
 
                 if (mh_search_with_jaccard) {
                     size_t mh_length = size_in_bytes / element_size_in_bytes;
-                    auto cur_query = (const char*)x + size_in_bytes * i;
-                    MinHashJaccardKNNSearchByNy(cur_query, (const char*)y, mh_length, element_size_in_bytes, ny, topk,
+                    auto cur_query = x + size_in_bytes * i;
+                    MinHashJaccardKNNSearchByNy(cur_query, y, mh_length, element_size_in_bytes, ny, topk,
                                                 bitset, cur_distances, cur_labels);
                 } else {
-                    auto cur_query = (const char*)x + size_in_bytes * i;
-                    MinHashLSHHitByNy(cur_query, (const char*)y, size_in_bytes, element_size_in_bytes, mh_lsh_band,
+                    auto cur_query = x + size_in_bytes * i;
+                    MinHashLSHHitByNy(cur_query, y, size_in_bytes, element_size_in_bytes, mh_lsh_band,
                                       mh_lsh_r, ny, topk, bitset, cur_distances, cur_labels);
                 }
             }
@@ -240,7 +242,10 @@ GenHashKV(const char* data, size_t rows, size_t data_size, size_t data_element_s
     auto batch_num = (rows + kBatch - 1) / kBatch;
     auto truncated_data_size = band_num * band_size * data_element_size;
     auto build_pool = ThreadPool::GetGlobalBuildThreadPool();
+
     std::vector<folly::Future<folly::Unit>> futures;
+    futures.reserve(batch_num);
+
     for (size_t i = 0; i < batch_num; i++) {
         futures.emplace_back(build_pool->push([&, idx = i]() {
             auto beg_id = idx * kBatch;
@@ -249,17 +254,17 @@ GenHashKV(const char* data, size_t rows, size_t data_size, size_t data_element_s
                 const char* data_j = data + data_size * j;
                 size_t b = 0;
                 for (; b + 4 <= band_num; b += 4) {
-                    res_kv.get()[j * band_num + b] = {GetHashKey(data_j, truncated_data_size, band_num, b),
-                                                      minhash::ValueType(j)};
-                    res_kv.get()[j * band_num + b + 1] = {GetHashKey(data_j, truncated_data_size, band_num, b + 1),
-                                                          minhash::ValueType(j)};
-                    res_kv.get()[j * band_num + b + 2] = {GetHashKey(data_j, truncated_data_size, band_num, b + 2),
-                                                          minhash::ValueType(j)};
-                    res_kv.get()[j * band_num + b + 3] = {GetHashKey(data_j, truncated_data_size, band_num, b + 3),
-                                                          minhash::ValueType(j)};
+                    res_kv.get()[j * band_num + b] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b),
+                                                      .Value=static_cast<minhash::ValueType>(j)};
+                    res_kv.get()[j * band_num + b + 1] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b + 1),
+                                                          .Value=static_cast<minhash::ValueType>(j)};
+                    res_kv.get()[j * band_num + b + 2] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b + 2),
+                                                          .Value=static_cast<minhash::ValueType>(j)};
+                    res_kv.get()[j * band_num + b + 3] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b + 3),
+                                                          .Value=static_cast<minhash::ValueType>(j)};
                 }
                 for (; b < band_num; b++) {
-                    minhash::KVPair kv = {GetHashKey(data_j, truncated_data_size, band_num, b), minhash::ValueType(j)};
+                    minhash::KVPair kv = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b), .Value=static_cast<minhash::ValueType>(j)};
                     res_kv.get()[j * band_num + b] = kv;
                 }
             }
@@ -276,7 +281,10 @@ GenTransposedHashKV(const char* data, size_t rows, size_t data_size, size_t data
     auto batch_num = (rows + kBatch - 1) / kBatch;
     auto build_pool = ThreadPool::GetGlobalBuildThreadPool();
     auto truncated_data_size = band_num * band_size * data_element_size;
+
     std::vector<folly::Future<folly::Unit>> futures;
+    futures.reserve(batch_num);
+
     for (size_t i = 0; i < batch_num; i++) {
         futures.emplace_back(build_pool->push([&, idx = i]() {
             auto beg_id = idx * kBatch;
@@ -285,17 +293,17 @@ GenTransposedHashKV(const char* data, size_t rows, size_t data_size, size_t data
                 const char* data_j = data + data_size * j;
                 size_t b = 0;
                 for (; b + 4 <= band_num; b += 4) {
-                    res_kv.get()[b * rows + j] = {GetHashKey(data_j, truncated_data_size, band_num, b),
-                                                  minhash::ValueType(j)};
-                    res_kv.get()[(b + 1) * rows + j] = {GetHashKey(data_j, truncated_data_size, band_num, b + 1),
-                                                        minhash::ValueType(j)};
-                    res_kv.get()[(b + 2) * rows + j] = {GetHashKey(data_j, truncated_data_size, band_num, b + 2),
-                                                        minhash::ValueType(j)};
-                    res_kv.get()[(b + 3) * rows + j] = {GetHashKey(data_j, truncated_data_size, band_num, b + 3),
-                                                        minhash::ValueType(j)};
+                    res_kv.get()[b * rows + j] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b),
+                                                  .Value=static_cast<minhash::ValueType>(j)};
+                    res_kv.get()[(b + 1) * rows + j] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b + 1),
+                                                        .Value=static_cast<minhash::ValueType>(j)};
+                    res_kv.get()[(b + 2) * rows + j] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b + 2),
+                                                        .Value=static_cast<minhash::ValueType>(j)};
+                    res_kv.get()[(b + 3) * rows + j] = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b + 3),
+                                                        .Value=static_cast<minhash::ValueType>(j)};
                 }
                 for (; b < band_num; b++) {
-                    minhash::KVPair kv = {GetHashKey(data_j, truncated_data_size, band_num, b), minhash::ValueType(j)};
+                    minhash::KVPair kv = {.Key=GetHashKey(data_j, truncated_data_size, band_num, b), .Value=static_cast<minhash::ValueType>(j)};
                     res_kv.get()[b * rows + j] = kv;
                 }
             }
@@ -308,7 +316,10 @@ GenTransposedHashKV(const char* data, size_t rows, size_t data_size, size_t data
 void
 SortHashKV(const std::shared_ptr<KVPair[]> kv_code, size_t rows, size_t band) {
     auto build_pool = ThreadPool::GetGlobalBuildThreadPool();
+
     std::vector<folly::Future<folly::Unit>> futures;
+    futures.reserve(band);
+
     for (size_t i = 0; i < band; i++) {
         futures.emplace_back(build_pool->push([&, idx = i]() {
             std::sort(kv_code.get() + rows * idx, kv_code.get() + rows * (idx + 1),
@@ -343,7 +354,7 @@ MinHashJaccardKNNSearchByNy(const char* x, const char* y, size_t length, size_t 
         ids[i] = -1;
     }
     auto computer = std::make_shared<MinHashJaccardComputer>(y, length, element_size);
-    computer->set_query((const float*)x);
+    computer->set_query(reinterpret_cast<const float*>(x));
     auto filter = [&](const size_t j) { return (bitset.empty() || !bitset.test(j)); };
 
     // the lambda that applies a valid element.
@@ -370,7 +381,7 @@ MinHashJaccardKNNSearchByIDs(const char* x, const char* y, const int64_t* sel_id
         }
     };
     auto computer = std::make_shared<MinHashJaccardComputer>(y, length, element_size);
-    computer->set_query((const float*)x);
+    computer->set_query(reinterpret_cast<const float*>(x));
     size_t i = 0;
     float dis0, dis1, dis2, dis3;
     for (; i + 4 < sel_ids_num; i += 4) {

--- a/src/index/sparse/block_inverted_index.h
+++ b/src/index/sparse/block_inverted_index.h
@@ -902,7 +902,8 @@ BlockInvertedIndex<DType, QType, MetricType>::serialize(MemoryIOWriter& writer) 
     writer.write(&nr_sections, sizeof(uint32_t));
 
     // since writer doesn't support seekp() for now, calculate all sizes of each sections first
-    InvertedIndexSectionHeader section_headers[nr_sections];
+    std::vector<InvertedIndexSectionHeader> section_headers(nr_sections);
+
     uint64_t used_offset = sizeof(InvertedIndexSectionHeader) * nr_sections + 36;
     section_headers[0].type = InvertedIndexSectionType::POSTING_LISTS;
     section_headers[0].offset = used_offset;
@@ -941,7 +942,7 @@ BlockInvertedIndex<DType, QType, MetricType>::serialize(MemoryIOWriter& writer) 
     }
 
     // write section headers table
-    writer.write(section_headers, sizeof(InvertedIndexSectionHeader), nr_sections);
+    writer.write(section_headers.data(), sizeof(InvertedIndexSectionHeader), nr_sections);
 
     // write index encoding type and encoded index
     writer.write(&index_encoding_type, sizeof(uint32_t));

--- a/src/index/sparse/flatten_inverted_index.h
+++ b/src/index/sparse/flatten_inverted_index.h
@@ -611,7 +611,8 @@ FlattenInvertedIndex<DType, QType>::serialize(MemoryIOWriter& writer) const {
     writer.write(&nr_sections, sizeof(uint32_t));
 
     // since writer doesn't support seekp() for now, calculate all sizes of each sections first
-    InvertedIndexSectionHeader section_headers[nr_sections];
+    std::vector<InvertedIndexSectionHeader> section_headers(nr_sections);
+
     uint64_t used_offset = sizeof(InvertedIndexSectionHeader) * nr_sections + 36;
     section_headers[0].type = InvertedIndexSectionType::POSTING_LISTS;
     section_headers[0].offset = used_offset;
@@ -661,7 +662,7 @@ FlattenInvertedIndex<DType, QType>::serialize(MemoryIOWriter& writer) const {
     assert(curr_section_idx == nr_sections);
 
     // write section headers table
-    writer.write(section_headers, sizeof(InvertedIndexSectionHeader), nr_sections);
+    writer.write(section_headers.data(), sizeof(InvertedIndexSectionHeader), nr_sections);
 
     // write index encoding type and encoded index
     uint32_t index_encoding_type = static_cast<uint32_t>(InvertedIndexEncoding::FLAT);

--- a/src/index/sparse/sparse_index_node.cc
+++ b/src/index/sparse/sparse_index_node.cc
@@ -230,7 +230,7 @@ class SparseInvertedIndexNode : public IndexNode {
                     distances_ids.reserve(distances.size() * 0.3);
                     for (size_t i = 0; i < distances.size(); i++) {
                         if (distances[i] != 0) {
-                            distances_ids.emplace_back((int64_t)i, distances[i]);
+                            distances_ids.emplace_back(static_cast<int64_t>(i), distances[i]);
                         }
                     }
                     return distances_ids;

--- a/src/simd/distances_avx.cc
+++ b/src/simd/distances_avx.cc
@@ -485,11 +485,11 @@ float
 fp16_vec_inner_product_avx(const ::knowhere::fp16* x, const ::knowhere::fp16* y, size_t d) {
     __m256 msum_0 = _mm256_setzero_ps();
     while (d >= 16) {
-        auto mx = _mm256_loadu_si256((__m256i*)x);
+        auto mx = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(x));
         auto mx_0 = _mm256_cvtph_ps(_mm256_extracti128_si256(mx, 0));
         auto mx_1 = _mm256_cvtph_ps(_mm256_extracti128_si256(mx, 1));
 
-        auto my = _mm256_loadu_si256((__m256i*)y);
+        auto my = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(y));
         auto my_0 = _mm256_cvtph_ps(_mm256_extracti128_si256(my, 0));
         auto my_1 = _mm256_cvtph_ps(_mm256_extracti128_si256(my, 1));
 
@@ -501,16 +501,16 @@ fp16_vec_inner_product_avx(const ::knowhere::fp16* x, const ::knowhere::fp16* y,
         d -= 16;
     }
     while (d >= 8) {
-        auto mx = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)x));
-        auto my = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y));
+        auto mx = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(x)));
+        auto my = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y)));
         msum_0 = _mm256_fmadd_ps(mx, my, msum_0);
         x += 8;
         y += 8;
         d -= 8;
     }
     if (d > 0) {
-        auto mx = _mm256_cvtph_ps(mm_masked_read_short(d, (uint16_t*)x));
-        auto my = _mm256_cvtph_ps(mm_masked_read_short(d, (uint16_t*)y));
+        auto mx = _mm256_cvtph_ps(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(x)));
+        auto my = _mm256_cvtph_ps(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(y)));
         msum_0 = _mm256_fmadd_ps(mx, my, msum_0);
     }
     auto res = _mm256_reduce_add_ps(msum_0);
@@ -521,11 +521,11 @@ float
 fp16_vec_L2sqr_avx(const ::knowhere::fp16* x, const ::knowhere::fp16* y, size_t d) {
     __m256 msum_0 = _mm256_setzero_ps();
     while (d >= 16) {
-        auto mx = _mm256_loadu_si256((__m256i*)x);
+        auto mx = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(x));
         auto mx_0 = _mm256_cvtph_ps(_mm256_extracti128_si256(mx, 0));
         auto mx_1 = _mm256_cvtph_ps(_mm256_extracti128_si256(mx, 1));
 
-        auto my = _mm256_loadu_si256((__m256i*)y);
+        auto my = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(y));
         auto my_0 = _mm256_cvtph_ps(_mm256_extracti128_si256(my, 0));
         auto my_1 = _mm256_cvtph_ps(_mm256_extracti128_si256(my, 1));
 
@@ -539,8 +539,8 @@ fp16_vec_L2sqr_avx(const ::knowhere::fp16* x, const ::knowhere::fp16* y, size_t 
         d -= 16;
     }
     while (d >= 8) {
-        auto mx = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)x));
-        auto my = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y));
+        auto mx = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(x)));
+        auto my = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y)));
         mx = _mm256_sub_ps(mx, my);
         msum_0 = _mm256_fmadd_ps(mx, mx, msum_0);
         x += 8;
@@ -548,8 +548,8 @@ fp16_vec_L2sqr_avx(const ::knowhere::fp16* x, const ::knowhere::fp16* y, size_t 
         d -= 8;
     }
     if (d > 0) {
-        auto mx = _mm256_cvtph_ps(mm_masked_read_short(d, (uint16_t*)x));
-        auto my = _mm256_cvtph_ps(mm_masked_read_short(d, (uint16_t*)y));
+        auto mx = _mm256_cvtph_ps(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(x)));
+        auto my = _mm256_cvtph_ps(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(y)));
         mx = _mm256_sub_ps(mx, my);
         msum_0 = _mm256_fmadd_ps(mx, mx, msum_0);
     }
@@ -561,7 +561,7 @@ float
 fp16_vec_norm_L2sqr_avx(const ::knowhere::fp16* x, size_t d) {
     __m256 msum_0 = _mm256_setzero_ps();
     while (d >= 16) {
-        auto mx = _mm256_loadu_si256((__m256i*)x);
+        auto mx = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(x));
         auto mx_0 = _mm256_cvtph_ps(_mm256_extracti128_si256(mx, 0));
         auto mx_1 = _mm256_cvtph_ps(_mm256_extracti128_si256(mx, 1));
         msum_0 = _mm256_fmadd_ps(mx_0, mx_0, msum_0);
@@ -571,13 +571,13 @@ fp16_vec_norm_L2sqr_avx(const ::knowhere::fp16* x, size_t d) {
         d -= 16;
     }
     while (d >= 8) {
-        auto mx = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)x));
+        auto mx = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(x)));
         msum_0 = _mm256_fmadd_ps(mx, mx, msum_0);
         x += 8;
         d -= 8;
     }
     if (d > 0) {
-        auto mx = _mm256_cvtph_ps(mm_masked_read_short(d, (uint16_t*)x));
+        auto mx = _mm256_cvtph_ps(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(x)));
         msum_0 = _mm256_fmadd_ps(mx, mx, msum_0);
     }
     auto res = _mm256_reduce_add_ps(msum_0);
@@ -595,11 +595,11 @@ fp16_vec_inner_product_batch_4_avx(const ::knowhere::fp16* x, const ::knowhere::
 
     size_t cur_d = d;
     while (cur_d >= 8) {
-        auto mx = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)x));
-        auto my0 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y0));
-        auto my1 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y1));
-        auto my2 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y2));
-        auto my3 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y3));
+        auto mx = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(x)));
+        auto my0 = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y0)));
+        auto my1 = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y1)));
+        auto my2 = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y2)));
+        auto my3 = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y3)));
         msum_0 = _mm256_fmadd_ps(mx, my0, msum_0);
         msum_1 = _mm256_fmadd_ps(mx, my1, msum_1);
         msum_2 = _mm256_fmadd_ps(mx, my2, msum_2);
@@ -612,11 +612,11 @@ fp16_vec_inner_product_batch_4_avx(const ::knowhere::fp16* x, const ::knowhere::
         cur_d -= 8;
     }
     if (cur_d > 0) {
-        auto mx = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)x));
-        auto my0 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y0));
-        auto my1 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y1));
-        auto my2 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y2));
-        auto my3 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y3));
+        auto mx = _mm256_cvtph_ps(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(x)));
+        auto my0 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y0)));
+        auto my1 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y1)));
+        auto my2 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y2)));
+        auto my3 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y3)));
         msum_0 = _mm256_fmadd_ps(mx, my0, msum_0);
         msum_1 = _mm256_fmadd_ps(mx, my1, msum_1);
         msum_2 = _mm256_fmadd_ps(mx, my2, msum_2);
@@ -638,11 +638,11 @@ fp16_vec_L2sqr_batch_4_avx(const ::knowhere::fp16* x, const ::knowhere::fp16* y0
     __m256 msum_3 = _mm256_setzero_ps();
     auto cur_d = d;
     while (cur_d >= 8) {
-        auto mx = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)x));
-        auto my0 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y0));
-        auto my1 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y1));
-        auto my2 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y2));
-        auto my3 = _mm256_cvtph_ps(_mm_loadu_si128((__m128i*)y3));
+        auto mx = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(x)));
+        auto my0 = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y0)));
+        auto my1 = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y1)));
+        auto my2 = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y2)));
+        auto my3 = _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y3)));
         my0 = _mm256_sub_ps(mx, my0);
         msum_0 = _mm256_fmadd_ps(my0, my0, msum_0);
         my1 = _mm256_sub_ps(mx, my1);
@@ -659,11 +659,11 @@ fp16_vec_L2sqr_batch_4_avx(const ::knowhere::fp16* x, const ::knowhere::fp16* y0
         cur_d -= 8;
     }
     if (cur_d > 0) {
-        auto mx = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)x));
-        auto my0 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y0));
-        auto my1 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y1));
-        auto my2 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y2));
-        auto my3 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, (uint16_t*)y3));
+        auto mx = _mm256_cvtph_ps(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(x)));
+        auto my0 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y0)));
+        auto my1 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y1)));
+        auto my2 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y2)));
+        auto my3 = _mm256_cvtph_ps(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y3)));
         my0 = _mm256_sub_ps(mx, my0);
         my1 = _mm256_sub_ps(mx, my1);
         my2 = _mm256_sub_ps(mx, my2);
@@ -686,11 +686,11 @@ float
 bf16_vec_inner_product_avx(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size_t d) {
     __m256 msum_0 = _mm256_setzero_ps();
     while (d >= 16) {
-        auto mx = _mm256_loadu_si256((__m256i*)x);
+        auto mx = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(x));
         auto mx_0 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(mx, 0));
         auto mx_1 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(mx, 1));
 
-        auto my = _mm256_loadu_si256((__m256i*)y);
+        auto my = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(y));
         auto my_0 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(my, 0));
         auto my_1 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(my, 1));
 
@@ -702,16 +702,16 @@ bf16_vec_inner_product_avx(const ::knowhere::bf16* x, const ::knowhere::bf16* y,
         d -= 16;
     }
     while (d >= 8) {
-        auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)x));
-        auto my = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y));
+        auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(x)));
+        auto my = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y)));
         msum_0 = _mm256_fmadd_ps(mx, my, msum_0);
         x += 8;
         y += 8;
         d -= 8;
     }
     if (d > 0) {
-        auto mx = _mm256_bf16_to_fp32(mm_masked_read_short(d, (uint16_t*)x));
-        auto my = _mm256_bf16_to_fp32(mm_masked_read_short(d, (uint16_t*)y));
+        auto mx = _mm256_bf16_to_fp32(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(x)));
+        auto my = _mm256_bf16_to_fp32(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(y)));
         msum_0 = _mm256_fmadd_ps(mx, my, msum_0);
     }
     auto res = _mm256_reduce_add_ps(msum_0);
@@ -722,11 +722,11 @@ float
 bf16_vec_L2sqr_avx(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size_t d) {
     __m256 msum_0 = _mm256_setzero_ps();
     while (d >= 16) {
-        auto mx = _mm256_loadu_si256((__m256i*)x);
+        auto mx = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(x));
         auto mx_0 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(mx, 0));
         auto mx_1 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(mx, 1));
 
-        auto my = _mm256_loadu_si256((__m256i*)y);
+        auto my = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(y));
         auto my_0 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(my, 0));
         auto my_1 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(my, 1));
         mx_0 = _mm256_sub_ps(mx_0, my_0);
@@ -738,8 +738,8 @@ bf16_vec_L2sqr_avx(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size_t 
         d -= 16;
     }
     while (d >= 8) {
-        auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)x));
-        auto my = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y));
+        auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(x)));
+        auto my = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y)));
         mx = _mm256_sub_ps(mx, my);
         msum_0 = _mm256_fmadd_ps(mx, mx, msum_0);
         x += 8;
@@ -747,8 +747,8 @@ bf16_vec_L2sqr_avx(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size_t 
         d -= 8;
     }
     if (d > 0) {
-        auto mx = _mm256_bf16_to_fp32(mm_masked_read_short(d, (uint16_t*)x));
-        auto my = _mm256_bf16_to_fp32(mm_masked_read_short(d, (uint16_t*)y));
+        auto mx = _mm256_bf16_to_fp32(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(x)));
+        auto my = _mm256_bf16_to_fp32(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(y)));
         mx = _mm256_sub_ps(mx, my);
         msum_0 = _mm256_fmadd_ps(mx, mx, msum_0);
     }
@@ -760,7 +760,7 @@ float
 bf16_vec_norm_L2sqr_avx(const ::knowhere::bf16* x, size_t d) {
     __m256 msum_0 = _mm256_setzero_ps();
     while (d >= 16) {
-        auto mx = _mm256_loadu_si256((__m256i*)x);
+        auto mx = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(x));
         auto mx_0 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(mx, 0));
         auto mx_1 = _mm256_bf16_to_fp32(_mm256_extracti128_si256(mx, 1));
         msum_0 = _mm256_fmadd_ps(mx_0, mx_0, msum_0);
@@ -770,13 +770,13 @@ bf16_vec_norm_L2sqr_avx(const ::knowhere::bf16* x, size_t d) {
         d -= 16;
     }
     while (d >= 8) {
-        auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)x));
+        auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(x)));
         msum_0 = _mm256_fmadd_ps(mx, mx, msum_0);
         x += 8;
         d -= 8;
     }
     if (d > 0) {
-        auto mx = _mm256_bf16_to_fp32(mm_masked_read_short(d, (uint16_t*)x));
+        auto mx = _mm256_bf16_to_fp32(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(x)));
         msum_0 = _mm256_fmadd_ps(mx, mx, msum_0);
     }
     auto res = _mm256_reduce_add_ps(msum_0);
@@ -793,11 +793,11 @@ bf16_vec_inner_product_batch_4_avx(const ::knowhere::bf16* x, const ::knowhere::
     __m256 msum_3 = _mm256_setzero_ps();
     size_t cur_d = d;
     while (cur_d >= 8) {
-        auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)x));
-        auto my0 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y0));
-        auto my1 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y1));
-        auto my2 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y2));
-        auto my3 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y3));
+        auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(x)));
+        auto my0 = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y0)));
+        auto my1 = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y1)));
+        auto my2 = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y2)));
+        auto my3 = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y3)));
         msum_0 = _mm256_fmadd_ps(mx, my0, msum_0);
         msum_1 = _mm256_fmadd_ps(mx, my1, msum_1);
         msum_2 = _mm256_fmadd_ps(mx, my2, msum_2);
@@ -810,11 +810,11 @@ bf16_vec_inner_product_batch_4_avx(const ::knowhere::bf16* x, const ::knowhere::
         cur_d -= 8;
     }
     if (cur_d > 0) {
-        auto mx = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)x));
-        auto my0 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y0));
-        auto my1 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y1));
-        auto my2 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y2));
-        auto my3 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y3));
+        auto mx = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(x)));
+        auto my0 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y0)));
+        auto my1 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y1)));
+        auto my2 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y2)));
+        auto my3 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y3)));
         msum_0 = _mm256_fmadd_ps(mx, my0, msum_0);
         msum_1 = _mm256_fmadd_ps(mx, my1, msum_1);
         msum_2 = _mm256_fmadd_ps(mx, my2, msum_2);
@@ -836,11 +836,11 @@ bf16_vec_L2sqr_batch_4_avx(const ::knowhere::bf16* x, const ::knowhere::bf16* y0
     __m256 msum_3 = _mm256_setzero_ps();
     size_t cur_d = d;
     while (cur_d >= 8) {
-        auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)x));
-        auto my0 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y0));
-        auto my1 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y1));
-        auto my2 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y2));
-        auto my3 = _mm256_bf16_to_fp32(_mm_loadu_si128((__m128i*)y3));
+        auto mx = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(x)));
+        auto my0 = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y0)));
+        auto my1 = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y1)));
+        auto my2 = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y2)));
+        auto my3 = _mm256_bf16_to_fp32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(y3)));
         my0 = _mm256_sub_ps(mx, my0);
         my1 = _mm256_sub_ps(mx, my1);
         my2 = _mm256_sub_ps(mx, my2);
@@ -857,11 +857,11 @@ bf16_vec_L2sqr_batch_4_avx(const ::knowhere::bf16* x, const ::knowhere::bf16* y0
         cur_d -= 8;
     }
     if (cur_d > 0) {
-        auto mx = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)x));
-        auto my0 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y0));
-        auto my1 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y1));
-        auto my2 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y2));
-        auto my3 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, (uint16_t*)y3));
+        auto mx = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(x)));
+        auto my0 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y0)));
+        auto my1 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y1)));
+        auto my2 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y2)));
+        auto my3 = _mm256_bf16_to_fp32(mm_masked_read_short(cur_d, reinterpret_cast<const uint16_t*>(y3)));
         my0 = _mm256_sub_ps(mx, my0);
         my1 = _mm256_sub_ps(mx, my1);
         my2 = _mm256_sub_ps(mx, my2);

--- a/src/simd/distances_avx.cc
+++ b/src/simd/distances_avx.cc
@@ -62,7 +62,7 @@ mm_masked_read_short(int d, const uint16_t* x) {
         case 1:
             buf[0] = x[0];
     }
-    return _mm_loadu_si128((__m128i*)buf);
+    return _mm_loadu_si128(reinterpret_cast<__m128i*>(buf));
 }
 
 inline __m256
@@ -462,7 +462,7 @@ int32_t
 ivec_inner_product_avx(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     for (size_t i = 0; i < d; i++) {
-        res += (int32_t)x[i] * y[i];
+        res += static_cast<int32_t>(x[i]) * y[i];
     }
     return res;
 }
@@ -472,7 +472,7 @@ int32_t
 ivec_L2sqr_avx(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     for (size_t i = 0; i < d; i++) {
-        const int32_t tmp = (int32_t)x[i] - (int32_t)y[i];
+        const int32_t tmp = static_cast<int32_t>(x[i]) - static_cast<int32_t>(y[i]);
         res += tmp * tmp;
     }
     return res;
@@ -886,9 +886,9 @@ int8_vec_inner_product_avx(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i < d; i++) {
-        res += (int32_t)x[i] * (int32_t)y[i];
+        res += static_cast<int32_t>(x[i]) * static_cast<int32_t>(y[i]);
     }
-    return (float)res;
+    return static_cast<float>(res);
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
@@ -898,10 +898,10 @@ int8_vec_L2sqr_avx(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i < d; i++) {
-        const int32_t tmp = (int32_t)x[i] - (int32_t)y[i];
+        const int32_t tmp = static_cast<int32_t>(x[i]) - static_cast<int32_t>(y[i]);
         res += tmp * tmp;
     }
-    return (float)res;
+    return static_cast<float>(res);
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
@@ -911,9 +911,9 @@ int8_vec_norm_L2sqr_avx(const int8_t* x, size_t d) {
     int32_t res = 0;
     FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i < d; i++) {
-        res += (int32_t)x[i] * (int32_t)x[i];
+        res += static_cast<int32_t>(x[i]) * static_cast<int32_t>(x[i]);
     }
-    return (float)res;
+    return static_cast<float>(res);
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
@@ -926,17 +926,17 @@ int8_vec_inner_product_batch_4_avx(const int8_t* x, const int8_t* y0, const int8
 
     FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i < d; ++i) {
-        auto x_i = (int32_t)x[i];
-        d0 += x_i * (int32_t)y0[i];
-        d1 += x_i * (int32_t)y1[i];
-        d2 += x_i * (int32_t)y2[i];
-        d3 += x_i * (int32_t)y3[i];
+        auto x_i = static_cast<int32_t>(x[i]);
+        d0 += x_i * static_cast<int32_t>(y0[i]);
+        d1 += x_i * static_cast<int32_t>(y1[i]);
+        d2 += x_i * static_cast<int32_t>(y2[i]);
+        d3 += x_i * static_cast<int32_t>(y3[i]);
     }
 
-    dis0 = (float)d0;
-    dis1 = (float)d1;
-    dis2 = (float)d2;
-    dis3 = (float)d3;
+    dis0 = static_cast<float>(d0);
+    dis1 = static_cast<float>(d1);
+    dis2 = static_cast<float>(d2);
+    dis3 = static_cast<float>(d3);
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
@@ -948,21 +948,21 @@ int8_vec_L2sqr_batch_4_avx(const int8_t* x, const int8_t* y0, const int8_t* y1, 
 
     FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i < d; ++i) {
-        auto x_i = (int32_t)x[i];
-        const int32_t q0 = x_i - (int32_t)y0[i];
-        const int32_t q1 = x_i - (int32_t)y1[i];
-        const int32_t q2 = x_i - (int32_t)y2[i];
-        const int32_t q3 = x_i - (int32_t)y3[i];
+        auto x_i = static_cast<int32_t>(x[i]);
+        const int32_t q0 = x_i - static_cast<int32_t>(y0[i]);
+        const int32_t q1 = x_i - static_cast<int32_t>(y1[i]);
+        const int32_t q2 = x_i - static_cast<int32_t>(y2[i]);
+        const int32_t q3 = x_i - static_cast<int32_t>(y3[i]);
         d0 += q0 * q0;
         d1 += q1 * q1;
         d2 += q2 * q2;
         d3 += q3 * q3;
     }
 
-    dis0 = (float)d0;
-    dis1 = (float)d1;
-    dis2 = (float)d2;
-    dis3 = (float)d3;
+    dis0 = static_cast<float>(d0);
+    dis1 = static_cast<float>(d1);
+    dis2 = static_cast<float>(d2);
+    dis3 = static_cast<float>(d3);
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
@@ -1046,8 +1046,8 @@ rabitq_dp_popcnt_avx(const uint8_t* q, const uint8_t* x, const size_t d, const s
         // process 64-bit popcounts
         int count_dot = 0;
         for (size_t i = 0; i < di_64b; i += 8) {
-            const auto qv = *(const uint64_t*)(q_j + i);
-            const auto xv = *(const uint64_t*)(x + i);
+            const auto qv = *reinterpret_cast<const uint64_t*>(q_j + i);
+            const auto xv = *reinterpret_cast<const uint64_t*>(x + i);
             count_dot += __builtin_popcountll(qv & xv);
         }
 

--- a/src/simd/distances_avx512.cc
+++ b/src/simd/distances_avx512.cc
@@ -279,7 +279,7 @@ int32_t
 ivec_inner_product_avx512(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     for (size_t i = 0; i < d; i++) {
-        res += (int32_t)x[i] * y[i];
+        res += static_cast<int32_t>(x[i]) * y[i];
     }
     return res;
 }
@@ -288,7 +288,7 @@ int32_t
 ivec_L2sqr_avx512(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     for (size_t i = 0; i < d; i++) {
-        const int32_t tmp = (int32_t)x[i] - (int32_t)y[i];
+        const int32_t tmp = static_cast<int32_t>(x[i]) - static_cast<int32_t>(y[i]);
         res += tmp * tmp;
     }
     return res;
@@ -693,9 +693,9 @@ int8_vec_inner_product_avx512(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i < d; i++) {
-        res += (int32_t)x[i] * (int32_t)y[i];
+        res += static_cast<int32_t>(x[i]) * static_cast<int32_t>(y[i]);
     }
-    return (float)res;
+    return static_cast<float>(res);
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
@@ -705,10 +705,10 @@ int8_vec_L2sqr_avx512(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i < d; i++) {
-        const int32_t tmp = (int32_t)x[i] - (int32_t)y[i];
+        const int32_t tmp = static_cast<int32_t>(x[i]) - static_cast<int32_t>(y[i]);
         res += tmp * tmp;
     }
-    return (float)res;
+    return static_cast<float>(res);
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
@@ -718,9 +718,9 @@ int8_vec_norm_L2sqr_avx512(const int8_t* x, size_t d) {
     int32_t res = 0;
     FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i < d; i++) {
-        res += (int32_t)x[i] * (int32_t)x[i];
+        res += static_cast<int32_t>(x[i]) * static_cast<int32_t>(x[i]);
     }
-    return (float)res;
+    return static_cast<float>(res);
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
@@ -733,17 +733,17 @@ int8_vec_inner_product_batch_4_avx512(const int8_t* x, const int8_t* y0, const i
 
     FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i < d; ++i) {
-        auto x_i = (int32_t)x[i];
-        d0 += x_i * (int32_t)y0[i];
-        d1 += x_i * (int32_t)y1[i];
-        d2 += x_i * (int32_t)y2[i];
-        d3 += x_i * (int32_t)y3[i];
+        auto x_i = static_cast<int32_t>(x[i]);
+        d0 += x_i * static_cast<int32_t>(y0[i]);
+        d1 += x_i * static_cast<int32_t>(y1[i]);
+        d2 += x_i * static_cast<int32_t>(y2[i]);
+        d3 += x_i * static_cast<int32_t>(y3[i]);
     }
 
-    dis0 = (float)d0;
-    dis1 = (float)d1;
-    dis2 = (float)d2;
-    dis3 = (float)d3;
+    dis0 = static_cast<float>(d0);
+    dis1 = static_cast<float>(d1);
+    dis2 = static_cast<float>(d2);
+    dis3 = static_cast<float>(d3);
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
@@ -755,21 +755,21 @@ int8_vec_L2sqr_batch_4_avx512(const int8_t* x, const int8_t* y0, const int8_t* y
 
     FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i < d; ++i) {
-        auto x_i = (int32_t)x[i];
-        const int32_t q0 = x_i - (int32_t)y0[i];
-        const int32_t q1 = x_i - (int32_t)y1[i];
-        const int32_t q2 = x_i - (int32_t)y2[i];
-        const int32_t q3 = x_i - (int32_t)y3[i];
+        auto x_i = static_cast<int32_t>(x[i]);
+        const int32_t q0 = x_i - static_cast<int32_t>(y0[i]);
+        const int32_t q1 = x_i - static_cast<int32_t>(y1[i]);
+        const int32_t q2 = x_i - static_cast<int32_t>(y2[i]);
+        const int32_t q3 = x_i - static_cast<int32_t>(y3[i]);
         d0 += q0 * q0;
         d1 += q1 * q1;
         d2 += q2 * q2;
         d3 += q3 * q3;
     }
 
-    dis0 = (float)d0;
-    dis1 = (float)d1;
-    dis2 = (float)d2;
-    dis3 = (float)d3;
+    dis0 = static_cast<float>(d0);
+    dis1 = static_cast<float>(d1);
+    dis2 = static_cast<float>(d2);
+    dis3 = static_cast<float>(d3);
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
@@ -782,7 +782,7 @@ fvec_masked_sum_avx512(const float* q, const uint8_t* x, const size_t d) {
     const size_t d_16 = (d / 16) * 16;
 
     for (size_t i = 0; i < d_16; i += 16) {
-        __mmask16 mask = *((const uint16_t*)(x + i / 8));
+        __mmask16 mask = *(reinterpret_cast<const uint16_t*>(x + i / 8));
         sum = _mm512_add_ps(sum, _mm512_maskz_loadu_ps(mask, q + i));
     }
 
@@ -792,7 +792,7 @@ fvec_masked_sum_avx512(const float* q, const uint8_t* x, const size_t d) {
 
         __mmask16 mask = 0;
         if (leftovers > 8) {
-            mask = *((const uint16_t*)(x + d_16 / 8));
+            mask = *(reinterpret_cast<const uint16_t*>(x + d_16 / 8));
         } else {
             mask = *(x + d_16 / 8);
         }
@@ -816,8 +816,8 @@ rabitq_dp_popcnt_avx512(const uint8_t* q, const uint8_t* x, const size_t d, cons
         // process 64-bit popcounts
         int count_dot = 0;
         for (size_t i = 0; i < di_64b; i += 8) {
-            const auto qv = *(const uint64_t*)(q_j + i);
-            const auto xv = *(const uint64_t*)(x + i);
+            const auto qv = *reinterpret_cast<const uint64_t*>(q_j + i);
+            const auto xv = *reinterpret_cast<const uint64_t*>(x + i);
             count_dot += __builtin_popcountll(qv & xv);
         }
 
@@ -994,7 +994,7 @@ u32_jaccard_distance_avx512(const char* x, const char* y, size_t element_length,
         __mmask16 cmp_result = _mm512_cmpeq_epu32_mask(mx, my);
         equal_sum += __builtin_popcount(static_cast<unsigned int>(cmp_result & mask));
     }
-    return float(equal_sum) / float(element_length);
+    return static_cast<float>(equal_sum) / static_cast<float>(element_length);
 }
 void
 u32_jaccard_distance_batch_4_avx512(const char* x, const char* y0, const char* y1, const char* y2, const char* y3,
@@ -1045,10 +1045,10 @@ u32_jaccard_distance_batch_4_avx512(const char* x, const char* y0, const char* y
         d2 += __builtin_popcount(static_cast<unsigned int>(cmp_result2 & mask));
         d3 += __builtin_popcount(static_cast<unsigned int>(cmp_result3 & mask));
     }
-    dis0 = float(d0) / float(element_length);
-    dis1 = float(d1) / float(element_length);
-    dis2 = float(d2) / float(element_length);
-    dis3 = float(d3) / float(element_length);
+    dis0 = static_cast<float>(d0) / static_cast<float>(element_length);
+    dis1 = static_cast<float>(d1) / static_cast<float>(element_length);
+    dis2 = static_cast<float>(d2) / static_cast<float>(element_length);
+    dis3 = static_cast<float>(d3) / static_cast<float>(element_length);
 }
 
 float
@@ -1074,7 +1074,7 @@ u64_jaccard_distance_avx512(const char* x, const char* y, size_t element_length,
         __mmask8 cmp_result = _mm512_cmpeq_epu64_mask(mx, my);
         equal_sum += __builtin_popcount(static_cast<unsigned int>(cmp_result & mask));
     }
-    return float(equal_sum) / element_length;
+    return static_cast<float>(equal_sum) / element_length;
 }
 void
 u64_jaccard_distance_batch_4_avx512(const char* x, const char* y0, const char* y1, const char* y2, const char* y3,
@@ -1125,10 +1125,10 @@ u64_jaccard_distance_batch_4_avx512(const char* x, const char* y0, const char* y
         d2 += __builtin_popcount(static_cast<unsigned int>(cmp_result2 & mask));
         d3 += __builtin_popcount(static_cast<unsigned int>(cmp_result3 & mask));
     }
-    dis0 = float(d0) / element_length;
-    dis1 = float(d1) / element_length;
-    dis2 = float(d2) / element_length;
-    dis3 = float(d3) / element_length;
+    dis0 = static_cast<float>(d0) / element_length;
+    dis1 = static_cast<float>(d1) / element_length;
+    dis2 = static_cast<float>(d2) / element_length;
+    dis3 = static_cast<float>(d3) / element_length;
 }
 
 }  // namespace faiss::cppcontrib::knowhere

--- a/src/simd/distances_avx512.cc
+++ b/src/simd/distances_avx512.cc
@@ -301,10 +301,10 @@ float
 fp16_vec_inner_product_avx512(const ::knowhere::fp16* x, const ::knowhere::fp16* y, size_t d) {
     __m512 m512_res = _mm512_setzero_ps();
     while (d >= 32) {
-        auto mx_0 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)x));
-        auto my_0 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)y));
-        auto mx_1 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)(x + 16)));
-        auto my_1 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)(y + 16)));
+        auto mx_0 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
+        auto my_0 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y)));
+        auto mx_1 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x + 16)));
+        auto my_1 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y + 16)));
         m512_res = _mm512_fmadd_ps(mx_0, my_0, m512_res);
         m512_res = _mm512_fmadd_ps(mx_1, my_1, m512_res);
         x += 32;
@@ -312,8 +312,8 @@ fp16_vec_inner_product_avx512(const ::knowhere::fp16* x, const ::knowhere::fp16*
         d -= 32;
     }
     if (d >= 16) {
-        auto mx = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)x));
-        auto my = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)y));
+        auto mx = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
+        auto my = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y)));
         m512_res = _mm512_fmadd_ps(mx, my, m512_res);
         x += 16;
         y += 16;
@@ -333,10 +333,10 @@ fp16_vec_L2sqr_avx512(const ::knowhere::fp16* x, const ::knowhere::fp16* y, size
     __m512 m512_res = _mm512_setzero_ps();
     __m512 m512_res_0 = _mm512_setzero_ps();
     while (d >= 32) {
-        auto mx_0 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)x));
-        auto my_0 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)y));
-        auto mx_1 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)(x + 16)));
-        auto my_1 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)(y + 16)));
+        auto mx_0 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
+        auto my_0 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y)));
+        auto mx_1 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x + 16)));
+        auto my_1 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y + 16)));
         mx_0 = mx_0 - my_0;
         mx_1 = mx_1 - my_1;
         m512_res = _mm512_fmadd_ps(mx_0, mx_0, m512_res);
@@ -347,8 +347,8 @@ fp16_vec_L2sqr_avx512(const ::knowhere::fp16* x, const ::knowhere::fp16* y, size
     }
     m512_res = m512_res + m512_res_0;
     if (d >= 16) {
-        auto mx = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)x));
-        auto my = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)y));
+        auto mx = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
+        auto my = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y)));
         mx = mx - my;
         m512_res = _mm512_fmadd_ps(mx, mx, m512_res);
         x += 16;
@@ -370,8 +370,8 @@ fp16_vec_norm_L2sqr_avx512(const ::knowhere::fp16* x, size_t d) {
     __m512 m512_res = _mm512_setzero_ps();
     __m512 m512_res_0 = _mm512_setzero_ps();
     while (d >= 32) {
-        auto mx_0 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)x));
-        auto mx_1 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)(x + 16)));
+        auto mx_0 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
+        auto mx_1 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x + 16)));
         m512_res = _mm512_fmadd_ps(mx_0, mx_0, m512_res);
         m512_res_0 = _mm512_fmadd_ps(mx_1, mx_1, m512_res_0);
         x += 32;
@@ -379,7 +379,7 @@ fp16_vec_norm_L2sqr_avx512(const ::knowhere::fp16* x, size_t d) {
     }
     m512_res = m512_res + m512_res_0;
     if (d >= 16) {
-        auto mx = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)x));
+        auto mx = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
         m512_res = _mm512_fmadd_ps(mx, mx, m512_res);
         x += 16;
         d -= 16;
@@ -402,11 +402,11 @@ fp16_vec_inner_product_batch_4_avx512(const ::knowhere::fp16* x, const ::knowher
     __m512 m512_res_3 = _mm512_setzero_ps();
     size_t cur_d = d;
     while (cur_d >= 16) {
-        auto mx = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)x));
-        auto my0 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)y0));
-        auto my1 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)y1));
-        auto my2 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)y2));
-        auto my3 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)y3));
+        auto mx = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
+        auto my0 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y0)));
+        auto my1 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y1)));
+        auto my2 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y2)));
+        auto my3 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y3)));
         m512_res_0 = _mm512_fmadd_ps(mx, my0, m512_res_0);
         m512_res_1 = _mm512_fmadd_ps(mx, my1, m512_res_1);
         m512_res_2 = _mm512_fmadd_ps(mx, my2, m512_res_2);
@@ -446,11 +446,11 @@ fp16_vec_L2sqr_batch_4_avx512(const ::knowhere::fp16* x, const ::knowhere::fp16*
     __m512 m512_res_3 = _mm512_setzero_ps();
     size_t cur_d = d;
     while (cur_d >= 16) {
-        auto mx = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)x));
-        auto my0 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)y0));
-        auto my1 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)y1));
-        auto my2 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)y2));
-        auto my3 = _mm512_cvtph_ps(_mm256_loadu_si256((__m256i*)y3));
+        auto mx = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
+        auto my0 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y0)));
+        auto my1 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y1)));
+        auto my2 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y2)));
+        auto my3 = _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y3)));
         my0 = _mm512_sub_ps(mx, my0);
         my1 = _mm512_sub_ps(mx, my1);
         my2 = _mm512_sub_ps(mx, my2);
@@ -496,10 +496,10 @@ bf16_vec_inner_product_avx512(const ::knowhere::bf16* x, const ::knowhere::bf16*
     __m512 m512_res = _mm512_setzero_ps();
     __m512 m512_res_0 = _mm512_setzero_ps();
     while (d >= 32) {
-        auto mx_0 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)x));
-        auto my_0 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)y));
-        auto mx_1 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)(x + 16)));
-        auto my_1 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)(y + 16)));
+        auto mx_0 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
+        auto my_0 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y)));
+        auto mx_1 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x + 16)));
+        auto my_1 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y + 16)));
         m512_res = _mm512_fmadd_ps(mx_0, my_0, m512_res);
         m512_res_0 = _mm512_fmadd_ps(mx_1, my_1, m512_res_0);
         x += 32;
@@ -508,8 +508,8 @@ bf16_vec_inner_product_avx512(const ::knowhere::bf16* x, const ::knowhere::bf16*
     }
     m512_res = m512_res + m512_res_0;
     if (d >= 16) {
-        auto mx = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)x));
-        auto my = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)y));
+        auto mx = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
+        auto my = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y)));
         m512_res = _mm512_fmadd_ps(mx, my, m512_res);
         x += 16;
         y += 16;
@@ -529,10 +529,10 @@ bf16_vec_L2sqr_avx512(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size
     __m512 m512_res = _mm512_setzero_ps();
     __m512 m512_res_0 = _mm512_setzero_ps();
     while (d >= 32) {
-        auto mx_0 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)x));
-        auto my_0 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)y));
-        auto mx_1 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)(x + 16)));
-        auto my_1 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)(y + 16)));
+        auto mx_0 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
+        auto my_0 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y)));
+        auto mx_1 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x + 16)));
+        auto my_1 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y + 16)));
         mx_0 = mx_0 - my_0;
         mx_1 = mx_1 - my_1;
         m512_res = _mm512_fmadd_ps(mx_0, mx_0, m512_res);
@@ -543,8 +543,8 @@ bf16_vec_L2sqr_avx512(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size
     }
     m512_res = m512_res + m512_res_0;
     if (d >= 16) {
-        auto mx = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)x));
-        auto my = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)y));
+        auto mx = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
+        auto my = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y)));
         mx = mx - my;
         m512_res = _mm512_fmadd_ps(mx, mx, m512_res);
         x += 16;
@@ -566,8 +566,8 @@ bf16_vec_norm_L2sqr_avx512(const ::knowhere::bf16* x, size_t d) {
     __m512 m512_res = _mm512_setzero_ps();
     __m512 m512_res_0 = _mm512_setzero_ps();
     while (d >= 32) {
-        auto mx_0 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)x));
-        auto mx_1 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)(x + 16)));
+        auto mx_0 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
+        auto mx_1 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x + 16)));
         m512_res = _mm512_fmadd_ps(mx_0, mx_0, m512_res);
         m512_res_0 = _mm512_fmadd_ps(mx_1, mx_1, m512_res_0);
         x += 32;
@@ -575,7 +575,7 @@ bf16_vec_norm_L2sqr_avx512(const ::knowhere::bf16* x, size_t d) {
     }
     m512_res = m512_res + m512_res_0;
     if (d >= 16) {
-        auto mx = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)x));
+        auto mx = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
         m512_res = _mm512_fmadd_ps(mx, mx, m512_res);
         x += 16;
         d -= 16;
@@ -598,11 +598,11 @@ bf16_vec_inner_product_batch_4_avx512(const ::knowhere::bf16* x, const ::knowher
     __m512 m512_res_3 = _mm512_setzero_ps();
     size_t cur_d = d;
     while (cur_d >= 16) {
-        auto mx = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)x));
-        auto my0 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)y0));
-        auto my1 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)y1));
-        auto my2 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)y2));
-        auto my3 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)y3));
+        auto mx = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
+        auto my0 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y0)));
+        auto my1 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y1)));
+        auto my2 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y2)));
+        auto my3 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y3)));
         m512_res_0 = _mm512_fmadd_ps(mx, my0, m512_res_0);
         m512_res_1 = _mm512_fmadd_ps(mx, my1, m512_res_1);
         m512_res_2 = _mm512_fmadd_ps(mx, my2, m512_res_2);
@@ -642,11 +642,11 @@ bf16_vec_L2sqr_batch_4_avx512(const ::knowhere::bf16* x, const ::knowhere::bf16*
     __m512 m512_res_3 = _mm512_setzero_ps();
     size_t cur_d = d;
     while (cur_d >= 16) {
-        auto mx = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)x));
-        auto my0 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)y0));
-        auto my1 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)y1));
-        auto my2 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)y2));
-        auto my3 = _mm512_bf16_to_fp32(_mm256_loadu_si256((__m256i*)y3));
+        auto mx = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(x)));
+        auto my0 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y0)));
+        auto my1 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y1)));
+        auto my2 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y2)));
+        auto my3 = _mm512_bf16_to_fp32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(y3)));
         my0 = mx - my0;
         my1 = mx - my1;
         my2 = mx - my2;

--- a/src/simd/distances_avx512icx.cc
+++ b/src/simd/distances_avx512icx.cc
@@ -46,9 +46,9 @@ rabitq_dp_q(const uint8_t* q, const uint8_t* x, const size_t d) {
     __m256i sum_256 = _mm256_add_epi32(_mm512_extracti32x8_epi32(sum_512, 0), _mm512_extracti32x8_epi32(sum_512, 1));
 
     if (d_256 != d_512) {
-        __m256i v_x = _mm256_loadu_si256((const __m256i*)(x + d_512 / 8));
+        __m256i v_x = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(x + d_512 / 8));
         for (size_t j = 0; j < qb; j++) {
-            __m256i v_q = _mm256_loadu_si256((const __m256i*)(q + j * di_8b + d_512 / 8));
+            __m256i v_q = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(q + j * di_8b + d_512 / 8));
             __m256i v_and = _mm256_and_si256(v_q, v_x);
             __m256i v_popcnt = _mm256_popcnt_epi32(v_and);
             sum_256 = _mm256_add_epi32(sum_256, _mm256_slli_epi32(v_popcnt, j));
@@ -58,9 +58,9 @@ rabitq_dp_q(const uint8_t* q, const uint8_t* x, const size_t d) {
     __m128i sum_128 = _mm_add_epi32(_mm256_extracti32x4_epi32(sum_256, 0), _mm256_extracti32x4_epi32(sum_256, 1));
 
     if (d_128 != d_256) {
-        __m128i v_x = _mm_loadu_si128((const __m128i*)(x + d_256 / 8));
+        __m128i v_x = _mm_loadu_si128(reinterpret_cast<const __m128i*>(x + d_256 / 8));
         for (size_t j = 0; j < qb; j++) {
-            __m128i v_q = _mm_loadu_si128((const __m128i*)(q + j * di_8b + d_256 / 8));
+            __m128i v_q = _mm_loadu_si128(reinterpret_cast<const __m128i*>(q + j * di_8b + d_256 / 8));
             __m128i v_and = _mm_and_si128(v_q, v_x);
             __m128i v_popcnt = _mm_popcnt_epi32(v_and);
             sum_128 = _mm_add_epi32(sum_128, _mm_slli_epi32(v_popcnt, j));
@@ -71,9 +71,9 @@ rabitq_dp_q(const uint8_t* q, const uint8_t* x, const size_t d) {
         const size_t leftovers = d - d_128;
         const __mmask16 mask = (1 << ((leftovers + 7) / 8)) - 1;
 
-        __m128i v_x = _mm_maskz_loadu_epi8(mask, (const __m128i*)(x + d_128 / 8));
+        __m128i v_x = _mm_maskz_loadu_epi8(mask, reinterpret_cast<const __m128i*>(x + d_128 / 8));
         for (size_t j = 0; j < qb; j++) {
-            __m128i v_q = _mm_maskz_loadu_epi8(mask, (const __m128i*)(q + j * di_8b + d_128 / 8));
+            __m128i v_q = _mm_maskz_loadu_epi8(mask, reinterpret_cast<const __m128i*>(q + j * di_8b + d_128 / 8));
             __m128i v_and = _mm_and_si128(v_q, v_x);
             __m128i v_popcnt = _mm_popcnt_epi32(v_and);
             sum_128 = _mm_add_epi32(sum_128, _mm_slli_epi32(v_popcnt, j));

--- a/src/simd/distances_ref.cc
+++ b/src/simd/distances_ref.cc
@@ -237,7 +237,7 @@ float
 fp16_vec_inner_product_ref(const ::knowhere::fp16* x, const ::knowhere::fp16* y, size_t d) {
     float res = 0;
     for (size_t i = 0; i < d; i++) {
-        res += (float)x[i] * (float)y[i];
+        res += static_cast<float>(x[i]) * static_cast<float>(y[i]);
     }
     return res;
 }
@@ -246,7 +246,7 @@ float
 fp16_vec_L2sqr_ref(const ::knowhere::fp16* x, const ::knowhere::fp16* y, size_t d) {
     float res = 0;
     for (size_t i = 0; i < d; i++) {
-        const float tmp = (float)x[i] - (float)y[i];
+        const float tmp = static_cast<float>(x[i]) - static_cast<float>(y[i]);
         res += tmp * tmp;
     }
     return res;
@@ -256,7 +256,7 @@ float
 fp16_vec_norm_L2sqr_ref(const ::knowhere::fp16* x, size_t d) {
     double res = 0;
     for (size_t i = 0; i < d; i++) {
-        res += (float)x[i] * (float)x[i];
+        res += static_cast<float>(x[i]) * static_cast<float>(x[i]);
     }
     return res;
 }
@@ -268,11 +268,11 @@ fp16_vec_inner_product_batch_4_ref(const ::knowhere::fp16* x, const ::knowhere::
     float d0 = 0, d1 = 0, d2 = 0, d3 = 0;
 
     for (size_t i = 0; i < d; ++i) {
-        auto x_i = (float)x[i];
-        d0 += x_i * (float)y0[i];
-        d1 += x_i * (float)y1[i];
-        d2 += x_i * (float)y2[i];
-        d3 += x_i * (float)y3[i];
+        auto x_i = static_cast<float>(x[i]);
+        d0 += x_i * static_cast<float>(y0[i]);
+        d1 += x_i * static_cast<float>(y1[i]);
+        d2 += x_i * static_cast<float>(y2[i]);
+        d3 += x_i * static_cast<float>(y3[i]);
     }
 
     dis0 = d0;
@@ -288,11 +288,11 @@ fp16_vec_L2sqr_batch_4_ref(const ::knowhere::fp16* x, const ::knowhere::fp16* y0
     float d0 = 0, d1 = 0, d2 = 0, d3 = 0;
 
     for (size_t i = 0; i < d; ++i) {
-        auto x_i = (float)x[i];
-        const float q0 = x_i - (float)y0[i];
-        const float q1 = x_i - (float)y1[i];
-        const float q2 = x_i - (float)y2[i];
-        const float q3 = x_i - (float)y3[i];
+        auto x_i = static_cast<float>(x[i]);
+        const float q0 = x_i - static_cast<float>(y0[i]);
+        const float q1 = x_i - static_cast<float>(y1[i]);
+        const float q2 = x_i - static_cast<float>(y2[i]);
+        const float q3 = x_i - static_cast<float>(y3[i]);
         d0 += q0 * q0;
         d1 += q1 * q1;
         d2 += q2 * q2;
@@ -312,7 +312,7 @@ float
 bf16_vec_inner_product_ref(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size_t d) {
     float res = 0;
     for (size_t i = 0; i < d; i++) {
-        res += (float)x[i] * (float)y[i];
+        res += static_cast<float>(x[i]) * static_cast<float>(y[i]);
     }
     return res;
 }
@@ -321,7 +321,7 @@ float
 bf16_vec_L2sqr_ref(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size_t d) {
     float res = 0;
     for (size_t i = 0; i < d; i++) {
-        const float tmp = (float)x[i] - (float)y[i];
+        const float tmp = static_cast<float>(x[i]) - static_cast<float>(y[i]);
         res += tmp * tmp;
     }
     return res;
@@ -331,7 +331,7 @@ float
 bf16_vec_norm_L2sqr_ref(const ::knowhere::bf16* x, size_t d) {
     double res = 0;
     for (size_t i = 0; i < d; i++) {
-        res += (float)x[i] * (float)x[i];
+        res += static_cast<float>(x[i]) * static_cast<float>(x[i]);
     }
     return res;
 }
@@ -343,11 +343,11 @@ bf16_vec_inner_product_batch_4_ref(const ::knowhere::bf16* x, const ::knowhere::
     float d0 = 0, d1 = 0, d2 = 0, d3 = 0;
 
     for (size_t i = 0; i < d; ++i) {
-        auto x_i = (float)x[i];
-        d0 += x_i * (float)y0[i];
-        d1 += x_i * (float)y1[i];
-        d2 += x_i * (float)y2[i];
-        d3 += x_i * (float)y3[i];
+        auto x_i = static_cast<float>(x[i]);
+        d0 += x_i * static_cast<float>(y0[i]);
+        d1 += x_i * static_cast<float>(y1[i]);
+        d2 += x_i * static_cast<float>(y2[i]);
+        d3 += x_i * static_cast<float>(y3[i]);
     }
 
     dis0 = d0;
@@ -363,11 +363,11 @@ bf16_vec_L2sqr_batch_4_ref(const ::knowhere::bf16* x, const ::knowhere::bf16* y0
     float d0 = 0, d1 = 0, d2 = 0, d3 = 0;
 
     for (size_t i = 0; i < d; ++i) {
-        auto x_i = (float)x[i];
-        const float q0 = x_i - (float)y0[i];
-        const float q1 = x_i - (float)y1[i];
-        const float q2 = x_i - (float)y2[i];
-        const float q3 = x_i - (float)y3[i];
+        auto x_i = static_cast<float>(x[i]);
+        const float q0 = x_i - static_cast<float>(y0[i]);
+        const float q1 = x_i - static_cast<float>(y1[i]);
+        const float q2 = x_i - static_cast<float>(y2[i]);
+        const float q3 = x_i - static_cast<float>(y3[i]);
         d0 += q0 * q0;
         d1 += q1 * q1;
         d2 += q2 * q2;

--- a/src/simd/distances_ref.cc
+++ b/src/simd/distances_ref.cc
@@ -215,7 +215,7 @@ int32_t
 ivec_inner_product_ref(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     for (size_t i = 0; i < d; i++) {
-        res += (int32_t)x[i] * y[i];
+        res += static_cast<int32_t>(x[i]) * y[i];
     }
     return res;
 }
@@ -224,7 +224,7 @@ int32_t
 ivec_L2sqr_ref(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     for (size_t i = 0; i < d; i++) {
-        const int32_t tmp = (int32_t)x[i] - (int32_t)y[i];
+        const int32_t tmp = static_cast<int32_t>(x[i]) - static_cast<int32_t>(y[i]);
         res += tmp * tmp;
     }
     return res;
@@ -387,28 +387,28 @@ float
 int8_vec_inner_product_ref(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     for (size_t i = 0; i < d; i++) {
-        res += (int32_t)x[i] * (int32_t)y[i];
+        res += static_cast<int32_t>(x[i]) * static_cast<int32_t>(y[i]);
     }
-    return (float)res;
+    return static_cast<float>(res);
 }
 
 float
 int8_vec_L2sqr_ref(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     for (size_t i = 0; i < d; i++) {
-        const int32_t tmp = (int32_t)x[i] - (int32_t)y[i];
+        const int32_t tmp = static_cast<int32_t>(x[i]) - static_cast<int32_t>(y[i]);
         res += tmp * tmp;
     }
-    return (float)res;
+    return static_cast<float>(res);
 }
 
 float
 int8_vec_norm_L2sqr_ref(const int8_t* x, size_t d) {
     int32_t res = 0;
     for (size_t i = 0; i < d; i++) {
-        res += (int32_t)x[i] * (int32_t)x[i];
+        res += static_cast<int32_t>(x[i]) * static_cast<int32_t>(x[i]);
     }
-    return (float)res;
+    return static_cast<float>(res);
 }
 
 void
@@ -418,17 +418,17 @@ int8_vec_inner_product_batch_4_ref(const int8_t* x, const int8_t* y0, const int8
     int32_t d0 = 0, d1 = 0, d2 = 0, d3 = 0;
 
     for (size_t i = 0; i < d; ++i) {
-        auto x_i = (int32_t)x[i];
-        d0 += x_i * (int32_t)y0[i];
-        d1 += x_i * (int32_t)y1[i];
-        d2 += x_i * (int32_t)y2[i];
-        d3 += x_i * (int32_t)y3[i];
+        auto x_i = static_cast<int32_t>(x[i]);
+        d0 += x_i * static_cast<int32_t>(y0[i]);
+        d1 += x_i * static_cast<int32_t>(y1[i]);
+        d2 += x_i * static_cast<int32_t>(y2[i]);
+        d3 += x_i * static_cast<int32_t>(y3[i]);
     }
 
-    dis0 = (float)d0;
-    dis1 = (float)d1;
-    dis2 = (float)d2;
-    dis3 = (float)d3;
+    dis0 = static_cast<float>(d0);
+    dis1 = static_cast<float>(d1);
+    dis2 = static_cast<float>(d2);
+    dis3 = static_cast<float>(d3);
 }
 
 void
@@ -437,21 +437,21 @@ int8_vec_L2sqr_batch_4_ref(const int8_t* x, const int8_t* y0, const int8_t* y1, 
     int32_t d0 = 0, d1 = 0, d2 = 0, d3 = 0;
 
     for (size_t i = 0; i < d; ++i) {
-        auto x_i = (int32_t)x[i];
-        const int32_t q0 = x_i - (int32_t)y0[i];
-        const int32_t q1 = x_i - (int32_t)y1[i];
-        const int32_t q2 = x_i - (int32_t)y2[i];
-        const int32_t q3 = x_i - (int32_t)y3[i];
+        auto x_i = static_cast<int32_t>(x[i]);
+        const int32_t q0 = x_i - static_cast<int32_t>(y0[i]);
+        const int32_t q1 = x_i - static_cast<int32_t>(y1[i]);
+        const int32_t q2 = x_i - static_cast<int32_t>(y2[i]);
+        const int32_t q3 = x_i - static_cast<int32_t>(y3[i]);
         d0 += q0 * q0;
         d1 += q1 * q1;
         d2 += q2 * q2;
         d3 += q3 * q3;
     }
 
-    dis0 = (float)d0;
-    dis1 = (float)d1;
-    dis2 = (float)d2;
-    dis3 = (float)d3;
+    dis0 = static_cast<float>(d0);
+    dis1 = static_cast<float>(d1);
+    dis2 = static_cast<float>(d2);
+    dis3 = static_cast<float>(d3);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -485,8 +485,8 @@ rabitq_dp_popcnt_ref(const uint8_t* q, const uint8_t* x, const size_t d, const s
         // process 64-bit popcounts
         int count_dot = 0;
         for (size_t i = 0; i < di_64b; i += 8) {
-            const auto qv = *(const uint64_t*)(q_j + i);
-            const auto xv = *(const uint64_t*)(x + i);
+            const auto qv = *reinterpret_cast<const uint64_t*>(q_j + i);
+            const auto xv = *reinterpret_cast<const uint64_t*>(x + i);
             count_dot += __builtin_popcountll(qv & xv);
         }
 
@@ -514,10 +514,10 @@ minhash_lsh_hit_ref(const char* x, const char* y, size_t dim, size_t mh_lsh_band
         size_t j = r;
         bool eq = true;
         while (j >= 16) {
-            if (*(const uint64_t*)(x_b + 8) != *(const uint64_t*)(y_b + 8)) {
+            if (*reinterpret_cast<const uint64_t*>(x_b + 8) != *reinterpret_cast<const uint64_t*>(y_b + 8)) {
                 goto next_band;
             }
-            if (*(const uint64_t*)(x_b) != *(const uint64_t*)(y_b)) {
+            if (*reinterpret_cast<const uint64_t*>(x_b) != *reinterpret_cast<const uint64_t*>(y_b)) {
                 goto next_band;
             }
             j -= 16;
@@ -525,7 +525,7 @@ minhash_lsh_hit_ref(const char* x, const char* y, size_t dim, size_t mh_lsh_band
             y_b += 16;
         }
         if (j >= 8) {
-            if (*(const uint64_t*)(x_b) != *(const uint64_t*)(y_b)) {
+            if (*reinterpret_cast<const uint64_t*>(x_b) != *reinterpret_cast<const uint64_t*>(y_b)) {
                 goto next_band;
             }
             j -= 8;
@@ -603,8 +603,8 @@ calculate_hash_ref(const char* data, size_t size) {
 float
 u32_jaccard_distance_ref(const char* x, const char* y, size_t element_length, size_t element_size) {
     float res = 0.0;
-    auto u32_x = (const uint32_t*)x;
-    auto u32_y = (const uint32_t*)y;
+    auto u32_x = reinterpret_cast<const uint32_t*>(x);
+    auto u32_y = reinterpret_cast<const uint32_t*>(y);
     for (size_t i = 0; i < element_length; i++) {
         res += (u32_x[i] == u32_y[i]);
     }
@@ -615,11 +615,11 @@ u32_jaccard_distance_batch_4_ref(const char* x, const char* y0, const char* y1, 
                                  size_t element_length, size_t element_size, float& dis0, float& dis1, float& dis2,
                                  float& dis3) {
     dis0 = dis1 = dis2 = dis3 = 0.0;
-    auto u32_x = (const uint32_t*)x;
-    auto u32_y0 = (const uint32_t*)y0;
-    auto u32_y1 = (const uint32_t*)y1;
-    auto u32_y2 = (const uint32_t*)y2;
-    auto u32_y3 = (const uint32_t*)y3;
+    auto u32_x = reinterpret_cast<const uint32_t*>(x);
+    auto u32_y0 = reinterpret_cast<const uint32_t*>(y0);
+    auto u32_y1 = reinterpret_cast<const uint32_t*>(y1);
+    auto u32_y2 = reinterpret_cast<const uint32_t*>(y2);
+    auto u32_y3 = reinterpret_cast<const uint32_t*>(y3);
     for (size_t i = 0; i < element_length; i++) {
         dis0 += (u32_x[i] == u32_y0[i]);
         dis1 += (u32_x[i] == u32_y1[i]);
@@ -635,8 +635,8 @@ u32_jaccard_distance_batch_4_ref(const char* x, const char* y0, const char* y1, 
 float
 u64_jaccard_distance_ref(const char* x, const char* y, size_t element_length, size_t element_size) {
     float res = 0.0;
-    auto u64_x = (const uint64_t*)x;
-    auto u64_y = (const uint64_t*)y;
+    auto u64_x = reinterpret_cast<const uint64_t*>(x);
+    auto u64_y = reinterpret_cast<const uint64_t*>(y);
     for (size_t i = 0; i < element_length; i++) {
         res += (u64_x[i] == u64_y[i]);
     }
@@ -647,11 +647,11 @@ u64_jaccard_distance_batch_4_ref(const char* x, const char* y0, const char* y1, 
                                  size_t element_length, size_t element_size, float& dis0, float& dis1, float& dis2,
                                  float& dis3) {
     dis0 = dis1 = dis2 = dis3 = 0.0;
-    auto u64_x = (const uint64_t*)x;
-    auto u64_y0 = (const uint64_t*)y0;
-    auto u64_y1 = (const uint64_t*)y1;
-    auto u64_y2 = (const uint64_t*)y2;
-    auto u64_y3 = (const uint64_t*)y3;
+    auto u64_x = reinterpret_cast<const uint64_t*>(x);
+    auto u64_y0 = reinterpret_cast<const uint64_t*>(y0);
+    auto u64_y1 = reinterpret_cast<const uint64_t*>(y1);
+    auto u64_y2 = reinterpret_cast<const uint64_t*>(y2);
+    auto u64_y3 = reinterpret_cast<const uint64_t*>(y3);
     for (size_t i = 0; i < element_length; i++) {
         dis0 += (u64_x[i] == u64_y0[i]);
         dis1 += (u64_x[i] == u64_y1[i]);

--- a/src/simd/distances_sse.cc
+++ b/src/simd/distances_sse.cc
@@ -64,7 +64,7 @@ mm_masked_read_short(int d, const uint16_t* x) {
         case 1:
             buf[0] = x[0];
     }
-    return _mm_loadu_si128((__m128i*)buf);
+    return _mm_loadu_si128(reinterpret_cast<__m128i*>(buf));
 }
 
 inline __m128
@@ -148,7 +148,7 @@ fvec_madd_sse(size_t n, const float* a, float bf, const float* b, float* c) {
     __m128 bf4 = _mm_set_ps1(bf);
     __m128* a4 = (__m128*)a;
     __m128* b4 = (__m128*)b;
-    __m128* c4 = (__m128*)c;
+    __m128* c4 = reinterpret_cast<__m128*>(c);
 
     while (n--) {
         *c4 = _mm_add_ps(*a4, _mm_mul_ps(bf4, *b4));
@@ -172,7 +172,7 @@ fvec_madd_and_argmin_sse(size_t n, const float* a, float bf, const float* b, flo
     __m128i inc4 = _mm_set1_epi32(4);
     __m128* a4 = (__m128*)a;
     __m128* b4 = (__m128*)b;
-    __m128* c4 = (__m128*)c;
+    __m128* c4 = reinterpret_cast<__m128*>(c);
 
     while (n--) {
         __m128 vc4 = _mm_add_ps(*a4, _mm_mul_ps(bf4, *b4));
@@ -414,7 +414,7 @@ int32_t
 ivec_inner_product_sse(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     for (size_t i = 0; i < d; i++) {
-        res += (int32_t)x[i] * y[i];
+        res += static_cast<int32_t>(x[i]) * y[i];
     }
     return res;
 }
@@ -423,7 +423,7 @@ int32_t
 ivec_L2sqr_sse(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     for (size_t i = 0; i < d; i++) {
-        const int32_t tmp = (int32_t)x[i] - (int32_t)y[i];
+        const int32_t tmp = static_cast<int32_t>(x[i]) - static_cast<int32_t>(y[i]);
         res += tmp * tmp;
     }
     return res;
@@ -436,8 +436,8 @@ float
 bf16_vec_inner_product_sse(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size_t d) {
     __m128 m_res = _mm_setzero_ps();
     while (d >= 4) {
-        __m128 m_x = _mm_bf16_to_fp32(_mm_loadl_epi64((const __m128i*)x));
-        __m128 m_y = _mm_bf16_to_fp32(_mm_loadl_epi64((const __m128i*)y));
+        __m128 m_x = _mm_bf16_to_fp32(_mm_loadl_epi64(reinterpret_cast<const __m128i*>(x)));
+        __m128 m_y = _mm_bf16_to_fp32(_mm_loadl_epi64(reinterpret_cast<const __m128i*>(y)));
         m_res = _mm_add_ps(m_res, _mm_mul_ps(m_x, m_y));
         x += 4;
         y += 4;
@@ -457,8 +457,8 @@ float
 bf16_vec_L2sqr_sse(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size_t d) {
     __m128 m_res = _mm_setzero_ps();
     while (d >= 4) {
-        __m128 m_x = _mm_bf16_to_fp32(_mm_loadl_epi64((const __m128i*)x));
-        __m128 m_y = _mm_bf16_to_fp32(_mm_loadl_epi64((const __m128i*)y));
+        __m128 m_x = _mm_bf16_to_fp32(_mm_loadl_epi64(reinterpret_cast<const __m128i*>(x)));
+        __m128 m_y = _mm_bf16_to_fp32(_mm_loadl_epi64(reinterpret_cast<const __m128i*>(y)));
         m_x = _mm_sub_ps(m_x, m_y);
         m_res = _mm_add_ps(m_res, _mm_mul_ps(m_x, m_x));
         x += 4;
@@ -480,7 +480,7 @@ float
 bf16_vec_norm_L2sqr_sse(const ::knowhere::bf16* x, size_t d) {
     __m128 m_res = _mm_setzero_ps();
     while (d >= 4) {
-        __m128 m_x = _mm_bf16_to_fp32(_mm_loadl_epi64((const __m128i*)x));
+        __m128 m_x = _mm_bf16_to_fp32(_mm_loadl_epi64(reinterpret_cast<const __m128i*>(x)));
         m_res = _mm_add_ps(m_res, _mm_mul_ps(m_x, m_x));
         x += 4;
         d -= 4;
@@ -503,9 +503,9 @@ int8_vec_inner_product_sse(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i < d; i++) {
-        res += (int32_t)x[i] * (int32_t)y[i];
+        res += static_cast<int32_t>(x[i]) * static_cast<int32_t>(y[i]);
     }
-    return (float)res;
+    return static_cast<float>(res);
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
@@ -515,10 +515,10 @@ int8_vec_L2sqr_sse(const int8_t* x, const int8_t* y, size_t d) {
     int32_t res = 0;
     FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i < d; i++) {
-        const int32_t tmp = (int32_t)x[i] - (int32_t)y[i];
+        const int32_t tmp = static_cast<int32_t>(x[i]) - static_cast<int32_t>(y[i]);
         res += tmp * tmp;
     }
-    return (float)res;
+    return static_cast<float>(res);
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
@@ -528,9 +528,9 @@ int8_vec_norm_L2sqr_sse(const int8_t* x, size_t d) {
     int32_t res = 0;
     FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i < d; i++) {
-        res += (int32_t)x[i] * (int32_t)x[i];
+        res += static_cast<int32_t>(x[i]) * static_cast<int32_t>(x[i]);
     }
-    return (float)res;
+    return static_cast<float>(res);
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
@@ -565,8 +565,8 @@ rabitq_dp_popcnt_sse(const uint8_t* q, const uint8_t* x, const size_t d, const s
         // process 64-bit popcounts
         int count_dot = 0;
         for (size_t i = 0; i < di_64b; i += 8) {
-            const auto qv = *(const uint64_t*)(q_j + i);
-            const auto xv = *(const uint64_t*)(x + i);
+            const auto qv = *reinterpret_cast<const uint64_t*>(q_j + i);
+            const auto xv = *reinterpret_cast<const uint64_t*>(x + i);
             count_dot += __builtin_popcountll(qv & xv);
         }
 

--- a/src/simd/distances_sse.cc
+++ b/src/simd/distances_sse.cc
@@ -139,28 +139,25 @@ fvec_Linf_sse(const float* x, const float* y, size_t d) {
 
 void
 fvec_madd_sse(size_t n, const float* a, float bf, const float* b, float* c) {
-    if ((n & 3) != 0 || ((((int64_t)a) | ((int64_t)b) | ((int64_t)c)) & 15) != 0) {
+    if ((n & 3) != 0) {
         fvec_madd_ref(n, a, bf, b, c);
         return;
     }
 
     n >>= 2;
     __m128 bf4 = _mm_set_ps1(bf);
-    __m128* a4 = (__m128*)a;
-    __m128* b4 = (__m128*)b;
-    __m128* c4 = reinterpret_cast<__m128*>(c);
 
     while (n--) {
-        *c4 = _mm_add_ps(*a4, _mm_mul_ps(bf4, *b4));
-        b4++;
-        a4++;
-        c4++;
+        _mm_storeu_ps(c, _mm_add_ps(_mm_loadu_ps(a), _mm_mul_ps(bf4, _mm_loadu_ps(b))));
+        a += 4;
+        b += 4;
+        c += 4;
     }
 }
 
 int
 fvec_madd_and_argmin_sse(size_t n, const float* a, float bf, const float* b, float* c) {
-    if ((n & 3) != 0 || ((((int64_t)a) | ((int64_t)b) | ((int64_t)c)) & 15) != 0) {
+    if ((n & 3) != 0) {
         return fvec_madd_and_argmin_ref(n, a, bf, b, c);
     }
 
@@ -170,21 +167,18 @@ fvec_madd_and_argmin_sse(size_t n, const float* a, float bf, const float* b, flo
     __m128i imin4 = _mm_set1_epi32(-1);
     __m128i idx4 = _mm_set_epi32(3, 2, 1, 0);
     __m128i inc4 = _mm_set1_epi32(4);
-    __m128* a4 = (__m128*)a;
-    __m128* b4 = (__m128*)b;
-    __m128* c4 = reinterpret_cast<__m128*>(c);
 
     while (n--) {
-        __m128 vc4 = _mm_add_ps(*a4, _mm_mul_ps(bf4, *b4));
-        *c4 = vc4;
+        __m128 vc4 = _mm_add_ps(_mm_loadu_ps(a), _mm_mul_ps(bf4, _mm_loadu_ps(b)));
+        _mm_storeu_ps(c, vc4);
         __m128i mask = _mm_castps_si128(_mm_cmpgt_ps(vmin4, vc4));
         // imin4 = _mm_blendv_epi8 (imin4, idx4, mask); // slower!
 
         imin4 = _mm_or_si128(_mm_and_si128(mask, idx4), _mm_andnot_si128(mask, imin4));
         vmin4 = _mm_min_ps(vmin4, vc4);
-        b4++;
-        a4++;
-        c4++;
+        a += 4;
+        b += 4;
+        c += 4;
         idx4 = _mm_add_epi32(idx4, inc4);
     }
 
@@ -444,8 +438,8 @@ bf16_vec_inner_product_sse(const ::knowhere::bf16* x, const ::knowhere::bf16* y,
         d -= 4;
     }
     if (d > 0) {
-        __m128 m_x = _mm_bf16_to_fp32(mm_masked_read_short(d, (uint16_t*)x));
-        __m128 m_y = _mm_bf16_to_fp32(mm_masked_read_short(d, (uint16_t*)y));
+        __m128 m_x = _mm_bf16_to_fp32(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(x)));
+        __m128 m_y = _mm_bf16_to_fp32(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(y)));
         m_res = _mm_add_ps(m_res, _mm_mul_ps(m_x, m_y));
     }
     m_res = _mm_hadd_ps(m_res, m_res);
@@ -466,8 +460,8 @@ bf16_vec_L2sqr_sse(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size_t 
         d -= 4;
     }
     if (d > 0) {
-        __m128 m_x = _mm_bf16_to_fp32(mm_masked_read_short(d, (uint16_t*)x));
-        __m128 m_y = _mm_bf16_to_fp32(mm_masked_read_short(d, (uint16_t*)y));
+        __m128 m_x = _mm_bf16_to_fp32(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(x)));
+        __m128 m_y = _mm_bf16_to_fp32(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(y)));
         m_x = _mm_sub_ps(m_x, m_y);
         m_res = _mm_add_ps(m_res, _mm_mul_ps(m_x, m_x));
     }
@@ -486,7 +480,7 @@ bf16_vec_norm_L2sqr_sse(const ::knowhere::bf16* x, size_t d) {
         d -= 4;
     }
     if (d > 0) {
-        __m128 m_x = _mm_bf16_to_fp32(mm_masked_read_short(d, (uint16_t*)x));
+        __m128 m_x = _mm_bf16_to_fp32(mm_masked_read_short(d, reinterpret_cast<const uint16_t*>(x)));
         m_res = _mm_add_ps(m_res, _mm_mul_ps(m_x, m_x));
     }
     m_res = _mm_hadd_ps(m_res, m_res);

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -163,7 +163,7 @@ supports_sve() {
 void
 fvec_hook(std::string& simd_type) {
     static std::mutex hook_mutex;
-    std::lock_guard<std::mutex> lock(hook_mutex);
+    std::scoped_lock lock(hook_mutex);
 #if defined(__x86_64__)
     if (use_avx512 && cpu_support_avx512()) {
         fvec_inner_product = fvec_inner_product_avx512;

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 import faiss
-from bfloat16 import bfloat16
+from ml_dtypes import bfloat16
 
 
 @pytest.fixture()
@@ -17,7 +17,7 @@ def gen_data():
 @pytest.fixture()
 def gen_data_with_type():
     def wrap(xb_rows, xq_rows, dim, type):
-        if type == np.float16 or bfloat16:
+        if type == np.float16 or type == bfloat16:
             xb = np.random.randn(xb_rows, dim).astype(type)
             xq = np.random.randn(xq_rows, dim).astype(type)
             # To fix nan or inf when type is equal to float16

--- a/tests/python/test_index_load_and_save.py
+++ b/tests/python/test_index_load_and_save.py
@@ -3,7 +3,7 @@ import json
 import pytest
 import os
 import numpy as np
-from bfloat16 import bfloat16
+from ml_dtypes import bfloat16
 
 test_data = [
     (

--- a/tests/python/test_index_random.py
+++ b/tests/python/test_index_random.py
@@ -2,7 +2,7 @@ import knowhere
 import json
 import pytest
 import numpy as np
-from bfloat16 import bfloat16
+from ml_dtypes import bfloat16
 
 test_data = [
     (


### PR DESCRIPTION
This change allows building on Ubuntu 22.04, Ubuntu 24.04 and Ubuntu 26.04 or x86 and ARM, for `gcc-12`/`gcc-13`/`gcc-15` and `clang-22`.

Additional changes:
* Upgrades `conan` to `2.28.1` in order to support `clang-22`
* Introduces `uv`
* replaces `bfloat16` with `ml-dtypes`
* replaces `numpy<2` with `numpy` 2+
* fixes a problem with `SWIG` on Ubuntu 26.04
* dumps Python 3.8 and 3.9, but adds 3.12, 3.13 and 3.14

This is the first change of the following updates.

/kind improvement
issue: #1615 