### PR TITLE
ci: remove CPU e2e timeout caps

### DIFF
--- a/ci/E2E-arm.groovy
+++ b/ci/E2E-arm.groovy
@@ -1,4 +1,3 @@
-int total_timeout_minutes = 120
 def knowhere_wheel=''
 pipeline {
     agent {
@@ -10,7 +9,6 @@ pipeline {
     }
 
     options {
-        timeout(time: total_timeout_minutes, unit: 'MINUTES')
         buildDiscarder logRotator(artifactDaysToKeepStr: '30')
         parallelsAlwaysFailFast()
         disableConcurrentBuilds(abortPrevious: true)

--- a/ci/E2E2.groovy
+++ b/ci/E2E2.groovy
@@ -1,4 +1,3 @@
-// int total_timeout_minutes = 120
 def knowhere_wheel=''
 pipeline {
     agent {
@@ -11,7 +10,6 @@ pipeline {
     }
 
     options {
-        // timeout(time: total_timeout_minutes, unit: 'MINUTES')
         buildDiscarder logRotator(artifactDaysToKeepStr: '30')
         parallelsAlwaysFailFast()
         disableConcurrentBuilds(abortPrevious: true)


### PR DESCRIPTION
issue: #1604

## Summary
- remove the active 120-minute top-level timeout from ARM CPU e2e
- remove the old commented timeout lines from x86 CPU e2e

## Testing
- `rg -n "total_timeout_minutes|timeout\(time: total_timeout_minutes" ci/E2E-arm.groovy ci/E2E2.groovy` returns no matches
- `git diff --check -- ci/E2E-arm.groovy ci/E2E2.groovy`