### PR TITLE
Optimize sparse query scorer dispatch

### DIFF
--- a/src/index/sparse/inverted_index.h
+++ b/src/index/sparse/inverted_index.h
@@ -541,23 +541,25 @@ CRTPInvertedIndex<IndexType, DType>::get_all_distances(const SparseRow<DType>& q
 
     std::vector<float> distances(this->nr_rows_, 0.0f);
 
-    std::shared_ptr<IndexScorer> search_scorer;
-    if (search_params.scorer_config.scorer_type == IndexScorerType::BM25) {
-        search_scorer = std::make_shared<BM25IndexScorer>(
-            search_params.scorer_config.scorer_params.bm25.k1, search_params.scorer_config.scorer_params.bm25.b,
-            search_params.scorer_config.scorer_params.bm25.avgdl, this->get_row_sums());
-    } else {
-        search_scorer = std::make_shared<IPIndexScorer>();
-    }
-
     const auto* self = static_cast<const IndexType*>(this);
-    for (const auto& [dim_id, dim_val] : q_vec) {
-        auto index_cursor = self->get_dim_plist_cursor(dim_id, bitset);
-        auto scorer = search_scorer->dim_scorer(dim_val);
-        while (index_cursor.valid()) {
-            distances[index_cursor.vec_id()] += scorer(index_cursor.vec_id(), index_cursor.val());
-            index_cursor.next();
+    auto accumulate_distances = [&](const auto& search_scorer) {
+        for (const auto& [dim_id, dim_val] : q_vec) {
+            auto index_cursor = self->get_dim_plist_cursor(dim_id, bitset);
+            auto scorer = search_scorer.dim_scorer(dim_val);
+            while (index_cursor.valid()) {
+                distances[index_cursor.vec_id()] += scorer(index_cursor.vec_id(), index_cursor.val());
+                index_cursor.next();
+            }
         }
+    };
+
+    if (search_params.scorer_config.scorer_type == IndexScorerType::BM25) {
+        BM25QueryScorer search_scorer(search_params.scorer_config.scorer_params.bm25.k1,
+                                      search_params.scorer_config.scorer_params.bm25.b,
+                                      search_params.scorer_config.scorer_params.bm25.avgdl, this->get_row_sums());
+        accumulate_distances(search_scorer);
+    } else {
+        accumulate_distances(IPQueryScorer{});
     }
 
     return distances;
@@ -568,15 +570,6 @@ void
 CRTPInvertedIndex<IndexType, DType>::search(const SparseRow<DType>& query, size_t k, float* distances, label_t* labels,
                                             const BitsetView& bitset,
                                             const InvertedIndexSearchParams& search_params) const {
-    std::shared_ptr<IndexScorer> search_scorer;
-    if (search_params.scorer_config.scorer_type == IndexScorerType::BM25) {
-        search_scorer = std::make_shared<BM25IndexScorer>(
-            search_params.scorer_config.scorer_params.bm25.k1, search_params.scorer_config.scorer_params.bm25.b,
-            search_params.scorer_config.scorer_params.bm25.avgdl, this->meta_data_.row_sums_);
-    } else {
-        search_scorer = std::make_shared<IPIndexScorer>();
-    }
-
     std::fill(distances, distances + k, std::numeric_limits<float>::quiet_NaN());
     std::fill(labels, labels + k, -1);
 
@@ -598,48 +591,58 @@ CRTPInvertedIndex<IndexType, DType>::search(const SparseRow<DType>& query, size_
         }
     };
 
-    switch (search_params.algo) {
-        case InvertedIndexAlgo::DAAT_WAND: {
-            DaatWandSearcher<std::remove_reference_t<IndexType>> searcher(*static_cast<const IndexType*>(this), q_vec,
-                                                                          search_scorer, k, this->nr_rows_, bitset,
-                                                                          search_params.approx.dim_max_score_ratio);
-            searcher.search();
-            process_search_results(searcher);
-            break;
+    const auto* self = static_cast<const IndexType*>(this);
+    auto run_search = [&](const auto& search_scorer) {
+        using SearcherIndexType = std::remove_reference_t<IndexType>;
+        using QueryScorer = std::decay_t<decltype(search_scorer)>;
+        switch (search_params.algo) {
+            case InvertedIndexAlgo::DAAT_WAND: {
+                DaatWandSearcher<SearcherIndexType, QueryScorer> searcher(
+                    *self, q_vec, search_scorer, k, this->nr_rows_, bitset, search_params.approx.dim_max_score_ratio);
+                searcher.search();
+                process_search_results(searcher);
+                break;
+            }
+            case InvertedIndexAlgo::DAAT_MAXSCORE: {
+                DaatMaxScoreSearcher<SearcherIndexType, QueryScorer> searcher(
+                    *self, q_vec, search_scorer, k, this->nr_rows_, bitset, search_params.approx.dim_max_score_ratio);
+                searcher.search();
+                process_search_results(searcher);
+                break;
+            }
+            case InvertedIndexAlgo::TAAT_NAIVE: {
+                TaatNaiveSearcher<SearcherIndexType, QueryScorer> searcher(*self, q_vec, search_scorer, k,
+                                                                           this->nr_rows_, bitset);
+                searcher.search();
+                process_search_results(searcher);
+                break;
+            }
+            case InvertedIndexAlgo::BLOCK_MAX_MAXSCORE: {
+                BlockMaxMaxScoreSearcher<SearcherIndexType, QueryScorer> searcher(
+                    *self, q_vec, search_scorer, k, this->nr_rows_, bitset, search_params.approx.dim_max_score_ratio);
+                searcher.search();
+                process_search_results(searcher);
+                break;
+            }
+            case InvertedIndexAlgo::BLOCK_MAX_WAND: {
+                BlockMaxWandSearcher<SearcherIndexType, QueryScorer> searcher(
+                    *self, q_vec, search_scorer, k, this->nr_rows_, bitset, search_params.approx.dim_max_score_ratio);
+                searcher.search();
+                process_search_results(searcher);
+                break;
+            }
+            default:
+                LOG_KNOWHERE_ERROR_ << "Unsupported search algorithm";
         }
-        case InvertedIndexAlgo::DAAT_MAXSCORE: {
-            DaatMaxScoreSearcher<std::remove_reference_t<IndexType>> searcher(
-                *static_cast<const IndexType*>(this), q_vec, search_scorer, k, this->nr_rows_, bitset,
-                search_params.approx.dim_max_score_ratio);
-            searcher.search();
-            process_search_results(searcher);
-            break;
-        }
-        case InvertedIndexAlgo::TAAT_NAIVE: {
-            TaatNaiveSearcher<std::remove_reference_t<IndexType>> searcher(*static_cast<const IndexType*>(this), q_vec,
-                                                                           search_scorer, k, this->nr_rows_, bitset);
-            searcher.search();
-            process_search_results(searcher);
-            break;
-        }
-        case InvertedIndexAlgo::BLOCK_MAX_MAXSCORE: {
-            BlockMaxMaxScoreSearcher<std::remove_reference_t<IndexType>> searcher(
-                *static_cast<const IndexType*>(this), q_vec, search_scorer, k, this->nr_rows_, bitset,
-                search_params.approx.dim_max_score_ratio);
-            searcher.search();
-            process_search_results(searcher);
-            break;
-        }
-        case InvertedIndexAlgo::BLOCK_MAX_WAND: {
-            BlockMaxWandSearcher<std::remove_reference_t<IndexType>> searcher(
-                *static_cast<const IndexType*>(this), q_vec, search_scorer, k, this->nr_rows_, bitset,
-                search_params.approx.dim_max_score_ratio);
-            searcher.search();
-            process_search_results(searcher);
-            break;
-        }
-        default:
-            LOG_KNOWHERE_ERROR_ << "Unsupported search algorithm";
+    };
+
+    if (search_params.scorer_config.scorer_type == IndexScorerType::BM25) {
+        BM25QueryScorer search_scorer(search_params.scorer_config.scorer_params.bm25.k1,
+                                      search_params.scorer_config.scorer_params.bm25.b,
+                                      search_params.scorer_config.scorer_params.bm25.avgdl, this->get_row_sums());
+        run_search(search_scorer);
+    } else {
+        run_search(IPQueryScorer{});
     }
 }
 

--- a/src/index/sparse/scorer.h
+++ b/src/index/sparse/scorer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include <functional>
+#include <vector>
 
 namespace knowhere::sparse::inverted {
 
@@ -19,13 +19,61 @@ struct IndexScorerConfig {
     } scorer_params;
 };
 
-/**
- * DimScorer is a function that computes a relevance score for a vector.
- * @param uint32_t The vector ID
- * @param float The vector's dimension value, such as term frequency in BM25 or value in IP
- * @return float The computed relevance score
- */
-using DimScorer = std::function<float(uint32_t, float)>;
+// Query-time scorers are small concrete functors used in hot loops.
+// Build-time scorers keep the existing virtual interface for index construction
+// and metadata generation paths that are outside query scoring hot paths.
+struct IPDimScorer {
+    float qval;
+
+    template <typename RType>
+    [[nodiscard]] float
+    operator()(uint32_t /*rid*/, RType rval) const noexcept {
+        return qval * static_cast<float>(rval);
+    }
+};
+
+struct BM25DimScorer {
+    float qval;
+    float p1;
+    float p2;
+    float p3;
+    const float* row_sums;
+
+    template <typename RType>
+    [[nodiscard]] float
+    operator()(uint32_t rid, RType rval) const noexcept {
+        const float tf = static_cast<float>(rval);
+        return qval * p1 * tf / (tf + p2 + p3 * row_sums[rid]);
+    }
+};
+
+struct IPQueryScorer {
+    static constexpr auto scorer_type = IndexScorerType::IP;
+
+    [[nodiscard]] IPDimScorer
+    dim_scorer(float qval) const noexcept {
+        return {qval};
+    }
+};
+
+struct BM25QueryScorer {
+    static constexpr auto scorer_type = IndexScorerType::BM25;
+
+    float p1;
+    float p2;
+    float p3;
+    const float* row_sums;
+
+    explicit BM25QueryScorer(float k1, float b, float avgdl, const std::vector<float>& row_sums_in)
+        // row_sums stays valid as long as the underlying vector is not reallocated.
+        : p1(k1 + 1), p2(k1 * (1 - b)), p3(k1 * b / avgdl), row_sums(row_sums_in.data()) {
+    }
+
+    [[nodiscard]] BM25DimScorer
+    dim_scorer(float qval) const noexcept {
+        return {qval, p1, p2, p3, row_sums};
+    }
+};
 
 /** Index scorer construct scorers for dimensions in the index. */
 class IndexScorer {
@@ -38,8 +86,6 @@ class IndexScorer {
     IndexScorer&
     operator=(IndexScorer&&) noexcept = delete;
     virtual ~IndexScorer() = default;
-    [[nodiscard]] virtual DimScorer
-    dim_scorer(float qval) const = 0;
     [[nodiscard]] virtual float
     vec_score(uint32_t rid, float rval) const = 0;
 
@@ -57,11 +103,6 @@ struct IPIndexScorer : public IndexScorer {
  public:
     explicit IPIndexScorer() {
         config_.scorer_type = IndexScorerType::IP;
-    }
-
-    [[nodiscard]] DimScorer
-    dim_scorer(float qval) const override {
-        return [qval](uint32_t rid, float rval) { return qval * rval; };
     }
 
     [[nodiscard]] float
@@ -82,13 +123,6 @@ struct BM25IndexScorer : public IndexScorer {
     }
 
     ~BM25IndexScorer() override = default;
-
-    // In senario of BM25, qval is IDF value, rval is TF value
-    [[nodiscard]] DimScorer
-    dim_scorer(float qval) const override {
-        return
-            [&, qval](uint32_t rid, uint32_t rval) { return qval * p1_ * rval / (rval + p2_ + p3_ * row_sums_[rid]); };
-    }
 
     [[nodiscard]] float
     vec_score(uint32_t rid, float rval) const override {

--- a/src/index/sparse/searcher/block_max_maxscore.h
+++ b/src/index/sparse/searcher/block_max_maxscore.h
@@ -20,9 +20,11 @@
 
 namespace knowhere::sparse::inverted {
 
-template <typename IndexType>
+template <typename IndexType, typename QueryScorer>
 class BlockMaxMaxScoreSearcher : public RankedSearcher {
  public:
+    using DimScorer = decltype(std::declval<const QueryScorer&>().dim_scorer(0.0f));
+
     struct Cursor {
         typename IndexType::posting_list_iterator index_cursor;
         DimScorer scorer;
@@ -72,8 +74,8 @@ class BlockMaxMaxScoreSearcher : public RankedSearcher {
     };
 
     explicit BlockMaxMaxScoreSearcher(const IndexType& index, std::vector<std::pair<uint32_t, float>>& query,
-                                      const std::shared_ptr<IndexScorer>& search_scorer, const uint32_t k,
-                                      const uint32_t max_vec_id, const BitsetView& bitset, float dim_max_score_ratio)
+                                      const QueryScorer& search_scorer, const uint32_t k, const uint32_t max_vec_id,
+                                      const BitsetView& bitset, float dim_max_score_ratio)
         : RankedSearcher(k),
           cursors_([&]() {
               std::sort(query.begin(), query.end(), [&](auto& a, auto& b) {
@@ -159,12 +161,11 @@ class BlockMaxMaxScoreSearcher : public RankedSearcher {
  private:
     static std::vector<Cursor>
     make_cursors(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
-                 const std::shared_ptr<IndexScorer>& index_scorer, const BitsetView& bitset,
-                 float dim_max_score_ratio) {
+                 const QueryScorer& index_scorer, const BitsetView& bitset, float dim_max_score_ratio) {
         std::vector<Cursor> cursors;
         cursors.reserve(query.size());
         for (const auto& [dim_id, dim_val] : query) {
-            cursors.push_back(Cursor{index.get_dim_plist_cursor(dim_id, bitset), index_scorer->dim_scorer(dim_val),
+            cursors.push_back(Cursor{index.get_dim_plist_cursor(dim_id, bitset), index_scorer.dim_scorer(dim_val),
                                      dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val),
                                      index.get_block_max_data_cursor(dim_id), dim_val});
         }

--- a/src/index/sparse/searcher/block_max_wand.h
+++ b/src/index/sparse/searcher/block_max_wand.h
@@ -18,9 +18,11 @@
 
 namespace knowhere::sparse::inverted {
 
-template <typename IndexType>
+template <typename IndexType, typename QueryScorer>
 class BlockMaxWandSearcher : public RankedSearcher {
  public:
+    using DimScorer = decltype(std::declval<const QueryScorer&>().dim_scorer(0.0f));
+
     struct Cursor {
         typename IndexType::posting_list_iterator index_cursor;
         DimScorer scorer;
@@ -70,8 +72,8 @@ class BlockMaxWandSearcher : public RankedSearcher {
     };
 
     explicit BlockMaxWandSearcher(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
-                                  const std::shared_ptr<IndexScorer>& search_scorer, const uint32_t k,
-                                  const uint32_t max_vec_id, const BitsetView& bitset, float dim_max_score_ratio)
+                                  const QueryScorer& search_scorer, const uint32_t k, const uint32_t max_vec_id,
+                                  const BitsetView& bitset, float dim_max_score_ratio)
         : RankedSearcher(k),
           cursors_(make_cursors(index, query, search_scorer, bitset, dim_max_score_ratio)),
           max_vec_id_(max_vec_id) {
@@ -220,12 +222,11 @@ class BlockMaxWandSearcher : public RankedSearcher {
  private:
     static std::vector<Cursor>
     make_cursors(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
-                 const std::shared_ptr<IndexScorer>& index_scorer, const BitsetView& bitset,
-                 float dim_max_score_ratio) {
+                 const QueryScorer& index_scorer, const BitsetView& bitset, float dim_max_score_ratio) {
         std::vector<Cursor> cursors;
         cursors.reserve(query.size());
         for (const auto& [dim_id, dim_val] : query) {
-            cursors.push_back(Cursor{index.get_dim_plist_cursor(dim_id, bitset), index_scorer->dim_scorer(dim_val),
+            cursors.push_back(Cursor{index.get_dim_plist_cursor(dim_id, bitset), index_scorer.dim_scorer(dim_val),
                                      dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val),
                                      index.get_block_max_data_cursor(dim_id), dim_val});
         }

--- a/src/index/sparse/searcher/daat_maxscore.h
+++ b/src/index/sparse/searcher/daat_maxscore.h
@@ -19,9 +19,11 @@
 
 namespace knowhere::sparse::inverted {
 
-template <typename IndexType>
+template <typename IndexType, typename QueryScorer>
 class DaatMaxScoreSearcher : public RankedSearcher {
  public:
+    using DimScorer = decltype(std::declval<const QueryScorer&>().dim_scorer(0.0f));
+
     struct Cursor {
         typename IndexType::posting_list_iterator index_cursor;
         DimScorer scorer;
@@ -54,13 +56,12 @@ class DaatMaxScoreSearcher : public RankedSearcher {
     };
 
     explicit DaatMaxScoreSearcher(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
-                                  const std::shared_ptr<IndexScorer>& search_scorer, const uint32_t k,
-                                  const uint32_t max_vec_id, const BitsetView& bitset, float dim_max_score_ratio)
+                                  const QueryScorer& search_scorer, const uint32_t k, const uint32_t max_vec_id,
+                                  const BitsetView& bitset, float dim_max_score_ratio)
         : RankedSearcher(k),
           cursors_(make_cursors(index, query, search_scorer, bitset, dim_max_score_ratio)),
           max_vec_id_(max_vec_id),
-          row_sums_(index.get_row_sums()),
-          scorer_type_(search_scorer->config().scorer_type) {
+          row_sums_(index.get_row_sums()) {
     }
 
     [[nodiscard]] auto
@@ -99,7 +100,6 @@ class DaatMaxScoreSearcher : public RankedSearcher {
     enum class UpdateResult : bool { Continue, ShortCircuit };
     enum class VectorStatus : bool { Insert, Skip };
 
-    template <IndexScorerType ScorerType>
     void
     run_sorted(std::vector<Cursor>& cursors, uint64_t max_vec_id) {
         auto upper_bounds = calc_upper_bounds(cursors);
@@ -137,7 +137,7 @@ class DaatMaxScoreSearcher : public RankedSearcher {
                 current_score = 0;
                 current_vec_id = std::exchange(next_vec_id, max_vec_id);
 
-                if constexpr (ScorerType == IndexScorerType::BM25) {
+                if constexpr (QueryScorer::scorer_type == IndexScorerType::BM25) {
                     // Prefetch row_sums_ for next iterations that will be used by the BM25 scorer
                     // Experiments show this prefetch pattern is optimal vs only prefetching next_vec_id
                     __builtin_prefetch(&row_sums_[current_vec_id], 0, 3);
@@ -147,7 +147,7 @@ class DaatMaxScoreSearcher : public RankedSearcher {
                     if (cursor.vec_id() == current_vec_id) {
                         current_score += cursor.score();
                         cursor.next();
-                        if constexpr (ScorerType == IndexScorerType::BM25) {
+                        if constexpr (QueryScorer::scorer_type == IndexScorerType::BM25) {
                             // Prefetch row_sums_ for next iterations that will be used by the BM25 scorer
                             // Experiments show this prefetch pattern is optimal vs only prefetching next_vec_id
                             __builtin_prefetch(&row_sums_[cursor.vec_id()], 0, 3);
@@ -185,23 +185,18 @@ class DaatMaxScoreSearcher : public RankedSearcher {
             return;
         }
         auto cursors = sorted(cursors_);
-        if (scorer_type_ == IndexScorerType::BM25) {
-            run_sorted<IndexScorerType::BM25>(cursors, max_vec_id_);
-        } else {
-            run_sorted<IndexScorerType::IP>(cursors, max_vec_id_);
-        }
+        run_sorted(cursors, max_vec_id_);
         std::swap(cursors, cursors_);
     }
 
  private:
     static std::vector<Cursor>
     make_cursors(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
-                 const std::shared_ptr<IndexScorer>& index_scorer, const BitsetView& bitset,
-                 float dim_max_score_ratio) {
+                 const QueryScorer& index_scorer, const BitsetView& bitset, float dim_max_score_ratio) {
         std::vector<Cursor> cursors;
         cursors.reserve(query.size());
         for (const auto& [dim_id, dim_val] : query) {
-            cursors.push_back(Cursor{index.get_dim_plist_cursor(dim_id, bitset), index_scorer->dim_scorer(dim_val),
+            cursors.push_back(Cursor{index.get_dim_plist_cursor(dim_id, bitset), index_scorer.dim_scorer(dim_val),
                                      dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val)});
         }
         return cursors;
@@ -211,7 +206,6 @@ class DaatMaxScoreSearcher : public RankedSearcher {
     uint32_t max_vec_id_;
     // row_sums_ is only used for BM25 scorer
     const std::vector<float>& row_sums_;
-    IndexScorerType scorer_type_;
 };
 
 }  // namespace knowhere::sparse::inverted

--- a/src/index/sparse/searcher/daat_wand.h
+++ b/src/index/sparse/searcher/daat_wand.h
@@ -17,9 +17,11 @@
 
 namespace knowhere::sparse::inverted {
 
-template <typename IndexType>
+template <typename IndexType, typename QueryScorer>
 class DaatWandSearcher : public RankedSearcher {
  public:
+    using DimScorer = decltype(std::declval<const QueryScorer&>().dim_scorer(0.0f));
+
     struct Cursor {
         typename IndexType::posting_list_iterator index_cursor;
         DimScorer scorer;
@@ -52,8 +54,8 @@ class DaatWandSearcher : public RankedSearcher {
     };
 
     explicit DaatWandSearcher(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
-                              const std::shared_ptr<IndexScorer>& search_scorer, const uint32_t k,
-                              const uint32_t max_vec_id, const BitsetView& bitset, float dim_max_score_ratio)
+                              const QueryScorer& search_scorer, const uint32_t k, const uint32_t max_vec_id,
+                              const BitsetView& bitset, float dim_max_score_ratio)
         : RankedSearcher(k),
           cursors_(make_cursors(index, query, search_scorer, bitset, dim_max_score_ratio)),
           max_vec_id_(max_vec_id) {
@@ -133,12 +135,11 @@ class DaatWandSearcher : public RankedSearcher {
  private:
     static std::vector<Cursor>
     make_cursors(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
-                 const std::shared_ptr<IndexScorer>& index_scorer, const BitsetView& bitset,
-                 float dim_max_score_ratio) {
+                 const QueryScorer& index_scorer, const BitsetView& bitset, float dim_max_score_ratio) {
         std::vector<Cursor> cursors;
         cursors.reserve(query.size());
         for (const auto& [dim_id, dim_val] : query) {
-            cursors.push_back(Cursor{index.get_dim_plist_cursor(dim_id, bitset), index_scorer->dim_scorer(dim_val),
+            cursors.push_back(Cursor{index.get_dim_plist_cursor(dim_id, bitset), index_scorer.dim_scorer(dim_val),
                                      dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val)});
         }
         return cursors;

--- a/src/index/sparse/searcher/taat_naive.h
+++ b/src/index/sparse/searcher/taat_naive.h
@@ -14,9 +14,11 @@
 
 namespace knowhere::sparse::inverted {
 
-template <typename IndexType>
+template <typename IndexType, typename QueryScorer>
 class TaatNaiveSearcher : public RankedSearcher {
  public:
+    using DimScorer = decltype(std::declval<const QueryScorer&>().dim_scorer(0.0f));
+
     struct Cursor {
         typename IndexType::posting_list_iterator index_cursor;
         DimScorer scorer;
@@ -48,7 +50,7 @@ class TaatNaiveSearcher : public RankedSearcher {
     };
 
     explicit TaatNaiveSearcher(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
-                               std::shared_ptr<IndexScorer> search_scorer, const uint32_t k, const uint32_t max_vec_id,
+                               const QueryScorer& search_scorer, const uint32_t k, const uint32_t max_vec_id,
                                const BitsetView& bitset)
         : RankedSearcher(k), cursors_(make_cursors(index, query, search_scorer, bitset)), max_vec_id_(max_vec_id) {
     }
@@ -81,11 +83,11 @@ class TaatNaiveSearcher : public RankedSearcher {
  private:
     static std::vector<Cursor>
     make_cursors(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
-                 const std::shared_ptr<IndexScorer>& index_scorer, const BitsetView& bitset) {
+                 const QueryScorer& index_scorer, const BitsetView& bitset) {
         std::vector<Cursor> cursors;
         cursors.reserve(query.size());
         for (const auto& [dim_id, dim_val] : query) {
-            cursors.push_back(Cursor{index.get_dim_plist_cursor(dim_id, bitset), index_scorer->dim_scorer(dim_val)});
+            cursors.push_back(Cursor{index.get_dim_plist_cursor(dim_id, bitset), index_scorer.dim_scorer(dim_val)});
         }
         return cursors;
     }


### PR DESCRIPTION
This change templatizes the sparse query scorer to remove std::function indirection from the hot path