### PR TITLE
enhance: sparse: add skip_window_calc pruning for SINDI search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,30 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64)")
         PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512vl -mavx512dq -mavx512cd -mavx2 -mfma -mf16c")
 endif()
 
+if(__AARCH64)
+    set(KNOWHERE_SVE_COMPILE_OPTIONS "")
+    if(HAS_ARMV9_SVE_BF16)
+        set(KNOWHERE_SVE_COMPILE_OPTIONS "-march=armv9-a+sve+bf16")
+    elseif(HAS_ARMV8_SVE_BF16)
+        set(KNOWHERE_SVE_COMPILE_OPTIONS "-march=armv8-a+sve+bf16")
+    elseif(HAS_ARMV9_SVE)
+        set(KNOWHERE_SVE_COMPILE_OPTIONS "-march=armv9-a+sve")
+    elseif(HAS_ARMV8_SVE)
+        set(KNOWHERE_SVE_COMPILE_OPTIONS "-march=armv8-a+sve")
+    endif()
+
+    if(KNOWHERE_SVE_COMPILE_OPTIONS)
+        set_source_files_properties(
+            src/index/sparse/sindi_simd_sve.cc
+            PROPERTIES
+                COMPILE_OPTIONS "${KNOWHERE_SVE_COMPILE_OPTIONS}"
+                COMPILE_DEFINITIONS KNOWHERE_USE_SVE)
+        set_source_files_properties(
+            src/index/sparse/sindi_simd.cc
+            PROPERTIES COMPILE_DEFINITIONS KNOWHERE_USE_SVE)
+    endif()
+endif()
+
 if(WITH_SVS)
   if(NOT __X86_64)
     message(FATAL_ERROR "SVS is only supported on x86_64 platforms")

--- a/src/index/sparse/inverted_index.h
+++ b/src/index/sparse/inverted_index.h
@@ -396,12 +396,12 @@ class InvertedIndex {
 
         std::vector<std::pair<uint32_t, float>> filtered_query;
         for (size_t i = 0; i < query.size(); ++i) {
-            auto [dim, val] = query[i];
-            auto dim_it = dim_map_.find(dim);
+            const auto [dim, val] = query[i];
+            const auto dim_it = dim_map_.find(dim);
             if (dim_it == dim_map_.cend() || std::abs(val) < q_threshold) {
                 continue;
             }
-            filtered_query.emplace_back(dim_it->second, val);
+            filtered_query.emplace_back(dim_it->second, std::abs(val));
         }
 
         return filtered_query;

--- a/src/index/sparse/sindi_inverted_index.h
+++ b/src/index/sparse/sindi_inverted_index.h
@@ -198,12 +198,14 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
 
     Status
     add(const SparseRow<DataType>* data, size_t rows, int64_t dim) override {
+        const size_t old_nr_rows = this->nr_rows_;
         this->max_dim_ = std::max(this->max_dim_, static_cast<uint32_t>(dim));
         // update dim_map_
         for (size_t i = 0; i < rows; ++i) {
             for (size_t j = 0; j < data[i].size(); ++j) {
-                auto [dim, val] = data[i][j];
-                if (std::abs(val) < std::numeric_limits<DataType>::epsilon()) {
+                const auto [dim, val] = data[i][j];
+                const auto abs_val = std::abs(val);
+                if (abs_val < std::numeric_limits<DataType>::epsilon()) {
                     continue;
                 }
                 if (this->dim_map_.find(dim) == this->dim_map_.end()) {
@@ -226,28 +228,32 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
                 float row_sum = 0.0f;
                 for (size_t j = 0; j < data[i].size(); ++j) {
                     const auto [dim, val] = data[i][j];
-                    if (std::abs(val) < std::numeric_limits<DataType>::epsilon()) {
+                    const auto abs_val = std::abs(val);
+                    if (abs_val < std::numeric_limits<DataType>::epsilon()) {
                         continue;
                     }
-                    row_sum += static_cast<float>(val);
+                    row_sum += static_cast<float>(abs_val);
                 }
                 row_sums_.push_back(row_sum);
             }
             row_sums_span_ = boost::span<const float>(row_sums_.data(), row_sums_.size());
         }
 
-        // Compute max score per dimension for early termination optimization
-        // For IP: max_score = max(val) across all postings
-        // For BM25: max_score = max((k1+1)*tf / (tf + k1*(1-b+b*dl/avgdl))) for each posting
+        // Incrementally update max score per dimension for early termination optimization.
+        // For IP: max_score = max(abs(val)) across quantized postings.
+        // For BM25: max_score = max((k1+1)*tf / (tf + k1*(1-b+b*dl/avgdl))) across postings.
         max_scores_per_dim_.resize(this->dim_map_.size());
         if constexpr (std::is_same_v<QuantType, knowhere::fp16>) {
-            // IP scoring: just find max value
-            for (size_t dim_id = 0; dim_id < this->dim_map_.size(); ++dim_id) {
-                const auto& vals = total_plists_vals_spans_[dim_id];
-                for (auto val : vals) {
-                    float v = static_cast<float>(val);
-                    if (v > max_scores_per_dim_[dim_id]) {
-                        max_scores_per_dim_[dim_id] = v;
+            for (size_t i = 0; i < rows; ++i) {
+                for (size_t j = 0; j < data[i].size(); ++j) {
+                    const auto [dim, val] = data[i][j];
+                    const auto abs_val = std::abs(val);
+                    if (abs_val < std::numeric_limits<DataType>::epsilon()) {
+                        continue;
+                    }
+                    const auto dim_id = this->dim_map_[dim];
+                    if (abs_val > max_scores_per_dim_[dim_id]) {
+                        max_scores_per_dim_[dim_id] = abs_val;
                     }
                 }
             }
@@ -263,27 +269,20 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
             const float p2 = k1 * (1.0f - b);
             const float p3 = k1 * b / avgdl;
 
-            for (size_t dim_id = 0; dim_id < this->dim_map_.size(); ++dim_id) {
-                const auto& ids = total_plists_ids_spans_[dim_id];
-                const auto& vals = total_plists_vals_spans_[dim_id];
-                const auto& wnnzs = window_index_plists_sz_spans_;
-
-                // Iterate through each posting and compute BM25 score with actual dl
-                size_t posting_idx = 0;
-                for (size_t wid = 0; wid < nr_windows_; ++wid) {
-                    size_t wnnz = wnnzs[wid][dim_id];
-                    size_t docid_base = wid * window_size_;
-                    for (size_t j = 0; j < wnnz; ++j) {
-                        uint16_t local_id = ids[posting_idx];
-                        float tf = static_cast<float>(vals[posting_idx]);
-                        size_t global_docid = docid_base + local_id;
-                        float dl = row_sums_span_[global_docid];
-                        // BM25 right part: (k1+1)*tf / (tf + k1*(1-b) + k1*b*dl/avgdl)
-                        float bm25_score = p1 * tf / (tf + p2 + p3 * dl);
-                        if (bm25_score > max_scores_per_dim_[dim_id]) {
-                            max_scores_per_dim_[dim_id] = bm25_score;
-                        }
-                        ++posting_idx;
+            for (size_t i = 0; i < rows; ++i) {
+                const size_t global_docid = old_nr_rows + i;
+                const float dl = row_sums_span_[global_docid];
+                for (size_t j = 0; j < data[i].size(); ++j) {
+                    const auto [dim, val] = data[i][j];
+                    const auto abs_val = std::abs(val);
+                    if (abs_val < std::numeric_limits<DataType>::epsilon()) {
+                        continue;
+                    }
+                    const auto dim_id = this->dim_map_[dim];
+                    const float tf = static_cast<float>(abs_val);
+                    const float bm25_score = p1 * tf / (tf + p2 + p3 * dl);
+                    if (bm25_score > max_scores_per_dim_[dim_id]) {
+                        max_scores_per_dim_[dim_id] = bm25_score;
                     }
                 }
             }
@@ -714,11 +713,11 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
             return;
         }
 
-        // Compute max contributions for each query term: qval * max_dim_val
+        // Compute max contributions for each query term.
         // and sort query terms by max contributions descending for early termination
         std::vector<float> max_contributions(q_vec.size());
         for (size_t i = 0; i < q_vec.size(); ++i) {
-            auto& [qid, qval] = q_vec[i];
+            const auto& [qid, qval] = q_vec[i];
             float dim_max = (qid < max_scores_per_dim_span_.size()) ? max_scores_per_dim_span_[qid] : 0.0f;
             max_contributions[i] = qval * dim_max;
         }

--- a/src/index/sparse/sindi_inverted_index.h
+++ b/src/index/sparse/sindi_inverted_index.h
@@ -258,6 +258,60 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
             row_sums_span_ = boost::span<const float>(row_sums_.data(), row_sums_.size());
         }
 
+        // Compute max score per dimension for early termination optimization
+        // For IP: max_score = max(val) across all postings
+        // For BM25: max_score = max((k1+1)*tf / (tf + k1*(1-b+b*dl/avgdl))) for each posting
+        max_scores_per_dim_.resize(this->dim_map_.size());
+        if constexpr (std::is_same_v<QuantType, knowhere::fp16>) {
+            // IP scoring: just find max value
+            for (size_t dim_id = 0; dim_id < this->dim_map_.size(); ++dim_id) {
+                const auto& vals = total_plists_vals_spans_[dim_id];
+                for (auto val : vals) {
+                    float v = static_cast<float>(val);
+                    if (v > max_scores_per_dim_[dim_id]) {
+                        max_scores_per_dim_[dim_id] = v;
+                    }
+                }
+            }
+        } else {
+            // BM25 scoring: compute exact max BM25 score per dimension
+            // For each posting, compute: (k1+1)*tf / (tf + k1*(1-b+b*dl/avgdl))
+            // using the actual document length (dl) from row_sums
+            const auto& cfg = this->build_scorer_->config();
+            const float k1 = cfg.scorer_params.bm25.k1;
+            const float b = cfg.scorer_params.bm25.b;
+            const float avgdl = cfg.scorer_params.bm25.avgdl;
+            const float p1 = k1 + 1.0f;
+            const float p2 = k1 * (1.0f - b);
+            const float p3 = k1 * b / avgdl;
+
+            for (size_t dim_id = 0; dim_id < this->dim_map_.size(); ++dim_id) {
+                const auto& ids = total_plists_ids_spans_[dim_id];
+                const auto& vals = total_plists_vals_spans_[dim_id];
+                const auto& wnnzs = window_index_plists_sz_spans_;
+
+                // Iterate through each posting and compute BM25 score with actual dl
+                size_t posting_idx = 0;
+                for (size_t wid = 0; wid < nr_windows_; ++wid) {
+                    size_t wnnz = wnnzs[wid][dim_id];
+                    size_t docid_base = wid * window_size_;
+                    for (size_t j = 0; j < wnnz; ++j) {
+                        uint16_t local_id = ids[posting_idx];
+                        float tf = static_cast<float>(vals[posting_idx]);
+                        size_t global_docid = docid_base + local_id;
+                        float dl = row_sums_span_[global_docid];
+                        // BM25 right part: (k1+1)*tf / (tf + k1*(1-b) + k1*b*dl/avgdl)
+                        float bm25_score = p1 * tf / (tf + p2 + p3 * dl);
+                        if (bm25_score > max_scores_per_dim_[dim_id]) {
+                            max_scores_per_dim_[dim_id] = bm25_score;
+                        }
+                        ++posting_idx;
+                    }
+                }
+            }
+        }
+        max_scores_per_dim_span_ = boost::span<const float>(max_scores_per_dim_.data(), max_scores_per_dim_.size());
+
         return Status::success;
     }
 
@@ -297,7 +351,10 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
         // 4. Dimension Map Section:
         //    - dim_map_reverse[nr_inner_dims]: Array mapping internal dimension IDs to original dimensions
         //
-        // 5. Optional Row Sums Section (for BM25 support, only when QuantType is uint16_t):
+        // 5. Max Values Per Dimension Section:
+        //    - dim_max_vals[nr_inner_dims]: Array of maximum values per dimension (float), used for pruning
+        //
+        // 6. Optional Row Sums Section (for BM25 support, only when QuantType is uint16_t):
         //    - row_sums[nr_rows]: Array of row sums (float)
         const uint32_t index_format_version = current_index_file_format_version_;
         writer.write(&index_format_version, sizeof(uint32_t));
@@ -310,7 +367,7 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
         // Determine if we need to write row sums (BM25 support)
         const bool has_row_sums = !row_sums_span_.empty();
 
-        uint32_t nr_sections = 2;  // base sections: inverted index and dim map
+        uint32_t nr_sections = 3;  // base sections: inverted index, dim map and max scores per dim
         if (has_row_sums) {
             nr_sections += 1;  // add row sums section
         }
@@ -363,12 +420,17 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
         section_headers[1].size = sizeof(uint32_t) * this->nr_inner_dims_;
         used_offset += section_headers[1].size;
 
+        section_headers[2].type = InvertedIndexSectionType::MAX_SCORES_PER_DIM;
+        section_headers[2].offset = used_offset;
+        section_headers[2].size = sizeof(float) * this->nr_inner_dims_;
+        used_offset += section_headers[2].size;
+
         // Add row sums section header if needed (BM25 support)
         if (has_row_sums) {
-            section_headers[2].type = InvertedIndexSectionType::ROW_SUMS;
-            section_headers[2].offset = used_offset;
-            section_headers[2].size = sizeof(float) * this->nr_rows_;
-            used_offset += section_headers[2].size;
+            section_headers[3].type = InvertedIndexSectionType::ROW_SUMS;
+            section_headers[3].offset = used_offset;
+            section_headers[3].size = sizeof(float) * this->nr_rows_;
+            used_offset += section_headers[3].size;
         }
 
         writer.write(section_headers.data(), sizeof(InvertedIndexSectionHeader), nr_sections);
@@ -419,6 +481,9 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
         }
         writer.write(dim_map_reverse.data(), sizeof(uint32_t), this->nr_inner_dims_);
 
+        // write dim max vals
+        writer.write(max_scores_per_dim_span_.data(), sizeof(float), max_scores_per_dim_span_.size());
+
         // write row sums if present (BM25 support)
         if (has_row_sums) {
             writer.write(row_sums_span_.data(), sizeof(float), row_sums_span_.size());
@@ -454,8 +519,8 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
         auto sections_handler = [&, this]() {
             uint32_t nr_sections = 0;
             reader.read(&nr_sections, sizeof(uint32_t));
-            // Allow 2 sections (base) or 3 sections (with row sums for BM25)
-            if (nr_sections < 2 || nr_sections > 3) {
+            // Allow 3 sections (base) or 4 sections (with row sums for BM25)
+            if (nr_sections < 3 || nr_sections > 4) {
                 return Status::invalid_serialized_index_type;
             }
             size_t sec_table_offset = reader.tellg();
@@ -614,6 +679,14 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
                                             << " total_section_bytes=" << section_header.size;
                         break;
                     }
+                    case InvertedIndexSectionType::MAX_SCORES_PER_DIM: {
+                        reader.seekg(section_header.offset);
+                        max_scores_per_dim_span_ = boost::span<const float>(
+                            reinterpret_cast<const float*>(reader.data() + section_header.offset),
+                            this->nr_inner_dims_);
+                        reader.advance(sizeof(float) * this->nr_inner_dims_);
+                        break;
+                    }
                     case InvertedIndexSectionType::ROW_SUMS: {
                         // Row sums section for BM25
                         reader.seekg(section_header.offset);
@@ -663,6 +736,36 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
             return;
         }
 
+        // Compute max contributions for each query term: qval * max_dim_val
+        // and sort query terms by max contributions descending for early termination
+        std::vector<float> max_contributions(q_vec.size());
+        for (size_t i = 0; i < q_vec.size(); ++i) {
+            auto& [qid, qval] = q_vec[i];
+            float dim_max = (qid < max_scores_per_dim_span_.size()) ? max_scores_per_dim_span_[qid] : 0.0f;
+            max_contributions[i] = qval * dim_max;
+        }
+
+        // Sort q_vec by max contribution descending (process high-impact terms first)
+        std::vector<size_t> sorted_indices(q_vec.size());
+        std::iota(sorted_indices.begin(), sorted_indices.end(), 0);
+        std::sort(sorted_indices.begin(), sorted_indices.end(),
+                  [&max_contributions](size_t a, size_t b) { return max_contributions[a] > max_contributions[b]; });
+
+        // Reorder q_vec and max_contributions according to sorted indices
+        std::vector<std::pair<uint32_t, float>> sorted_q_vec(q_vec.size());
+        std::vector<float> sorted_max_contributions(q_vec.size());
+        for (size_t i = 0; i < q_vec.size(); ++i) {
+            sorted_q_vec[i] = q_vec[sorted_indices[i]];
+            sorted_max_contributions[i] = max_contributions[sorted_indices[i]];
+        }
+
+        // Compute suffix sums of max contributions for early termination
+        // suffix_sum[i] = sum of max_contributions from index i to end
+        std::vector<float> suffix_sum(q_vec.size() + 1, 0.0f);
+        for (int i = static_cast<int>(q_vec.size()) - 1; i >= 0; --i) {
+            suffix_sum[i] = suffix_sum[i + 1] + sorted_max_contributions[i];
+        }
+
         knowhere::ResultMinHeap<float, uint32_t> topk_q(k);
         std::vector<float> wscores_final_vec(window_size_, 0.0f);
         float* wscores_final = wscores_final_vec.data();
@@ -675,8 +778,8 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
         // Initialize posting list cursors for each query term
         // Cursors track position in posting lists and handle window-by-window iteration
         std::vector<PostingCursor> cursors;
-        cursors.reserve(q_vec.size());
-        for (auto& [qid, qval] : q_vec) {
+        cursors.reserve(sorted_q_vec.size());
+        for (auto& [qid, qval] : sorted_q_vec) {
             const uint8_t* wnnz_buf = nullptr;
             size_t wnnz_buf_sz = 0;
             if (!plists_window_nnzs_spans_.empty() && qid < plists_window_nnzs_spans_.size()) {
@@ -713,20 +816,33 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
                     std::min(window_size_, static_cast<uint32_t>(this->nr_rows_ - docid_start));
                 std::fill_n(wscores_final, curr_window_size, 0);
 
-                for (auto& cur : cursors) {
+                float curr_max_score = 0.0f;
+                bool skip_window_calc = false;
+                for (size_t ci = 0; ci < cursors.size(); ++ci) {
+                    auto& cur = cursors[ci];
                     if (cur.wnnz_buf == nullptr || cur.wnnz_buf_sz == 0) {
                         continue;
                     }
 
                     auto [soff, wnnz] = cur.advance_window(widx);
-                    if (wnnz == 0) {
+
+                    if (skip_window_calc || wnnz == 0) {
+                        continue;
+                    }
+
+                    // Skip window calculation if current max + remaining max contributions <= threshold
+                    if (curr_max_score + search_params.approx.dim_max_score_ratio * suffix_sum[ci] <= threshold) {
+                        skip_window_calc = true;
                         continue;
                     }
 
                     const uint16_t* plist_ids = cur.ids_base + soff;
                     const QuantType* plist_vals = cur.vals_base + soff;
 
-                    scatter_fn(cur.qval, plist_vals, plist_ids, wnnz, wscores_final);
+                    float dispatch_max = scatter_fn(cur.qval, plist_vals, plist_ids, wnnz, wscores_final);
+                    if (dispatch_max > curr_max_score) {
+                        curr_max_score = dispatch_max;
+                    }
                 }
 
                 batch_insert_fn(wscores_final, docid_start, curr_window_size, topk_q, threshold, bitset);
@@ -746,21 +862,34 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
                     std::min(window_size_, static_cast<uint32_t>(this->nr_rows_ - docid_start));
                 std::fill_n(wscores_final, curr_window_size, 0);
 
-                for (auto& cur : cursors) {
+                float curr_max_score = 0.0f;
+                bool skip_window_calc = false;
+                for (size_t ci = 0; ci < cursors.size(); ++ci) {
+                    auto& cur = cursors[ci];
                     if (cur.wnnz_buf == nullptr || cur.wnnz_buf_sz == 0) {
                         continue;
                     }
 
                     auto [soff, wnnz] = cur.advance_window(widx);
-                    if (wnnz == 0) {
+
+                    if (skip_window_calc || wnnz == 0) {
+                        continue;
+                    }
+
+                    // Skip window calculation if current max + remaining max contributions <= threshold
+                    if (curr_max_score + search_params.approx.dim_max_score_ratio * suffix_sum[ci] <= threshold) {
+                        skip_window_calc = true;
                         continue;
                     }
 
                     const uint16_t* plist_ids = cur.ids_base + soff;
                     const QuantType* plist_vals = cur.vals_base + soff;
 
-                    accumulate_fn(cur.qval, plist_vals, plist_ids, wnnz, wscores_final, bm25_k1, bm25_b, bm25_avgdl,
-                                  row_sums_ptr + docid_start);
+                    float dispatch_max = accumulate_fn(cur.qval, plist_vals, plist_ids, wnnz, wscores_final, bm25_k1,
+                                                       bm25_b, bm25_avgdl, row_sums_ptr + docid_start);
+                    if (dispatch_max > curr_max_score) {
+                        curr_max_score = dispatch_max;
+                    }
                 }
 
                 batch_insert_fn(wscores_final, docid_start, curr_window_size, topk_q, threshold, bitset);
@@ -927,6 +1056,8 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
     std::vector<boost::span<const uint8_t>> plists_window_nnzs_spans_;
     std::vector<uint32_t> plists_dim_offsets_;
     boost::span<const uint32_t> plists_dim_offsets_span_;
+    std::vector<float> max_scores_per_dim_;
+    boost::span<const float> max_scores_per_dim_span_;
 
     // Row sums only needed for BM25
     std::vector<float> row_sums_;

--- a/src/index/sparse/sindi_inverted_index.h
+++ b/src/index/sparse/sindi_inverted_index.h
@@ -90,7 +90,6 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
 
     void
     append_window_indexes(const SparseRow<DataType>* data, size_t rows) {
-        // Initialize global posting lists
         total_plists_ids_.resize(this->dim_map_.size());
         total_plists_vals_.resize(this->dim_map_.size());
         total_plists_ids_spans_.resize(this->dim_map_.size());
@@ -110,46 +109,19 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
             wif.resize(this->dim_map_.size());
         }
 
-        std::vector<size_t> prev_offsets(this->dim_map_.size(), 0);
-        std::vector<int32_t> cnt_nonempty_windows(this->dim_map_.size(), 0);
-
         for (size_t vecid = 0; vecid < rows; ++vecid) {
+            const uint32_t global_vecid = static_cast<uint32_t>(this->nr_rows_ + vecid);
+            const uint32_t widx = global_vecid / window_size_;
+            const uint16_t local_id = static_cast<uint16_t>(global_vecid % window_size_);
             for (size_t j = 0; j < data[vecid].size(); ++j) {
                 auto [dim, val] = data[vecid][j];
                 if (std::abs(val) < std::numeric_limits<DataType>::epsilon()) {
                     continue;
                 }
                 auto dim_id = this->dim_map_[dim];
-                total_plists_ids_[dim_id].push_back(static_cast<uint16_t>((vecid + this->nr_rows_) % window_size_));
+                total_plists_ids_[dim_id].push_back(local_id);
                 total_plists_vals_[dim_id].push_back(static_cast<QuantType>(static_cast<float>(val)));
-            }
-
-            if ((this->nr_rows_ + vecid + 1) % window_size_ == 0) {
-                for (size_t dim_id = 0; dim_id < this->dim_map_.size(); ++dim_id) {
-                    auto delta_sz = total_plists_ids_[dim_id].size() - prev_offsets[dim_id];
-                    window_index_plists_sz_[curr_widx_][dim_id] = static_cast<uint16_t>(delta_sz);
-                    if (delta_sz > 0) {
-                        cnt_nonempty_windows[dim_id] += 1;
-                    }
-                    prev_offsets[dim_id] = total_plists_ids_[dim_id].size();
-                }
-                ++curr_widx_;
-                // When we've just closed the last existing window, curr_widx_ may point
-                // beyond our current window count. It will become valid when a new window
-                // is opened by subsequent add() calls.
-            }
-        }
-
-        // If the last window is only partially filled, record its offsets as well,
-        // so that window_index_plists_sz_ stores per-window nnz consistently.
-        if ((this->nr_rows_ + rows) % window_size_ != 0 && curr_widx_ < nr_windows_) {
-            for (size_t dim_id = 0; dim_id < this->dim_map_.size(); ++dim_id) {
-                auto delta_sz = total_plists_ids_[dim_id].size() - prev_offsets[dim_id];
-                window_index_plists_sz_[curr_widx_][dim_id] = static_cast<uint16_t>(delta_sz);
-                if (delta_sz > 0) {
-                    cnt_nonempty_windows[dim_id] += 1;
-                }
-                prev_offsets[dim_id] = total_plists_ids_[dim_id].size();
+                ++window_index_plists_sz_[widx][dim_id];
             }
         }
 
@@ -175,9 +147,15 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
         // Encode window nnzs with sparse/dense format selection
         // Sparse format: (wid, wnnz) pairs when cnt_nonempty * 4 < nr_windows * 2
         // Dense format: one uint16_t per window otherwise
-        auto encode_dim_nnzs = [&](size_t dimid, int32_t cnt_nonempty) {
+        auto encode_dim_nnzs = [&](size_t dimid) {
             plists_window_nnzs_[dimid].clear();
             auto* mskptr = plists_wnnzs_fmts_msk_.data() + (dimid >> 3);
+            int32_t cnt_nonempty = 0;
+            for (size_t wid = 0; wid < nr_windows_; ++wid) {
+                if (window_index_plists_sz_spans_[wid][dimid] > 0) {
+                    ++cnt_nonempty;
+                }
+            }
             const bool use_sparse =
                 static_cast<size_t>(cnt_nonempty) * sizeof(uint32_t) < nr_windows_ * sizeof(uint16_t);
 
@@ -211,7 +189,7 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
         };
 
         for (size_t dimid = 0; dimid < this->dim_map_.size(); ++dimid) {
-            encode_dim_nnzs(dimid, cnt_nonempty_windows[dimid]);
+            encode_dim_nnzs(dimid);
         }
 
         plists_wnnzs_fmts_msk_span_ =
@@ -1065,7 +1043,6 @@ class SindiInvertedIndex : public InvertedIndex<DataType> {
 
     uint32_t window_size_{max_window_size};
     uint32_t nr_windows_{0};
-    uint32_t curr_widx_{0};
 
     // Cursor for iterating over a dimension's posting list by windows
     struct PostingCursor {

--- a/src/index/sparse/sindi_simd.cc
+++ b/src/index/sparse/sindi_simd.cc
@@ -4,27 +4,37 @@
 
 namespace knowhere::sparse::inverted::sindi {
 
-void
-ip_scatter_scalar_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out) {
+float
+ip_accumulate_scalar_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out) {
+    float max_val = 0.0f;
     for (int32_t i = 0; i < num; ++i) {
-        out[ids[i]] += qval * static_cast<float>(vals[i]);
+        float new_val = (out[ids[i]] += qval * static_cast<float>(vals[i]));
+        if (new_val > max_val) {
+            max_val = new_val;
+        }
     }
+    return max_val;
 }
 
-void
-bm25_scatter_scalar_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
-                        float b, float avgdl, const float* row_sums) {
+float
+bm25_accumulate_scalar_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
+                           float b, float avgdl, const float* row_sums) {
     const float p1 = k1 + 1.0f;
     const float p2 = k1 * (1.0f - b);
     const float p3 = k1 * b / avgdl;
 
+    float max_val = 0.0f;
     for (int32_t i = 0; i < num; ++i) {
         float tf = static_cast<float>(vals[i]);
         uint16_t docid = ids[i];
         float dl = row_sums[docid];
         float bm25_score = qval * p1 * tf / (tf + p2 + p3 * dl);
-        out[docid] += bm25_score;
+        float new_val = (out[docid] += bm25_score);
+        if (new_val > max_val) {
+            max_val = new_val;
+        }
     }
+    return max_val;
 }
 
 void
@@ -51,24 +61,25 @@ get_ip_kernels() {
     static const IPKernels kernels = []() {
         IPKernels k{};
 #if defined(__x86_64__)
-        if (faiss::cppcontrib::knowhere::cpu_support_avx512()) {
-            k.accumulate = ip_scatter_avx512_fp16;
+        const bool support_f16c = faiss::cppcontrib::knowhere::cpu_support_f16c();
+        if (support_f16c && faiss::cppcontrib::knowhere::cpu_support_avx512()) {
+            k.accumulate = ip_accumulate_avx512_fp16;
             k.batch_insert = batch_insert_avx512;
             return k;
         }
-        if (faiss::cppcontrib::knowhere::cpu_support_avx2()) {
-            k.accumulate = ip_scatter_avx2_fp16;
+        if (support_f16c && faiss::cppcontrib::knowhere::cpu_support_avx2()) {
+            k.accumulate = ip_accumulate_avx2_fp16;
             k.batch_insert = batch_insert_avx2;
             return k;
         }
-#elif defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#elif defined(__aarch64__) && defined(KNOWHERE_USE_SVE)
         if (faiss::cppcontrib::knowhere::supports_sve()) {
-            k.accumulate = ip_scatter_sve_fp16;
+            k.accumulate = ip_accumulate_sve_fp16;
             k.batch_insert = batch_insert_sve;
             return k;
         }
 #endif
-        k.accumulate = ip_scatter_scalar_fp16;
+        k.accumulate = ip_accumulate_scalar_fp16;
         k.batch_insert = batch_insert_scalar;
         return k;
     }();
@@ -80,24 +91,25 @@ get_bm25_kernels() {
     static const BM25Kernels kernels = []() {
         BM25Kernels k{};
 #if defined(__x86_64__)
-        if (faiss::cppcontrib::knowhere::cpu_support_avx512()) {
-            k.accumulate = bm25_scatter_avx512_u16;
+        const bool support_f16c = faiss::cppcontrib::knowhere::cpu_support_f16c();
+        if (support_f16c && faiss::cppcontrib::knowhere::cpu_support_avx512()) {
+            k.accumulate = bm25_accumulate_avx512_u16;
             k.batch_insert = batch_insert_avx512;
             return k;
         }
-        if (faiss::cppcontrib::knowhere::cpu_support_avx2()) {
-            k.accumulate = bm25_scatter_avx2_u16;
+        if (support_f16c && faiss::cppcontrib::knowhere::cpu_support_avx2()) {
+            k.accumulate = bm25_accumulate_avx2_u16;
             k.batch_insert = batch_insert_avx2;
             return k;
         }
-#elif defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#elif defined(__aarch64__) && defined(KNOWHERE_USE_SVE)
         if (faiss::cppcontrib::knowhere::supports_sve()) {
-            k.accumulate = bm25_scatter_sve_u16;
+            k.accumulate = bm25_accumulate_sve_u16;
             k.batch_insert = batch_insert_sve;
             return k;
         }
 #endif
-        k.accumulate = bm25_scatter_scalar_u16;
+        k.accumulate = bm25_accumulate_scalar_u16;
         k.batch_insert = batch_insert_scalar;
         return k;
     }();

--- a/src/index/sparse/sindi_simd.h
+++ b/src/index/sparse/sindi_simd.h
@@ -8,11 +8,11 @@
 
 namespace knowhere::sparse::inverted::sindi {
 
-using ip_accumulate_fn_t = void (*)(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num,
-                                    float* out);
+using ip_accumulate_fn_t = float (*)(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num,
+                                     float* out);
 
-using bm25_accumulate_fn_t = void (*)(float qval, const uint16_t* tf_vals, const uint16_t* ids, int32_t num, float* out,
-                                      float k1, float b, float avgdl, const float* row_sums);
+using bm25_accumulate_fn_t = float (*)(float qval, const uint16_t* tf_vals, const uint16_t* ids, int32_t num,
+                                       float* out, float k1, float b, float avgdl, const float* row_sums);
 
 using batch_insert_fn_t = void (*)(const float* scores, size_t docid_start, size_t count,
                                    knowhere::ResultMinHeap<float, uint32_t>& topk_q, float& threshold,
@@ -34,44 +34,44 @@ const BM25Kernels&
 get_bm25_kernels();
 
 // Scalar implementations (always available)
-void
-ip_scatter_scalar_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out);
-void
-bm25_scatter_scalar_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
-                        float b, float avgdl, const float* row_sums);
+float
+ip_accumulate_scalar_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out);
+float
+bm25_accumulate_scalar_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
+                           float b, float avgdl, const float* row_sums);
 void
 batch_insert_scalar(const float* scores, size_t docid_start, size_t count,
                     knowhere::ResultMinHeap<float, uint32_t>& topk_q, float& threshold, const BitsetView& bitset);
 
 #if defined(__x86_64__)
 // AVX2 implementations (compiled separately with -mavx2)
-void
-ip_scatter_avx2_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out);
-void
-bm25_scatter_avx2_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1, float b,
-                      float avgdl, const float* row_sums);
+float
+ip_accumulate_avx2_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out);
+float
+bm25_accumulate_avx2_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
+                         float b, float avgdl, const float* row_sums);
 void
 batch_insert_avx2(const float* scores, size_t docid_start, size_t count,
                   knowhere::ResultMinHeap<float, uint32_t>& topk_q, float& threshold, const BitsetView& bitset);
 
 // AVX512 implementations (compiled separately with -mavx512f)
-void
-ip_scatter_avx512_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out);
-void
-bm25_scatter_avx512_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
-                        float b, float avgdl, const float* row_sums);
+float
+ip_accumulate_avx512_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out);
+float
+bm25_accumulate_avx512_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
+                           float b, float avgdl, const float* row_sums);
 void
 batch_insert_avx512(const float* scores, size_t docid_start, size_t count,
                     knowhere::ResultMinHeap<float, uint32_t>& topk_q, float& threshold, const BitsetView& bitset);
 #endif
 
-#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#if defined(__aarch64__) && defined(KNOWHERE_USE_SVE)
 // SVE implementations (compiled with SVE support)
-void
-ip_scatter_sve_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out);
-void
-bm25_scatter_sve_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1, float b,
-                     float avgdl, const float* row_sums);
+float
+ip_accumulate_sve_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out);
+float
+bm25_accumulate_sve_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
+                        float b, float avgdl, const float* row_sums);
 void
 batch_insert_sve(const float* scores, size_t docid_start, size_t count,
                  knowhere::ResultMinHeap<float, uint32_t>& topk_q, float& threshold, const BitsetView& bitset);

--- a/src/index/sparse/sindi_simd_avx2.cc
+++ b/src/index/sparse/sindi_simd_avx2.cc
@@ -5,10 +5,11 @@
 
 namespace knowhere::sparse::inverted::sindi {
 
-void
-ip_scatter_avx2_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out) {
+float
+ip_accumulate_avx2_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out) {
     int32_t i = 0;
     const __m256 vq = _mm256_set1_ps(qval);
+    __m256 v_max = _mm256_setzero_ps();
     for (; i + 8 <= num; i += 8) {
         const uint16_t* hptr = reinterpret_cast<const uint16_t*>(vals + i);
         __m128i h = _mm_loadu_si128(reinterpret_cast<const __m128i*>(hptr));
@@ -32,15 +33,24 @@ ip_scatter_avx2_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids
         out[tmp_idx[5]] = tmp_sum[5];
         out[tmp_idx[6]] = tmp_sum[6];
         out[tmp_idx[7]] = tmp_sum[7];
+        v_max = _mm256_max_ps(v_max, v_sum);
     }
+    __m128 v_max128 = _mm_max_ps(_mm256_castps256_ps128(v_max), _mm256_extractf128_ps(v_max, 1));
+    v_max128 = _mm_max_ps(v_max128, _mm_shuffle_ps(v_max128, v_max128, _MM_SHUFFLE(2, 3, 0, 1)));
+    v_max128 = _mm_max_ps(v_max128, _mm_shuffle_ps(v_max128, v_max128, _MM_SHUFFLE(1, 0, 3, 2)));
+    float max_val = _mm_cvtss_f32(v_max128);
     for (; i < num; ++i) {
-        out[ids[i]] += qval * static_cast<float>(vals[i]);
+        float new_val = (out[ids[i]] += qval * static_cast<float>(vals[i]));
+        if (new_val > max_val) {
+            max_val = new_val;
+        }
     }
+    return max_val;
 }
 
-void
-bm25_scatter_avx2_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1, float b,
-                      float avgdl, const float* row_sums) {
+float
+bm25_accumulate_avx2_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
+                         float b, float avgdl, const float* row_sums) {
     const float p1 = k1 + 1.0f;
     const float p2 = k1 * (1.0f - b);
     const float p3 = k1 * b / avgdl;
@@ -50,6 +60,7 @@ bm25_scatter_avx2_u16(float qval, const uint16_t* vals, const uint16_t* ids, int
     const __m256 vp1 = _mm256_set1_ps(p1);
     const __m256 vp2 = _mm256_set1_ps(p2);
     const __m256 vp3 = _mm256_set1_ps(p3);
+    __m256 v_max = _mm256_setzero_ps();
 
     for (; i + 8 <= num; i += 8) {
         const uint16_t* hptr = vals + i;
@@ -84,15 +95,25 @@ bm25_scatter_avx2_u16(float qval, const uint16_t* vals, const uint16_t* ids, int
         out[tmp_idx[5]] = tmp_sum[5];
         out[tmp_idx[6]] = tmp_sum[6];
         out[tmp_idx[7]] = tmp_sum[7];
+        v_max = _mm256_max_ps(v_max, v_sum);
     }
+
+    __m128 v_max128 = _mm_max_ps(_mm256_castps256_ps128(v_max), _mm256_extractf128_ps(v_max, 1));
+    v_max128 = _mm_max_ps(v_max128, _mm_shuffle_ps(v_max128, v_max128, _MM_SHUFFLE(2, 3, 0, 1)));
+    v_max128 = _mm_max_ps(v_max128, _mm_shuffle_ps(v_max128, v_max128, _MM_SHUFFLE(1, 0, 3, 2)));
+    float max_val = _mm_cvtss_f32(v_max128);
 
     for (; i < num; ++i) {
         float tf = static_cast<float>(vals[i]);
         uint16_t docid = ids[i];
         float dl = row_sums[docid];
         float bm25_score = qval * p1 * tf / (tf + p2 + p3 * dl);
-        out[docid] += bm25_score;
+        float new_val = (out[docid] += bm25_score);
+        if (new_val > max_val) {
+            max_val = new_val;
+        }
     }
+    return max_val;
 }
 
 void

--- a/src/index/sparse/sindi_simd_avx512.cc
+++ b/src/index/sparse/sindi_simd_avx512.cc
@@ -5,11 +5,13 @@
 
 namespace knowhere::sparse::inverted::sindi {
 
-void
-ip_scatter_avx512_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out) {
+float
+ip_accumulate_avx512_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out) {
     int32_t i = 0;
     const __m512 vq512 = _mm512_set1_ps(qval);
     const __m256 vq256 = _mm256_set1_ps(qval);
+    __m512 v_max = _mm512_setzero_ps();
+    __m256 v_max256 = _mm256_setzero_ps();
     for (; i + 16 <= num; i += 16) {
         const uint16_t* hptr = reinterpret_cast<const uint16_t*>(vals + i);
         __m256i h = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(hptr));
@@ -21,6 +23,7 @@ ip_scatter_avx512_fp16(float qval, const knowhere::fp16* vals, const uint16_t* i
         __m512 v_old = _mm512_i32gather_ps(v_idx, out, 4);
         __m512 v_sum = _mm512_add_ps(v_old, v_mul);
         _mm512_i32scatter_ps(out, v_idx, v_sum, 4);
+        v_max = _mm512_max_ps(v_max, v_sum);
     }
     for (; i + 8 <= num; i += 8) {
         const uint16_t* hptr = reinterpret_cast<const uint16_t*>(vals + i);
@@ -32,15 +35,28 @@ ip_scatter_avx512_fp16(float qval, const knowhere::fp16* vals, const uint16_t* i
         __m256 v_old = _mm256_i32gather_ps(out, v_idx, 4);
         __m256 v_sum = _mm256_add_ps(v_old, v_mul);
         _mm256_i32scatter_ps(out, v_idx, v_sum, 4);
+        v_max256 = _mm256_max_ps(v_max256, v_sum);
+    }
+    float max_val = _mm512_reduce_max_ps(v_max);
+    __m128 v_max128 = _mm_max_ps(_mm256_castps256_ps128(v_max256), _mm256_extractf128_ps(v_max256, 1));
+    v_max128 = _mm_max_ps(v_max128, _mm_shuffle_ps(v_max128, v_max128, _MM_SHUFFLE(2, 3, 0, 1)));
+    v_max128 = _mm_max_ps(v_max128, _mm_shuffle_ps(v_max128, v_max128, _MM_SHUFFLE(1, 0, 3, 2)));
+    float max256_scalar = _mm_cvtss_f32(v_max128);
+    if (max256_scalar > max_val) {
+        max_val = max256_scalar;
     }
     for (; i < num; ++i) {
-        out[ids[i]] += qval * static_cast<float>(vals[i]);
+        float new_val = (out[ids[i]] += qval * static_cast<float>(vals[i]));
+        if (new_val > max_val) {
+            max_val = new_val;
+        }
     }
+    return max_val;
 }
 
-void
-bm25_scatter_avx512_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
-                        float b, float avgdl, const float* row_sums) {
+float
+bm25_accumulate_avx512_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
+                           float b, float avgdl, const float* row_sums) {
     const float p1 = k1 + 1.0f;
     const float p2 = k1 * (1.0f - b);
     const float p3 = k1 * b / avgdl;
@@ -50,6 +66,7 @@ bm25_scatter_avx512_u16(float qval, const uint16_t* vals, const uint16_t* ids, i
     const __m512 vp1 = _mm512_set1_ps(p1);
     const __m512 vp2 = _mm512_set1_ps(p2);
     const __m512 vp3 = _mm512_set1_ps(p3);
+    __m512 v_max = _mm512_setzero_ps();
 
     for (; i + 16 <= num; i += 16) {
         const uint16_t* hptr = vals + i;
@@ -74,15 +91,22 @@ bm25_scatter_avx512_u16(float qval, const uint16_t* vals, const uint16_t* ids, i
         __m512 v_old = _mm512_i32gather_ps(v_idx, out, 4);
         __m512 v_sum = _mm512_add_ps(v_old, bm25_vec);
         _mm512_i32scatter_ps(out, v_idx, v_sum, 4);
+        v_max = _mm512_max_ps(v_max, v_sum);
     }
+
+    float max_val = _mm512_reduce_max_ps(v_max);
 
     for (; i < num; ++i) {
         float tf = static_cast<float>(vals[i]);
         uint16_t docid = ids[i];
         float dl = row_sums[docid];
         float bm25_score = qval * p1 * tf / (tf + p2 + p3 * dl);
-        out[docid] += bm25_score;
+        float new_val = (out[docid] += bm25_score);
+        if (new_val > max_val) {
+            max_val = new_val;
+        }
     }
+    return max_val;
 }
 
 void

--- a/src/index/sparse/sindi_simd_sve.cc
+++ b/src/index/sparse/sindi_simd_sve.cc
@@ -1,0 +1,281 @@
+#include "index/sparse/sindi_simd.h"
+
+#if defined(__aarch64__) && defined(KNOWHERE_USE_SVE) && defined(__ARM_FEATURE_SVE)
+
+#include <arm_sve.h>
+
+namespace knowhere::sparse::inverted::sindi {
+
+float
+ip_accumulate_sve_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out) {
+    const svfloat32_t vq32 = svdup_f32(qval);
+    const uint32_t vl32 = svcntw();
+    const svbool_t pg32 = svptrue_b32();
+    const svbool_t pg16 = svptrue_b16();
+    svfloat32_t v_max = svdup_f32(0.0f);
+
+    int32_t i = 0;
+    const int32_t step = static_cast<int32_t>(vl32 * 2);
+    for (; i + step <= num; i += step) {
+        const __fp16* hptr = reinterpret_cast<const __fp16*>(vals + i);
+
+        svfloat16_t vh = svld1_f16(pg16, hptr);
+        svfloat32_t vf_even = svcvt_f32_f16_x(pg32, vh);
+        svfloat16_t vh_shift = svext_f16(vh, vh, 1);
+        svfloat32_t vf_odd = svcvt_f32_f16_x(pg32, vh_shift);
+
+        svuint16_t id16 = svld1_u16(pg16, ids + i);
+        svuint16_t id_even16 = svuzp1_u16(id16, id16);
+        svuint16_t id_odd16 = svuzp2_u16(id16, id16);
+        svuint32_t vidx_even = svunpklo_u32(id_even16);
+        svuint32_t vidx_odd = svunpklo_u32(id_odd16);
+
+        svfloat32_t vold_even = svld1_gather_u32index_f32(pg32, out, vidx_even);
+        svfloat32_t vsum_even = svmad_f32_x(pg32, vf_even, vq32, vold_even);
+        svst1_scatter_u32index_f32(pg32, out, vidx_even, vsum_even);
+        v_max = svmax_f32_x(pg32, v_max, vsum_even);
+
+        svfloat32_t vold_odd = svld1_gather_u32index_f32(pg32, out, vidx_odd);
+        svfloat32_t vsum_odd = svmad_f32_x(pg32, vf_odd, vq32, vold_odd);
+        svst1_scatter_u32index_f32(pg32, out, vidx_odd, vsum_odd);
+        v_max = svmax_f32_x(pg32, v_max, vsum_odd);
+    }
+
+    if (i < num) {
+        int32_t remaining = num - i;
+        svbool_t pg16_tail = svwhilelt_b16(static_cast<uint32_t>(0), static_cast<uint32_t>(remaining));
+
+        const __fp16* hptr = reinterpret_cast<const __fp16*>(vals + i);
+        svfloat16_t vh = svld1_f16(pg16_tail, hptr);
+        svfloat16_t vh_shift = svext_f16(vh, vh, 1);
+
+        uint32_t n_even = static_cast<uint32_t>((remaining + 1) >> 1);
+        uint32_t n_odd = static_cast<uint32_t>(remaining >> 1);
+
+        svbool_t pg32_even = svwhilelt_b32(static_cast<uint32_t>(0), n_even);
+        svbool_t pg32_odd = svwhilelt_b32(static_cast<uint32_t>(0), n_odd);
+
+        svfloat32_t vf_even = svcvt_f32_f16_x(pg32_even, vh);
+        svfloat32_t vf_odd = svcvt_f32_f16_x(pg32_odd, vh_shift);
+
+        svuint16_t id16 = svld1_u16(pg16_tail, ids + i);
+        svuint16_t id_even16 = svuzp1_u16(id16, id16);
+        svuint16_t id_odd16 = svuzp2_u16(id16, id16);
+        svuint32_t vidx_even = svunpklo_u32(id_even16);
+        svuint32_t vidx_odd = svunpklo_u32(id_odd16);
+
+        if (n_even) {
+            svfloat32_t vold_even = svld1_gather_u32index_f32(pg32_even, out, vidx_even);
+            svfloat32_t vsum_even = svmad_f32_x(pg32_even, vf_even, vq32, vold_even);
+            svst1_scatter_u32index_f32(pg32_even, out, vidx_even, vsum_even);
+            v_max = svmax_f32_m(pg32_even, v_max, vsum_even);
+        }
+
+        if (n_odd) {
+            svfloat32_t vold_odd = svld1_gather_u32index_f32(pg32_odd, out, vidx_odd);
+            svfloat32_t vsum_odd = svmad_f32_x(pg32_odd, vf_odd, vq32, vold_odd);
+            svst1_scatter_u32index_f32(pg32_odd, out, vidx_odd, vsum_odd);
+            v_max = svmax_f32_m(pg32_odd, v_max, vsum_odd);
+        }
+    }
+    return svmaxv_f32(svptrue_b32(), v_max);
+}
+
+namespace {
+
+svfloat32_t
+sv_fast_recip_f32(svbool_t pg, svfloat32_t x) {
+    svfloat32_t recip = svrecpe_f32(x);
+    svfloat32_t step = svrecps_f32(x, recip);
+    return svmul_f32_x(pg, recip, step);
+}
+
+}  // namespace
+
+float
+bm25_accumulate_sve_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
+                        float b, float avgdl, const float* row_sums) {
+    const float p1 = k1 + 1.0f;
+    const float p2 = k1 * (1.0f - b);
+    const float p3 = k1 * b / avgdl;
+
+    const svfloat32_t vp2 = svdup_f32(p2);
+    const svfloat32_t vp3 = svdup_f32(p3);
+    const svfloat32_t vqp1 = svdup_f32(qval * p1);
+    svfloat32_t v_max = svdup_f32(0.0f);
+
+    const uint32_t vl32 = svcntw();
+    const svbool_t pg32 = svptrue_b32();
+    const svbool_t pg16 = svptrue_b16();
+
+    int32_t i = 0;
+    const int32_t step = static_cast<int32_t>(vl32 * 2);
+    for (; i + step <= num; i += step) {
+        svuint16_t tf16 = svld1_u16(pg16, vals + i);
+
+        svuint16_t tf_even16 = svuzp1_u16(tf16, tf16);
+        svuint16_t tf_odd16 = svuzp2_u16(tf16, tf16);
+        svuint32_t tf_even_u32 = svunpklo_u32(tf_even16);
+        svuint32_t tf_odd_u32 = svunpklo_u32(tf_odd16);
+
+        svfloat32_t tf_even = svcvt_f32_u32_x(pg32, tf_even_u32);
+        svfloat32_t tf_odd = svcvt_f32_u32_x(pg32, tf_odd_u32);
+
+        svuint16_t id16 = svld1_u16(pg16, ids + i);
+        svuint16_t id_even16 = svuzp1_u16(id16, id16);
+        svuint16_t id_odd16 = svuzp2_u16(id16, id16);
+        svuint32_t vidx_even = svunpklo_u32(id_even16);
+        svuint32_t vidx_odd = svunpklo_u32(id_odd16);
+
+        svfloat32_t dl_even = svld1_gather_u32index_f32(pg32, row_sums, vidx_even);
+        svfloat32_t dl_odd = svld1_gather_u32index_f32(pg32, row_sums, vidx_odd);
+
+        svfloat32_t num_even = svmul_f32_x(pg32, tf_even, vqp1);
+        svfloat32_t denom_even = svmad_f32_x(pg32, dl_even, vp3, vp2);
+        denom_even = svadd_f32_x(pg32, tf_even, denom_even);
+        svfloat32_t bm25_even = svmul_f32_x(pg32, num_even, sv_fast_recip_f32(pg32, denom_even));
+
+        svfloat32_t num_odd = svmul_f32_x(pg32, tf_odd, vqp1);
+        svfloat32_t denom_odd = svmad_f32_x(pg32, dl_odd, vp3, vp2);
+        denom_odd = svadd_f32_x(pg32, tf_odd, denom_odd);
+        svfloat32_t bm25_odd = svmul_f32_x(pg32, num_odd, sv_fast_recip_f32(pg32, denom_odd));
+
+        svfloat32_t vold_even = svld1_gather_u32index_f32(pg32, out, vidx_even);
+        svfloat32_t vsum_even = svadd_f32_x(pg32, vold_even, bm25_even);
+        svst1_scatter_u32index_f32(pg32, out, vidx_even, vsum_even);
+        v_max = svmax_f32_x(pg32, v_max, vsum_even);
+
+        svfloat32_t vold_odd = svld1_gather_u32index_f32(pg32, out, vidx_odd);
+        svfloat32_t vsum_odd = svadd_f32_x(pg32, vold_odd, bm25_odd);
+        svst1_scatter_u32index_f32(pg32, out, vidx_odd, vsum_odd);
+        v_max = svmax_f32_x(pg32, v_max, vsum_odd);
+    }
+
+    if (i < num) {
+        int32_t remaining = num - i;
+        svbool_t pg16_tail = svwhilelt_b16(static_cast<uint32_t>(0), static_cast<uint32_t>(remaining));
+
+        svuint16_t tf16 = svld1_u16(pg16_tail, vals + i);
+        svuint16_t tf_even16 = svuzp1_u16(tf16, tf16);
+        svuint16_t tf_odd16 = svuzp2_u16(tf16, tf16);
+
+        uint32_t n_even = static_cast<uint32_t>((remaining + 1) >> 1);
+        uint32_t n_odd = static_cast<uint32_t>(remaining >> 1);
+
+        svbool_t pg32_even = svwhilelt_b32(static_cast<uint32_t>(0), n_even);
+        svbool_t pg32_odd = svwhilelt_b32(static_cast<uint32_t>(0), n_odd);
+
+        svuint32_t tf_even_u32 = svunpklo_u32(tf_even16);
+        svuint32_t tf_odd_u32 = svunpklo_u32(tf_odd16);
+        svfloat32_t tf_even = svcvt_f32_u32_x(pg32_even, tf_even_u32);
+        svfloat32_t tf_odd = svcvt_f32_u32_x(pg32_odd, tf_odd_u32);
+
+        svuint16_t id16 = svld1_u16(pg16_tail, ids + i);
+        svuint16_t id_even16 = svuzp1_u16(id16, id16);
+        svuint16_t id_odd16 = svuzp2_u16(id16, id16);
+        svuint32_t vidx_even = svunpklo_u32(id_even16);
+        svuint32_t vidx_odd = svunpklo_u32(id_odd16);
+
+        if (n_even) {
+            svfloat32_t dl_even = svld1_gather_u32index_f32(pg32_even, row_sums, vidx_even);
+            svfloat32_t num_even = svmul_f32_x(pg32_even, tf_even, vqp1);
+            svfloat32_t denom_even = svmad_f32_x(pg32_even, dl_even, vp3, vp2);
+            denom_even = svadd_f32_x(pg32_even, tf_even, denom_even);
+            svfloat32_t bm25_even = svmul_f32_x(pg32_even, num_even, sv_fast_recip_f32(pg32_even, denom_even));
+
+            svfloat32_t vold_even = svld1_gather_u32index_f32(pg32_even, out, vidx_even);
+            svfloat32_t vsum_even = svadd_f32_x(pg32_even, vold_even, bm25_even);
+            svst1_scatter_u32index_f32(pg32_even, out, vidx_even, vsum_even);
+            v_max = svmax_f32_m(pg32_even, v_max, vsum_even);
+        }
+
+        if (n_odd) {
+            svfloat32_t dl_odd = svld1_gather_u32index_f32(pg32_odd, row_sums, vidx_odd);
+            svfloat32_t num_odd = svmul_f32_x(pg32_odd, tf_odd, vqp1);
+            svfloat32_t denom_odd = svmad_f32_x(pg32_odd, dl_odd, vp3, vp2);
+            denom_odd = svadd_f32_x(pg32_odd, tf_odd, denom_odd);
+            svfloat32_t bm25_odd = svmul_f32_x(pg32_odd, num_odd, sv_fast_recip_f32(pg32_odd, denom_odd));
+
+            svfloat32_t vold_odd = svld1_gather_u32index_f32(pg32_odd, out, vidx_odd);
+            svfloat32_t vsum_odd = svadd_f32_x(pg32_odd, vold_odd, bm25_odd);
+            svst1_scatter_u32index_f32(pg32_odd, out, vidx_odd, vsum_odd);
+            v_max = svmax_f32_m(pg32_odd, v_max, vsum_odd);
+        }
+    }
+    return svmaxv_f32(svptrue_b32(), v_max);
+}
+
+void
+batch_insert_sve(const float* scores, size_t docid_start, size_t count,
+                 knowhere::ResultMinHeap<float, uint32_t>& topk_q, float& threshold, const BitsetView& bitset) {
+    const uint32_t vl = svcntw();
+    size_t i = 0;
+    svfloat32_t vthr = svdup_f32(threshold);
+
+    for (; i + vl <= count; i += vl) {
+        svbool_t pg = svptrue_b32();
+        svfloat32_t v = svld1(pg, scores + i);
+        svbool_t pg_sel = svcmpgt_f32(pg, v, vthr);
+
+        if (!svptest_any(pg, pg_sel)) {
+            continue;
+        }
+
+        alignas(64) uint32_t tmp_mask[64];
+        svuint32_t ones = svdup_u32(1);
+        svuint32_t zeros = svdup_u32(0);
+        svuint32_t vmask = svsel_u32(pg_sel, ones, zeros);
+        svst1(pg, tmp_mask, vmask);
+
+        for (uint32_t j = 0; j < vl; ++j) {
+            if (tmp_mask[j]) {
+                size_t idx = i + j;
+                if (!bitset.empty() && bitset.test(static_cast<int64_t>(docid_start + idx))) {
+                    continue;
+                }
+                float s = scores[idx];
+                if (topk_q.Push(s, static_cast<uint32_t>(docid_start + idx))) {
+                    if (topk_q.Full()) {
+                        threshold = topk_q.Threshold();
+                        vthr = svdup_f32(threshold);
+                    }
+                }
+            }
+        }
+    }
+
+    if (i < count) {
+        const uint32_t step = static_cast<uint32_t>(count - i);
+        svbool_t pg = svwhilelt_b32(static_cast<uint32_t>(0), step);
+        svfloat32_t v = svld1(pg, scores + i);
+        svbool_t pg_sel = svcmpgt_f32(pg, v, vthr);
+
+        if (svptest_any(pg, pg_sel)) {
+            alignas(64) uint32_t tmp_mask[64];
+            svuint32_t ones = svdup_u32(1);
+            svuint32_t zeros = svdup_u32(0);
+            svuint32_t vmask = svsel_u32(pg_sel, ones, zeros);
+            svst1(pg, tmp_mask, vmask);
+
+            for (uint32_t j = 0; j < step; ++j) {
+                if (tmp_mask[j]) {
+                    size_t idx = i + j;
+                    if (!bitset.empty() && bitset.test(static_cast<int64_t>(docid_start + idx))) {
+                        continue;
+                    }
+                    float s = scores[idx];
+                    if (topk_q.Push(s, static_cast<uint32_t>(docid_start + idx))) {
+                        if (topk_q.Full()) {
+                            threshold = topk_q.Threshold();
+                            vthr = svdup_f32(threshold);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+}  // namespace knowhere::sparse::inverted::sindi
+
+#endif

--- a/src/index/sparse/sindi_simd_sve.cc
+++ b/src/index/sparse/sindi_simd_sve.cc
@@ -81,17 +81,6 @@ ip_accumulate_sve_fp16(float qval, const knowhere::fp16* vals, const uint16_t* i
     return svmaxv_f32(svptrue_b32(), v_max);
 }
 
-namespace {
-
-svfloat32_t
-sv_fast_recip_f32(svbool_t pg, svfloat32_t x) {
-    svfloat32_t recip = svrecpe_f32(x);
-    svfloat32_t step = svrecps_f32(x, recip);
-    return svmul_f32_x(pg, recip, step);
-}
-
-}  // namespace
-
 float
 bm25_accumulate_sve_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
                         float b, float avgdl, const float* row_sums) {
@@ -133,12 +122,12 @@ bm25_accumulate_sve_u16(float qval, const uint16_t* vals, const uint16_t* ids, i
         svfloat32_t num_even = svmul_f32_x(pg32, tf_even, vqp1);
         svfloat32_t denom_even = svmad_f32_x(pg32, dl_even, vp3, vp2);
         denom_even = svadd_f32_x(pg32, tf_even, denom_even);
-        svfloat32_t bm25_even = svmul_f32_x(pg32, num_even, sv_fast_recip_f32(pg32, denom_even));
+        svfloat32_t bm25_even = svdiv_f32_x(pg32, num_even, denom_even);
 
         svfloat32_t num_odd = svmul_f32_x(pg32, tf_odd, vqp1);
         svfloat32_t denom_odd = svmad_f32_x(pg32, dl_odd, vp3, vp2);
         denom_odd = svadd_f32_x(pg32, tf_odd, denom_odd);
-        svfloat32_t bm25_odd = svmul_f32_x(pg32, num_odd, sv_fast_recip_f32(pg32, denom_odd));
+        svfloat32_t bm25_odd = svdiv_f32_x(pg32, num_odd, denom_odd);
 
         svfloat32_t vold_even = svld1_gather_u32index_f32(pg32, out, vidx_even);
         svfloat32_t vsum_even = svadd_f32_x(pg32, vold_even, bm25_even);
@@ -181,7 +170,7 @@ bm25_accumulate_sve_u16(float qval, const uint16_t* vals, const uint16_t* ids, i
             svfloat32_t num_even = svmul_f32_x(pg32_even, tf_even, vqp1);
             svfloat32_t denom_even = svmad_f32_x(pg32_even, dl_even, vp3, vp2);
             denom_even = svadd_f32_x(pg32_even, tf_even, denom_even);
-            svfloat32_t bm25_even = svmul_f32_x(pg32_even, num_even, sv_fast_recip_f32(pg32_even, denom_even));
+            svfloat32_t bm25_even = svdiv_f32_x(pg32_even, num_even, denom_even);
 
             svfloat32_t vold_even = svld1_gather_u32index_f32(pg32_even, out, vidx_even);
             svfloat32_t vsum_even = svadd_f32_x(pg32_even, vold_even, bm25_even);
@@ -194,7 +183,7 @@ bm25_accumulate_sve_u16(float qval, const uint16_t* vals, const uint16_t* ids, i
             svfloat32_t num_odd = svmul_f32_x(pg32_odd, tf_odd, vqp1);
             svfloat32_t denom_odd = svmad_f32_x(pg32_odd, dl_odd, vp3, vp2);
             denom_odd = svadd_f32_x(pg32_odd, tf_odd, denom_odd);
-            svfloat32_t bm25_odd = svmul_f32_x(pg32_odd, num_odd, sv_fast_recip_f32(pg32_odd, denom_odd));
+            svfloat32_t bm25_odd = svdiv_f32_x(pg32_odd, num_odd, denom_odd);
 
             svfloat32_t vold_odd = svld1_gather_u32index_f32(pg32_odd, out, vidx_odd);
             svfloat32_t vsum_odd = svadd_f32_x(pg32_odd, vold_odd, bm25_odd);

--- a/tests/ut/test_sparse.cc
+++ b/tests/ut/test_sparse.cc
@@ -1087,6 +1087,126 @@ TEST_CASE("Test Sparse Index CC Build Add Search", "[sparse]") {
     }
 }
 
+TEST_CASE("Test SINDI Sparse Inverted Index CC Build Add Search", "[sparse][sindi]") {
+    auto nb = 10;
+    auto extra_nb = 4;
+    auto dim = 8;
+    auto topk = 8;
+    auto nq = 3;
+    auto version = knowhere::Version::GetMaximumVersion().VersionNumber();
+
+    auto dense_sparse_ds = [](int32_t rows, int32_t dim, float value) {
+        std::vector<std::map<int32_t, float>> data(rows);
+        for (int32_t i = 0; i < rows; ++i) {
+            for (int32_t j = 0; j < dim; ++j) {
+                data[i][j] = value;
+            }
+        }
+        return GenSparseDataSet(data, dim);
+    };
+
+    auto train_ds = dense_sparse_ds(nb, dim, 1.0f);
+    auto query_ds = dense_sparse_ds(nq, dim, 1.0f);
+
+    knowhere::Json json;
+    json[knowhere::meta::DIM] = dim;
+    json[knowhere::meta::METRIC_TYPE] = knowhere::metric::IP;
+    json[knowhere::meta::TOPK] = topk;
+    json[knowhere::indexparam::INVERTED_INDEX_ALGO] = "SINDI";
+    json[knowhere::indexparam::SEARCH_ALGO] = "SINDI";
+
+    const std::string cc_name = knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC;
+    auto idx = knowhere::IndexFactory::Instance().Create<knowhere::sparse_u32_f32>(cc_name, version).value();
+    CAPTURE(cc_name);
+
+    REQUIRE(idx.Build(train_ds, json) == knowhere::Status::success);
+
+    auto extra_ds = dense_sparse_ds(extra_nb, dim, 2.0f);
+    REQUIRE(idx.Add(extra_ds, json) == knowhere::Status::success);
+
+    auto results = idx.Search(query_ds, json, nullptr);
+    REQUIRE(results.has_value());
+
+    auto* ids = results.value()->GetIds();
+    auto k = results.value()->GetDim();
+    for (int64_t i = 0; i < nq; ++i) {
+        int64_t valid_count = 0;
+        for (int64_t j = 0; j < k; ++j) {
+            if (ids[i * k + j] != -1) {
+                ++valid_count;
+            }
+        }
+        REQUIRE(valid_count == topk);
+    }
+}
+
+TEST_CASE("Test SINDI Sparse Inverted Index CC Train Multi Add Cross Window Search", "[sparse][sindi]") {
+    auto window_size = 1024;
+    auto first_nb = window_size;
+    auto second_nb = 8;
+    auto dim = 8;
+    auto topk = 16;
+    int64_t nq = 3;
+    auto version = knowhere::Version::GetMaximumVersion().VersionNumber();
+
+    auto dense_sparse_ds = [](int32_t rows, int32_t dim, float value) {
+        std::vector<std::map<int32_t, float>> data(rows);
+        for (int32_t i = 0; i < rows; ++i) {
+            for (int32_t j = 0; j < dim; ++j) {
+                data[i][j] = value;
+            }
+        }
+        return GenSparseDataSet(data, dim);
+    };
+
+    knowhere::Json json;
+    json[knowhere::meta::DIM] = dim;
+    json[knowhere::meta::METRIC_TYPE] = knowhere::metric::IP;
+    json[knowhere::meta::TOPK] = topk;
+    json[knowhere::indexparam::INVERTED_INDEX_ALGO] = "SINDI";
+    json[knowhere::indexparam::SEARCH_ALGO] = "SINDI";
+    json["sindi_window_size"] = window_size;
+
+    const std::string cc_name = knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC;
+    auto idx = knowhere::IndexFactory::Instance().Create<knowhere::sparse_u32_f32>(cc_name, version).value();
+    CAPTURE(cc_name);
+
+    auto train_ds = dense_sparse_ds(1, dim, 1.0f);
+    REQUIRE(idx.Train(train_ds, json) == knowhere::Status::success);
+
+    auto first_ds = dense_sparse_ds(first_nb, dim, 1.0f);
+    REQUIRE(idx.Add(first_ds, json) == knowhere::Status::success);
+
+    auto second_ds = dense_sparse_ds(second_nb, dim, 2.0f);
+    REQUIRE(idx.Add(second_ds, json) == knowhere::Status::success);
+    REQUIRE(idx.Count() == first_nb + second_nb);
+
+    auto query_ds = dense_sparse_ds(nq, dim, 1.0f);
+    auto results = idx.Search(query_ds, json, nullptr);
+    REQUIRE(results.has_value());
+
+    auto* ids = results.value()->GetIds();
+    auto k = results.value()->GetDim();
+    REQUIRE(k == topk);
+    for (int64_t i = 0; i < nq; ++i) {
+        int64_t valid_count = 0;
+        bool found_first_window = false;
+        bool found_second_window = false;
+        for (int64_t j = 0; j < k; ++j) {
+            auto id = ids[i * k + j];
+            if (id == -1) {
+                continue;
+            }
+            ++valid_count;
+            found_first_window = found_first_window || id < first_nb;
+            found_second_window = found_second_window || id >= first_nb;
+        }
+        REQUIRE(valid_count == topk);
+        REQUIRE(found_first_window);
+        REQUIRE(found_second_window);
+    }
+}
+
 TEST_CASE("Test SINDI Index Build and Search", "[sparse][sindi]") {
     auto [nb, dim, doc_sparsity, query_sparsity] = GENERATE(table<int32_t, int32_t, float, float>({
         {2000, 300, 0.95, 0.97},

--- a/tests/ut/test_sparse.cc
+++ b/tests/ut/test_sparse.cc
@@ -1054,11 +1054,6 @@ TEST_CASE("Test Sparse Index CC Build Add Search", "[sparse]") {
     }
 
     SECTION("Build then Add more data to CC index") {
-#if defined(__APPLE__)
-        // TODO: CC sparse index Add() returns all -1 IDs on macOS ARM.
-        // Needs investigation; skip until the root cause is identified.
-        SKIP("CC sparse index Add not supported on macOS yet");
-#else
         auto idx = knowhere::IndexFactory::Instance().Create<knowhere::sparse_u32_f32>(cc_name, version).value();
         // Build with initial data first (required for CC indices)
         REQUIRE(idx.Build(train_ds, json) == knowhere::Status::success);
@@ -1073,6 +1068,7 @@ TEST_CASE("Test Sparse Index CC Build Add Search", "[sparse]") {
         // but original results should still be findable
         auto* ids = results.value()->GetIds();
         auto k = results.value()->GetDim();
+        const auto* queries = static_cast<const knowhere::sparse::SparseRow<float>*>(query_ds->GetTensor());
         for (int64_t i = 0; i < nq; ++i) {
             bool found_valid = false;
             for (int64_t j = 0; j < k; ++j) {
@@ -1081,9 +1077,12 @@ TEST_CASE("Test Sparse Index CC Build Add Search", "[sparse]") {
                     break;
                 }
             }
-            REQUIRE(found_valid);
+            if (queries[i].size() == 0) {
+                REQUIRE_FALSE(found_valid);
+            } else {
+                REQUIRE(found_valid);
+            }
         }
-#endif
     }
 }
 


### PR DESCRIPTION
issue: #1555

Add early termination optimization that skips remaining terms in a window when the current max score plus remaining max contributions cannot exceed the top-k threshold. Includes per-dimension max score computation, query term sorting by max contribution, and suffix sum based pruning.