### PR TITLE
fix: allow CAGRA adapt-for-cpu load without GPU

### DIFF
--- a/src/index/gpu_cuvs/gpu_cuvs.h
+++ b/src/index/gpu_cuvs/gpu_cuvs.h
@@ -21,6 +21,7 @@
 #include <exception>
 #include <fstream>
 #include <istream>
+#include <memory>
 #include <numeric>
 #include <thread>
 #include <tuple>
@@ -73,7 +74,7 @@ struct GpuCuvsIndexNode : public IndexNode {
     using knowhere_config_type = typename KnowhereConfigType<index_kind>::Type;
     using data_type = typename cuvs_knowhere::cuvs_data_type_mapper<DataType>::data_type;
 
-    GpuCuvsIndexNode(int32_t, const Object& object) : index_{} {
+    GpuCuvsIndexNode(int32_t, const Object& object) {
     }
 
     Status
@@ -86,7 +87,8 @@ struct GpuCuvsIndexNode : public IndexNode {
             LOG_KNOWHERE_ERROR_ << e.what();
             result = Status::invalid_args;
         }
-        if (index_.is_trained()) {
+        auto& cuvs_index = GetOrCreateIndex();
+        if (cuvs_index.is_trained()) {
             result = Status::index_already_trained;
         }
         if (result == Status::success) {
@@ -94,8 +96,8 @@ struct GpuCuvsIndexNode : public IndexNode {
             auto dim = dataset->GetDim();
             auto const* data = reinterpret_cast<const data_type*>(dataset->GetTensor());
             try {
-                index_.train(cuvs_cfg, data, rows, dim);
-                index_.synchronize(true);
+                cuvs_index.train(cuvs_cfg, data, rows, dim);
+                cuvs_index.synchronize(true);
             } catch (const std::exception& e) {
                 LOG_KNOWHERE_ERROR_ << e.what();
                 result = Status::cuvs_inner_error;
@@ -127,10 +129,14 @@ struct GpuCuvsIndexNode : public IndexNode {
                 auto rows = dataset->GetRows();
                 auto dim = dataset->GetDim();
                 auto const* data = reinterpret_cast<const data_type*>(dataset->GetTensor());
+                if (!index_) {
+                    LOG_KNOWHERE_ERROR_ << "Empty index.";
+                    return expected<DataSetPtr>::Err(Status::empty_index, "empty index");
+                }
                 auto search_result =
-                    index_.search(cuvs_cfg, data, rows, dim, bitset.data(), bitset.byte_size(), bitset.size());
+                    index_->search(cuvs_cfg, data, rows, dim, bitset.data(), bitset.byte_size(), bitset.size());
                 std::this_thread::yield();
-                index_.synchronize();
+                index_->synchronize();
                 return GenResultDataSet(rows, cuvs_cfg.k, std::get<0>(search_result), std::get<1>(search_result));
             } catch (const std::exception& e) {
                 err_msg = std::string{e.what()};
@@ -161,14 +167,14 @@ struct GpuCuvsIndexNode : public IndexNode {
     Serialize(BinarySet& binset) const override {
         auto result = Status::success;
         std::stringbuf buf;
-        if (!index_.is_trained()) {
+        if (!index_ || !index_->is_trained()) {
             result = Status::empty_index;
         } else {
             std::ostream os(&buf);
 
             try {
-                index_.serialize(os);
-                index_.synchronize(true);
+                index_->serialize(os);
+                index_->synchronize(true);
             } catch (const std::exception& e) {
                 LOG_KNOWHERE_ERROR_ << e.what();
                 result = Status::cuvs_inner_error;
@@ -221,7 +227,7 @@ struct GpuCuvsIndexNode : public IndexNode {
 
     int64_t
     Dim() const override {
-        return index_.dim();
+        return index_ ? index_->dim() : 0;
     }
 
     int64_t
@@ -231,7 +237,7 @@ struct GpuCuvsIndexNode : public IndexNode {
 
     int64_t
     Count() const override {
-        return index_.size();
+        return index_ ? index_->size() : 0;
     }
 
     std::string
@@ -250,14 +256,22 @@ struct GpuCuvsIndexNode : public IndexNode {
     using cuvs_knowhere_index_type = typename cuvs_knowhere::cuvs_knowhere_index<K, DataType>;
 
  protected:
-    cuvs_knowhere_index_type index_;
+    std::unique_ptr<cuvs_knowhere_index_type> index_;
+
+    cuvs_knowhere_index_type&
+    GetOrCreateIndex() {
+        if (!index_) {
+            index_ = std::make_unique<cuvs_knowhere_index_type>();
+        }
+        return *index_;
+    }
 
     Status
     DeserializeFromStream(std::istream& stream) {
         auto result = Status::success;
         try {
-            index_ = cuvs_knowhere_index_type::deserialize(stream);
-            index_.synchronize(true);
+            index_ = std::make_unique<cuvs_knowhere_index_type>(cuvs_knowhere_index_type::deserialize(stream));
+            index_->synchronize(true);
         } catch (const std::exception& e) {
             LOG_KNOWHERE_ERROR_ << e.what();
             result = Status::cuvs_inner_error;

--- a/src/index/gpu_cuvs/gpu_cuvs_cagra.cc
+++ b/src/index/gpu_cuvs/gpu_cuvs_cagra.cc
@@ -90,13 +90,13 @@ class GpuCuvsCagraHybridIndexNode : public GpuCuvsCagraIndexNode<DataType> {
             return GpuCuvsCagraIndexNode<DataType>::Serialize(binset);
         auto result = Status::success;
         std::stringbuf buf;
-        if (!this->index_.is_trained()) {
+        if (!this->index_ || !this->index_->is_trained()) {
             result = Status::empty_index;
         } else {
             std::ostream os(&buf);
             try {
-                this->index_.serialize_to_hnswlib(os);
-                this->index_.synchronize(true);
+                this->index_->serialize_to_hnswlib(os);
+                this->index_->synchronize(true);
             } catch (const std::exception& e) {
                 LOG_KNOWHERE_ERROR_ << e.what();
                 result = Status::cuvs_inner_error;
@@ -170,55 +170,34 @@ class GpuCuvsCagraHybridIndexNode : public GpuCuvsCagraIndexNode<DataType> {
     std::unique_ptr<hnswlib::HierarchicalNSW<DataType, float, hnswlib::None>> hnsw_index_ = nullptr;
 };
 
+size_t
+GetCagraThreadPoolSize() {
+    int count = 0;
+    auto status = cudaGetDeviceCount(&count);
+    if (status != cudaSuccess || count < 1) {
+        return 1;
+    }
+
+    return count * cuda_concurrent_size_per_device;
+}
+
 KNOWHERE_REGISTER_GLOBAL_WITH_THREAD_POOL(GPU_CUVS_CAGRA, GpuCuvsCagraHybridIndexNode, fp32,
-                                          knowhere::feature::GPU_ANN_FLOAT_INDEX, []() {
-                                              int count;
-                                              RAFT_CUDA_TRY(cudaGetDeviceCount(&count));
-                                              return count * cuda_concurrent_size_per_device;
-                                          }());
+                                          knowhere::feature::GPU_ANN_FLOAT_INDEX, GetCagraThreadPoolSize());
 KNOWHERE_REGISTER_GLOBAL_WITH_THREAD_POOL(GPU_CAGRA, GpuCuvsCagraHybridIndexNode, fp32,
-                                          knowhere::feature::GPU_ANN_FLOAT_INDEX, []() {
-                                              int count;
-                                              RAFT_CUDA_TRY(cudaGetDeviceCount(&count));
-                                              return count * cuda_concurrent_size_per_device;
-                                          }());
+                                          knowhere::feature::GPU_ANN_FLOAT_INDEX, GetCagraThreadPoolSize());
 
 KNOWHERE_REGISTER_GLOBAL_WITH_THREAD_POOL(GPU_CUVS_CAGRA, GpuCuvsCagraHybridIndexNode, fp16,
-                                          knowhere::feature::GPU | knowhere::feature::FP16, []() {
-                                              int count;
-                                              RAFT_CUDA_TRY(cudaGetDeviceCount(&count));
-                                              return count * cuda_concurrent_size_per_device;
-                                          }());
+                                          knowhere::feature::GPU | knowhere::feature::FP16, GetCagraThreadPoolSize());
 KNOWHERE_REGISTER_GLOBAL_WITH_THREAD_POOL(GPU_CAGRA, GpuCuvsCagraHybridIndexNode, fp16,
-                                          knowhere::feature::GPU | knowhere::feature::FP16, []() {
-                                              int count;
-                                              RAFT_CUDA_TRY(cudaGetDeviceCount(&count));
-                                              return count * cuda_concurrent_size_per_device;
-                                          }());
+                                          knowhere::feature::GPU | knowhere::feature::FP16, GetCagraThreadPoolSize());
 // TODO: Add HNSW support for INT8. Not using the hybrid CAGRA+HNSW for INT8
 KNOWHERE_REGISTER_GLOBAL_WITH_THREAD_POOL(GPU_CUVS_CAGRA, GpuCuvsCagraIndexNode, int8,
-                                          knowhere::feature::GPU | knowhere::feature::INT8, []() {
-                                              int count;
-                                              RAFT_CUDA_TRY(cudaGetDeviceCount(&count));
-                                              return count * cuda_concurrent_size_per_device;
-                                          }());
+                                          knowhere::feature::GPU | knowhere::feature::INT8, GetCagraThreadPoolSize());
 KNOWHERE_REGISTER_GLOBAL_WITH_THREAD_POOL(GPU_CAGRA, GpuCuvsCagraIndexNode, int8,
-                                          knowhere::feature::GPU | knowhere::feature::INT8, []() {
-                                              int count;
-                                              RAFT_CUDA_TRY(cudaGetDeviceCount(&count));
-                                              return count * cuda_concurrent_size_per_device;
-                                          }());
+                                          knowhere::feature::GPU | knowhere::feature::INT8, GetCagraThreadPoolSize());
 KNOWHERE_REGISTER_GLOBAL_WITH_THREAD_POOL(GPU_CUVS_CAGRA, GpuCuvsCagraHybridIndexNode, bin1,
-                                          knowhere::feature::GPU | knowhere::feature::BINARY, []() {
-                                              int count;
-                                              RAFT_CUDA_TRY(cudaGetDeviceCount(&count));
-                                              return count * cuda_concurrent_size_per_device;
-                                          }());
+                                          knowhere::feature::GPU | knowhere::feature::BINARY, GetCagraThreadPoolSize());
 KNOWHERE_REGISTER_GLOBAL_WITH_THREAD_POOL(GPU_CAGRA, GpuCuvsCagraHybridIndexNode, bin1,
-                                          knowhere::feature::GPU | knowhere::feature::BINARY, []() {
-                                              int count;
-                                              RAFT_CUDA_TRY(cudaGetDeviceCount(&count));
-                                              return count * cuda_concurrent_size_per_device;
-                                          }());
+                                          knowhere::feature::GPU | knowhere::feature::BINARY, GetCagraThreadPoolSize());
 
 }  // namespace knowhere

--- a/src/index/index_factory.cc
+++ b/src/index/index_factory.cc
@@ -28,9 +28,8 @@ namespace knowhere {
 
 bool
 checkGpuAvailable(const std::string& name) {
-    if (name == "GPU_CUVS_BRUTE_FORCE" || name == "GPU_BRUTE_FORCE" || name == "GPU_CUVS_CAGRA" ||
-        name == "GPU_CAGRA" || name == "GPU_CUVS_IVF_FLAT" || name == "GPU_IVF_FLAT" || name == "GPU_CUVS_IVF_PQ" ||
-        name == "GPU_IVF_PQ") {
+    if (name == "GPU_CUVS_BRUTE_FORCE" || name == "GPU_BRUTE_FORCE" || name == "GPU_CUVS_IVF_FLAT" ||
+        name == "GPU_IVF_FLAT" || name == "GPU_CUVS_IVF_PQ" || name == "GPU_IVF_PQ") {
         int count = 0;
         auto status = cudaGetDeviceCount(&count);
         if (status != cudaSuccess) {


### PR DESCRIPTION
## Summary

- Allow `GPU_CAGRA` / `GPU_CUVS_CAGRA` factory creation to proceed without a create-time GPU availability check.
- Lazily instantiate the underlying cuVS CAGRA index so `adapt_for_cpu=true` deserialize can enter the CPU-compatible path on CPU-only nodes.
- Make CAGRA thread-pool registration tolerate no-GPU hosts by falling back to a non-zero thread pool size.

Fixes #1631
Related Milvus issue: milvus-io/milvus#49836

## Test plan

- [x] `git diff --check -- src/index/gpu_cuvs/gpu_cuvs.h src/index/gpu_cuvs/gpu_cuvs_cagra.cc src/index/index_factory.cc`
- [x] Validated through Milvus mixed GPU/CPU deployment with GPU-built `GPU_CAGRA` and CPU-only QueryNode load/search using `adapt_for_cpu=true`.
- [ ] Knowhere standalone build/UT not run in this workspace.
