### PR TITLE
ci: disable SSE CI

### DIFF
--- a/ci/E2E2-SSE.groovy
+++ b/ci/E2E2-SSE.groovy
@@ -1,92 +1,10 @@
-int total_timeout_minutes = 480
-def knowhere_wheel=''
 pipeline {
-    agent {
-        kubernetes {
-            cloud "new_ci_idc"
-            inheritFrom 'default'
-            yamlFile 'ci/pod/e2e-cpu.yaml'
-            defaultContainer 'main'
-            podRetention never()
-            idleMinutes 0
-        }
-    }
+    agent none
 
-    options {
-        timeout(time: total_timeout_minutes, unit: 'MINUTES')
-        buildDiscarder logRotator(artifactDaysToKeepStr: '30')
-        parallelsAlwaysFailFast()
-        disableConcurrentBuilds(abortPrevious: true)
-        preserveStashes(buildCount: 10)
-    }
     stages {
-        stage("Build"){
+        stage("Disabled"){
             steps {
-                container("main"){
-                    script{
-                        def date = sh(returnStdout: true, script: 'date +%Y%m%d').trim()
-                        def gitShortCommit = sh(returnStdout: true, script: "echo ${env.GIT_COMMIT} | cut -b 1-7 ").trim()
-                        version="${env.CHANGE_ID}.${date}.${gitShortCommit}"
-                        sh "bash scripts/install_deps.sh"
-                        // SSE: override libopenblas-openmp-dev with non-openmp variant
-                        sh "apt-get install -y libopenblas-dev"
-                        sh "cmake --version"
-                        sh "make"
-                        sh "cd python && VERSION=${version} ./build_portable_wheel.sh"
-                        dir('python/dist'){
-                        knowhere_wheel=sh(returnStdout: true, script: 'ls | grep manylinux.*\\.whl').trim()
-                        archiveArtifacts artifacts: "${knowhere_wheel}", followSymlinks: false
-                        }
-                        // stash knowhere info for rebuild E2E Test only
-                        sh "echo ${knowhere_wheel} > knowhere.txt"
-                        stash includes: 'knowhere.txt', name: 'knowhereWheel'
-                    }
-                }
-            }
-        }
-        stage("Test"){
-            agent {
-                kubernetes {
-                    cloud "new_ci_idc"
-                    inheritFrom 'default'
-                    yamlFile 'ci/pod/e2e-sse.yaml'
-                    defaultContainer 'main'
-                    podRetention never()
-                    idleMinutes 0
-                }
-            }
-            steps {
-                script{
-                    if ("${knowhere_wheel}"==''){
-                        dir ("knowhereWheel"){
-                            try{
-                                unstash 'knowhereWheel'
-                                knowhere_wheel=sh(returnStdout: true, script: 'cat knowhere.txt | tr -d \'\n\r\'')
-                            }catch(e){
-                                error "No knowhereWheel info remained ,please rerun build to build new package."
-                            }
-                        }
-                    }
-                    checkout([$class: 'GitSCM', branches: [[name: '*/main']], extensions: [],
-                    userRemoteConfigs: [[credentialsId: 'milvus-ci', url: 'https://github.com/milvus-io/knowhere-test.git']]])
-                    dir('tests'){
-                      unarchive mapping: ["${knowhere_wheel}": "${knowhere_wheel}"]
-                      sh "apt-get update || true"
-                      sh "apt-get install -y libopenblas-dev libaio-dev libdouble-conversion-dev libevent-dev"
-                      sh "pip3 install ${knowhere_wheel}"
-                      sh "cat requirements.txt | xargs -n 1 pip3 install"
-                      sh "cp -r /home/data/milvus/ann_fbin/ ."
-                      sh "pytest -v -m 'L0'"
-                    }
-                }
-            }
-            post{
-                always {
-                    script{
-                        sh 'cat tests/pytest.log'
-                        archiveArtifacts artifacts: 'tests/pytest.log', followSymlinks: false
-                    }
-                }
+                echo "SSE CI is disabled."
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace the SSE Jenkins pipeline with a no-op stage
- use `agent none` so the disabled job does not allocate the SSE Kubernetes pod

## Testing
- `if rg -n "ci/pod/e2e-sse.yaml|build_portable_wheel|pytest -v -m 'L0'" ci/E2E2-SSE.groovy; then echo "SSE CI is still active"; exit 1; fi; echo "SSE CI no-op check passed"`
- `git diff --check`
