### PR TITLE
fix: resize Segment data_ to match capacity in ConcurrentArrayInvertedLists

### DIFF
--- a/thirdparty/faiss/faiss/cppcontrib/knowhere/invlists/InvertedLists.h
+++ b/thirdparty/faiss/faiss/cppcontrib/knowhere/invlists/InvertedLists.h
@@ -162,7 +162,7 @@ struct ConcurrentArrayInvertedLists : ::faiss::InvertedLists, NormInvertedLists 
     template <typename T>
     struct Segment {
         Segment(size_t segment_size, size_t code_size) : segment_size_(segment_size), code_size_(code_size) {
-            data_.reserve(segment_size_ * code_size_);
+            data_.resize(segment_size_ * code_size_);
         }
         T& operator[](idx_t idx) {
             assert(idx < segment_size_);


### PR DESCRIPTION
## Problem

In `thirdparty/faiss/faiss/cppcontrib/knowhere/invlists/InvertedLists.h`, the `Segment` helper inside `ConcurrentArrayInvertedLists` reserves capacity in its constructor but never sizes the underlying buffer:

```cpp
template <typename T>
struct Segment {
    Segment(size_t segment_size, size_t code_size)
        : segment_size_(segment_size), code_size_(code_size) {
        data_.reserve(segment_size_ * code_size_);
    }
    T& operator[](idx_t idx) {
        assert(idx < segment_size_);
        return data_[idx * code_size_];
    }
    ...
    std::vector<T> data_;
};
```

After the constructor runs, `data_.size() == 0` while `data_.capacity()` is `segment_size_ * code_size_`. The subsequent `operator[]` accesses (directly and via the `memcpy` calls in `add_entries`) read and write at offsets that are within the allocation but past `size()`. Calling `std::vector::operator[]` with an index that is not less than `size()` is undefined behavior even when the bytes are allocated.

## What this breaks

On a libstdc++ built with `-D_GLIBCXX_ASSERTIONS` (the hardened libstdc++ shipped by several distributions), `operator[]` has a bounds check compiled in. The first streaming insert into an `IVF_FLAT_CC` or `IndexIVFScalarQuantizerCC` collection trips it and the process aborts:

```
/usr/lib/gcc/x86_64-pc-linux-gnu/12/include/c++/bits/stl_vector.h:1128:
std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type)
[with _Tp = long int; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
SIGABRT: abort signal arrived during cgo execution
_ZSt21__glibcxx_assert_failPKciS0_S0_
_ZN5faiss28ConcurrentArrayInvertedLists11add_entriesEmmPKlPKhPKf
_ZN5faiss13InvertedLists9add_entryEmlPKhPKfPv
_ZN5faiss12IndexIVFFlat8add_coreElPKfS2_PKlS4_Pv
```

Unhardened libstdc++ compiles `operator[]` to plain pointer arithmetic with no check, so the same code runs without complaint.

## Fix

Use `resize()` instead of `reserve()` so `size() == capacity()` after construction. `operator[]` is then in-bounds, and the `memcpy` writes that follow keep working unchanged (they were already assuming the storage existed).

`resize()` does the same allocation `reserve()` did, plus a zero-fill of the bytes. For the trivial `T` types in use here (`uint8_t`, `idx_t`, `float`) that's a single `memset(0)`, dominated by the allocation cost. Segment construction is not on the hot path; inserts immediately overwrite the zero bytes via `memcpy`.

## Backport

The same constructor exists on the `v2.5.x` and `v2.6.x` lines at the older path `thirdparty/faiss/faiss/invlists/InvertedLists.h` (moved to `cppcontrib/knowhere/invlists/` in #1554). Same one-line change applies on both with offset adjustment.

Fixes: https://github.com/zilliztech/knowhere/issues/1643