### PR TITLE
fix: install uv inside active venv

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -89,7 +89,11 @@ install_uv() {
 
     if ! command -v uv >/dev/null 2>&1; then
         echo "[install_deps] Installing uv with pip3..."
-        pip3_install --user uv
+        if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+            pip3_install uv
+        else
+            pip3_install --user uv
+        fi
     fi
 
     if ! command -v uv >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Fix `scripts/install_deps.sh` so `uv` is installed into the active virtualenv when `VIRTUAL_ENV` is set.
- Keep the existing `pip3 install --user uv` path for non-virtualenv installs.
- PR https://github.com/zilliztech/knowhere/pull/1619 introduced the `uv` bootstrap path; this adjusts it for Jenkins jobs that already put a venv first in `PATH`.

## Test Plan
- Reproduced the old failure with a temporary virtualenv and no pre-existing `uv` on `PATH`.
- Verified the virtualenv path installs and resolves `uv` from the temp venv.
- Verified the non-virtualenv path still installs and resolves `uv` from the Python user bin.
- `bash -n scripts/install_deps.sh`
- `git diff --check origin/main..origin/tmp_knowhere_python_ver_fix`
