### PR TITLE
fix: validate sparse index build params

### DIFF
--- a/src/index/sparse/sparse_index_config.h
+++ b/src/index/sparse/sparse_index_config.h
@@ -12,6 +12,11 @@
 #ifndef SPARSE_INVERTED_INDEX_CONFIG_H
 #define SPARSE_INVERTED_INDEX_CONFIG_H
 
+#include <algorithm>
+#include <cctype>
+#include <limits>
+#include <string>
+
 // Compile-time option: index versions below this threshold use raw data format; others use codec.
 // Default is 8. Override at compile time, e.g. -DSPARSE_INDEX_VERSION_USE_RAW_DATA_THRESHOLD=10
 #ifndef SPARSE_INDEX_VERSION_USE_RAW_DATA_THRESHOLD
@@ -28,6 +33,26 @@
 #include "knowhere/config.h"
 
 namespace knowhere {
+
+inline std::string
+NormalizeSparseInvertedIndexAlgo(std::string algo) {
+    std::transform(algo.begin(), algo.end(), algo.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return algo;
+}
+
+inline bool
+IsSupportedSparseInvertedIndexAlgo(const std::string& algo) {
+    const auto normalized_algo = NormalizeSparseInvertedIndexAlgo(algo);
+    return normalized_algo.empty() || normalized_algo == "TAAT_NAIVE" || normalized_algo == "DAAT_WAND" ||
+           normalized_algo == "DAAT_MAXSCORE" || normalized_algo == "BLOCK_MAX_MAXSCORE" ||
+           normalized_algo == "BLOCK_MAX_WAND" || normalized_algo == "SINDI";
+}
+
+inline bool
+IsSupportedSparseInvertedIndexCodec(const std::string& codec) {
+    return codec.empty() || codec == "block_streamvbyte" || codec == "block_maskedvbyte";
+}
 
 class SparseInvertedIndexConfig : public BaseConfig {
  public:
@@ -120,6 +145,7 @@ class SparseInvertedIndexConfig : public BaseConfig {
         KNOWHERE_CONFIG_DECLARE_FIELD(block_max_block_size)
             .description("block max block size")
             .set_default(128)
+            .set_range(1, std::numeric_limits<CFG_INT::value_type>::max())
             .for_train()
             .for_deserialize()
             .for_deserialize_from_file();
@@ -138,6 +164,20 @@ class SparseInvertedIndexConfig : public BaseConfig {
 
     Status
     CheckAndAdjust(PARAM_TYPE param_type, std::string* err_msg) override {
+        if (inverted_index_algo.has_value() && !IsSupportedSparseInvertedIndexAlgo(inverted_index_algo.value())) {
+            return HandleError(
+                err_msg,
+                "inverted_index_algo " + inverted_index_algo.value() +
+                    " not found or not supported, supported: [TAAT_NAIVE DAAT_WAND DAAT_MAXSCORE BLOCK_MAX_MAXSCORE "
+                    "BLOCK_MAX_WAND SINDI]",
+                Status::invalid_args);
+        }
+        if (inverted_index_codec.has_value() && !IsSupportedSparseInvertedIndexCodec(inverted_index_codec.value())) {
+            return HandleError(err_msg,
+                               "inverted_index_codec " + inverted_index_codec.value() +
+                                   " not found or not supported, supported: [block_streamvbyte block_maskedvbyte]",
+                               Status::invalid_args);
+        }
         if (quant_type.has_value() && !quant_type.value().empty()) {
             auto qt = quant_type.value();
             auto mt = metric_type.value();

--- a/src/index/sparse/sparse_index_node.cc
+++ b/src/index/sparse/sparse_index_node.cc
@@ -439,6 +439,15 @@ class SparseInvertedIndexNode : public IndexNode {
         return Status::success;
     }
 
+    Status
+    ValidateInvertedIndexCodec(const std::string& codec) const {
+        if (IsSupportedSparseInvertedIndexCodec(codec)) {
+            return Status::success;
+        }
+        LOG_KNOWHERE_ERROR_ << "Unsupported sparse inverted index codec " << codec;
+        return Status::invalid_args;
+    }
+
     template <typename DType, typename QType, sparse::inverted::IndexScorerType MetricType>
     expected<std::unique_ptr<sparse::inverted::InvertedIndex<value_type>>>
     CreateIndexImpl(const SparseInvertedIndexConfig& cfg, bool is_growable = false,
@@ -504,6 +513,8 @@ class SparseInvertedIndexNode : public IndexNode {
                             codec = std::make_shared<sparse::inverted::MaskedVByteBlockCodec>();
                         }
                         index = std::make_unique<sparse::inverted::BlockInvertedIndex<DType, QType, MetricType>>(codec);
+                    } else if (!inverted_index_codec.empty()) {
+                        return expected<IndexPtr>::Err(Status::invalid_args, "unsupported sparse inverted index codec");
                     } else {
                         index = std::make_unique<sparse::inverted::FlattenInvertedIndex<DType, QType>>();
                     }
@@ -588,6 +599,11 @@ class SparseInvertedIndexNode : public IndexNode {
         if (status != Status::success) {
             return expected<std::unique_ptr<sparse::inverted::InvertedIndex<value_type>>>::Err(
                 status, "unsupported sparse inverted index algorithm");
+        }
+        const auto codec_status = ValidateInvertedIndexCodec(cfg.inverted_index_codec.value_or(""));
+        if (codec_status != Status::success) {
+            return expected<std::unique_ptr<sparse::inverted::InvertedIndex<value_type>>>::Err(
+                codec_status, "unsupported sparse inverted index codec");
         }
 
         auto qt = cfg.quant_type.value_or("");

--- a/tests/ut/test_config.cc
+++ b/tests/ut/test_config.cc
@@ -148,6 +148,33 @@ TEST_CASE("Test config json parse", "[config]") {
         CHECK(s == knowhere::Status::out_of_range_in_json);
     }
 
+    SECTION("check sparse inverted index invalid build params") {
+        auto invalid_sparse_param = GENERATE(table<knowhere::Json, knowhere::Status, std::string>({
+            {knowhere::Json({{knowhere::meta::DIM, 16},
+                             {knowhere::meta::METRIC_TYPE, knowhere::metric::IP},
+                             {knowhere::indexparam::INVERTED_INDEX_ALGO, "DAAT_MAXSCORE"},
+                             {"inverted_index_codec", "invalid_codec"}}),
+             knowhere::Status::invalid_args, "inverted_index_codec"},
+            {knowhere::Json({{knowhere::meta::DIM, 16},
+                             {knowhere::meta::METRIC_TYPE, knowhere::metric::IP},
+                             {knowhere::indexparam::INVERTED_INDEX_ALGO, "BLOCK_MAX_WAND"},
+                             {"block_max_block_size", 0}}),
+             knowhere::Status::out_of_range_in_json, "block_max_block_size"},
+            {knowhere::Json({{knowhere::meta::DIM, 16},
+                             {knowhere::meta::METRIC_TYPE, knowhere::metric::IP},
+                             {knowhere::indexparam::INVERTED_INDEX_ALGO, "NOT_A_REAL_ALGO"}}),
+             knowhere::Status::invalid_args, knowhere::indexparam::INVERTED_INDEX_ALGO},
+        }));
+        const auto& [params, expected_status, expected_msg] = invalid_sparse_param;
+
+        std::string msg;
+        s = knowhere::IndexStaticFaced<knowhere::sparse_u32_f32>::ConfigCheck(
+            knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX, knowhere::Version::GetCurrentVersion().VersionNumber(),
+            params, msg);
+        CHECK(s == expected_status);
+        CHECK(msg.find(expected_msg) != std::string::npos);
+    }
+
     SECTION("check invalid json values") {
         auto invalid_json_str = GENERATE(as<std::string>{},
                                          R"({

--- a/tests/ut/test_sparse.cc
+++ b/tests/ut/test_sparse.cc
@@ -1302,6 +1302,39 @@ TEST_CASE("Test Sparse Index Rejects Unsupported Inverted Index Algo", "[sparse]
     REQUIRE(std::remove(tmp_file) == 0);
 }
 
+TEST_CASE("Test Sparse Index Rejects Invalid Inverted Index Build Params", "[sparse]") {
+    const auto version = knowhere::Version::GetMaximumVersion().VersionNumber();
+    constexpr auto dim = 16;
+    auto train_ds = GenSparseDataSet(100, dim, 0.8);
+
+    const std::string name = knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX;
+
+    SECTION("reject invalid inverted index codec") {
+        knowhere::Json build_json;
+        build_json[knowhere::meta::DIM] = dim;
+        build_json[knowhere::meta::METRIC_TYPE] = knowhere::metric::IP;
+        build_json[knowhere::indexparam::INVERTED_INDEX_ALGO] = "DAAT_MAXSCORE";
+        build_json["inverted_index_codec"] = "invalid_codec";
+
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::sparse_u32_f32>(name, version).value();
+        REQUIRE(idx.Build(train_ds, build_json) == knowhere::Status::invalid_args);
+    }
+
+    SECTION("reject non-positive block max block size") {
+        auto block_size = GENERATE(0, -1);
+        CAPTURE(block_size);
+
+        knowhere::Json build_json;
+        build_json[knowhere::meta::DIM] = dim;
+        build_json[knowhere::meta::METRIC_TYPE] = knowhere::metric::IP;
+        build_json[knowhere::indexparam::INVERTED_INDEX_ALGO] = "BLOCK_MAX_WAND";
+        build_json["block_max_block_size"] = block_size;
+
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::sparse_u32_f32>(name, version).value();
+        REQUIRE(idx.Build(train_ds, build_json) == knowhere::Status::out_of_range_in_json);
+    }
+}
+
 TEST_CASE("Test SINDI Index Window Size", "[sparse][sindi]") {
     auto nb = 2000;
     auto dim = 1000;


### PR DESCRIPTION
- Reject unsupported sparse inverted index codecs during config/build checks.
- Reject non-positive block max block sizes.
- Add sparse negative tests for the Milvus issue cases.

issue: milvus-io/milvus#50257
