### PR TITLE
[2.6] Fix E2E NumPy 2 wheel compatibility

### DIFF
--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -65,13 +65,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Install Dependency
         run: |
           sudo apt update \
           && sudo apt install -y cmake g++ gcc libopenblas-openmp-dev libaio-dev libcurl4-openssl-dev libevent-dev libgflags-dev python3 python3-pip python3-setuptools ccache unzip binutils patchelf \
-          && pip3 install conan==1.61.0 pytest faiss-cpu numpy wheel \
-          && pip3 install bfloat16 \
+          && pip3 install conan==1.61.0 pytest faiss-cpu 'numpy>=2,<3' wheel ml-dtypes \
           && (conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local || true) \
           && pip3 install -U setuptools
       - name: Restore Cache

--- a/ci/E2E-arm.groovy
+++ b/ci/E2E-arm.groovy
@@ -26,7 +26,7 @@ pipeline {
                         version="${env.CHANGE_ID}.${date}.${gitShortCommit}"
                         sh "apt-get update || true"
                         sh "apt-get install -y libaio-dev libopenblas-openmp-dev libcurl4-openssl-dev libdouble-conversion-dev libevent-dev libgflags-dev unzip binutils patchelf"
-                        sh "pip3 install conan==1.61.0 'numpy<2' bfloat16"
+                        sh "pip3 install conan==1.61.0 'numpy>=2,<3' ml-dtypes"
                         // sh "conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local"
                         sh "pip3 install -U setuptools"
                         sh "cmake --version"

--- a/ci/E2E2-SSE.groovy
+++ b/ci/E2E2-SSE.groovy
@@ -1,92 +1,10 @@
-// int total_timeout_minutes = 120
-def knowhere_wheel=''
 pipeline {
-    agent {
-        kubernetes {
-            cloud "new_ci_idc"
-            inheritFrom 'default'
-            yamlFile 'ci/pod/e2e-cpu.yaml'
-            defaultContainer 'main'
-        }
-    }
+    agent none
 
-    options {
-        // timeout(time: total_timeout_minutes, unit: 'MINUTES')
-        buildDiscarder logRotator(artifactDaysToKeepStr: '30')
-        parallelsAlwaysFailFast()
-        disableConcurrentBuilds(abortPrevious: true)
-        preserveStashes(buildCount: 10)
-    }
     stages {
-        stage("Build"){
+        stage("Disabled"){
             steps {
-                container("main"){
-                    script{
-                        def date = sh(returnStdout: true, script: 'date +%Y%m%d').trim()
-                        def gitShortCommit = sh(returnStdout: true, script: "echo ${env.GIT_COMMIT} | cut -b 1-7 ").trim()
-                        version="${env.CHANGE_ID}.${date}.${gitShortCommit}"
-                        sh "apt-get update || true"
-                        sh "apt-get install -y libaio-dev libopenblas-dev libcurl4-openssl-dev libdouble-conversion-dev libevent-dev libgflags-dev unzip binutils patchelf"
-                        sh "pip3 install conan==1.61.0 'numpy<2' bfloat16"
-                        // sh "conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local"
-                        sh "pip3 install -U setuptools"
-                        sh "cmake --version"
-                        sh "mkdir build"
-                        sh "cd build/ && conan install .. --build=missing -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .."
-                        sh "pip3 install auditwheel"
-                        sh "cd python && VERSION=${version} ./build_portable_wheel.sh"
-                        dir('python/dist'){
-                        knowhere_wheel=sh(returnStdout: true, script: 'ls | grep manylinux.*\\.whl').trim()
-                        archiveArtifacts artifacts: "${knowhere_wheel}", followSymlinks: false
-                        }
-                        // stash knowhere info for rebuild E2E Test only
-                        sh "echo ${knowhere_wheel} > knowhere.txt"
-                        stash includes: 'knowhere.txt', name: 'knowhereWheel'
-                    }
-                }
-            }
-        }
-        stage("Test"){
-            agent {
-                kubernetes {
-                    cloud "new_ci_idc"
-                    inheritFrom 'default'
-                    yamlFile 'ci/pod/e2e-sse.yaml'
-                    defaultContainer 'main'
-                }
-            }
-            steps {
-                script{
-                    if ("${knowhere_wheel}"==''){
-                        dir ("knowhereWheel"){
-                            try{
-                                unstash 'knowhereWheel'
-                                knowhere_wheel=sh(returnStdout: true, script: 'cat knowhere.txt | tr -d \'\n\r\'')
-                            }catch(e){
-                                error "No knowhereWheel info remained ,please rerun build to build new package."
-                            }
-                        }
-                    }
-                    checkout([$class: 'GitSCM', branches: [[name: '*/main']], extensions: [],
-                    userRemoteConfigs: [[credentialsId: 'milvus-ci', url: 'https://github.com/milvus-io/knowhere-test.git']]])
-                    dir('tests'){
-                      unarchive mapping: ["${knowhere_wheel}": "${knowhere_wheel}"]
-                      sh "apt-get update || true"
-                      sh "apt-get install -y libopenblas-dev libaio-dev libdouble-conversion-dev libevent-dev"
-                      sh "pip3 install ${knowhere_wheel}"
-                      sh "cat requirements.txt | xargs -n 1 pip3 install"
-                      sh "cp -r /home/data/milvus/ann_fbin/ ."
-                      sh "pytest -v -m 'L0'"
-                    }
-                }
-            }
-            post{
-                always {
-                    script{
-                        sh 'cat tests/pytest.log'
-                        archiveArtifacts artifacts: 'tests/pytest.log', followSymlinks: false
-                    }
-                }
+                echo "SSE CI is disabled."
             }
         }
     }

--- a/ci/E2E2.groovy
+++ b/ci/E2E2.groovy
@@ -27,7 +27,7 @@ pipeline {
                         version="${env.CHANGE_ID}.${date}.${gitShortCommit}"
                         sh "apt-get update || true"
                         sh "apt-get install -y libaio-dev libopenblas-openmp-dev libcurl4-openssl-dev libdouble-conversion-dev libevent-dev libgflags-dev unzip binutils patchelf"
-                        sh "pip3 install conan==1.61.0 'numpy<2' bfloat16"
+                        sh "pip3 install conan==1.61.0 'numpy>=2,<3' ml-dtypes"
                         // sh "conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local"
                         sh "pip3 install -U setuptools"
                         sh "cmake --version"

--- a/python/build_portable_wheel.sh
+++ b/python/build_portable_wheel.sh
@@ -74,7 +74,7 @@ check_deps() {
     command -v "$PYTHON" >/dev/null || { log_error "Python not found: $PYTHON"; exit 1; }
 
     $PYTHON -c "import numpy" 2>/dev/null || {
-        log_error "numpy not found. Install with: pip3 install 'numpy<2'"
+        log_error "numpy not found. Install with: pip3 install 'numpy>=2,<3'"
         exit 1
     }
 

--- a/python/knowhere/__init__.py
+++ b/python/knowhere/__init__.py
@@ -8,7 +8,7 @@ from .swigknowhere import BruteForceSearchInt8, BruteForceRangeSearchInt8
 from .swigknowhere import BruteForceSearchBin, BruteForceRangeSearchBin
 
 import numpy as np
-from bfloat16 import bfloat16
+from ml_dtypes import bfloat16
 
 
 def CreateIndex(name, version, type=np.float32):

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 import faiss
-from bfloat16 import bfloat16
+from ml_dtypes import bfloat16
 
 
 @pytest.fixture()
@@ -17,7 +17,7 @@ def gen_data():
 @pytest.fixture()
 def gen_data_with_type():
     def wrap(xb_rows, xq_rows, dim, type):
-        if type == np.float16 or bfloat16:
+        if type == np.float16 or type == bfloat16:
             xb = np.random.randn(xb_rows, dim).astype(type)
             xq = np.random.randn(xq_rows, dim).astype(type)
             # To fix nan or inf when type is equal to float16

--- a/tests/python/test_index_load_and_save.py
+++ b/tests/python/test_index_load_and_save.py
@@ -3,7 +3,7 @@ import json
 import pytest
 import os
 import numpy as np
-from bfloat16 import bfloat16
+from ml_dtypes import bfloat16
 
 test_data = [
     (

--- a/tests/python/test_index_random.py
+++ b/tests/python/test_index_random.py
@@ -2,7 +2,7 @@ import knowhere
 import json
 import pytest
 import numpy as np
-from bfloat16 import bfloat16
+from ml_dtypes import bfloat16
 
 test_data = [
     (


### PR DESCRIPTION
## Summary

Fixes #1662
- Build 2.6 x86 and ARM E2E pyknowhere wheels against NumPy 2 headers.
- Switch the Python bfloat16 import to `ml_dtypes`, matching the current knowhere-test dependency set.
- Update the 2.6 GitHub Actions Python wheel smoke test and repo Python tests to use Python 3.10, NumPy 2, and `ml-dtypes`.
- Disable the 2.6 SSE Jenkins pipeline with the same no-agent disabled stage used on main.
- Keep the 2.6 Conan 1.61 build flow intact instead of backporting the broader Conan 2 changes from main.

PR https://github.com/zilliztech/knowhere/pull/1619 updates the main-branch Python build scripts and Python tests for the NumPy 2 dependency set. This PR backports only the minimal 2.6-safe pieces needed by the E2E and wheel-smoke jobs, because the full PR also pulls in Conan 2 and unrelated source churn.

PR https://github.com/zilliztech/knowhere/pull/1620 disables the main-branch SSE CI pipeline. This PR applies the same SSE Jenkinsfile disablement to 2.6.

## Test Plan
- [x] `git grep -n -E "numpy<2|from bfloat16 import bfloat16|pip3 install conan==1\\.61\\.0 'numpy<2' bfloat16" -- ci/E2E2.groovy ci/E2E-arm.groovy python/knowhere/__init__.py python/build_portable_wheel.sh`
- [x] `bash -n python/build_portable_wheel.sh`
- [x] `python3 -m py_compile python/knowhere/__init__.py tests/python/conftest.py tests/python/test_index_load_and_save.py tests/python/test_index_random.py`
- [x] `git diff --check`
- [x] temporary venv import check for `numpy>=2,<3` and `ml-dtypes`
- [x] temporary venv import check for `tests/python/conftest.py` with NumPy 2, `ml-dtypes`, and `faiss-cpu`
- [x] workflow assertion check for Python 3.10, `numpy>=2,<3`, and `ml-dtypes` in `.github/workflows/ut.yaml`
- [x] `git rev-parse origin/main:ci/E2E2-SSE.groovy` matches `git hash-object ci/E2E2-SSE.groovy`
- [x] `git grep -n -E "yamlFile 'ci/pod/e2e-sse.yaml'|pytest -v -m 'L0'|pip3 install conan==1\\.61\\.0 'numpy<2' bfloat16" -- ci/E2E2-SSE.groovy`
