### PR TITLE
fix: filter system fields from vanilla FAISS params

### DIFF
--- a/src/index/faiss/faiss_config.h
+++ b/src/index/faiss/faiss_config.h
@@ -12,9 +12,52 @@
 
 #pragma once
 
+#include <unordered_set>
+
 #include "knowhere/config.h"
 
 namespace knowhere {
+
+inline bool
+IsFaissRawParamBlacklisted(const std::string& key) {
+    static const std::unordered_set<std::string> kParams = {
+        "analyzer_extra_info",
+        "build_dram_budget_gb",
+        "build_id",
+        "cluster_id",
+        "collection_id",
+        "current_index_version",
+        "current_scalar_index_version",
+        "data_type",
+        "element_type",
+        "field_id",
+        "index.nonEncoding",
+        "index_build_id",
+        "index_engine_version",
+        "index_file_prefix",
+        "index_id",
+        "index_num_rows",
+        "index_store_path_version",
+        "index_type",
+        "index_version",
+        "insert_files",
+        "lack_binlog_rows",
+        "manifest",
+        "num_rows",
+        "num_build_thread_ratio",
+        "opt_fields",
+        "partition_id",
+        "partition_key_isolation",
+        "scalar_index_engine_version",
+        "segment_id",
+        "segment_insert_files",
+        "segment_manifest",
+        "stats_base_path",
+        "storage_version",
+        "tantivy_index_version",
+    };
+    return kParams.count(key) > 0;
+}
 
 class FaissConfig : public BaseConfig {
  public:
@@ -44,10 +87,10 @@ class FaissConfig : public BaseConfig {
     CaptureRawJson(const Json& json) override {
         raw_params = Json::object();
         for (auto it = json.begin(); it != json.end(); ++it) {
-            // Skip any key already declared as a typed field on BaseConfig or
-            // FaissConfig — those are Knowhere's own and will be consumed by
-            // Config::Load. Everything else is a faiss-bound knob we forward.
-            if (__DICT__.count(it.key()) == 0) {
+            // Skip keys consumed by Knowhere's typed config layer and framework
+            // metadata injected by callers such as Milvus. Everything left is a
+            // faiss-bound knob and will be validated by faiss_dispatch.
+            if (__DICT__.count(it.key()) == 0 && !IsFaissRawParamBlacklisted(it.key())) {
                 raw_params[it.key()] = it.value();
             }
         }

--- a/tests/ut/test_faiss_vanilla.cc
+++ b/tests/ut/test_faiss_vanilla.cc
@@ -42,8 +42,18 @@ gen_bin(size_t nb, size_t dim_bits, uint64_t seed = 42) {
 
 TEST_CASE("FaissConfig parses faiss_index_name and captures raw JSON", "[faiss_vanilla]") {
     knowhere::FaissConfig cfg;
-    knowhere::Json j =
-        knowhere::Json::parse(R"({"metric_type":"L2","faiss_index_name":"IVF256,Flat","nprobe":16,"efSearch":32})");
+    knowhere::Json j = knowhere::Json::parse(R"({
+            "metric_type":"L2",
+            "faiss_index_name":"IVF256,Flat",
+            "nprobe":16,
+            "efSearch":32,
+            "index_type":"FAISS",
+            "build_id":"1000",
+            "index_num_rows":1000,
+            "storage_version":2,
+            "build_dram_budget_gb":"4.0",
+            "index.nonEncoding":"false"
+        })");
     std::string msg;
 
     // Replicate LoadConfig's internal sequence using only public-header entry points.
@@ -56,6 +66,12 @@ TEST_CASE("FaissConfig parses faiss_index_name and captures raw JSON", "[faiss_v
     REQUIRE(cfg.raw_params.contains("nprobe"));
     REQUIRE(cfg.raw_params["nprobe"] == 16);
     REQUIRE(cfg.raw_params.contains("efSearch"));
+    REQUIRE_FALSE(cfg.raw_params.contains("index_type"));
+    REQUIRE_FALSE(cfg.raw_params.contains("build_id"));
+    REQUIRE_FALSE(cfg.raw_params.contains("index_num_rows"));
+    REQUIRE_FALSE(cfg.raw_params.contains("storage_version"));
+    REQUIRE_FALSE(cfg.raw_params.contains("build_dram_budget_gb"));
+    REQUIRE_FALSE(cfg.raw_params.contains("index.nonEncoding"));
 }
 
 TEST_CASE("IndexFactory creates FAISS index for fp32", "[faiss_vanilla]") {


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/1648

## Summary
- Filter framework metadata out of vanilla FAISS raw parameter forwarding
- Keep valid FAISS parameters such as nprobe and efSearch in raw_params
- Add unit coverage for filtering system fields while preserving FAISS params

## Tests
- pre-commit run --files src/index/faiss/faiss_config.h tests/ut/test_faiss_vanilla.cc
- LD_LIBRARY_PATH=/home/fox/.conan/data/gflags/2.2.2/_/_/package/2a6a3278a322171d7bc88cf0269269647987854f/lib:$LD_LIBRARY_PATH ./build/tests/ut/knowhere_tests "FaissConfig parses faiss_index_name and captures raw JSON"
- LD_LIBRARY_PATH=/home/fox/.conan/data/gflags/2.2.2/_/_/package/2a6a3278a322171d7bc88cf0269269647987854f/lib:$LD_LIBRARY_PATH ./build/tests/ut/knowhere_tests "FAISS: typo key surfaces faiss error at build"