### PR TITLE
Fix build errors when WITH_CARDINAL=true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ WITH_BENCHMARK ?=
 WITH_ASAN ?=
 WITH_SVS ?=
 WITH_CARDINAL ?=
+CARDINAL_VERSION_FORCE_CHECKOUT ?=
 WITH_DEBUG ?=
 CONAN_PROFILE ?=
 
@@ -35,7 +36,7 @@ CONAN_PROFILE ?=
 # variables such as WITH_ASAN to every sub-process, which causes the custom
 # folly recipe to pick up $ENV{WITH_ASAN} and compile folly itself with
 # -fsanitize=address — breaking the build on GCC.
-unexport WITH_GPU WITH_UT WITH_BENCHMARK WITH_ASAN WITH_CARDINAL WITH_DEBUG
+unexport WITH_GPU WITH_UT WITH_BENCHMARK WITH_ASAN WITH_CARDINAL CARDINAL_VERSION_FORCE_CHECKOUT WITH_DEBUG
 
 # ---------- Derived settings ----------
 ifdef WITH_DEBUG
@@ -90,6 +91,16 @@ endif
 
 ifdef WITH_CARDINAL
     CONAN_SETTINGS += -o \&:with_cardinal=True
+endif
+
+ifneq ($(CARDINAL_VERSION_FORCE_CHECKOUT),)
+    ifneq ($(filter True true ON on 1,$(CARDINAL_VERSION_FORCE_CHECKOUT)),)
+        CONAN_SETTINGS += -o \&:cardinal_version_force_checkout=True
+    else ifneq ($(filter False false OFF off 0,$(CARDINAL_VERSION_FORCE_CHECKOUT)),)
+        CONAN_SETTINGS += -o \&:cardinal_version_force_checkout=False
+    else
+        $(error CARDINAL_VERSION_FORCE_CHECKOUT must be True/False, ON/OFF, or 1/0)
+    endif
 endif
 
 ifdef CONAN_PROFILE
@@ -160,6 +171,7 @@ help: ## Show available targets
 	@echo "  WITH_ASAN=True     Enable AddressSanitizer"
 	@echo "  WITH_SVS=True      Enable SVS (Intel Scalable Vector Search, x86 only)"
 	@echo "  WITH_CARDINAL=True Enable Cardinal build"
+	@echo "  CARDINAL_VERSION_FORCE_CHECKOUT=True Force Cardinal checkout to configured version"
 	@echo "  WITH_DEBUG=True    Debug build (default: Release)"
 	@echo "  CONAN_PROFILE=<p>  Use a custom Conan profile (e.g. clang, gcc-15)"
 	@echo "  LIBCXX=<lib>       Override compiler.libcxx (auto-detected from OS)"

--- a/cmake/libs/cardinal/v1/CMakeLists.txt
+++ b/cmake/libs/cardinal/v1/CMakeLists.txt
@@ -3,7 +3,7 @@ project(knowhere CXX C)
 
 # Use short SHA1 as version
 # v2.5 tag is used for cardinal v1
-set(CARDINAL_VERSION v2.5.105)
+set(CARDINAL_VERSION v1_blas)
 set(CARDINAL_REPO_URL "https://github.com/zilliztech/cardinal.git")
 
 set(CARDINAL_ROOT  "${KNOWHERE_THRID_ROOT}/cardinalv1")

--- a/cmake/libs/cardinal/v2/CMakeLists.txt
+++ b/cmake/libs/cardinal/v2/CMakeLists.txt
@@ -3,7 +3,7 @@ project(knowhere CXX C)
 
 # Use short SHA1 as version
 # v2.6 tag is used for cardinal v2
-set(CARDINAL_VERSION v3.0.1)
+set(CARDINAL_VERSION recipe)
 set(CARDINAL_REPO_URL "https://github.com/zilliztech/cardinal.git")
 
 set(CARDINAL_ROOT  "${KNOWHERE_THRID_ROOT}/cardinalv2")

--- a/conanfile.py
+++ b/conanfile.py
@@ -28,6 +28,7 @@ class KnowhereConan(ConanFile):
         "with_diskann": [True, False],
         "with_svs": [True, False],
         "with_cardinal": [True, False],
+        "cardinal_version_force_checkout": [True, False],
         "with_profiler": [True, False],
         "with_ut": [True, False],
         "with_benchmark": [True, False],
@@ -44,6 +45,7 @@ class KnowhereConan(ConanFile):
         "with_diskann": False,
         "with_svs": False,
         "with_cardinal": False,
+        "cardinal_version_force_checkout": False,
         "with_profiler": False,
         "with_ut": False,
         "glog/*:shared": True,
@@ -59,6 +61,7 @@ class KnowhereConan(ConanFile):
         "openssl/*:no_apps": True,
         "gflags/*:shared": True,
         "fmt/*:header_only": False,
+        "openblas/*:dynamic_arch": True,
         "with_faiss_tests": False,
         "opentelemetry-cpp/*:with_stl": True,
         "libcurl/*:with_ssl": False,
@@ -107,7 +110,7 @@ class KnowhereConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-        if self.settings.os in ["Linux", "Android"] and str(self.settings.arch) in self._openblas_dynamic_arches:
+        if self.settings.os == "Linux" and str(self.settings.arch) in self._openblas_dynamic_arches:
             self.options["openblas"].dynamic_arch = True
 
     def requirements(self):
@@ -136,11 +139,9 @@ class KnowhereConan(ConanFile):
         self.requires("xxhash/0.8.3#caa6d0af1b951c247922e38fbcebdbe6")
         if self.settings.os == "Linux":
             self.requires("openblas/0.3.30")
-        if self.settings.os == "Android":
-            self.requires("openblas/0.3.30")
         if not self.options.with_light:
             self.requires("opentelemetry-cpp/1.23.0@milvus/dev#11bc565ec6e82910ae8f7471da756720")
-        if self.settings.os not in ["Macos", "Android"]:
+        if self.settings.os != "Macos":
             self.requires("libunwind/1.8.1#748a981ace010b80163a08867b732e71")
         if self.options.with_ut:
             self.requires("catch2/3.7.1")
@@ -210,6 +211,7 @@ class KnowhereConan(ConanFile):
         tc.variables["WITH_DISKANN"] = self.options.with_diskann
         tc.variables["WITH_SVS"] = self.options.with_svs
         tc.variables["WITH_CARDINAL"] = self.options.with_cardinal
+        tc.variables["CARDINAL_VERSION_FORCE_CHECKOUT"] = self.options.cardinal_version_force_checkout
         tc.variables["WITH_CUVS"] = self.options.with_cuvs
         tc.variables["WITH_PROFILER"] = self.options.with_profiler
         tc.variables["WITH_UT"] = self.options.with_ut


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/1580

We are currently using the recipe branch of the Cardinal repository because the pull request has not yet been merged into the Cardinal repository: https://github.com/zilliztech/cardinal/pull/834. The Cardinal repository fetches Knowhere to execute the CI workflow, creating a coupling between the two repositories. To decouple them:
1. Use the Cardinal recipe branch in Knowhere to pass the CI check.
2. In Cardinal's PR [#834](https://github.com/zilliztech/cardinal/pull/834), use the Knowhere branch to run CI.
3. Merge the Knowhere PR.
4. In Cardinal's PR [#834](https://github.com/zilliztech/cardinal/pull/834), switch to using the Knowhere master branch to run CI, and merge the Cardinal PR once CI has passed.

Expose a variable CARDINAL_VERSION_FORCE_CHECKOUT, so local/CI builds can force thirdparty/cardinalv2 to the configured branch/tag.
After this fix, both "make" command and "make WITH_CARDINAL=true" can succeed.