### PR TITLE
fix: build pyknowhere against NumPy 2

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -44,12 +44,12 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BEFORE_ALL_LINUX: "bash scripts/install_deps.sh && make"
           # Use portable wheel build script instead of plain setup.py
-          CIBW_BEFORE_BUILD: "pip3 install pytest numpy faiss-cpu bfloat16 auditwheel"
+          CIBW_BEFORE_BUILD: "pip3 install pytest numpy faiss-cpu ml-dtypes auditwheel"
           # Custom build command using our portable wheel builder
           CIBW_BUILD_FRONTEND: "build"
           # Note: cibuildwheel will use our build_portable_wheel.sh via setup.py
           # The script automatically handles auditwheel repair
-          CIBW_TEST_REQUIRES: "pytest numpy<2 faiss-cpu bfloat16"
+          CIBW_TEST_REQUIRES: "pytest numpy>=2,<3 faiss-cpu ml-dtypes"
           CIBW_TEST_COMMAND: "pytest {project}/tests/python/test_index_with_random.py"
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.tag }}"
         with:

--- a/python/build_portable_wheel.sh
+++ b/python/build_portable_wheel.sh
@@ -74,7 +74,7 @@ check_deps() {
     command -v "$PYTHON" >/dev/null || { log_error "Python not found: $PYTHON"; exit 1; }
 
     $PYTHON -c "import numpy" 2>/dev/null || {
-        log_error "numpy not found. Install with: pip3 install 'numpy<2'"
+        log_error "numpy not found. Install with: pip3 install 'numpy>=2,<3'"
         exit 1
     }
 

--- a/python/knowhere/__init__.py
+++ b/python/knowhere/__init__.py
@@ -8,7 +8,7 @@ from .swigknowhere import BruteForceSearchInt8, BruteForceRangeSearchInt8
 from .swigknowhere import BruteForceSearchBin, BruteForceRangeSearchBin
 
 import numpy as np
-from bfloat16 import bfloat16
+from ml_dtypes import bfloat16
 
 
 def CreateIndex(name, version, type=np.float32):

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -125,11 +125,8 @@ else
     pip3 install conan==${CONAN_VERSION}  # C/C++ package manager
 
     pip3 install -U setuptools
-    # wheel must be installed before bfloat16: bfloat16 has no pre-built wheel
-    # for Python 3.8, so pip builds from source. Without the wheel package, pip
-    # uses PEP 517 build isolation which can't see the installed numpy.
-    pip3 install wheel 'numpy<2'
-    pip3 install bfloat16   # wheel: bfloat16 dtype support for PyKnowhere
+    pip3 install wheel 'numpy>=2,<3'
+    pip3 install 'ml-dtypes>=0.5,<1'  # wheel: bfloat16 dtype support for PyKnowhere
     pip3 install auditwheel  # wheel: manylinux wheel repair
 fi
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 import faiss
-from bfloat16 import bfloat16
+from ml_dtypes import bfloat16
 
 
 @pytest.fixture()

--- a/tests/python/test_index_load_and_save.py
+++ b/tests/python/test_index_load_and_save.py
@@ -3,7 +3,7 @@ import json
 import pytest
 import os
 import numpy as np
-from bfloat16 import bfloat16
+from ml_dtypes import bfloat16
 
 test_data = [
     (

--- a/tests/python/test_index_random.py
+++ b/tests/python/test_index_random.py
@@ -2,7 +2,7 @@ import knowhere
 import json
 import pytest
 import numpy as np
-from bfloat16 import bfloat16
+from ml_dtypes import bfloat16
 
 test_data = [
     (


### PR DESCRIPTION
## Summary
This PR updates the PyKnowhere Python build and test setup to target NumPy 2 instead of pinning the package/test environment to NumPy 1.x.

## Details
- Changes the Python release workflow dependency setup from `numpy<2` to `numpy>=2,<3` for cibuildwheel test requirements.
- Replaces the `bfloat16` package dependency with `ml-dtypes` in the release workflow and dependency installation script.
- Updates PyKnowhere's exported `bfloat16` import path from `bfloat16.bfloat16` to `ml_dtypes.bfloat16`.
- Updates Python tests and fixtures to import `bfloat16` from `ml_dtypes`, matching the package dependency change.
- Updates the portable wheel build dependency error message so it points users at the new NumPy 2 version range.

## Files changed
- `.github/workflows/release-python.yml`: installs/tests with `numpy>=2,<3` and `ml-dtypes`.
- `scripts/install_deps.sh`: installs `numpy>=2,<3` and `ml-dtypes>=0.5,<1` for Python dependency setup.
- `python/build_portable_wheel.sh`: updates the missing NumPy hint for portable wheel builds.
- `python/knowhere/__init__.py`: imports `bfloat16` from `ml_dtypes`.
- `tests/python/conftest.py`, `tests/python/test_index_load_and_save.py`, `tests/python/test_index_random.py`: update test imports to use `ml_dtypes.bfloat16`.

## Verification
- Not run locally; this PR was created from the already pushed branch.
- DCO check is passing on the PR.
