### PR TITLE
Fix SVS recall variability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ ifdef WITH_ASAN
 endif
 
 ifdef WITH_SVS
-    CONAN_FLAGS += -o \&:with_svs=True
+    CONAN_SETTINGS += -o \&:with_svs=True
 endif
 
 ifdef WITH_CARDINAL

--- a/cmake/libs/libfaiss.cmake
+++ b/cmake/libs/libfaiss.cmake
@@ -410,7 +410,7 @@ if(__X86_64)
     if(NOT svs_runtime_FOUND)
       include(FetchContent)
       set(SVS_TARBALL_URL
-          "https://github.com/intel/ScalableVectorSearch/releases/download/v0.3.0/svs-cpp-runtime-bindings-0.3.0.tar.gz"
+          "https://github.com/intel/ScalableVectorSearch/releases/download/nightly/svs-cpp-runtime-bindings-nightly-2026-05-18-1299.tar.gz"
           CACHE STRING "URL for pre-built SVS runtime bindings tarball")
       FetchContent_Declare(svs URL "${SVS_TARBALL_URL}" DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
       FetchContent_MakeAvailable(svs)

--- a/conanfile.py
+++ b/conanfile.py
@@ -129,7 +129,7 @@ class KnowhereConan(ConanFile):
         self.requires("lz4/1.10.0#982d9b673900f665a1da109e09c17cab", force=True, override=True)
         if self.settings.os == "Linux":
             self.requires("liburing/2.8", force=True, override=True)
-        self.requires("fmt/11.2.0#eb98daa559c7c59d591f4720dde4cd5c", force=True, override=True)
+        self.requires("fmt/12.1.0", force=True, override=True)
         self.requires("libevent/2.1.12#95065aaefcd58d3956d6dfbfc5631d97")
         self.requires("grpc/1.67.1@milvus/dev#efeaa484b59bffaa579004d5e82ec4fd")
         self.requires("folly/2026.04.20.00@milvus/dev#06852bea5b6449f0c4eb0df002b5779c")


### PR DESCRIPTION
Use SVS nightly release with improves filtered search, fixing the root cause of recall variability.

Update fmt to match SVS.

Fix Conan SVS flag.

issue: #1654 