### PR TITLE
feat: support nullable external id mapping

### DIFF
--- a/include/knowhere/bitsetview.h
+++ b/include/knowhere/bitsetview.h
@@ -13,12 +13,23 @@
 #define BITSET_H
 
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <sstream>
 #include <string>
 
 namespace knowhere {
+struct ValidBitmapView {
+    const uint8_t* data = nullptr;
+    size_t size = 0;
+
+    bool
+    empty() const {
+        return data == nullptr || size == 0;
+    }
+};
+
 class BitsetView {
  public:
     BitsetView() = default;
@@ -39,7 +50,7 @@ class BitsetView {
     // return the number of the bits. if with id mapping, return the number of the internal ids.
     size_t
     size() const {
-        if (out_ids_ != nullptr) {
+        if (has_out_ids()) {
             return num_internal_ids_;
         }
         return num_bits_;
@@ -48,7 +59,7 @@ class BitsetView {
     // return the number of filtered out bits. if with id mapping, return the number of filtered out ids.
     size_t
     count() const {
-        if (out_ids_ != nullptr) {
+        if (has_out_ids()) {
             return num_filtered_out_ids_;
         }
         return num_filtered_out_bits_;
@@ -64,13 +75,50 @@ class BitsetView {
         return bits_;
     }
 
+    static size_t
+    count_filtered_bits(const uint8_t* bitset, const uint8_t* valid_bitmap, size_t num_bits) {
+        if (bitset == nullptr || num_bits == 0) {
+            return 0;
+        }
+
+        size_t count = 0;
+        const auto len_uint8 = (num_bits + 8 - 1) >> 3;
+        const auto len_uint64 = len_uint8 >> 3;
+
+        auto* p_bitset_uint64 = reinterpret_cast<const uint64_t*>(bitset);
+        auto* p_valid_uint64 = valid_bitmap == nullptr ? nullptr : reinterpret_cast<const uint64_t*>(valid_bitmap);
+        for (size_t i = 0; i < len_uint64; ++i) {
+            auto bits = *p_bitset_uint64;
+            if (valid_bitmap != nullptr) {
+                bits &= *p_valid_uint64;
+                ++p_valid_uint64;
+            }
+            count += __builtin_popcountll(bits);
+            ++p_bitset_uint64;
+        }
+
+        auto* p_bitset_uint8 = bitset + (len_uint64 << 3);
+        auto* p_valid_uint8 = valid_bitmap == nullptr ? nullptr : valid_bitmap + (len_uint64 << 3);
+        for (size_t i = (len_uint64 << 3); i < len_uint8; ++i) {
+            auto bits = *p_bitset_uint8;
+            if (valid_bitmap != nullptr) {
+                bits &= *p_valid_uint8;
+                ++p_valid_uint8;
+            }
+            count += __builtin_popcount(static_cast<unsigned>(bits));
+            ++p_bitset_uint8;
+        }
+
+        return count;
+    }
+
     bool
     has_out_ids() const {
         return out_ids_ != nullptr;
     }
 
     void
-    set_out_ids(const uint32_t* out_ids, size_t num_internal_ids,
+    set_out_ids(const int32_t* out_ids, size_t num_internal_ids,
                 std::optional<size_t> num_filtered_out_ids = std::nullopt) {
         out_ids_ = out_ids;
         num_internal_ids_ = num_internal_ids;
@@ -82,11 +130,8 @@ class BitsetView {
         }
     }
 
-    const uint32_t*
+    const int32_t*
     out_ids_data() const {
-        if (out_ids_ == nullptr) {
-            return nullptr;
-        }
         return out_ids_;
     }
 
@@ -99,11 +144,15 @@ class BitsetView {
     bool
     test(int64_t index) const {
         int64_t out_id = index + id_offset_;
-        if (out_ids_ != nullptr) {
+        if (has_out_ids()) {
+            if (out_id < 0) {
+                return true;
+            }
             out_id = out_ids_[out_id];
         }
         // when index is larger than the max_offset, ignore it
-        return (out_id >= static_cast<int64_t>(num_bits_)) || (bits_[out_id >> 3] & (0x1 << (out_id & 0x7)));
+        return (out_id < 0 || out_id >= static_cast<int64_t>(num_bits_)) ||
+               (bits_[out_id >> 3] & (0x1 << (out_id & 0x7)));
     }
     // return the filtered ratio. if with id mapping, calculated by internal_ids rather than bits.
     float
@@ -116,7 +165,7 @@ class BitsetView {
         if (empty()) {
             return 0;
         }
-        if (out_ids_ != nullptr) {
+        if (has_out_ids()) {
             // if with id mapping, there is no optimization for the traversal.
             size_t count = 0;
             for (size_t i = 0; i < num_internal_ids_; i++) {
@@ -126,38 +175,13 @@ class BitsetView {
             }
             return count;
         }
-        // if without id mapping, use a better algorithm to calculate the number of filtered out bits.
-        size_t ret = 0;
-        auto len_uint8 = byte_size();
-        auto len_uint64 = len_uint8 >> 3;
-
-        auto popcount8 = [&](uint8_t x) -> int {
-            x = (x & 0x55) + ((x >> 1) & 0x55);
-            x = (x & 0x33) + ((x >> 2) & 0x33);
-            x = (x & 0x0F) + ((x >> 4) & 0x0F);
-            return x;
-        };
-
-        uint64_t* p_uint64 = (uint64_t*)bits_;
-        for (size_t i = 0; i < len_uint64; i++) {
-            ret += __builtin_popcountll(*p_uint64);
-            p_uint64++;
-        }
-
-        // calculate remainder
-        uint8_t* p_uint8 = (uint8_t*)bits_ + (len_uint64 << 3);
-        for (size_t i = (len_uint64 << 3); i < len_uint8; i++) {
-            ret += popcount8(*p_uint8);
-            p_uint8++;
-        }
-
-        return ret;
+        return count_filtered_bits(bits_, nullptr, num_bits_);
     }
 
     // return the first valid idx. if with id mapping, return the first valid internal_id.
     size_t
     get_first_valid_index() const {
-        if (out_ids_ != nullptr) {
+        if (has_out_ids()) {
             // if with id mapping, there is no optimization for the traversal.
             for (size_t i = 0; i < num_internal_ids_; i++) {
                 if (!test(i)) {
@@ -221,7 +245,7 @@ class BitsetView {
 
     // optional. bitset supports id mapping.
     // Even allows multiple ids to map to the same bit, so the number of internal ids and bits may be not equal.
-    const uint32_t* out_ids_ = nullptr;
+    const int32_t* out_ids_ = nullptr;
     size_t num_internal_ids_ = 0;
     size_t num_filtered_out_ids_ = 0;
 };

--- a/include/knowhere/comp/index_param.h
+++ b/include/knowhere/comp/index_param.h
@@ -113,6 +113,7 @@ constexpr const char* TRACE_FLAGS = "trace_flags";
 constexpr const char* SCALAR_INFO = "scalar_info";
 constexpr const char* MATERIALIZED_VIEW_SEARCH_INFO = "materialized_view_search_info";
 constexpr const char* MATERIALIZED_VIEW_OPT_FIELDS_PATH = "opt_fields_path";
+constexpr const char* EXTERNAL_ID_MAP = "EXTERNAL_ID_MAP";
 constexpr const char* MAX_EMPTY_RESULT_BUCKETS = "max_empty_result_buckets";
 constexpr const char* BM25_K1 = "bm25_k1";
 constexpr const char* BM25_B = "bm25_b";

--- a/include/knowhere/config.h
+++ b/include/knowhere/config.h
@@ -632,6 +632,7 @@ class BaseConfig : public Config {
      * - A factor for top-k in the first ANNS round.
      */
     CFG_FLOAT retrieval_ann_ratio;
+    CFG_STRING external_id_map_file_path;     // for mmap external id map
     CFG_STRING emb_list_meta_file_path;       // for mmap
     CFG_STRING emb_list_raw_index_file_path;  // for mmap (raw vector index)
     CFG_STRING emb_list_offset_file_path;     // for build
@@ -822,6 +823,10 @@ class BaseConfig : public Config {
             .description("Factor for top-k in the first ANNS round, only used for emb_list")
             .set_default(3.0f)
             .for_search();
+        KNOWHERE_CONFIG_DECLARE_FIELD(external_id_map_file_path)
+            .description("file name of external id map for mmap load")
+            .allow_empty_without_default()
+            .for_deserialize_from_file();
         KNOWHERE_CONFIG_DECLARE_FIELD(emb_list_meta_file_path)
             .description("file name of emb_list meta for mmap load")
             .allow_empty_without_default()

--- a/include/knowhere/dataset.h
+++ b/include/knowhere/dataset.h
@@ -13,14 +13,19 @@
 #define DATASET_H
 
 #include <any>
+#include <cstdint>
+#include <limits>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <stdexcept>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "comp/index_param.h"
+#include "knowhere/external_id_map.h"
 #include "knowhere/range_util.h"
 #include "knowhere/sparse_utils.h"
 
@@ -172,6 +177,25 @@ class DataSet : public std::enable_shared_from_this<const DataSet> {
     SetTensorBeginId(const int64_t offset) {
         std::unique_lock lock(mutex_);
         this->data_[meta::INPUT_BEG_ID] = Var(std::in_place_index<4>, offset);
+    }
+
+    void
+    SetValidBitmap(const uint8_t* valid_bitmap, int64_t total_count) {
+        auto rows = GetRows();
+        auto internal_to_external_ids =
+            BuildInternalToExternalIds(valid_bitmap, total_count, rows);
+        std::unique_lock lock(mutex_);
+        internal_to_external_ids_ = std::move(internal_to_external_ids);
+        external_count_ = rows == total_count ? 0 : static_cast<size_t>(total_count);
+    }
+
+    void
+    SetInternalToExternalIds(
+        std::vector<int32_t> internal_to_external_ids,
+        size_t external_count) {
+        std::unique_lock lock(mutex_);
+        internal_to_external_ids_ = std::move(internal_to_external_ids);
+        external_count_ = external_count;
     }
 
     void
@@ -327,6 +351,37 @@ class DataSet : public std::enable_shared_from_this<const DataSet> {
         return 0;
     }
 
+    const std::vector<int32_t>&
+    GetInternalToExternalIds() const {
+        std::shared_lock lock(mutex_);
+        return internal_to_external_ids_;
+    }
+
+    size_t
+    GetExternalCount() const {
+        std::shared_lock lock(mutex_);
+        return external_count_;
+    }
+
+    ExternalIdMap
+    GetExternalIdMap(bool include_tensor_begin_id = false) const {
+        std::shared_lock lock(mutex_);
+        ExternalIdMap external_id_map;
+        if (!internal_to_external_ids_.empty() || external_count_ != 0) {
+            external_id_map.SetInternalToExternalIds(
+                internal_to_external_ids_.empty() ? nullptr : internal_to_external_ids_.data(),
+                static_cast<int64_t>(internal_to_external_ids_.size()),
+                static_cast<int64_t>(external_count_));
+        }
+        if (include_tensor_begin_id) {
+            auto it = data_.find(meta::INPUT_BEG_ID);
+            if (it != data_.end()) {
+                external_id_map.SetExternalIdOffset(*std::get_if<4>(&it->second));
+            }
+        }
+        return external_id_map;
+    }
+
     // deprecated API
     template <typename T>
     void
@@ -347,12 +402,58 @@ class DataSet : public std::enable_shared_from_this<const DataSet> {
     }
 
  private:
+    static std::vector<int32_t>
+    BuildInternalToExternalIds(const uint8_t* valid_bitmap, int64_t total_count, int64_t rows) {
+        if (valid_bitmap == nullptr || total_count == 0) {
+            return {};
+        }
+        if (total_count < 0 || rows < 0) {
+            throw std::runtime_error("invalid nullable vector valid data size");
+        }
+        if (rows == total_count) {
+            return {};
+        }
+        if (static_cast<uint64_t>(total_count) >
+            static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+            throw std::runtime_error("nullable vector external row count exceeds int32_t");
+        }
+
+        std::vector<int32_t> internal_to_external_ids;
+        internal_to_external_ids.reserve(static_cast<size_t>(rows));
+        const auto full_bytes = total_count / 8;
+        for (int64_t byte_idx = 0; byte_idx < full_bytes; ++byte_idx) {
+            AppendInternalToExternalIdsFromByte(
+                internal_to_external_ids, valid_bitmap[byte_idx], byte_idx * 8);
+        }
+        const auto remaining_bits = total_count & 7;
+        if (remaining_bits != 0) {
+            const auto mask = static_cast<uint8_t>((1U << remaining_bits) - 1U);
+            AppendInternalToExternalIdsFromByte(
+                internal_to_external_ids, valid_bitmap[full_bytes] & mask, full_bytes * 8);
+        }
+        if (internal_to_external_ids.size() != static_cast<size_t>(rows)) {
+            throw std::runtime_error("nullable vector valid row count does not match dataset rows");
+        }
+        return internal_to_external_ids;
+    }
+
+    static void
+    AppendInternalToExternalIdsFromByte(std::vector<int32_t>& internal_to_external_ids, uint8_t bits, int64_t base) {
+        while (bits != 0) {
+            const auto bit = __builtin_ctz(static_cast<unsigned int>(bits));
+            internal_to_external_ids.push_back(static_cast<int32_t>(base + bit));
+            bits &= static_cast<uint8_t>(bits - 1);
+        }
+    }
+
     mutable std::shared_mutex mutex_;
     std::map<std::string, Var> data_;
     bool is_owner = true;
     bool is_sparse = false;
     bool is_chunk = false;
     int64_t num_chunk = 1;
+    std::vector<int32_t> internal_to_external_ids_;
+    size_t external_count_ = 0;
 };
 using DataSetPtr = std::shared_ptr<DataSet>;
 

--- a/include/knowhere/external_id_map.h
+++ b/include/knowhere/external_id_map.h
@@ -1,0 +1,476 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#ifndef EXTERNAL_ID_MAP_H
+#define EXTERNAL_ID_MAP_H
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "knowhere/bitsetview.h"
+
+namespace knowhere {
+
+struct ExternalIdMap {
+    // State.
+    void
+    Clear() {
+        internal_to_external_ids_.clear();
+        internal_id_to_emb_list_id_.clear();
+        external_to_internal_ids_.clear();
+        valid_bitmap_.clear();
+        external_count_ = 0;
+        external_id_offset_ = 0;
+    }
+
+    bool
+    HasInternalToExternalIds() const {
+        return !internal_to_external_ids_.empty();
+    }
+
+    bool
+    HasInternalToEmbListIds() const {
+        return !internal_id_to_emb_list_id_.empty();
+    }
+
+    bool
+    HasResultIdMap() const {
+        return HasInternalToEmbListIds() || HasInternalToExternalIds() || HasExternalIdOffset();
+    }
+
+    int64_t
+    ExternalCount(int64_t default_count) const {
+        return external_count_ == 0 ? default_count : static_cast<int64_t>(external_count_);
+    }
+
+    ValidBitmapView
+    GetValidBitmapView() const {
+        if (valid_bitmap_.empty()) {
+            return {};
+        }
+        return {valid_bitmap_.data(), external_count_};
+    }
+
+    const std::vector<int32_t>&
+    GetInternalToExternalIds() const {
+        return internal_to_external_ids_;
+    }
+
+    const std::vector<int32_t>&
+    GetInternalToEmbListIds() const {
+        return internal_id_to_emb_list_id_;
+    }
+
+    // Mapping construction.
+    void
+    SetExternalIdOffset(int64_t external_id_offset) {
+        external_id_offset_ = external_id_offset;
+    }
+
+    void
+    SetInternalToExternalIds(const int32_t* ids, int64_t internal_count, int64_t external_count) {
+        Clear();
+        if (internal_count < 0 || external_count <= 0 || internal_count > external_count ||
+            external_count > std::numeric_limits<int32_t>::max()) {
+            throw std::runtime_error("invalid external id map size");
+        }
+        if (ids == nullptr && internal_count != 0) {
+            throw std::runtime_error("invalid external id map data");
+        }
+        external_count_ = static_cast<size_t>(external_count);
+        internal_to_external_ids_.reserve(static_cast<size_t>(internal_count));
+        external_to_internal_ids_.reserve(static_cast<size_t>(internal_count));
+        for (int64_t i = 0; i < internal_count; ++i) {
+            AddInternalToExternalId(ids[i], static_cast<int32_t>(i));
+        }
+        BuildValidBitmap();
+    }
+
+    void
+    SetInternalToExternalIds(std::vector<int32_t> ids, size_t external_count) {
+        Clear();
+        if (external_count == 0 || ids.size() > external_count ||
+            external_count > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+            throw std::runtime_error("invalid external id map size");
+        }
+        external_count_ = external_count;
+        internal_to_external_ids_ = std::move(ids);
+        RebuildInternalToExternalDerivedData();
+    }
+
+    void
+    SetInternalToEmbListIds(std::vector<int32_t> ids) {
+        internal_id_to_emb_list_id_ = std::move(ids);
+    }
+
+    void
+    AppendInternalToEmbListIds(size_t internal_id_begin, size_t internal_id_end, size_t emb_list_id) {
+        if (internal_id_to_emb_list_id_.size() < internal_id_end) {
+            internal_id_to_emb_list_id_.resize(internal_id_end);
+        }
+        std::fill(
+            internal_id_to_emb_list_id_.begin() + internal_id_begin,
+            internal_id_to_emb_list_id_.begin() + internal_id_end,
+            ToExternalId(emb_list_id)
+        );
+    }
+
+    // Incremental append for mutable indexes.
+    void
+    AddInternalToExternalIds(
+        const int32_t* ids, int64_t internal_count, int64_t external_count, int64_t internal_id_begin
+    ) {
+        if (internal_count < 0 || external_count < 0 || internal_id_begin < 0 ||
+            external_count > std::numeric_limits<int32_t>::max()) {
+            throw std::runtime_error("invalid external id map size");
+        }
+        if (ids == nullptr && internal_count != 0 && external_count != 0) {
+            throw std::runtime_error("invalid external id map data");
+        }
+
+        if (internal_id_begin == 0) {
+            if (ids == nullptr && external_count == 0) {
+                Clear();
+                return;
+            }
+            SetInternalToExternalIds(ids, internal_count, external_count);
+            return;
+        }
+
+        if (ids == nullptr && external_count == 0 && !HasInternalToExternalIds() && external_count_ == 0) {
+            return;
+        }
+
+        auto id_begin = static_cast<size_t>(internal_id_begin);
+        auto count = static_cast<size_t>(internal_count);
+        if (internal_to_external_ids_.empty() && external_count_ == 0) {
+            external_count_ = external_count == 0 ? id_begin + count : static_cast<size_t>(external_count);
+            if (external_count_ > static_cast<size_t>(std::numeric_limits<int32_t>::max()) ||
+                id_begin > external_count_) {
+                throw std::runtime_error("invalid external id map size");
+            }
+            internal_to_external_ids_.reserve(id_begin + count);
+            external_to_internal_ids_.reserve(id_begin + count);
+            for (size_t i = 0; i < id_begin; ++i) {
+                AddInternalToExternalId(static_cast<int32_t>(i), static_cast<int32_t>(i));
+            }
+        } else if (internal_to_external_ids_.size() != id_begin) {
+            throw std::runtime_error("external id map append position mismatch");
+        }
+
+        auto external_id_begin = external_count_;
+        if (external_count != 0) {
+            if (static_cast<size_t>(external_count) < external_count_) {
+                throw std::runtime_error("invalid external id map size");
+            }
+            external_count_ = static_cast<size_t>(external_count);
+        } else if (count != 0) {
+            if (external_count_ > static_cast<size_t>(std::numeric_limits<int32_t>::max()) - count) {
+                throw std::runtime_error("invalid external id map size");
+            }
+            external_count_ += count;
+        }
+
+        internal_to_external_ids_.reserve(id_begin + count);
+        external_to_internal_ids_.reserve(id_begin + count);
+        if (ids != nullptr) {
+            for (size_t i = 0; i < count; ++i) {
+                AddInternalToExternalId(ids[i], static_cast<int32_t>(id_begin + i));
+            }
+        } else {
+            for (size_t i = 0; i < count; ++i) {
+                AddInternalToExternalId(static_cast<int32_t>(external_id_begin + i),
+                                        static_cast<int32_t>(id_begin + i));
+            }
+        }
+        BuildValidBitmap();
+    }
+
+    // Relayout.
+    template <typename SourceIdGetter>
+    void
+    ApplyInternalToExternalRelayout(size_t internal_count, SourceIdGetter source_id_getter) {
+        std::vector<int32_t> remapped_ids(internal_count);
+        for (size_t i = 0; i < internal_count; ++i) {
+            remapped_ids[i] = ToExternalId(source_id_getter(i));
+        }
+        if (external_count_ == 0 && !remapped_ids.empty()) {
+            const auto max_external_id = *std::max_element(remapped_ids.begin(), remapped_ids.end());
+            if (max_external_id < 0) {
+                throw std::runtime_error("external id map points outside external rows");
+            }
+            external_count_ = static_cast<size_t>(max_external_id) + 1;
+        }
+        internal_to_external_ids_ = std::move(remapped_ids);
+        RebuildInternalToExternalDerivedData();
+    }
+
+    template <typename SourceIdGetter>
+    void
+    ApplyInternalToEmbListRelayout(size_t internal_count, SourceIdGetter source_id_getter) {
+        if (!HasInternalToEmbListIds()) {
+            return;
+        }
+        std::vector<int32_t> remapped_ids(internal_count);
+        for (size_t i = 0; i < internal_count; ++i) {
+            remapped_ids[i] = internal_id_to_emb_list_id_[source_id_getter(i)];
+        }
+        internal_id_to_emb_list_id_ = std::move(remapped_ids);
+    }
+
+    // Filtering.
+    void
+    SetOutIdsToBitset(BitsetView& bitset, size_t num_internal_ids = 0,
+                      std::optional<size_t> num_filtered_out_ids = std::nullopt,
+                      size_t internal_id_offset = 0) const {
+        if (HasInternalToEmbListIds()) {
+            bitset.set_id_offset(internal_id_offset);
+            bitset.set_out_ids(
+                internal_id_to_emb_list_id_.data(),
+                num_internal_ids == 0 ? internal_id_to_emb_list_id_.size() : num_internal_ids,
+                num_filtered_out_ids
+            );
+            return;
+        }
+        if (HasInternalToExternalIds()) {
+            bitset.set_id_offset(internal_id_offset);
+            bitset.set_out_ids(
+                internal_to_external_ids_.data(),
+                num_internal_ids == 0 ? internal_to_external_ids_.size() : num_internal_ids,
+                num_filtered_out_ids
+            );
+            return;
+        }
+        const auto id_offset = external_id_offset_ + static_cast<int64_t>(internal_id_offset);
+        if (id_offset >= 0) {
+            bitset.set_id_offset(static_cast<size_t>(id_offset));
+        }
+    }
+
+    // ID conversion.
+    int32_t
+    ToExternalId(size_t internal_id) const {
+        if (!HasInternalToExternalIds()) {
+            return static_cast<int32_t>(static_cast<int64_t>(internal_id) + external_id_offset_);
+        }
+        return internal_to_external_ids_[internal_id];
+    }
+
+    int64_t
+    ToInternalId(int64_t external_id) const {
+        if (!HasInternalToExternalIds()) {
+            auto internal_id = external_id - external_id_offset_;
+            return internal_id < 0 ? -1 : internal_id;
+        }
+        if (external_id < 0 || external_id > std::numeric_limits<int32_t>::max()) {
+            return -1;
+        }
+        auto iter = external_to_internal_ids_.find(static_cast<int32_t>(external_id));
+        return iter == external_to_internal_ids_.end() ? -1 : iter->second;
+    }
+
+    template <typename IdType>
+    const IdType*
+    ToInternalIds(const IdType* external_ids, size_t count, std::vector<IdType>& internal_ids) const {
+        if (!HasInternalToExternalIds()) {
+            if (!HasExternalIdOffset()) {
+                return external_ids;
+            }
+            internal_ids.resize(count);
+            for (size_t i = 0; i < count; ++i) {
+                const auto internal_id = static_cast<int64_t>(external_ids[i]) - external_id_offset_;
+                internal_ids[i] = internal_id < 0 ? static_cast<IdType>(-1) : static_cast<IdType>(internal_id);
+            }
+            return internal_ids.data();
+        }
+        internal_ids.resize(count);
+        for (size_t i = 0; i < count; ++i) {
+            const auto external_id = static_cast<int64_t>(external_ids[i]);
+            if (external_id < 0 || external_id > std::numeric_limits<int32_t>::max()) {
+                internal_ids[i] = static_cast<IdType>(-1);
+                continue;
+            }
+            auto iter = external_to_internal_ids_.find(static_cast<int32_t>(external_id));
+            internal_ids[i] =
+                iter == external_to_internal_ids_.end() ? static_cast<IdType>(-1) : static_cast<IdType>(iter->second);
+        }
+        return internal_ids.data();
+    }
+
+    template <typename IdType>
+    IdType
+    MapResultId(IdType id) const {
+        if constexpr (std::is_signed_v<IdType>) {
+            if (id < 0) {
+                return id;
+            }
+        }
+        return static_cast<IdType>(ToResultId(static_cast<size_t>(id)));
+    }
+
+    template <typename IdType>
+    void
+    MapResultIds(IdType* ids, size_t count) const {
+        if (ids == nullptr || !HasResultIdMap()) {
+            return;
+        }
+        for (size_t i = 0; i < count; ++i) {
+            ids[i] = MapResultId(ids[i]);
+        }
+    }
+
+    template <typename IdType>
+    void
+    MapResultIds(std::vector<IdType>& ids) const {
+        if (!HasResultIdMap()) {
+            return;
+        }
+        for (auto& id : ids) {
+            id = MapResultId(id);
+        }
+    }
+
+    template <typename IdType>
+    void
+    MapResultIds(std::vector<std::vector<IdType>>& ids) const {
+        if (!HasResultIdMap()) {
+            return;
+        }
+        for (auto& row_ids : ids) {
+            MapResultIds(row_ids);
+        }
+    }
+
+    // Serialization. Only vector-level external id mapping is persisted.
+    size_t
+    BinarySize() const {
+        return 2 * sizeof(uint64_t) + internal_to_external_ids_.size() * sizeof(int32_t);
+    }
+
+    void
+    Serialize(uint8_t* data, size_t size) const {
+        if (data == nullptr || size < BinarySize()) {
+            throw std::runtime_error("external id map binary buffer is too small");
+        }
+        auto* ptr = data;
+        auto wire_external_count = static_cast<uint64_t>(external_count_);
+        auto wire_map_size = static_cast<uint64_t>(internal_to_external_ids_.size());
+        std::memcpy(ptr, &wire_external_count, sizeof(uint64_t));
+        ptr += sizeof(uint64_t);
+        std::memcpy(ptr, &wire_map_size, sizeof(uint64_t));
+        ptr += sizeof(uint64_t);
+        std::memcpy(ptr, internal_to_external_ids_.data(), internal_to_external_ids_.size() * sizeof(int32_t));
+    }
+
+    void
+    Deserialize(const uint8_t* data, int64_t size) {
+        Clear();
+        if (data == nullptr) {
+            return;
+        }
+        if (size < static_cast<int64_t>(2 * sizeof(uint64_t))) {
+            throw std::runtime_error("invalid external id map binary size");
+        }
+
+        auto* ptr = data;
+        uint64_t wire_external_count = 0;
+        uint64_t wire_map_size = 0;
+        std::memcpy(&wire_external_count, ptr, sizeof(uint64_t));
+        ptr += sizeof(uint64_t);
+        std::memcpy(&wire_map_size, ptr, sizeof(uint64_t));
+        ptr += sizeof(uint64_t);
+
+        auto expected_size = 2 * sizeof(uint64_t) + wire_map_size * sizeof(int32_t);
+        if (static_cast<uint64_t>(size) < expected_size) {
+            throw std::runtime_error("invalid external id map binary size");
+        }
+
+        std::vector<int32_t> ids(wire_map_size);
+        std::memcpy(ids.data(), ptr, wire_map_size * sizeof(int32_t));
+        SetInternalToExternalIds(std::move(ids), static_cast<size_t>(wire_external_count));
+    }
+
+ private:
+    bool
+    HasExternalIdOffset() const {
+        return external_id_offset_ != 0;
+    }
+
+    int32_t
+    ToResultId(size_t internal_id) const {
+        if (HasInternalToEmbListIds()) {
+            return internal_id_to_emb_list_id_[internal_id];
+        }
+        return ToExternalId(internal_id);
+    }
+
+    void
+    RebuildInternalToExternalDerivedData() {
+        external_to_internal_ids_.clear();
+        valid_bitmap_.clear();
+        external_to_internal_ids_.reserve(internal_to_external_ids_.size());
+        for (size_t i = 0; i < internal_to_external_ids_.size(); ++i) {
+            AddExternalToInternalId(internal_to_external_ids_[i], static_cast<int32_t>(i));
+        }
+        BuildValidBitmap();
+    }
+
+    void
+    AddInternalToExternalId(int32_t external_id, int32_t internal_id) {
+        AddExternalToInternalId(external_id, internal_id);
+        internal_to_external_ids_.push_back(external_id);
+    }
+
+    void
+    AddExternalToInternalId(int32_t external_id, int32_t internal_id) {
+        if (external_id < 0 || static_cast<size_t>(external_id) >= external_count_) {
+            throw std::runtime_error("external id map points outside external rows");
+        }
+        auto insert_result = external_to_internal_ids_.emplace(external_id, internal_id);
+        if (!insert_result.second) {
+            throw std::runtime_error("external id map contains duplicate external id");
+        }
+    }
+
+    void
+    BuildValidBitmap() {
+        valid_bitmap_.assign((external_count_ + 7) / 8, 0);
+        for (auto external_id : internal_to_external_ids_) {
+            valid_bitmap_[external_id >> 3] |= static_cast<uint8_t>(1U << (external_id & 7));
+        }
+    }
+
+    std::vector<int32_t> internal_to_external_ids_;
+    std::vector<int32_t> internal_id_to_emb_list_id_;
+    std::unordered_map<int32_t, int32_t> external_to_internal_ids_;
+    std::vector<uint8_t> valid_bitmap_;
+    size_t external_count_ = 0;
+    int64_t external_id_offset_ = 0;
+};
+
+inline const ExternalIdMap&
+EmptyExternalIdMap() {
+    static const ExternalIdMap empty_map;
+    return empty_map;
+}
+
+}  // namespace knowhere
+
+#endif /* EXTERNAL_ID_MAP_H */

--- a/include/knowhere/index/index.h
+++ b/include/knowhere/index/index.h
@@ -210,6 +210,9 @@ class Index {
     int64_t
     Count() const;
 
+    int64_t
+    ExternalCount() const;
+
     std::string
     Type() const;
 

--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -12,9 +12,14 @@
 #ifndef INDEX_NODE_H
 #define INDEX_NODE_H
 
+#include <algorithm>
 #include <functional>
+#include <memory>
 #include <mutex>
+#include <numeric>
+#include <optional>
 #include <queue>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -24,6 +29,7 @@
 #include "knowhere/dataset.h"
 #include "knowhere/emb_list_utils.h"
 #include "knowhere/expected.h"
+#include "knowhere/external_id_map.h"
 #include "knowhere/index/emb_list_strategy.h"
 #include "knowhere/object.h"
 #include "knowhere/operands.h"
@@ -87,6 +93,12 @@ class IndexNode : public Object {
      */
     virtual Status
     Build(const DataSetPtr dataset, std::shared_ptr<Config> cfg, bool use_knowhere_build_pool = true) {
+        if (dataset != nullptr && dataset->GetRows() == 0) {
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(SetExternalIdMapFromDataset(dataset));
+            }
+            return Status::empty_index;
+        }
         RETURN_IF_ERROR(Train(dataset, cfg, use_knowhere_build_pool));
         return Add(dataset, std::move(cfg), use_knowhere_build_pool);
     }
@@ -219,6 +231,7 @@ class IndexNode : public Object {
      * the same as the input data when we do @see Add or @see Build. For example, if the datatype is BF16, then we need
      * to return a dataset with BF16 vectors.
      * 2. It doesn't guarantee the index contains raw data, so it's better to check with @see HasRawData() before
+     * 3. When called by GetEmbListByIds(), the input IDs are internal vector IDs expanded from emb-list rows.
      */
     virtual expected<DataSetPtr>
     GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context = nullptr) const = 0;
@@ -318,6 +331,31 @@ class IndexNode : public Object {
     virtual int64_t
     Count() const = 0;
 
+    virtual int64_t
+    ExternalCount() const {
+        auto default_count = Count();
+        if (emb_list_offset_ != nullptr) {
+            default_count = static_cast<int64_t>(emb_list_offset_->num_el());
+        }
+        return external_id_map_.ExternalCount(default_count);
+    }
+
+    virtual const ExternalIdMap&
+    GetExternalIdMap() const {
+        return external_id_map_;
+    }
+
+    virtual Status
+    SetExternalIdMap(ExternalIdMap map) {
+        external_id_map_ = std::move(map);
+        return Status::success;
+    }
+
+    virtual const EmbListOffset*
+    GetEmbListOffset() const {
+        return emb_list_offset_.get();
+    }
+
     virtual std::string
     Type() const = 0;
 
@@ -361,24 +399,12 @@ class IndexNode : public Object {
      * @return A reference to the mapping vector.
      * @note If not implemented, the default implementation is to return a mapping, from 0 to Count()-1.
      */
-    virtual std::shared_ptr<std::vector<uint32_t>>
+    virtual std::shared_ptr<std::vector<int32_t>>
     GetInternalIdToExternalIdMap() const {
         auto n_rows = Count();
-        auto internal_id_to_external_id_map = std::make_shared<std::vector<uint32_t>>(n_rows);
+        auto internal_id_to_external_id_map = std::make_shared<std::vector<int32_t>>(n_rows);
         std::iota(internal_id_to_external_id_map->begin(), internal_id_to_external_id_map->end(), 0);
         return internal_id_to_external_id_map;
-    }
-
-    /**
-     * @brief Sets the mapping from internal IDs to "most external" IDs for 1-hop bitset check!
-     * Only used for hierarchical indexnode, such as emb_list + hnsw, each index node has its own relayout mapping.
-     *
-     * @param map The mapping vector to set.
-     * @return Status indicating success or failure of the mapping.
-     */
-    virtual Status
-    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) {
-        return Status::not_implemented;
     }
 
     virtual Status
@@ -550,26 +576,30 @@ class IndexNode : public Object {
         int64_t strategy_blob_size;
     };
 
-    /**
-     * @brief Establishes the mapping from internal base-index IDs to emb_list IDs.
-     *
-     * This mapping is essential for base indexes to correctly apply bitset filtering using only a 1-hop mapping during
-     * search. In some cases, such as with mv-only *relayout*, a base-index may have its own
-     * (base)internal-to-external ID mapping.
-     * However, the emb_list search bitset operates on emb_list IDs, which we refer to as the "most external" IDs.
-     * Therefore, we need to create a mapping from the base_internal_id (used by the base-index) to the most external
-     * emb_list_id, ensuring that bitset checks and search results are consistent at the emb_list level.
-     */
     Status
     SetBaseIndexIDMap() {
         auto internal_id_to_external_id_map = GetInternalIdToExternalIdMap();
         size_t id_map_size = internal_id_to_external_id_map->size();
         assert(id_map_size == static_cast<size_t>(Count()));
-        std::vector<uint32_t> internal_id_to_most_external_id_map(id_map_size);
-        for (size_t i = 0; i < id_map_size; i++) {
-            internal_id_to_most_external_id_map[i] = emb_list_offset_->get_el_id(internal_id_to_external_id_map->at(i));
+
+        size_t source_size = emb_list_strategy_->NeedsBaseIndexIDMap() ? emb_list_offset_->offset.back()
+                                                                       : emb_list_offset_->num_el();
+        std::vector<int32_t> internal_id_to_emb_list_id_map(source_size);
+        if (emb_list_strategy_->NeedsBaseIndexIDMap()) {
+            for (size_t i = 0; i < emb_list_offset_->num_el(); ++i) {
+                std::fill(internal_id_to_emb_list_id_map.begin() + emb_list_offset_->offset[i],
+                          internal_id_to_emb_list_id_map.begin() + emb_list_offset_->offset[i + 1],
+                          external_id_map_.ToExternalId(i));
+            }
+        } else {
+            for (size_t i = 0; i < internal_id_to_emb_list_id_map.size(); ++i) {
+                internal_id_to_emb_list_id_map[i] = external_id_map_.ToExternalId(i);
+            }
         }
-        return SetInternalIdToMostExternalIdMap(std::move(internal_id_to_most_external_id_map));
+        external_id_map_.SetInternalToEmbListIds(std::move(internal_id_to_emb_list_id_map));
+        external_id_map_.ApplyInternalToEmbListRelayout(id_map_size,
+                                                        [&](size_t i) { return internal_id_to_external_id_map->at(i); });
+        return SetExternalIdMap(external_id_map_);
     }
 
     virtual Status
@@ -617,6 +647,39 @@ class IndexNode : public Object {
     static EmbListMetaHeader
     ParseEmbListMetaHeader(const uint8_t* data, int64_t size);
 
+    Status
+    SetExternalIdMapFromDataset(const DataSetPtr dataset);
+
+    Status
+    AddExternalIdMapFromDataset(const DataSetPtr dataset, int64_t internal_id_begin);
+
+    Status
+    AddEmbListExternalIdMapFromDataset(const DataSetPtr dataset, int64_t internal_el_id_begin,
+                                       int64_t internal_el_count);
+
+    Status
+    AppendExternalIdMapToBinarySet(BinarySet& binset, const std::string& key) const;
+
+    Status
+    LoadExternalIdMap(const uint8_t* data, int64_t size);
+
+    Status
+    LoadExternalIdMapFromBinarySet(const BinarySet& binset, const std::string& key);
+
+    Status
+    SaveExternalIdMapToLocalFile(const std::string& id_map_file_path) const;
+
+    Status
+    LoadExternalIdMapFromLocalFile(const std::string& id_map_file_path);
+
+    Status
+    SaveExternalIdMapToFileManager(std::shared_ptr<milvus::FileManager> file_manager,
+                                   const std::string& id_map_file_path) const;
+
+    Status
+    LoadExternalIdMapFromFileManager(std::shared_ptr<milvus::FileManager> file_manager,
+                                     const std::string& id_map_file_path);
+
  protected:
     /**
      * @brief Compute distances using emb_list_raw_index_ (raw vector storage).
@@ -634,6 +697,7 @@ class IndexNode : public Object {
 
     Version version_;
     std::shared_ptr<EmbListOffset> emb_list_offset_;  // emb_list group offset structure (shared with strategy)
+    ExternalIdMap external_id_map_;
     std::string el_metric_type_;
     EmbListStrategyPtr emb_list_strategy_;  // emb_list encoding strategy (tokenann/muvera)
     // Raw vector storage for EmbList strategies (MUVERA/LEMUR) that encode documents
@@ -667,12 +731,14 @@ class IndexNode : public Object {
 //   If False, will Not involve thread scheduling internally, so please take caution.
 class IndexIterator : public IndexNode::iterator {
  public:
-    IndexIterator(bool larger_is_closer, bool use_knowhere_search_pool = true, float refine_ratio = 0.0f,
+    IndexIterator(bool larger_is_closer, const ExternalIdMap& external_id_map = EmptyExternalIdMap(),
+                  bool use_knowhere_search_pool = true, float refine_ratio = 0.0f,
                   bool retain_iterator_order = false)
         : refine_ratio_(refine_ratio),
           refine_(refine_ratio != 0.0f),
           retain_iterator_order_(retain_iterator_order),
           sign_(larger_is_closer ? -1 : 1),
+          external_id_map_(external_id_map),
           use_knowhere_search_pool_(use_knowhere_search_pool) {
     }
 
@@ -720,7 +786,7 @@ class IndexIterator : public IndexNode::iterator {
             update_next_func();
         }
 
-        return std::make_pair(ret.id, ret.val * sign_);
+        return std::make_pair(external_id_map_.MapResultId(ret.id), ret.val * sign_);
     }
 
     [[nodiscard]] bool
@@ -771,6 +837,8 @@ class IndexIterator : public IndexNode::iterator {
     std::priority_queue<DistId, std::vector<DistId>, std::greater<DistId>> refined_res_;
 
  private:
+    const ExternalIdMap& external_id_map_;
+
     void
     UpdateNext() {
         auto batch_handler = [this](const std::vector<DistId>& batch) {
@@ -799,9 +867,11 @@ class IndexIterator : public IndexNode::iterator {
 class PrecomputedDistanceIterator : public IndexNode::iterator {
  public:
     PrecomputedDistanceIterator(std::function<std::vector<DistId>()> compute_dist_func, bool larger_is_closer,
+                                const ExternalIdMap& external_id_map = EmptyExternalIdMap(),
                                 bool use_knowhere_search_pool = true)
         : compute_dist_func_(compute_dist_func),
           larger_is_closer_(larger_is_closer),
+          external_id_map_(external_id_map),
           use_knowhere_search_pool_(use_knowhere_search_pool) {
     }
 
@@ -825,7 +895,7 @@ class PrecomputedDistanceIterator : public IndexNode::iterator {
             sort_next();
         }
         auto& result = results_[next_++];
-        return std::make_pair(result.id, result.val);
+        return std::make_pair(external_id_map_.MapResultId(result.id), result.val);
     }
 
     [[nodiscard]] bool
@@ -886,6 +956,7 @@ class PrecomputedDistanceIterator : public IndexNode::iterator {
 
     std::function<std::vector<DistId>()> compute_dist_func_;
     const bool larger_is_closer_;
+    const ExternalIdMap& external_id_map_;
     bool use_knowhere_search_pool_ = true;
     bool initialized_ = false;
     std::vector<DistId> results_;

--- a/include/knowhere/index/index_node_data_mock_wrapper.h
+++ b/include/knowhere/index/index_node_data_mock_wrapper.h
@@ -57,11 +57,6 @@ class IndexNodeDataMockWrapper : public IndexNode {
     expected<DataSetPtr>
     CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
                   const bool is_cosine, milvus::OpContext* op_context) const override;
-    Status
-    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) override {
-        return index_node_->SetInternalIdToMostExternalIdMap(std::move(map));
-    }
-
     std::optional<size_t>
     GetQueryCodeSize(const DataSetPtr dataset) const override {
         auto dim = dataset->GetDim();
@@ -119,6 +114,26 @@ class IndexNodeDataMockWrapper : public IndexNode {
     int64_t
     Count() const override {
         return index_node_->Count();
+    }
+
+    int64_t
+    ExternalCount() const override {
+        return index_node_->ExternalCount();
+    }
+
+    const ExternalIdMap&
+    GetExternalIdMap() const override {
+        return index_node_->GetExternalIdMap();
+    }
+
+    Status
+    SetExternalIdMap(ExternalIdMap map) override {
+        return index_node_->SetExternalIdMap(std::move(map));
+    }
+
+    const EmbListOffset*
+    GetEmbListOffset() const override {
+        return index_node_->GetEmbListOffset();
     }
 
     std::string

--- a/include/knowhere/index/index_node_thread_pool_wrapper.h
+++ b/include/knowhere/index/index_node_thread_pool_wrapper.h
@@ -91,6 +91,26 @@ class IndexNodeThreadPoolWrapper : public IndexNode {
         return index_node_->Count();
     }
 
+    int64_t
+    ExternalCount() const override {
+        return index_node_->ExternalCount();
+    }
+
+    const ExternalIdMap&
+    GetExternalIdMap() const override {
+        return index_node_->GetExternalIdMap();
+    }
+
+    Status
+    SetExternalIdMap(ExternalIdMap map) override {
+        return index_node_->SetExternalIdMap(std::move(map));
+    }
+
+    const EmbListOffset*
+    GetEmbListOffset() const override {
+        return index_node_->GetEmbListOffset();
+    }
+
     std::string
     Type() const override {
         return index_node_->Type();

--- a/include/knowhere/utils.h
+++ b/include/knowhere/utils.h
@@ -135,7 +135,7 @@ data_type_conversion(const DataSet& src, const std::optional<int64_t> start = st
 
     // check the acceptable range
     int64_t start_row = start.value_or(0);
-    if (start_row < 0 || start_row >= rows) {
+    if (start_row < 0 || start_row > rows) {
         return nullptr;
     }
 
@@ -200,8 +200,8 @@ data_type_conversion(const DataSet& src, const std::optional<int64_t> start = st
 
     // for emb_list
     auto lims = src.Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+    size_t lims_size = 0;
     if (lims != nullptr) {
-        size_t lims_size = 0;
         if (is_chunk) {
             lims_size = src.GetNumChunk();
         } else {
@@ -220,6 +220,31 @@ data_type_conversion(const DataSet& src, const std::optional<int64_t> start = st
         }
         const size_t* lims_data_const = lims_data.release();
         des->Set(knowhere::meta::EMB_LIST_OFFSET, lims_data_const);
+    }
+    const auto& internal_to_external_ids = src.GetInternalToExternalIds();
+    if (!internal_to_external_ids.empty() || src.GetExternalCount() != 0) {
+        if (internal_to_external_ids.empty()) {
+            des->SetInternalToExternalIds({}, src.GetExternalCount());
+        } else if (lims != nullptr) {
+            if (internal_to_external_ids.size() < lims_size) {
+                throw std::runtime_error("emb_list internal-to-external id map does not match offsets.");
+            }
+            des->SetInternalToExternalIds(
+                std::vector<int32_t>(internal_to_external_ids.begin(),
+                                     internal_to_external_ids.begin() + lims_size),
+                src.GetExternalCount());
+        } else if (internal_to_external_ids.size() == static_cast<size_t>(rows)) {
+            if (start_row == 0 && count_rows == rows) {
+                des->SetInternalToExternalIds(internal_to_external_ids, src.GetExternalCount());
+            } else {
+                des->SetInternalToExternalIds(
+                    std::vector<int32_t>(internal_to_external_ids.begin() + start_row,
+                                         internal_to_external_ids.begin() + start_row + count_rows),
+                    src.GetExternalCount());
+            }
+        } else {
+            throw std::runtime_error("internal-to-external id map does not match dataset rows.");
+        }
     }
     return des;
 }

--- a/src/common/comp/brute_force.cc
+++ b/src/common/comp/brute_force.cc
@@ -308,10 +308,11 @@ brute_force_minhash_impl(const void* xq, const void* xb, int64_t* labels, float*
 
 template <typename DataType>
 Status
-brute_force_emb_list_impl(const void* xq, size_t query_el_idx, const void* xb, int64_t* ids, float* dis, size_t topk,
-                          size_t dim, const EmbListOffset& base_el_offset, const EmbListOffset& query_el_offset,
-                          const std::string& el_metric_type, const std::string& el_sub_metric_type,
-                          const BitsetView& bitset, const BaseConfig& cfg, size_t xb_id_offset) {
+brute_force_emb_list_impl(const void* xq, size_t query_el_idx, size_t result_el_idx, const void* xb, int64_t* ids,
+                          float* dis, size_t topk, size_t dim, const EmbListOffset& base_el_offset,
+                          const EmbListOffset& query_el_offset, const std::string& el_metric_type,
+                          const std::string& el_sub_metric_type, const BitsetView& bitset, const BaseConfig& cfg,
+                          size_t xb_id_offset) {
     auto num_base_el = base_el_offset.num_el();
 
     auto el_agg_func_or = get_emb_list_agg_func(el_metric_type);
@@ -438,29 +439,30 @@ brute_force_emb_list_impl(const void* xq, size_t query_el_idx, const void* xb, i
         }
     }
     size_t real_el_k = 0;
+    const auto result_offset = result_el_idx * topk;
     if (larger_is_closer) {
         real_el_k = minheap.size();
         for (size_t j = 0; j < real_el_k; j++) {
             auto& a = minheap.top();
-            ids[query_el_idx * topk + real_el_k - j - 1] = a.id;
-            dis[query_el_idx * topk + real_el_k - j - 1] = a.val;
+            ids[result_offset + real_el_k - j - 1] = a.id;
+            dis[result_offset + real_el_k - j - 1] = a.val;
             minheap.pop();
         }
         for (size_t j = real_el_k; j < topk; j++) {
-            ids[query_el_idx * topk + j] = -1;
-            dis[query_el_idx * topk + j] = std::numeric_limits<float>::min();
+            ids[result_offset + j] = -1;
+            dis[result_offset + j] = std::numeric_limits<float>::min();
         }
     } else {
         real_el_k = maxheap.size();
         for (size_t j = 0; j < real_el_k; j++) {
             auto& a = maxheap.top();
-            ids[query_el_idx * topk + real_el_k - j - 1] = a.id;
-            dis[query_el_idx * topk + real_el_k - j - 1] = a.val;
+            ids[result_offset + real_el_k - j - 1] = a.id;
+            dis[result_offset + real_el_k - j - 1] = a.val;
             maxheap.pop();
         }
         for (size_t j = real_el_k; j < topk; j++) {
-            ids[query_el_idx * topk + j] = -1;
-            dis[query_el_idx * topk + j] = std::numeric_limits<float>::max();
+            ids[result_offset + j] = -1;
+            dis[result_offset + j] = std::numeric_limits<float>::max();
         }
     }
     return Status::success;
@@ -478,9 +480,9 @@ BruteForce::SearchWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_
     auto nb = base_dataset->GetRows();
     auto dim = base_dataset->GetDim();
     bool base_data_is_emb_list = base_dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET) != nullptr;
-    auto xb_id_offset = base_dataset->GetTensorBeginId();
+    auto external_id_map = base_dataset->GetExternalIdMap(true);
     BitsetView bitset = bitset_;
-    bitset.set_id_offset(xb_id_offset);
+    external_id_map.SetOutIdsToBitset(bitset);
 
     auto xq = query_dataset->GetTensor();
     auto nq = query_dataset->GetRows();
@@ -542,23 +544,20 @@ BruteForce::SearchWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_
             }
             futs.emplace_back(pool->push([&, query_el_idx = query_el_i] {
                 ThreadPool::ScopedSearchOmpSetter setter(1);
-                RETURN_IF_ERROR(brute_force_emb_list_impl<DataType>(xq, query_el_idx, xb, ids, dis, topk, dim,
-                                                                    base_el_offset, query_el_offset, el_metric_type,
-                                                                    el_sub_metric_type, bitset, cfg, xb_id_offset));
+                RETURN_IF_ERROR(brute_force_emb_list_impl<DataType>(xq, query_el_idx, query_el_idx, xb, ids, dis, topk,
+                                                                    dim, base_el_offset, query_el_offset,
+                                                                    el_metric_type, el_sub_metric_type, bitset, cfg, 0));
                 return Status::success;
             }));
         }
 
         RETURN_IF_ERROR(WaitAllSuccess(futs));
+        external_id_map.MapResultIds(ids, num_query_el * topk);
     } else if (IsMetricType(metric_str, metric::MHJACCARD)) {
         auto labels = ids;
         auto distances = dis;
         RETURN_IF_ERROR(brute_force_minhash_impl<DataType>(xq, xb, labels, distances, dim, nb, nq, topk, bitset, cfg));
-        if (xb_id_offset != 0) {
-            for (auto i = 0; i < nq * topk; i++) {
-                labels[i] = labels[i] == -1 ? -1 : labels[i] + xb_id_offset;
-            }
-        }
+        external_id_map.MapResultIds(labels, nq * topk);
     } else {
         if (query_is_emb_list) {
             LOG_KNOWHERE_ERROR_ << "query dataset is emb_list, but metric is not for emb_list";
@@ -591,12 +590,7 @@ BruteForce::SearchWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_
             }));
         }
         RETURN_IF_ERROR(WaitAllSuccess(futs));
-
-        if (xb_id_offset != 0) {
-            for (auto i = 0; i < nq * topk; i++) {
-                labels[i] = labels[i] == -1 ? -1 : labels[i] + xb_id_offset;
-            }
-        }
+        external_id_map.MapResultIds(labels, nq * topk);
     }
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
@@ -628,9 +622,8 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
         return Status::invalid_args;
     }
 
-    auto xb_id_offset = base_dataset->GetTensorBeginId();
+    auto external_id_map = base_dataset->GetExternalIdMap(true);
     BitsetView bitset = bitset_;
-    bitset.set_id_offset(xb_id_offset);
 
     BruteForceConfig cfg;
     RETURN_IF_ERROR(Config::Load(cfg, config, knowhere::SEARCH));
@@ -710,9 +703,9 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                     std::fill(tmp_distances.begin(), tmp_distances.end(),
                               larger_is_closer ? std::numeric_limits<float>::min() : std::numeric_limits<float>::max());
 
-                    // adjust bitset offset for this chunk so selector indices map to global ids
                     BitsetView chunk_bitset = bitset;
-                    chunk_bitset.set_id_offset(xb_id_offset + chunk_lims[chunk_idx]);
+                    external_id_map.SetOutIdsToBitset(chunk_bitset, num_base_vectors, std::nullopt,
+                                                      chunk_lims[chunk_idx]);
                     auto chunk_inv_norms = inv_norms == nullptr ? nullptr : inv_norms.get() + chunk_lims[chunk_idx];
 
                     RETURN_IF_ERROR(brute_force_dense_impl<DataType>(
@@ -778,12 +771,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
             }));
         }
         RETURN_IF_ERROR(WaitAllSuccess(futs));
-
-        if (xb_id_offset != 0) {
-            for (auto i = 0; i < nq * k; i++) {
-                ids[i] = ids[i] == -1 ? -1 : ids[i] + xb_id_offset;
-            }
-        }
+        external_id_map.MapResultIds(ids, nq * k);
 
     } else {
         if (!base_is_emb_list || !query_is_emb_list) {
@@ -833,7 +821,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                               larger_is_closer ? std::numeric_limits<float>::min() : std::numeric_limits<float>::max());
 
                     BitsetView chunk_bitset = bitset;
-                    chunk_bitset.set_id_offset(xb_id_offset + chunk_idx);
+                    external_id_map.SetOutIdsToBitset(chunk_bitset, 1, std::nullopt, chunk_idx);
 
                     std::vector<size_t> tmp_base_lims = {0, num_base_vectors};
                     auto tmp_base_el_offset = EmbListOffset(tmp_base_lims);
@@ -841,9 +829,9 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
                     auto cur_base = (static_cast<const DataType* const*>(base_tensor))[chunk_idx];
 
                     RETURN_IF_ERROR(brute_force_emb_list_impl<DataType>(
-                        xq, query_el_idx, cur_base, tmp_labels.data(), tmp_distances.data(), k, dim, tmp_base_el_offset,
-                        query_el_offset, el_metric_type, el_sub_metric_type, chunk_bitset, cfg,
-                        xb_id_offset + chunk_idx));
+                        xq, query_el_idx, 0, cur_base, tmp_labels.data(), tmp_distances.data(), k, dim,
+                        tmp_base_el_offset, query_el_offset, el_metric_type, el_sub_metric_type, chunk_bitset, cfg,
+                        chunk_idx));
 
                     // merge chunk-topk results to heap
                     for (int j = 0; j < k; j++) {
@@ -904,6 +892,7 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
             }));
         }
         RETURN_IF_ERROR(WaitAllSuccess(futs));
+        external_id_map.MapResultIds(ids, num_query_el * k);
     }
     return Status::success;
 }
@@ -918,9 +907,9 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
     auto xb = base_dataset->GetTensor();
     auto nb = base_dataset->GetRows();
     auto dim = base_dataset->GetDim();
-    auto xb_id_offset = base_dataset->GetTensorBeginId();
+    auto external_id_map = base_dataset->GetExternalIdMap(true);
     BitsetView bitset = bitset_;
-    bitset.set_id_offset(xb_id_offset);
+    external_id_map.SetOutIdsToBitset(bitset);
     auto xq = query_dataset->GetTensor();
     auto nq = query_dataset->GetRows();
 
@@ -999,7 +988,6 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                 auto xb_sparse = static_cast<const sparse::SparseRow<float>*>(xb);
                 std::set<std::pair<float, int64_t>, std::greater<>> result;
                 for (int j = 0; j < nb; ++j) {
-                    auto xid = xb_id_offset + j;
                     // bitset has already set the id_offset, so we need to use j instead of xid
                     if (!bitset.empty() && bitset.test(j)) {
                         continue;
@@ -1013,7 +1001,7 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                     }
                     auto dist = cur_query->dot(xb_sparse[j], sparse_computer, row_sum);
                     if (dist > radius && dist <= range_filter) {
-                        result.insert({dist, xid});
+                        result.insert({dist, j});
                     }
                 }
                 result_id_array[index].reserve(result.size());
@@ -1100,7 +1088,7 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
                 result_id_array[index].resize(elem_cnt);
                 for (size_t j = 0; j < elem_cnt; j++) {
                     result_dist_array[index][j] = res.distances[j];
-                    result_id_array[index][j] = res.labels[j] + xb_id_offset;
+                    result_id_array[index][j] = res.labels[j];
                 }
                 if (cfg.range_filter.value() != defaultRangeFilter) {
                     FilterRangeSearchResultForOneNq(result_dist_array[index], result_id_array[index],
@@ -1116,6 +1104,7 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
         return expected<DataSetPtr>::Err(ret, "failed to brute force search");
     }
 
+    external_id_map.MapResultIds(result_id_array);
     auto range_search_result =
         GetRangeSearchResult(result_dist_array, result_id_array, the_larger_the_closer, nq, radius, range_filter);
     auto res = GenResultDataSet(nq, std::move(range_search_result));
@@ -1137,7 +1126,9 @@ BruteForce::SearchSparseWithBuf(const DataSetPtr base_dataset, const DataSetPtr 
                                 milvus::OpContext* op_context) {
     auto base = static_cast<const sparse::SparseRow<float>*>(base_dataset->GetTensor());
     auto rows = base_dataset->GetRows();
-    auto xb_id_offset = base_dataset->GetTensorBeginId();
+    auto external_id_map = base_dataset->GetExternalIdMap(true);
+    BitsetView mapped_bitset = bitset;
+    external_id_map.SetOutIdsToBitset(mapped_bitset);
 
     auto xq = static_cast<const sparse::SparseRow<float>*>(query_dataset->GetTensor());
     auto nq = query_dataset->GetRows();
@@ -1197,8 +1188,7 @@ BruteForce::SearchSparseWithBuf(const DataSetPtr base_dataset, const DataSetPtr 
             }
             ResultMinHeap<float, int64_t> heap(topk);
             for (int64_t j = 0; j < rows; ++j) {
-                auto x_id = j + xb_id_offset;
-                if (!bitset.empty() && bitset.test(x_id)) {
+                if (!mapped_bitset.empty() && mapped_bitset.test(j)) {
                     continue;
                 }
                 float row_sum = 0;
@@ -1210,7 +1200,7 @@ BruteForce::SearchSparseWithBuf(const DataSetPtr base_dataset, const DataSetPtr 
                 }
                 float dist = row.dot(base[j], computer, row_sum);
                 if (dist > 0) {
-                    heap.Push(dist, x_id);
+                    heap.Push(dist, j);
                 }
             }
             heap.Finalize();
@@ -1222,6 +1212,7 @@ BruteForce::SearchSparseWithBuf(const DataSetPtr base_dataset, const DataSetPtr 
         }));
     }
     WaitAllSuccess(futs);
+    external_id_map.MapResultIds(labels, nq * topk);
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
     // LCOV_EXCL_START
@@ -1309,6 +1300,7 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
     }
     auto vec = std::vector<IndexNode::IteratorPtr>(nq, nullptr);
     std::shared_ptr<float[]> inv_norms = GetInverseVecNorms<DataType>(base_dataset);
+    auto external_id_map = std::make_shared<ExternalIdMap>(base_dataset->GetExternalIdMap(true));
 
     try {
         for (int i = 0; i < nq; ++i) {
@@ -1316,9 +1308,8 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
             auto compute_dist_func = [=]() -> std::vector<DistId> {
                 auto xb = base_dataset->GetTensor();
                 auto xq = query_dataset->GetTensor();
-                auto xb_id_offset = base_dataset->GetTensorBeginId();
                 BitsetView bitset = bitset_;
-                bitset.set_id_offset(xb_id_offset);
+                external_id_map->SetOutIdsToBitset(bitset);
                 BitsetViewIDSelector bw_idselector(bitset);
                 [[maybe_unused]] faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
                 auto max_dis =
@@ -1424,15 +1415,10 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
                         KNOWHERE_THROW_MSG(err_msg);
                     }
                 }
-                if (xb_id_offset != 0) {
-                    for (auto& distances_id : distances_ids) {
-                        distances_id.id = distances_id.id == -1 ? -1 : distances_id.id + xb_id_offset;
-                    }
-                }
                 return distances_ids;
             };
             vec[i] = std::make_shared<PrecomputedDistanceIterator>(compute_dist_func, larger_is_closer,
-                                                                   use_knowhere_search_pool);
+                                                                   *external_id_map, use_knowhere_search_pool);
         }
     } catch (const std::exception& e) {
         return expected<std::vector<IndexNode::IteratorPtr>>::Err(Status::brute_force_inner_error, e.what());
@@ -1515,6 +1501,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
     bool is_cosine = IsMetricType(metric_str, metric::COSINE);
     auto vec = std::vector<IndexNode::IteratorPtr>(nq, nullptr);
     std::shared_ptr<float[]> inv_norms = GetInverseVecNorms<DataType>(base_dataset);
+    auto external_id_map = std::make_shared<ExternalIdMap>(base_dataset->GetExternalIdMap(true));
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
     // LCOV_EXCL_START
@@ -1540,7 +1527,6 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
             auto compute_dist_func = [=]() -> std::vector<DistId> {
                 auto chunk_tensor = static_cast<const DataType* const*>(base_dataset->GetTensor());
                 auto xq = query_dataset->GetTensor();
-                auto xb_id_offset = base_dataset->GetTensorBeginId();
 
                 auto max_dis =
                     larger_is_closer ? std::numeric_limits<float>::lowest() : std::numeric_limits<float>::max();
@@ -1556,7 +1542,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                     auto xb = chunk_tensor[chunk_idx];
 
                     BitsetView bitset = bitset_;
-                    bitset.set_id_offset(xb_id_offset + chunk_lims[chunk_idx]);
+                    external_id_map->SetOutIdsToBitset(bitset, num_base_vectors, std::nullopt, chunk_lims[chunk_idx]);
                     BitsetViewIDSelector bw_idselector(bitset);
                     [[maybe_unused]] faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
                     std::vector<DistId> chunk_distances_ids(num_base_vectors, {-1, max_dis});
@@ -1578,10 +1564,13 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                             }
                             // copy chunk_distances_ids to distances_ids
                             for (size_t j = 0; j < num_base_vectors; ++j) {
-                                distances_ids[chunk_lims[chunk_idx] + j].id =
-                                    chunk_distances_ids[j].id == -1
-                                        ? -1
-                                        : chunk_distances_ids[j].id + xb_id_offset + chunk_lims[chunk_idx];
+                                if (chunk_distances_ids[j].id == -1) {
+                                    distances_ids[chunk_lims[chunk_idx] + j].id = -1;
+                                } else {
+                                    auto global_id = chunk_distances_ids[j].id +
+                                                     static_cast<int64_t>(chunk_lims[chunk_idx]);
+                                    distances_ids[chunk_lims[chunk_idx] + j].id = global_id;
+                                }
                                 distances_ids[chunk_lims[chunk_idx] + j].val = chunk_distances_ids[j].val;
                             }
                             break;
@@ -1607,10 +1596,13 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                                 }
                                 // copy chunk_distances_ids to distances_ids
                                 for (size_t j = 0; j < num_base_vectors; ++j) {
-                                    distances_ids[chunk_lims[chunk_idx] + j].id =
-                                        chunk_distances_ids[j].id == -1
-                                            ? -1
-                                            : chunk_distances_ids[j].id + xb_id_offset + chunk_lims[chunk_idx];
+                                    if (chunk_distances_ids[j].id == -1) {
+                                        distances_ids[chunk_lims[chunk_idx] + j].id = -1;
+                                    } else {
+                                        auto global_id = chunk_distances_ids[j].id +
+                                                         static_cast<int64_t>(chunk_lims[chunk_idx]);
+                                        distances_ids[chunk_lims[chunk_idx] + j].id = global_id;
+                                    }
                                     distances_ids[chunk_lims[chunk_idx] + j].val = chunk_distances_ids[j].val;
                                 }
                             } else {
@@ -1629,10 +1621,13 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                                 }
                                 // copy chunk_distances_ids to distances_ids
                                 for (size_t j = 0; j < num_base_vectors; ++j) {
-                                    distances_ids[chunk_lims[chunk_idx] + j].id =
-                                        chunk_distances_ids[j].id == -1
-                                            ? -1
-                                            : chunk_distances_ids[j].id + xb_id_offset + chunk_lims[chunk_idx];
+                                    if (chunk_distances_ids[j].id == -1) {
+                                        distances_ids[chunk_lims[chunk_idx] + j].id = -1;
+                                    } else {
+                                        auto global_id = chunk_distances_ids[j].id +
+                                                         static_cast<int64_t>(chunk_lims[chunk_idx]);
+                                        distances_ids[chunk_lims[chunk_idx] + j].id = global_id;
+                                    }
                                     distances_ids[chunk_lims[chunk_idx] + j].val = chunk_distances_ids[j].val;
                                 }
                             }
@@ -1649,8 +1644,8 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                                         distances_ids[chunk_lims[chunk_idx] + j].id = -1;
                                         distances_ids[chunk_lims[chunk_idx] + j].val = max_dis;
                                     } else {
-                                        distances_ids[chunk_lims[chunk_idx] + j].id =
-                                            xb_id_offset + chunk_lims[chunk_idx] + j;
+                                        auto global_id = static_cast<int64_t>(chunk_lims[chunk_idx] + j);
+                                        distances_ids[chunk_lims[chunk_idx] + j].id = global_id;
                                         distances_ids[chunk_lims[chunk_idx] + j].val = static_cast<float>(distances[j]);
                                     }
                                 }
@@ -1672,8 +1667,8 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                                         distances_ids[chunk_lims[chunk_idx] + j].id = -1;
                                         distances_ids[chunk_lims[chunk_idx] + j].val = max_dis;
                                     } else {
-                                        distances_ids[chunk_lims[chunk_idx] + j].id =
-                                            xb_id_offset + chunk_lims[chunk_idx] + j;
+                                        auto global_id = static_cast<int64_t>(chunk_lims[chunk_idx] + j);
+                                        distances_ids[chunk_lims[chunk_idx] + j].id = global_id;
                                         distances_ids[chunk_lims[chunk_idx] + j].val = distances[j];
                                     }
                                 }
@@ -1694,7 +1689,7 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
                 return distances_ids;
             };
             vec[i] = std::make_shared<PrecomputedDistanceIterator>(compute_dist_func, larger_is_closer,
-                                                                   use_knowhere_search_pool);
+                                                                   *external_id_map, use_knowhere_search_pool);
         }
     } catch (const std::exception& e) {
         return expected<std::vector<IndexNode::IteratorPtr>>::Err(Status::brute_force_inner_error, e.what());
@@ -1710,7 +1705,6 @@ BruteForce::AnnIterator<knowhere::sparse::SparseRow<float>>(const DataSetPtr bas
                                                             const BitsetView& bitset, bool use_knowhere_search_pool,
                                                             milvus::OpContext* op_context) {
     auto rows = base_dataset->GetRows();
-    auto xb_id_offset = base_dataset->GetTensorBeginId();
     auto nq = query_dataset->GetRows();
 
     BruteForceConfig cfg;
@@ -1752,6 +1746,7 @@ BruteForce::AnnIterator<knowhere::sparse::SparseRow<float>>(const DataSetPtr bas
     auto computer = computer_or.value();
 
     auto vec = std::vector<IndexNode::IteratorPtr>(nq, nullptr);
+    auto external_id_map = std::make_shared<ExternalIdMap>(base_dataset->GetExternalIdMap(true));
     try {
         for (int64_t i = 0; i < nq; ++i) {
             // Heavy computations with `compute_dist_func` will be deferred until the first call to 'Iterator->Next()'.
@@ -1759,11 +1754,12 @@ BruteForce::AnnIterator<knowhere::sparse::SparseRow<float>>(const DataSetPtr bas
                 auto xq = static_cast<const sparse::SparseRow<float>*>(query_dataset->GetTensor());
                 auto base = static_cast<const sparse::SparseRow<float>*>(base_dataset->GetTensor());
                 const auto& row = xq[i];
+                BitsetView mapped_bitset = bitset;
+                external_id_map->SetOutIdsToBitset(mapped_bitset);
                 std::vector<DistId> distances_ids;
                 if (row.size() > 0) {
                     for (int64_t j = 0; j < rows; ++j) {
-                        auto xb_id = j + xb_id_offset;
-                        if (!bitset.empty() && bitset.test(xb_id)) {
+                        if (!mapped_bitset.empty() && mapped_bitset.test(j)) {
                             continue;
                         }
                         float row_sum = 0;
@@ -1775,14 +1771,16 @@ BruteForce::AnnIterator<knowhere::sparse::SparseRow<float>>(const DataSetPtr bas
                         }
                         auto dist = row.dot(base[j], computer, row_sum);
                         if (dist > 0) {
-                            distances_ids.emplace_back(xb_id, dist);
+                            distances_ids.emplace_back(j, dist);
                         }
                     }
                 }
                 return distances_ids;
             };
 
-            vec[i] = std::make_shared<PrecomputedDistanceIterator>(compute_dist_func, true, use_knowhere_search_pool);
+            vec[i] =
+                std::make_shared<PrecomputedDistanceIterator>(compute_dist_func, true, *external_id_map,
+                                                              use_knowhere_search_pool);
         }
     } catch (const std::exception& e) {
         return expected<std::vector<IndexNode::IteratorPtr>>::Err(Status::brute_force_inner_error, e.what());

--- a/src/common/utils.cc
+++ b/src/common/utils.cc
@@ -127,6 +127,11 @@ CopyAndNormalizeDataset(const DataSetPtr dataset) {
     auto norms = NormalizeVecs<DataType>(x_normalized, rows, dim);
     auto normalize_bs = GenDataSet(rows, dim, x_normalized);
     normalize_bs->SetIsOwner(true);
+    const auto& internal_to_external_ids = dataset->GetInternalToExternalIds();
+    if (!internal_to_external_ids.empty() || dataset->GetExternalCount() != 0) {
+        normalize_bs->SetInternalToExternalIds(
+            internal_to_external_ids, dataset->GetExternalCount());
+    }
     return std::make_tuple(normalize_bs, norms);
 }
 

--- a/src/index/data_view_dense_index/data_view_dense_index.h
+++ b/src/index/data_view_dense_index/data_view_dense_index.h
@@ -31,6 +31,7 @@
 #include "knowhere/comp/task.h"
 #include "knowhere/config.h"
 #include "knowhere/context.h"
+#include "knowhere/external_id_map.h"
 #include "knowhere/operands.h"
 #include "knowhere/range_util.h"
 
@@ -46,14 +47,16 @@ DataViewIndexBase only keep index meta and data codes(!= raw data) in memory.
 class DataViewIndexBase {
  public:
     DataViewIndexBase(idx_t d, DataFormatEnum data_type, MetricType metric_type, ViewDataOp view, bool is_cosine,
-                      RefineType refine_type, std::optional<int> build_thread_num)
+                      RefineType refine_type, std::optional<int> build_thread_num,
+                      const ExternalIdMap& external_id_map)
         : d_(d),
           data_type_(data_type),
           metric_type_(metric_type),
           view_data_(view),
           is_cosine_(is_cosine),
           refine_type_(refine_type),
-          build_thread_num_(build_thread_num) {
+          build_thread_num_(build_thread_num),
+          external_id_map_(external_id_map) {
         if (metric_type != metric::L2 && metric_type != metric::IP) {
             throw std::runtime_error("DataViewIndexBase only support L2 or IP.");
         }
@@ -185,13 +188,15 @@ class DataViewIndexBase {
     RefineType refine_type_;
     std::shared_ptr<QuantRefine> quant_data_ = nullptr;
     std::optional<int> build_thread_num_ = std::nullopt;
+    const ExternalIdMap& external_id_map_;
 };
 
 class DataViewIndexFlat : public DataViewIndexBase {
  public:
     DataViewIndexFlat(idx_t d, DataFormatEnum data_type, MetricType metric_type, ViewDataOp view, bool is_cosine,
-                      RefineType refine_type, std::optional<int> build_thread_num = std::nullopt)
-        : DataViewIndexBase(d, data_type, metric_type, view, is_cosine, refine_type, build_thread_num) {
+                      RefineType refine_type, std::optional<int> build_thread_num, const ExternalIdMap& external_id_map)
+        : DataViewIndexBase(d, data_type, metric_type, view, is_cosine, refine_type, build_thread_num,
+                            external_id_map) {
         this->ntotal_.store(0);
     }
     void
@@ -290,13 +295,14 @@ class DataViewIndexFlat : public DataViewIndexBase {
 
     float
     GetDataNorm(idx_t id) const {
-        assert(id < ntotal_);
+        auto norm_id = external_id_map_.HasInternalToEmbListIds() ? id
+                                                                  : static_cast<idx_t>(external_id_map_.ToInternalId(id));
         idx_t current_norms_size = 0;
         {
             std::shared_lock lock(norms_mutex_);
             current_norms_size = norms_.size();
         }
-        if (current_norms_size < id) {  // maybe cosine is false, get norm in place
+        if (norm_id < 0 || current_norms_size <= norm_id) {  // maybe cosine is false, get norm in place
             auto data = view_data_(id);
             if (data_type_ == DataFormatEnum::fp32) {
                 return GetL2Norm<fp32>((const fp32*)data, d_);
@@ -307,7 +313,7 @@ class DataViewIndexFlat : public DataViewIndexBase {
             }
         } else {
             std::shared_lock lock(norms_mutex_);
-            return norms_[id];
+            return norms_[norm_id];
         }
     }
 
@@ -459,10 +465,14 @@ DataViewIndexFlat::SearchWithIds(const idx_t n, const void* __restrict x, const 
             assert(base_n >= k);
             ComputeDistanceSubset(x_i, base_n, base_dist.get(), base_ids, use_quant);
             if (is_cosine_) {
+                std::vector<idx_t> internal_ids;
+                const auto* norm_ids = external_id_map_.HasInternalToEmbListIds()
+                                           ? base_ids
+                                           : external_id_map_.ToInternalIds(base_ids, base_n, internal_ids);
                 std::shared_lock lock(norms_mutex_);
                 for (auto j = 0; j < base_n; j++) {
                     if (base_ids[j] != -1) {
-                        base_dist[j] /= norms_[base_ids[j]];
+                        base_dist[j] /= norms_[norm_ids[j]];
                     }
                 }
             }
@@ -491,9 +501,13 @@ DataViewIndexFlat::CalcDistByIDs(const idx_t num_queries, const void* __restrict
             auto query = (const char*)queries + code_size_ * idx;
             ComputeDistanceSubset(query, num_ids, out_dist + idx * num_ids, ids, use_quant);
             if (is_cosine_) {
+                std::vector<idx_t> internal_ids;
+                const auto* norm_ids = external_id_map_.HasInternalToEmbListIds()
+                                           ? ids
+                                           : external_id_map_.ToInternalIds(ids, num_ids, internal_ids);
                 std::shared_lock lock(norms_mutex_);
                 for (auto j = 0; j < num_ids; j++) {
-                    out_dist[idx * num_ids + j] /= norms_[ids[j]];
+                    out_dist[idx * num_ids + j] /= norms_[norm_ids[j]];
                 }
             }
         }));
@@ -606,9 +620,13 @@ DataViewIndexFlat::RangeSearchWithIds(const idx_t n, const void* __restrict x, c
             auto x_i = (const char*)x + code_size_ * i;
             ComputeDistanceSubset((const void*)x_i, base_n, base_dist.get(), base_ids, use_quant);
             if (is_cosine_) {
+                std::vector<idx_t> internal_ids;
+                const auto* norm_ids = external_id_map_.HasInternalToEmbListIds()
+                                           ? base_ids
+                                           : external_id_map_.ToInternalIds(base_ids, base_n, internal_ids);
                 std::shared_lock lock(norms_mutex_);
                 for (auto j = 0; j < base_n; j++) {
-                    base_dist[j] = base_dist[j] / norms_[base_ids[j]];
+                    base_dist[j] = base_dist[j] / norms_[norm_ids[j]];
                 }
             }
             for (auto j = 0; j < base_n; j++) {

--- a/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
+++ b/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
@@ -73,12 +73,6 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
         return refine_offset_index_->GetQueryCodeSize();
     }
 
-    Status
-    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) override {
-        internal_offset_to_most_external_id_ = std::move(map);
-        return Status::success;
-    }
-
     expected<DataSetPtr>
     CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
                   const bool is_cosine, milvus::OpContext* op_context) const override;
@@ -206,11 +200,13 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
      public:
         iterator(std::shared_ptr<DataViewIndexFlat> refine_offset_index, IndexNode::IteratorPtr base_workspace,
                  std::unique_ptr<DataType[]>&& copied_query, bool larger_is_closer, bool use_quant,
-                 float refine_ratio = 0.5f, bool retain_iterator_order = false)
-            : IndexIterator(larger_is_closer, false, refine_ratio, retain_iterator_order),
+                 float refine_ratio = 0.5f, bool retain_iterator_order = false,
+                 const ExternalIdMap& external_id_map = EmptyExternalIdMap())
+            : IndexIterator(larger_is_closer, external_id_map, false, refine_ratio, retain_iterator_order),
               refine_offset_index_(refine_offset_index),
               copied_query_(std::move(copied_query)),
-              base_workspace_(base_workspace) {
+              base_workspace_(base_workspace),
+              external_id_map_(external_id_map) {
             refine_computer_ = SelectDataViewComputer(refine_offset_index->GetViewData(),
                                                       refine_offset_index->DataFormat(), refine_offset_index->Metric(),
                                                       refine_offset_index_->Dim(), refine_offset_index_->IsCosine(),
@@ -224,7 +220,8 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
                 initialize();
             }
             if (!refine_) {
-                return base_workspace_->Next();
+                auto ret = base_workspace_->Next();
+                return ret;
             } else {
                 auto ret = refined_res_.top();
                 refined_res_.pop();
@@ -239,7 +236,8 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
                         UpdateNext();
                     }
                 }
-                return std::make_pair(ret.id, ret.val * sign_);
+                auto id = external_id_map_.HasInternalToEmbListIds() ? external_id_map_.MapResultId(ret.id) : ret.id;
+                return std::make_pair(id, ret.val * sign_);
             }
         }
 
@@ -270,9 +268,6 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
             if (refine_computer_ == nullptr) {
                 throw std::runtime_error("refine computer is null in offset refine index.");
             }
-            if (refine_offset_index_->Count() <= id) {
-                throw std::runtime_error("the id of result larger than index rows count.");
-            }
             float dis = refine_computer_->operator()(id);
             dis = refine_offset_index_->IsCosine() ? dis / refine_offset_index_->GetDataNorm(id) : dis;
             return dis;
@@ -290,11 +285,11 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
             }
         }
 
-     private:
         bool initialized_ = false;
         std::shared_ptr<DataViewIndexFlat> refine_offset_index_ = nullptr;
         std::unique_ptr<DataType[]> copied_query_ = nullptr;
         IndexNode::IteratorPtr base_workspace_ = nullptr;
+        const ExternalIdMap& external_id_map_;
         std::unique_ptr<faiss::DistanceComputer> refine_computer_ = nullptr;
     };
     bool is_cosine_;
@@ -304,7 +299,6 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
     std::unique_ptr<IndexNode> base_index_;  // base_index will hold data codes in memory, datatype is fp32
     std::unique_ptr<FairRWLock>
         base_index_lock_;  // base_index_lock_ protect all concurrent writes/reads access of base_index_
-    std::vector<uint32_t> internal_offset_to_most_external_id_;
 };
 
 namespace {
@@ -360,7 +354,8 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::Train(const DataSetPtr da
     auto [fp32_train_ds, _] =
         ConvertToBaseIndexFp32DataSet<DataType>(dataset, this->is_cosine_, 0, train_rows, base_index_dim);
     refine_offset_index_ = std::make_unique<DataViewIndexFlat>(
-        dim, datatype_v<DataType>, refine_metric, this->view_data_op_, is_cosine_, refine_type, build_thread_num);
+        dim, datatype_v<DataType>, refine_metric, this->view_data_op_, is_cosine_, refine_type, build_thread_num,
+        external_id_map_);
     try {
         refine_offset_index_->Train(train_rows, data, use_knowhere_build_pool);
     } catch (const std::exception& e) {
@@ -379,6 +374,17 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::Add(const DataSetPtr data
     auto rows = dataset->GetRows();
     auto dim = dataset->GetDim();
     auto data = (const DataType*)dataset->GetTensor();
+    if (refine_offset_index_ == nullptr) {
+        LOG_KNOWHERE_ERROR_ << "Can not add data to empty Data View Index.";
+        return Status::empty_index;
+    }
+    auto old_rows = Count();
+    if (rows == 0) {
+        if (this->emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+        }
+        return Status::success;
+    }
     AdaptToBaseIndexConfig(cfg.get(), PARAM_TYPE::TRAIN, dim);
     Status add_stat;
     for (auto blk_i = 0; blk_i < rows; blk_i += kBatchSize) {
@@ -399,6 +405,12 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::Add(const DataSetPtr data
         if (add_stat != Status::success) {
             return add_stat;
         }
+        if (this->emb_list_strategy_ != nullptr) {
+            RETURN_IF_ERROR(base_index_->SetExternalIdMap(ExternalIdMap{}));
+        }
+    }
+    if (this->emb_list_strategy_ == nullptr) {
+        RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
     }
     return Status::success;
 }
@@ -442,27 +454,29 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::AddEmbList(const DataSetP
             LOG_KNOWHERE_WARNING_ << "emb list offset is not continuous";
             return Status::emb_list_inner_error;
         }
+        if (num_rows == 0) {
+            RETURN_IF_ERROR(AddEmbListExternalIdMapFromDataset(dataset, old_num_el, 0));
+            return Status::success;
+        }
+
         idx++;
-        internal_offset_to_most_external_id_.resize(new_rows_cnt);
         while (lims[idx] < new_rows_cnt) {
             if (lims[idx] < lims[idx - 1]) {
                 LOG_KNOWHERE_WARNING_ << "emb list offset is not increasing";
                 return Status::emb_list_inner_error;
             }
-            emb_list_offset_->offset.push_back(lims[idx]);
-            auto cur_el_id = old_num_el + idx - 1;
-            std::fill_n(internal_offset_to_most_external_id_.begin() + lims[idx - 1], lims[idx] - lims[idx - 1],
-                        cur_el_id);
             idx++;
         }
         if (lims[idx] != new_rows_cnt) {
             LOG_KNOWHERE_WARNING_ << "emb list offset should end with the total_cnt of the whole index";
             return Status::emb_list_inner_error;
         }
-        emb_list_offset_->offset.push_back(new_rows_cnt);
-        auto cur_el_id = old_num_el + idx - 1;
-        std::fill_n(internal_offset_to_most_external_id_.begin() + lims[idx - 1], new_rows_cnt - lims[idx - 1],
-                    cur_el_id);
+        RETURN_IF_ERROR(AddEmbListExternalIdMapFromDataset(dataset, old_num_el, static_cast<int64_t>(idx)));
+        for (size_t offset_idx = 1; offset_idx <= idx; ++offset_idx) {
+            emb_list_offset_->offset.push_back(lims[offset_idx]);
+            auto cur_el_id = old_num_el + offset_idx - 1;
+            external_id_map_.AppendInternalToEmbListIds(lims[offset_idx - 1], lims[offset_idx], cur_el_id);
+        }
     }
 
     // 3. add to index
@@ -496,19 +510,7 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::Search(const DataSetPtr d
     {
         FairReadLockGuard guard(*this->base_index_lock_);
         BitsetView new_bitset(bitset);
-        if (!internal_offset_to_most_external_id_.empty()) {
-            size_t num_filtered_out_ids = 0;
-            if (!bitset.empty()) {
-                // todo: optimize the calculation
-                for (size_t i = 0; i < new_bitset.size(); i++) {
-                    if (new_bitset.test(i)) {
-                        num_filtered_out_ids += emb_list_offset_->offset[i + 1] - emb_list_offset_->offset[i];
-                    }
-                }
-            }
-            new_bitset.set_out_ids(internal_offset_to_most_external_id_.data(),
-                                   internal_offset_to_most_external_id_.size(), num_filtered_out_ids);
-        }
+        external_id_map_.SetOutIdsToBitset(new_bitset);
         quant_res = base_index_->Search(base_index_ds, std::move(cfg), new_bitset, op_context);
     }
     if (!quant_res.has_value()) {
@@ -529,6 +531,9 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::Search(const DataSetPtr d
     } catch (const std::exception& e) {
         LOG_KNOWHERE_WARNING_ << "data view index inner error: " << e.what();
         return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
+    }
+    if (external_id_map_.HasInternalToEmbListIds()) {
+        external_id_map_.MapResultIds(labels.get(), nq * topk);
     }
     return GenResultDataSet(nq, topk, std::move(labels), std::move(distances));
 }
@@ -553,9 +558,19 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::CalcDistByIDs(const DataS
     auto num_queries = dataset->GetRows();
     auto query_data = dataset->GetTensor();
     auto distances = std::make_unique<float[]>(num_queries * labels_len);
+    std::vector<int64_t> internal_labels;
+    const int64_t* labels_to_calc = labels;
+    if (this->emb_list_strategy_ == nullptr) {
+        labels_to_calc = this->external_id_map_.ToInternalIds(labels, labels_len, internal_labels);
+    }
+    for (size_t i = 0; i < labels_len; ++i) {
+        if (labels_to_calc[i] < 0 || labels_to_calc[i] >= Count()) {
+            return expected<DataSetPtr>::Err(Status::invalid_args, "invalid label id");
+        }
+    }
     try {
         bool refine_with_quant = false;
-        refine_offset_index_->CalcDistByIDs(num_queries, query_data, labels_len, labels, distances.get(),
+        refine_offset_index_->CalcDistByIDs(num_queries, query_data, labels_len, labels_to_calc, distances.get(),
                                             refine_with_quant);
     } catch (const std::exception& e) {
         LOG_KNOWHERE_WARNING_ << "data view index inner error: " << e.what();
@@ -596,8 +611,10 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::AnnIterator(const DataSet
     knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>> base_index_init;
     {
         FairReadLockGuard guard(*this->base_index_lock_);
+        BitsetView new_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(new_bitset);
         base_index_init =
-            base_index_->AnnIterator(base_index_ds, std::move(cfg), bitset, use_knowhere_search_pool, op_context);
+            base_index_->AnnIterator(base_index_ds, std::move(cfg), new_bitset, use_knowhere_search_pool, op_context);
     }
     if (!base_index_init.has_value()) {
         return base_index_init;
@@ -615,7 +632,7 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::AnnIterator(const DataSet
         std::copy_n(cur_query, dim, copied_query.get());
         vec[i] = std::shared_ptr<iterator>(new iterator(this->refine_offset_index_, base_workspace_iters[i],
                                                         std::move(copied_query), larger_is_closer, refine_with_quant,
-                                                        refine_ratio));
+                                                        refine_ratio, false, this->external_id_map_));
     }
     return vec;
 }

--- a/src/index/diskann/diskann.cc
+++ b/src/index/diskann/diskann.cc
@@ -92,12 +92,6 @@ class DiskANNIndexNode : public IndexNode {
         return std::nullopt;
     }
 
-    Status
-    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) override {
-        internal_id_to_most_external_id_map_ = std::move(map);
-        return Status::success;
-    }
-
     expected<DataSetPtr>
     CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
                   const bool is_cosine, milvus::OpContext* op_context) const override;
@@ -132,12 +126,16 @@ class DiskANNIndexNode : public IndexNode {
     Status
     Serialize(BinarySet& binset) const override {
         LOG_KNOWHERE_INFO_ << "DiskANN does nothing for serialize";
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP));
+        }
         return Status::success;
     }
 
     Status
     SerializeEmbListIfNeed(BinarySet& binset) const override {
         LOG_KNOWHERE_INFO_ << "DiskANN does nothing for serialize (with emb list if needed)";
+        RETURN_IF_ERROR(AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP));
         return Status::success;
     }
 
@@ -226,8 +224,9 @@ class DiskANNIndexNode : public IndexNode {
      public:
         iterator(const bool transform, const DataType* query_data, const uint64_t lsearch, const uint64_t beam_width,
                  const float filter_ratio, const knowhere::BitsetView& bitset, diskann::PQFlashIndex<DataType>* index,
+                 const ExternalIdMap& external_id_map,
                  bool use_knowhere_search_pool = true)
-            : IndexIterator(transform, use_knowhere_search_pool),
+            : IndexIterator(transform, external_id_map, use_knowhere_search_pool),
               index_(index),
               transform_(transform),
               workspace_(index_->getIteratorWorkspace(query_data, lsearch, beam_width, filter_ratio, bitset)) {
@@ -246,7 +245,7 @@ class DiskANNIndexNode : public IndexNode {
             workspace_->backup_res.clear();
         }
 
-     private:
+    private:
         diskann::PQFlashIndex<DataType>* index_;
         const bool transform_;
         std::unique_ptr<diskann::IteratorWorkspace<DataType>> workspace_;
@@ -282,7 +281,6 @@ class DiskANNIndexNode : public IndexNode {
     std::atomic_int64_t dim_;
     std::atomic_int64_t count_;
     std::shared_ptr<ThreadPool> search_pool_;
-    std::vector<uint32_t> internal_id_to_most_external_id_map_;  // for 1-hop bitset check
 };
 
 }  // namespace knowhere
@@ -448,12 +446,18 @@ DiskANNIndexNode<DataType>::Build(const DataSetPtr dataset, std::shared_ptr<Conf
     auto data_path = build_conf.data_path.value();
 
     index_prefix_ = build_conf.index_prefix.value();
+    if (emb_list_strategy_ == nullptr) {
+        RETURN_IF_ERROR(SetExternalIdMapFromDataset(dataset));
+    }
 
     size_t count;
     size_t dim;
     diskann::get_bin_metadata(build_conf.data_path.value(), count, dim);
     count_.store(count);
     dim_.store(dim);
+    if (count == 0) {
+        return Status::empty_index;
+    }
 
     bool need_norm = IsMetricType(build_conf.metric_type.value(), knowhere::metric::IP) ||
                      IsMetricType(build_conf.metric_type.value(), knowhere::metric::COSINE);
@@ -509,6 +513,9 @@ DiskANNIndexNode<DataType>::Build(const DataSetPtr dataset, std::shared_ptr<Conf
             LOG_KNOWHERE_ERROR_ << "Failed to add file " << filename << ".";
             return Status::disk_file_error;
         }
+    }
+    if (emb_list_strategy_ == nullptr) {
+        RETURN_IF_ERROR(SaveExternalIdMapToFileManager(file_manager_, index_prefix_ + "_id_map"));
     }
 
     is_prepared_.store(false);
@@ -576,6 +583,8 @@ DiskANNIndexNode<DataType>::BuildEmbListIfNeed(const DataSetPtr dataset, std::sh
         }
     }
 
+    RETURN_IF_ERROR(SaveExternalIdMapToFileManager(file_manager_, index_prefix_ + "_id_map"));
+
     return Status::success;
 }
 
@@ -623,6 +632,13 @@ DiskANNIndexNode<DataType>::Deserialize(const BinarySet& binset, std::shared_ptr
         }
         if (is_exist_op.value() && !LoadFile(filename)) {
             return Status::disk_file_error;
+        }
+    }
+    if (emb_list_strategy_ == nullptr) {
+        if (binset.GetByName(meta::EXTERNAL_ID_MAP) != nullptr) {
+            RETURN_IF_ERROR(LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP));
+        } else {
+            RETURN_IF_ERROR(LoadExternalIdMapFromFileManager(file_manager_, index_prefix_ + "_id_map"));
         }
     }
 
@@ -780,10 +796,18 @@ DiskANNIndexNode<DataType>::DeserializeEmbListIfNeed(const BinarySet& binset, st
     }
     config.metric_type = sub_metric_type_or.value();
 
-    // Step 2: Deserialize base index with sub_metric_type
+    // Step 2: Create strategy before base index deserialize, so base index skips id-map loading.
+    auto strategy_or = CreateEmbListStrategy(meta::EMB_LIST_STRATEGY_TOKENANN, config);
+    if (!strategy_or.has_value()) {
+        LOG_KNOWHERE_ERROR_ << "Failed to create emb_list strategy";
+        return strategy_or.error();
+    }
+    emb_list_strategy_ = std::move(strategy_or.value());
+
+    // Step 3: Deserialize base index with sub_metric_type
     RETURN_IF_ERROR(Deserialize(binset, cfg));
 
-    // Step 3: Deserialize emb_list offset from file
+    // Step 4: Deserialize emb_list offset from file
     // Note: emb_list_offset_file is in optional files list, but for emb_list metric type it should exist
     const auto emb_list_offset_file = diskann::get_emb_list_offset_file(index_prefix_);
     auto is_exist_op = file_manager_->IsExisted(emb_list_offset_file);
@@ -809,20 +833,14 @@ DiskANNIndexNode<DataType>::DeserializeEmbListIfNeed(const BinarySet& binset, st
     LOG_KNOWHERE_INFO_ << "Read emb_list offset from file: " << emb_list_offset_file << ", size: " << offset.size()
                        << ", first offset: " << offset.front() << ", last offset: " << offset.back();
 
-    // Step 4: Create strategy and set offset directly
-    auto strategy_or = CreateEmbListStrategy(meta::EMB_LIST_STRATEGY_TOKENANN, config);
-    if (!strategy_or.has_value()) {
-        LOG_KNOWHERE_ERROR_ << "Failed to create emb_list strategy";
-        return strategy_or.error();
-    }
-    emb_list_strategy_ = std::move(strategy_or.value());
-
+    // Step 5: Set offset directly.
     emb_list_offset_ = std::make_shared<EmbListOffset>(std::move(offset));
     RETURN_IF_ERROR(emb_list_strategy_->SetEmbListOffset(emb_list_offset_));
     LOG_KNOWHERE_INFO_ << "Created emb_list strategy: " << emb_list_strategy_->Type()
                        << ", doc_count=" << emb_list_strategy_->GetDocCount();
 
-    // Step 5: Set base index id map for 1-hop bitset check
+    // Step 6: Load emb-list id map and set base index id map for 1-hop bitset check.
+    RETURN_IF_ERROR(LoadExternalIdMapFromFileManager(file_manager_, index_prefix_ + "_id_map"));
     return SetBaseIndexIDMap();
 }
 
@@ -853,13 +871,15 @@ DiskANNIndexNode<DataType>::AnnIterator(const DataSetPtr dataset, std::unique_pt
     auto vec = std::vector<IndexNode::IteratorPtr>(nq, nullptr);
     auto metric = search_conf.metric_type.value();
     bool transform = metric != knowhere::metric::L2;
+    BitsetView mapped_bitset(bitset);
+    external_id_map_.SetOutIdsToBitset(mapped_bitset);
 
     try {
         for (int i = 0; i < nq; i++) {
             auto single_query = static_cast<const DataType*>(xq) + i * dim;
-            auto it = std::make_shared<iterator>(transform, single_query, lsearch, beamwidth, filter_ratio, bitset,
-                                                 pq_flash_index_.get(), use_knowhere_search_pool);
-            vec[i] = it;
+            vec[i] = std::make_shared<iterator>(transform, single_query, lsearch, beamwidth, filter_ratio,
+                                                mapped_bitset, pq_flash_index_.get(), external_id_map_,
+                                                use_knowhere_search_pool);
         }
     } catch (const std::exception& e) {
         return expected<std::vector<IndexNode::IteratorPtr>>::Err(Status::diskann_inner_error, e.what());
@@ -900,29 +920,7 @@ DiskANNIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Con
     }
 
     BitsetView bitset(bitset_);
-    if (!internal_id_to_most_external_id_map_.empty()) {
-        if (emb_list_offset_ != nullptr) {
-            // if emb list, manually calculate the number of filtered out ids
-            size_t num_filtered_out_ids = 0;
-            const auto num_el = std::min(
-                bitset.size(), emb_list_offset_->offset.empty() ? size_t{0} : emb_list_offset_->offset.size() - 1);
-            if (emb_list_offset_->offset.size() < bitset.size() + 1) {
-                LOG_KNOWHERE_WARNING_ << "Bitset size(" << bitset.size() << ") doesn't match emb_list offset size("
-                                      << emb_list_offset_->offset.size()
-                                      << "), will compute filtered ids using min size(" << num_el << ")";
-            }
-            for (size_t i = 0; i < num_el; i++) {
-                if (bitset.test(i)) {
-                    num_filtered_out_ids += emb_list_offset_->offset[i + 1] - emb_list_offset_->offset[i];
-                }
-            }
-            bitset.set_out_ids(internal_id_to_most_external_id_map_.data(), internal_id_to_most_external_id_map_.size(),
-                               num_filtered_out_ids);
-        } else {
-            bitset.set_out_ids(internal_id_to_most_external_id_map_.data(),
-                               internal_id_to_most_external_id_map_.size());
-        }
-    }
+    external_id_map_.SetOutIdsToBitset(bitset);
 
     auto p_id = std::make_unique<int64_t[]>(k * nq);
     auto p_dist = std::make_unique<DistType[]>(k * nq);
@@ -945,6 +943,7 @@ DiskANNIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Con
     if (TryDiskANNCall([&]() { WaitAllSuccess(futures); }) != Status::success) {
         return expected<DataSetPtr>::Err(Status::diskann_inner_error, "some search failed");
     }
+    external_id_map_.MapResultIds(p_id.get(), k * nq);
 
     auto res = GenResultDataSet(nq, k, std::move(p_id), std::move(p_dist));
 
@@ -988,13 +987,23 @@ DiskANNIndexNode<DataType>::CalcDistByIDs(const DataSetPtr dataset, const Bitset
     auto dim = dataset->GetDim();
     auto xq = static_cast<const DataType*>(dataset->GetTensor());
     auto p_dist = std::make_unique<DistType[]>(nq * labels_len);
+    std::vector<int64_t> internal_labels;
+    const int64_t* labels_to_calc = labels;
+    if (emb_list_strategy_ == nullptr) {
+        labels_to_calc = external_id_map_.ToInternalIds(labels, labels_len, internal_labels);
+    }
+    for (size_t i = 0; i < labels_len; ++i) {
+        if (labels_to_calc[i] < 0 || labels_to_calc[i] >= count_.load()) {
+            return expected<DataSetPtr>::Err(Status::invalid_args, "invalid label id");
+        }
+    }
 
     std::vector<folly::Future<folly::Unit>> futures;
     futures.reserve(nq);
     for (int64_t row = 0; row < nq; ++row) {
         futures.emplace_back(search_pool_->push([&, index = row, p_dist_ptr = p_dist.get()]() {
             knowhere::checkCancellation(op_context);
-            pq_flash_index_->calc_dist_by_ids(xq + (index * dim), labels, static_cast<int64_t>(labels_len),
+            pq_flash_index_->calc_dist_by_ids(xq + (index * dim), labels_to_calc, static_cast<int64_t>(labels_len),
                                               p_dist_ptr + index * labels_len);
         }));
     }
@@ -1021,6 +1030,15 @@ DiskANNIndexNode<DataType>::GetVectorByIds(const DataSetPtr dataset, milvus::OpC
     auto dim = Dim();
     auto rows = dataset->GetRows();
     auto ids = dataset->GetIds();
+    std::vector<int64_t> internal_ids;
+    if (emb_list_strategy_ == nullptr) {
+        ids = external_id_map_.ToInternalIds(ids, rows, internal_ids);
+    }
+    for (int64_t i = 0; i < rows; ++i) {
+        if (ids[i] < 0 || ids[i] >= count_.load()) {
+            return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+        }
+    }
     auto* data = new DataType[dim * rows];
     if (data == nullptr) {
         LOG_KNOWHERE_ERROR_ << "Failed to allocate memory for data.";

--- a/src/index/diskann/diskann_aisaq.cc
+++ b/src/index/diskann/diskann_aisaq.cc
@@ -78,6 +78,9 @@ class AisaqIndexNode : public IndexNode {
     Status
     Serialize(BinarySet& binset) const override {
         LOG_KNOWHERE_INFO_ << "AiSAQ does nothing for serialize";
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP));
+        }
         return Status::success;
     }
 
@@ -351,11 +354,18 @@ AisaqIndexNode<DataType>::Build(const DataSetPtr dataset, std::shared_ptr<Config
     auto data_path = build_conf.data_path.value();
 
     index_prefix_ = build_conf.index_prefix.value();
+    if (emb_list_strategy_ == nullptr) {
+        RETURN_IF_ERROR(SetExternalIdMapFromDataset(dataset));
+    }
+
     size_t count;
     size_t dim;
     diskann::get_bin_metadata(build_conf.data_path.value(), count, dim);
     count_.store(count);
     dim_.store(dim);
+    if (count == 0) {
+        return Status::empty_index;
+    }
 
     bool need_norm = IsMetricType(build_conf.metric_type.value(), knowhere::metric::IP) ||
                      IsMetricType(build_conf.metric_type.value(), knowhere::metric::COSINE);
@@ -429,6 +439,10 @@ AisaqIndexNode<DataType>::Build(const DataSetPtr dataset, std::shared_ptr<Config
             return Status::disk_file_error;
         }
     }
+    if (emb_list_strategy_ == nullptr) {
+        RETURN_IF_ERROR(SaveExternalIdMapToFileManager(file_manager_, index_prefix_ + "_id_map"));
+    }
+
     is_prepared_.store(false);
     return Status::success;
 }
@@ -492,6 +506,13 @@ AisaqIndexNode<DataType>::Deserialize(const BinarySet& binset, std::shared_ptr<C
         }
         if (is_exist_op.value() && !LoadFile(filename)) {
             return Status::disk_file_error;
+        }
+    }
+    if (emb_list_strategy_ == nullptr) {
+        if (binset.GetByName(meta::EXTERNAL_ID_MAP) != nullptr) {
+            RETURN_IF_ERROR(LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP));
+        } else {
+            RETURN_IF_ERROR(LoadExternalIdMapFromFileManager(file_manager_, index_prefix_ + "_id_map"));
         }
     }
 
@@ -694,6 +715,8 @@ AisaqIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
 
     auto p_id = std::make_unique<int64_t[]>(k * nq);
     auto p_dist = std::make_unique<DistType[]>(k * nq);
+    BitsetView mapped_bitset(bitset);
+    external_id_map_.SetOutIdsToBitset(mapped_bitset);
 
     std::vector<folly::Future<folly::Unit>> futures;
     futures.reserve(nq);
@@ -703,7 +726,7 @@ AisaqIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
             diskann::QueryStats stats;
             pq_flash_index_->aisaq_cached_beam_search(xq + (index * dim), k, lsearch, p_id_ptr + (index * k),
                                                       p_dist_ptr + (index * k), beamwidth, false, &stats, feder_result,
-                                                      bitset, filter_ratio, &aisaq_search_config);
+                                                      mapped_bitset, filter_ratio, &aisaq_search_config);
 #ifdef NOT_COMPILE_FOR_SWIG
             knowhere_diskann_search_hops.Observe(stats.n_hops);
 #endif
@@ -714,6 +737,7 @@ AisaqIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
         return expected<DataSetPtr>::Err(Status::aisaq_error, "some search failed");
     }
 
+    external_id_map_.MapResultIds(p_id.get(), k * nq);
     auto res = GenResultDataSet(nq, k, std::move(p_id), std::move(p_dist));
 
     // set visit_info json string into result dataset
@@ -742,6 +766,15 @@ AisaqIndexNode<DataType>::GetVectorByIds(const DataSetPtr dataset, milvus::OpCon
     auto dim = Dim();
     auto rows = dataset->GetRows();
     auto ids = dataset->GetIds();
+    std::vector<int64_t> internal_ids;
+    if (emb_list_strategy_ == nullptr) {
+        ids = external_id_map_.ToInternalIds(ids, rows, internal_ids);
+    }
+    for (int64_t i = 0; i < rows; ++i) {
+        if (ids[i] < 0 || ids[i] >= count_.load()) {
+            return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+        }
+    }
     auto* data = new DataType[dim * rows];
     if (data == nullptr) {
         LOG_KNOWHERE_ERROR_ << "Failed to allocate memory for data.";

--- a/src/index/emb_list/emb_list_strategy.cc
+++ b/src/index/emb_list/emb_list_strategy.cc
@@ -94,14 +94,15 @@ RerankByCalcDistByIDs(const std::vector<int64_t>& candidate_docs, const DataSetP
 
     // Extract results in sorted order
     size_t result_count = larger_is_closer ? minheap.size() : maxheap.size();
+    const auto& external_id_map = index->GetExternalIdMap();
     for (size_t j = 0; j < result_count; ++j) {
         size_t idx = result_count - j - 1;
         if (larger_is_closer) {
-            out_ids[idx] = minheap.top().id;
+            out_ids[idx] = external_id_map.ToExternalId(minheap.top().id);
             out_dists[idx] = minheap.top().val;
             minheap.pop();
         } else {
-            out_ids[idx] = maxheap.top().id;
+            out_ids[idx] = external_id_map.ToExternalId(maxheap.top().id);
             out_dists[idx] = maxheap.top().val;
             maxheap.pop();
         }

--- a/src/index/emb_list/emb_list_strategy_lemur.cc
+++ b/src/index/emb_list/emb_list_strategy_lemur.cc
@@ -276,6 +276,10 @@ class LemurEmbListStrategy : public EmbListStrategy {
         }
         auto W_dataset = GenDataSet(num_docs_, final_hidden_dim_, W_data.release());
         W_dataset->SetIsOwner(true);
+        const auto& internal_to_external_ids = dataset->GetInternalToExternalIds();
+        if (!internal_to_external_ids.empty() || dataset->GetExternalCount() != 0) {
+            W_dataset->SetInternalToExternalIds(internal_to_external_ids, dataset->GetExternalCount());
+        }
 
         auto end_time = std::chrono::high_resolution_clock::now();
         double total_ms = std::chrono::duration<double, std::milli>(end_time - start_time).count();
@@ -376,6 +380,8 @@ class LemurEmbListStrategy : public EmbListStrategy {
 
         LOG_KNOWHERE_DEBUG_ << "[LEMUR] Stage2 ANN search: ann_k=" << ann_k;
 
+        const auto& external_id_map = index->GetExternalIdMap();
+
         // 5. If reranking disabled, return ANN results directly
         if (!do_rerank) {
             auto ids = std::make_unique<int64_t[]>(num_query_docs * k);
@@ -423,7 +429,7 @@ class LemurEmbListStrategy : public EmbListStrategy {
             // Collect candidate doc IDs (no dedup needed — ANN returns doc-level IDs)
             candidate_docs.clear();
             for (int32_t i = 0; i < ann_k; ++i) {
-                int64_t doc_id = ann_ids[q * ann_k + i];
+                int64_t doc_id = external_id_map.ToInternalId(ann_ids[q * ann_k + i]);
                 if (doc_id >= 0 && doc_id < num_docs_) {
                     candidate_docs.push_back(doc_id);
                 }

--- a/src/index/emb_list/emb_list_strategy_muvera.cc
+++ b/src/index/emb_list/emb_list_strategy_muvera.cc
@@ -142,6 +142,10 @@ class MuveraEmbListStrategy : public EmbListStrategy {
         // 7. Create encoded dataset (takes ownership of encoded_data)
         auto encoded_dataset = GenDataSet(num_docs_, encoded_dim_, encoded_data.release());
         encoded_dataset->SetIsOwner(true);
+        const auto& internal_to_external_ids = dataset->GetInternalToExternalIds();
+        if (!internal_to_external_ids.empty() || dataset->GetExternalCount() != 0) {
+            encoded_dataset->SetInternalToExternalIds(internal_to_external_ids, dataset->GetExternalCount());
+        }
 
         return std::optional<DataSetPtr>(encoded_dataset);
     }
@@ -219,6 +223,8 @@ class MuveraEmbListStrategy : public EmbListStrategy {
         LOG_KNOWHERE_DEBUG_ << "[MUVERA] Stage2 ANN search: ann_k=" << ann_k << ", encoded_dim=" << encoded_dim_
                             << ", rerank=" << do_rerank;
 
+        const auto& external_id_map = index->GetExternalIdMap();
+
         // 5. If reranking disabled, directly return ANN results
         if (!do_rerank) {
             auto ids = std::make_unique<int64_t[]>(num_query_docs * k);
@@ -265,7 +271,7 @@ class MuveraEmbListStrategy : public EmbListStrategy {
             // Collect candidate doc IDs (no dedup needed — ANN returns doc-level IDs)
             candidate_docs.clear();
             for (int32_t i = 0; i < ann_k; ++i) {
-                int64_t doc_id = ann_ids[q * ann_k + i];
+                int64_t doc_id = external_id_map.ToInternalId(ann_ids[q * ann_k + i]);
                 if (doc_id >= 0 && doc_id < num_docs_) {
                     candidate_docs.push_back(doc_id);
                 }

--- a/src/index/emb_list/emb_list_strategy_token_ann.cc
+++ b/src/index/emb_list/emb_list_strategy_token_ann.cc
@@ -122,6 +122,7 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
 
         std::vector<int64_t> candidate_docs;
         std::unordered_set<size_t> el_ids_set;
+        const auto& external_id_map = index->GetExternalIdMap();
         for (size_t i = 0; i < num_q_el; i++) {
             auto start_offset = query_offset.offset[i];
             auto end_offset = query_offset.offset[i + 1];
@@ -133,7 +134,11 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
                 if (stage1_ids[j] < 0) {
                     continue;
                 }
-                el_ids_set.emplace(emb_list_offset_->get_el_id(static_cast<size_t>(stage1_ids[j])));
+                auto internal_el_id = external_id_map.ToInternalId(stage1_ids[j]);
+                if (internal_el_id < 0) {
+                    continue;
+                }
+                el_ids_set.emplace(static_cast<size_t>(internal_el_id));
             }
 
             // Convert to vector for RerankByCalcDistByIDs

--- a/src/index/faiss/faiss.cc
+++ b/src/index/faiss/faiss.cc
@@ -114,9 +114,16 @@ class FaissIndexNode : public IndexNode {
         if (!index_) {
             return Status::empty_index;
         }
+        auto old_rows = Count();
+        const auto n = dataset->GetRows();
+        if (n == 0) {
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+            }
+            return Status::success;
+        }
         try {
             const auto* raw = dataset->GetTensor();
-            const auto n = dataset->GetRows();
             if constexpr (std::is_same_v<DataType, fp32>) {
                 auto data = static_cast<const float*>(raw);
                 std::unique_ptr<float[]> copy;
@@ -132,6 +139,9 @@ class FaissIndexNode : public IndexNode {
             LOG_KNOWHERE_ERROR_ << "faiss add failed: " << e.what();
             return Status::faiss_inner_error;
         }
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+        }
         return Status::success;
     }
 
@@ -146,8 +156,10 @@ class FaissIndexNode : public IndexNode {
         const auto nq = dataset->GetRows();
         const auto dim = dataset->GetDim();
 
-        BitsetViewIDSelector bw_sel(bitset);
-        ::faiss::IDSelector* sel = bitset.empty() ? nullptr : &bw_sel;
+        BitsetView mapped_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(mapped_bitset);
+        BitsetViewIDSelector bw_sel(mapped_bitset);
+        ::faiss::IDSelector* sel = mapped_bitset.empty() ? nullptr : &bw_sel;
 
         std::unique_ptr<::faiss::SearchParameters> search_params;
         std::string err_msg;
@@ -215,6 +227,7 @@ class FaissIndexNode : public IndexNode {
             LOG_KNOWHERE_ERROR_ << "faiss search failed: " << e.what();
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
         }
+        external_id_map_.MapResultIds(ids.get(), nq * k);
         return GenResultDataSet(nq, k, std::move(ids), std::move(distances));
     }
 
@@ -235,8 +248,10 @@ class FaissIndexNode : public IndexNode {
             const auto nq = dataset->GetRows();
             const auto dim = dataset->GetDim();
 
-            BitsetViewIDSelector bw_sel(bitset);
-            ::faiss::IDSelector* sel = bitset.empty() ? nullptr : &bw_sel;
+            BitsetView mapped_bitset(bitset);
+            external_id_map_.SetOutIdsToBitset(mapped_bitset);
+            BitsetViewIDSelector bw_sel(mapped_bitset);
+            ::faiss::IDSelector* sel = mapped_bitset.empty() ? nullptr : &bw_sel;
 
             std::unique_ptr<::faiss::SearchParameters> search_params;
             std::string err_msg;
@@ -281,6 +296,7 @@ class FaissIndexNode : public IndexNode {
             }
 
             const bool is_ip = is_cosine_ || IsMetricType(fc->metric_type.value(), knowhere::metric::IP);
+            external_id_map_.MapResultIds(result_labels);
             auto rr = GetRangeSearchResult(result_distances, result_labels, is_ip, nq, radius, range_filter);
             return GenResultDataSet(nq, std::move(rr));
         }
@@ -321,6 +337,9 @@ class FaissIndexNode : public IndexNode {
             std::shared_ptr<uint8_t[]> buf(new uint8_t[sz]);
             std::memcpy(buf.get(), writer.data.data(), sz);
             binset.Append(Type(), buf, static_cast<int64_t>(sz));
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP));
+            }
             return Status::success;
         } catch (const ::faiss::FaissException& e) {
             LOG_KNOWHERE_ERROR_ << "Serialize failed: " << e.what();
@@ -342,11 +361,14 @@ class FaissIndexNode : public IndexNode {
             } else {
                 index_.reset(::faiss::read_index_binary(&reader));
             }
-            return Status::success;
         } catch (const ::faiss::FaissException& e) {
             LOG_KNOWHERE_ERROR_ << "Deserialize failed: " << e.what();
             return Status::faiss_inner_error;
         }
+        if (emb_list_strategy_ == nullptr) {
+            return LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP);
+        }
+        return Status::success;
     }
 
     Status
@@ -373,11 +395,14 @@ class FaissIndexNode : public IndexNode {
                     index_.reset(faiss::read_index_binary(&reader));
                 }
             }
-            return Status::success;
         } catch (const ::faiss::FaissException& e) {
             LOG_KNOWHERE_ERROR_ << "DeserializeFromFile failed: " << e.what();
             return Status::faiss_inner_error;
         }
+        if (emb_list_strategy_ == nullptr) {
+            return LoadExternalIdMapFromLocalFile(fc->external_id_map_file_path.value_or(""));
+        }
+        return Status::success;
     }
 
     static std::unique_ptr<BaseConfig>

--- a/src/index/flat/flat.cc
+++ b/src/index/flat/flat.cc
@@ -66,9 +66,23 @@ class FlatIndexNode : public IndexNode {
 
     Status
     Add(const DataSetPtr dataset, std::shared_ptr<Config> cfg, bool use_knowhere_build_pool) override {
+        if (!index_) {
+            LOG_KNOWHERE_ERROR_ << "Can not add data to empty Flat index.";
+            return Status::empty_index;
+        }
+        auto old_rows = Count();
         auto x = dataset->GetTensor();
         auto n = dataset->GetRows();
+        if (n == 0) {
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+            }
+            return Status::success;
+        }
         index_->add(n, static_cast<const DataType*>(x));
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+        }
         return Status::success;
     }
 
@@ -88,6 +102,8 @@ class FlatIndexNode : public IndexNode {
         auto nq = dataset->GetRows();
         auto x = dataset->GetTensor();
         auto dim = dataset->GetDim();
+        BitsetView mapped_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(mapped_bitset);
 
         auto len = k * nq;
         int64_t* ids = nullptr;
@@ -105,8 +121,8 @@ class FlatIndexNode : public IndexNode {
                     auto cur_ids = ids + k * index;
                     auto cur_dis = distances + k * index;
 
-                    BitsetViewIDSelector bw_idselector(bitset);
-                    faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
+                    BitsetViewIDSelector bw_idselector(mapped_bitset);
+                    faiss::IDSelector* id_selector = (mapped_bitset.empty()) ? nullptr : &bw_idselector;
 
                     if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
                         auto cur_query = static_cast<const DataType*>(x) + dim * index;
@@ -146,6 +162,7 @@ class FlatIndexNode : public IndexNode {
             LOG_KNOWHERE_WARNING_ << "error inner faiss: " << e.what();
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
         }
+        external_id_map_.MapResultIds(ids, len);
         return GenResultDataSet(nq, k, ids, distances);
     }
 
@@ -163,6 +180,8 @@ class FlatIndexNode : public IndexNode {
         auto nq = dataset->GetRows();
         auto xq = dataset->GetTensor();
         auto dim = dataset->GetDim();
+        BitsetView mapped_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(mapped_bitset);
 
         float radius = f_cfg.radius.value();
         float range_filter = f_cfg.range_filter.value();
@@ -181,8 +200,8 @@ class FlatIndexNode : public IndexNode {
                     ThreadPool::ScopedSearchOmpSetter setter(1);
                     faiss::RangeSearchResult res(1);
 
-                    BitsetViewIDSelector bw_idselector(bitset);
-                    faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
+                    BitsetViewIDSelector bw_idselector(mapped_bitset);
+                    faiss::IDSelector* id_selector = (mapped_bitset.empty()) ? nullptr : &bw_idselector;
 
                     if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
                         auto cur_query = static_cast<const DataType*>(xq) + dim * index;
@@ -219,6 +238,7 @@ class FlatIndexNode : public IndexNode {
             }
             // wait for the completion
             WaitAllSuccess(futs);
+            external_id_map_.MapResultIds(result_id_array);
             range_search_result =
                 GetRangeSearchResult(result_dist_array, result_id_array, is_ip, nq, radius, range_filter);
         } catch (const std::exception& e) {
@@ -239,7 +259,13 @@ class FlatIndexNode : public IndexNode {
             try {
                 data = new DataType[rows * dim];
                 for (int64_t i = 0; i < rows; i++) {
-                    index_->reconstruct(ids[i], data + i * dim);
+                    auto id = emb_list_strategy_ == nullptr ? external_id_map_.ToInternalId(ids[i]) : ids[i];
+                    if (id < 0 || id >= index_->ntotal) {
+                        delete[] data;
+                        data = nullptr;
+                        return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+                    }
+                    index_->reconstruct(id, data + i * dim);
                 }
                 return GenResultDataSet(rows, dim, data);
             } catch (const std::exception& e) {
@@ -253,7 +279,13 @@ class FlatIndexNode : public IndexNode {
             try {
                 data = new uint8_t[rows * ((dim + 7) / 8)];
                 for (int64_t i = 0; i < rows; i++) {
-                    index_->reconstruct(ids[i], data + i * ((dim + 7) / 8));
+                    auto id = emb_list_strategy_ == nullptr ? external_id_map_.ToInternalId(ids[i]) : ids[i];
+                    if (id < 0 || id >= index_->ntotal) {
+                        delete[] data;
+                        data = nullptr;
+                        return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+                    }
+                    index_->reconstruct(id, data + i * ((dim + 7) / 8));
                 }
                 return GenResultDataSet(rows, dim, data);
             } catch (const std::exception& e) {
@@ -315,6 +347,9 @@ class FlatIndexNode : public IndexNode {
             }
             std::shared_ptr<uint8_t[]> data(writer.data());
             binset.Append(Type(), data, writer.tellg());
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP));
+            }
             return Status::success;
         } catch (const std::exception& e) {
             LOG_KNOWHERE_WARNING_ << "error inner faiss: " << e.what();
@@ -342,12 +377,15 @@ class FlatIndexNode : public IndexNode {
             faiss::cppcontrib::knowhere::IndexBinary* index = faiss::cppcontrib::knowhere::read_index_binary(&reader);
             index_.reset(static_cast<IndexType*>(index));
         }
+        if (emb_list_strategy_ == nullptr) {
+            return LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP);
+        }
         return Status::success;
     }
 
     Status
     DeserializeFromFile(const std::string& filename, std::shared_ptr<Config> cfg) override {
-        auto flat_cfg = static_cast<const knowhere::BaseConfig&>(*cfg);
+        const auto& flat_cfg = static_cast<const knowhere::BaseConfig&>(*cfg);
 
         int io_flags = 0;
         if (flat_cfg.enable_mmap.value()) {
@@ -362,6 +400,9 @@ class FlatIndexNode : public IndexNode {
             faiss::cppcontrib::knowhere::IndexBinary* index =
                 faiss::cppcontrib::knowhere::read_index_binary(filename.data(), io_flags);
             index_.reset(static_cast<IndexType*>(index));
+        }
+        if (emb_list_strategy_ == nullptr) {
+            return LoadExternalIdMapFromLocalFile(flat_cfg.external_id_map_file_path.value_or(""));
         }
         return Status::success;
     }

--- a/src/index/gpu/flat_gpu/flat_gpu.cc
+++ b/src/index/gpu/flat_gpu/flat_gpu.cc
@@ -16,6 +16,7 @@
 #include "index/flat_gpu/flat_gpu_config.h"
 #include "index/gpu/gpu_res_mgr.h"
 #include "io/memory_io.h"
+#include "knowhere/comp/index_param.h"
 #include "knowhere/index/index_factory.h"
 #include "knowhere/log.h"
 
@@ -41,14 +42,28 @@ class GpuFlatIndexNode : public IndexNode {
 
     Status
     Add(const DataSetPtr dataset, const Config& cfg, bool use_knowhere_build_pool) override {
+        if (!index_) {
+            LOG_KNOWHERE_ERROR_ << "Can not add data to empty GpuFlatIndex.";
+            return Status::empty_index;
+        }
+        auto old_rows = Count();
         const void* x = dataset->GetTensor();
         const int64_t n = dataset->GetRows();
+        if (n == 0) {
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+            }
+            return Status::success;
+        }
         try {
             index_->add(n, (const float*)x);
             // need not copy index from CPU to GPU for IDMAP
         } catch (const std::exception& e) {
             LOG_KNOWHERE_WARNING_ << "faiss inner error, " << e.what();
             return Status::faiss_inner_error;
+        }
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
         }
         return Status::success;
     }
@@ -67,12 +82,14 @@ class GpuFlatIndexNode : public IndexNode {
         auto len = f_cfg.k * nq;
         int64_t* ids = nullptr;
         float* dis = nullptr;
+        BitsetView mapped_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(mapped_bitset);
         try {
             ids = new (std::nothrow) int64_t[len];
             dis = new (std::nothrow) float[len];
 
             ResScope rs(res_, false);
-            index_->search(nq, (const float*)x, f_cfg.k, dis, ids, bitset);
+            index_->search(nq, (const float*)x, f_cfg.k, dis, ids, mapped_bitset);
         } catch (const std::exception& e) {
             std::unique_ptr<int64_t[]> auto_delete_ids(ids);
             std::unique_ptr<float[]> auto_delete_dis(dis);
@@ -80,6 +97,7 @@ class GpuFlatIndexNode : public IndexNode {
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
         }
 
+        external_id_map_.MapResultIds(ids, len);
         return GenResultDataSet(nq, f_cfg.k, ids, dis);
     }
 
@@ -98,7 +116,11 @@ class GpuFlatIndexNode : public IndexNode {
         try {
             float* xq = new (std::nothrow) float[nq * dim];
             for (int64_t i = 0; i < nq; i++) {
-                int64_t id = in_ids[i];
+                int64_t id = emb_list_strategy_ == nullptr ? external_id_map_.ToInternalId(in_ids[i]) : in_ids[i];
+                if (id < 0 || id >= index_->ntotal) {
+                    delete[] xq;
+                    return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+                }
                 index_->reconstruct(id, xq + i * dim);
             }
             return GenResultDataSet(xq);
@@ -125,6 +147,9 @@ class GpuFlatIndexNode : public IndexNode {
             faiss::write_index(index_.get(), &writer);
             std::shared_ptr<uint8_t[]> data(writer.data());
             binset.Append(Type(), data, writer.tellg());
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP));
+            }
         } catch (const std::exception& e) {
             LOG_KNOWHERE_WARNING_ << "faiss inner error, " << e.what();
             return Status::faiss_inner_error;
@@ -153,6 +178,9 @@ class GpuFlatIndexNode : public IndexNode {
             return Status::faiss_inner_error;
         }
 
+        if (emb_list_strategy_ == nullptr) {
+            return LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP);
+        }
         return Status::success;
     }
 

--- a/src/index/gpu/ivf_gpu/ivf_gpu.cc
+++ b/src/index/gpu/ivf_gpu/ivf_gpu.cc
@@ -117,14 +117,24 @@ class GpuIvfIndexNode : public IndexNode {
             LOG_KNOWHERE_ERROR_ << "Can not add data to not trained GpuIvfIndex.";
             return Status::index_not_trained;
         }
+        auto old_rows = Count();
         auto rows = dataset->GetRows();
         auto tensor = dataset->GetTensor();
+        if (rows == 0) {
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+            }
+            return Status::success;
+        }
         try {
             ResScope rs(res_, false);
             index_->add(rows, (const float*)tensor);
         } catch (std::exception& e) {
             LOG_KNOWHERE_WARNING_ << "faiss inner error, " << e.what();
             return Status::faiss_inner_error;
+        }
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
         }
         return Status::success;
     }
@@ -141,13 +151,15 @@ class GpuIvfIndexNode : public IndexNode {
         auto dim = dataset->GetDim();
         float* dis = new (std::nothrow) float[rows * k];
         int64_t* ids = new (std::nothrow) int64_t[rows * k];
+        BitsetView mapped_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(mapped_bitset);
         try {
             ResScope rs(res_, false);
             auto gpu_index = dynamic_cast<faiss::gpu::GpuIndexIVF*>(index_.get());
             for (int i = 0; i < rows; i += block_size) {
                 int64_t search_size = (rows - i > block_size) ? block_size : (rows - i);
                 gpu_index->search_thread_safe(search_size, reinterpret_cast<const float*>(tensor) + i * dim, k,
-                                              ivf_gpu_cfg.nprobe, dis + i * k, ids + i * k, bitset);
+                                              ivf_gpu_cfg.nprobe, dis + i * k, ids + i * k, mapped_bitset);
             }
         } catch (std::exception& e) {
             std::unique_ptr<float> auto_delete_dis(dis);
@@ -156,6 +168,7 @@ class GpuIvfIndexNode : public IndexNode {
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
         }
 
+        external_id_map_.MapResultIds(ids, rows * k);
         return GenResultDataSet(rows, ivf_gpu_cfg.k, ids, dis);
     }
 
@@ -195,6 +208,9 @@ class GpuIvfIndexNode : public IndexNode {
             }
             std::shared_ptr<uint8_t[]> data(writer.data());
             binset.Append(Type(), data, writer.tellg());
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP));
+            }
         } catch (std::exception& e) {
             LOG_KNOWHERE_WARNING_ << "faiss inner error, " << e.what();
             return Status::faiss_inner_error;
@@ -221,6 +237,9 @@ class GpuIvfIndexNode : public IndexNode {
         } catch (std::exception& e) {
             LOG_KNOWHERE_WARNING_ << "faiss inner error, " << e.what();
             return Status::faiss_inner_error;
+        }
+        if (emb_list_strategy_ == nullptr) {
+            return LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP);
         }
         return Status::success;
     }

--- a/src/index/gpu_cuvs/gpu_cuvs.h
+++ b/src/index/gpu_cuvs/gpu_cuvs.h
@@ -103,6 +103,9 @@ struct GpuCuvsIndexNode : public IndexNode {
                 result = Status::cuvs_inner_error;
             }
         }
+        if (result == Status::success && emb_list_strategy_ == nullptr) {
+            result = SetExternalIdMapFromDataset(dataset);
+        }
         return result;
     }
 
@@ -133,10 +136,24 @@ struct GpuCuvsIndexNode : public IndexNode {
                     LOG_KNOWHERE_ERROR_ << "Empty index.";
                     return expected<DataSetPtr>::Err(Status::empty_index, "empty index");
                 }
+                BitsetView mapped_bitset(bitset);
+                external_id_map_.SetOutIdsToBitset(mapped_bitset);
+                std::vector<uint8_t> internal_bitset;
+                if (!mapped_bitset.empty() && mapped_bitset.has_out_ids()) {
+                    internal_bitset.assign((mapped_bitset.size() + 7) / 8, 0);
+                    for (size_t i = 0; i < mapped_bitset.size(); ++i) {
+                        if (mapped_bitset.test(i)) {
+                            internal_bitset[i >> 3] |= static_cast<uint8_t>(1U << (i & 7));
+                        }
+                    }
+                    mapped_bitset = BitsetView(internal_bitset.data(), mapped_bitset.size(), mapped_bitset.count());
+                }
                 auto search_result =
-                    index_->search(cuvs_cfg, data, rows, dim, bitset.data(), bitset.byte_size(), bitset.size());
+                    index_->search(cuvs_cfg, data, rows, dim, mapped_bitset.data(), mapped_bitset.byte_size(),
+                                   mapped_bitset.size());
                 std::this_thread::yield();
                 index_->synchronize();
+                external_id_map_.MapResultIds(std::get<0>(search_result), rows * cuvs_cfg.k);
                 return GenResultDataSet(rows, cuvs_cfg.k, std::get<0>(search_result), std::get<1>(search_result));
             } catch (const std::exception& e) {
                 err_msg = std::string{e.what()};
@@ -185,6 +202,9 @@ struct GpuCuvsIndexNode : public IndexNode {
             std::shared_ptr<uint8_t[]> index_binary(new (std::nothrow) uint8_t[buf.str().size()]);
             memcpy(index_binary.get(), buf.str().c_str(), buf.str().size());
             binset.Append(this->Type(), index_binary, buf.str().size());
+            if (emb_list_strategy_ == nullptr) {
+                result = AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP);
+            }
         }
         return result;
     }
@@ -201,6 +221,9 @@ struct GpuCuvsIndexNode : public IndexNode {
             buf.sputn((char*)binary->data.get(), binary->size);
             std::istream is(&buf);
             result = DeserializeFromStream(is);
+        }
+        if (result == Status::success && emb_list_strategy_ == nullptr) {
+            result = LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP);
         }
         return result;
     }

--- a/src/index/gpu_cuvs/gpu_cuvs_cagra.cc
+++ b/src/index/gpu_cuvs/gpu_cuvs_cagra.cc
@@ -60,12 +60,14 @@ class GpuCuvsCagraHybridIndexNode : public GpuCuvsCagraIndexNode<DataType> {
         hnswlib::SearchParam param{(size_t)cagra_cfg.ef.value()};
         bool transform = (hnsw_index_->metric_type_ == hnswlib::Metric::INNER_PRODUCT ||
                           hnsw_index_->metric_type_ == hnswlib::Metric::COSINE);
+        BitsetView mapped_bitset(bitset);
+        this->external_id_map_.SetOutIdsToBitset(mapped_bitset);
 
         for (int i = 0; i < nq; ++i) {
             auto p_id_ptr = p_id.get();
             auto p_dist_ptr = p_dist.get();
             auto single_query = (const char*)xq + i * hnsw_index_->data_size_;
-            auto rst = hnsw_index_->searchKnn(single_query, k, bitset, &param);
+            auto rst = hnsw_index_->searchKnn(single_query, k, mapped_bitset, &param);
             size_t rst_size = rst.size();
             auto p_single_dis = p_dist_ptr + i * k;
             auto p_single_id = p_id_ptr + i * k;
@@ -80,6 +82,7 @@ class GpuCuvsCagraHybridIndexNode : public GpuCuvsCagraIndexNode<DataType> {
             }
         }
 
+        this->external_id_map_.MapResultIds(p_id.get(), k * nq);
         auto res = GenResultDataSet(nq, k, p_id.release(), p_dist.release());
 
         return res;
@@ -108,6 +111,9 @@ class GpuCuvsCagraHybridIndexNode : public GpuCuvsCagraIndexNode<DataType> {
             memcpy(index_binary.get(), buf.str().c_str(), buf.str().size());
             // Use the key to differentiate whether CPU search support is needed.
             binset.Append(std::string(this->Type()) + "_cpu", index_binary, buf.str().size());
+            if (this->emb_list_strategy_ == nullptr) {
+                result = this->AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP);
+            }
         }
         return result;
     }
@@ -152,6 +158,9 @@ class GpuCuvsCagraHybridIndexNode : public GpuCuvsCagraIndexNode<DataType> {
                 } catch (std::exception& e) {
                     LOG_KNOWHERE_WARNING_ << "hnsw inner error: " << e.what();
                     return Status::hnsw_inner_error;
+                }
+                if (this->emb_list_strategy_ == nullptr) {
+                    return this->LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP);
                 }
                 return Status::success;
             }

--- a/src/index/hnsw/faiss_hnsw.cc
+++ b/src/index/hnsw/faiss_hnsw.cc
@@ -180,6 +180,26 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
     }
 
     Status
+    Add(const DataSetPtr dataset, std::shared_ptr<Config> cfg, bool use_knowhere_build_pool) override {
+        auto old_rows = Count();
+        if (dataset->GetRows() == 0) {
+            if (isIndexEmpty()) {
+                return Status::empty_index;
+            }
+            if (emb_list_strategy_ == nullptr) {
+                return AddExternalIdMapFromDataset(dataset, old_rows);
+            }
+            return Status::success;
+        }
+        RETURN_IF_ERROR(BaseFaissIndexNode::Add(dataset, std::move(cfg), use_knowhere_build_pool));
+        if (emb_list_strategy_ != nullptr) {
+            return Status::success;
+        }
+        RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+        return ApplyCurrentLayoutToExternalIdMap();
+    }
+
+    Status
     Serialize(BinarySet& binset) const override {
         if (isIndexEmpty()) {
             return Status::empty_index;
@@ -208,6 +228,10 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
             return Status::faiss_inner_error;
         }
 
+        if (emb_list_strategy_ == nullptr &&
+            external_id_map_.ExternalCount(Count()) != Count()) {
+            RETURN_IF_ERROR(AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP));
+        }
         return Status::success;
     }
 
@@ -248,6 +272,12 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
             }
         }
 
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP));
+            if (!external_id_map_.HasInternalToExternalIds()) {
+                RETURN_IF_ERROR(ApplyCurrentLayoutToExternalIdMap());
+            }
+        }
         return Status::success;
     }
 
@@ -302,6 +332,12 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
             }
         }
 
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(LoadExternalIdMapFromLocalFile(cfg.external_id_map_file_path.value_or("")));
+            if (!external_id_map_.HasInternalToExternalIds()) {
+                RETURN_IF_ERROR(ApplyCurrentLayoutToExternalIdMap());
+            }
+        }
         return Status::success;
     }
 
@@ -345,9 +381,9 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
         return writer.total_size;
     }
 
-    std::shared_ptr<std::vector<uint32_t>>
+    std::shared_ptr<std::vector<int32_t>>
     GetInternalIdToExternalIdMap() const override {
-        auto internal_offset_to_label = std::make_shared<std::vector<uint32_t>>();
+        auto internal_offset_to_label = std::make_shared<std::vector<int32_t>>();
         assert(indexes.size() > 0);
         if (indexes.size() == 1) {
             // without mv-only labels, the id mapping is the same as the internal offset.
@@ -365,31 +401,55 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
                 auto par_size = index_rows_sum[par_idx + 1] - index_rows_sum[par_idx];
                 assert(par_size == labels[par_idx]->size());
                 std::memcpy(internal_offset_to_label->data() + index_rows_sum[par_idx], labels[par_idx]->data(),
-                            par_size * sizeof(uint32_t));
+                            par_size * sizeof(int32_t));
             }
         }
         return internal_offset_to_label;
     }
 
+ protected:
     Status
-    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) override {
-        internal_offset_to_most_external_id = std::move(map);
+    ApplyCurrentLayoutToExternalIdMap() {
+        if (labels.empty()) {
+            return Status::success;
+        }
+
+        auto internal_to_external_ids = GetInternalIdToExternalIdMap();
+        try {
+            external_id_map_.ApplyInternalToExternalRelayout(
+                internal_to_external_ids->size(), [&](size_t i) { return internal_to_external_ids->at(i); });
+        } catch (const std::exception& e) {
+            LOG_KNOWHERE_WARNING_ << "invalid external id map: " << e.what();
+            return Status::invalid_args;
+        }
         return Status::success;
     }
 
- protected:
+    void
+    SetBitsetForMvIndex(BitsetView& bitset, int index_id) const {
+        if (indexes.size() <= 1) {
+            return;
+        }
+
+        size_t num_mv_ids = labels[index_id]->size();
+        if (!bitset.has_out_ids()) {
+            bitset.set_out_ids(labels[index_id]->data(), num_mv_ids);
+            return;
+        }
+
+        external_id_map_.SetOutIdsToBitset(bitset, num_mv_ids, std::nullopt, index_rows_sum[index_id]);
+    }
+
     // it is std::shared_ptr, not std::unique_ptr, because it can be
     //    shared with FaissHnswIterator
     std::vector<std::shared_ptr<faiss::Index>> indexes;
     // each index's out ids(label), can be shared with FaissHnswIterator
-    std::vector<std::shared_ptr<std::vector<uint32_t>>> labels;
+    std::vector<std::shared_ptr<std::vector<int32_t>>> labels;
 
     // index rows, help to locate index id by offset
     std::vector<uint32_t> index_rows_sum;
     // label to locate internal offset
     std::vector<uint32_t> label_to_internal_offset;
-    // internal offset to most external id, only for 1-hop bitset check
-    std::vector<uint32_t> internal_offset_to_most_external_id;
 
     int
     getIndexToSearchByScalarInfo(const BitsetView& bitset) const {
@@ -427,7 +487,8 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
         uint32_t cluster_size = labels.size();
         faiss::cppcontrib::knowhere::write_value(cluster_size, f);
         for (const auto& label : labels) {
-            faiss::cppcontrib::knowhere::write_vector(*label, f);
+            std::vector<uint32_t> serialized_label(label->begin(), label->end());
+            faiss::cppcontrib::knowhere::write_vector(serialized_label, f);
         }
         faiss::cppcontrib::knowhere::write_vector(index_rows_sum, f);
         faiss::cppcontrib::knowhere::write_vector(label_to_internal_offset, f);
@@ -441,8 +502,9 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
         labels.resize(cluster_size);
 
         for (uint32_t j = 0; j < cluster_size; ++j) {
-            labels[j] = std::make_shared<std::vector<uint32_t>>();
-            faiss::cppcontrib::knowhere::read_vector(*labels[j], f);
+            std::vector<uint32_t> serialized_label;
+            faiss::cppcontrib::knowhere::read_vector(serialized_label, f);
+            labels[j] = std::make_shared<std::vector<int32_t>>(serialized_label.begin(), serialized_label.end());
         }
         faiss::cppcontrib::knowhere::read_vector(index_rows_sum, f);
         faiss::cppcontrib::knowhere::read_vector(label_to_internal_offset, f);
@@ -843,11 +905,13 @@ struct FaissHnswIteratorWorkspace {
 class FaissHnswIterator : public IndexIterator {
  public:
     FaissHnswIterator(const std::shared_ptr<faiss::Index>& index_in,
-                      const std::shared_ptr<std::vector<uint32_t>>& labels_in, std::unique_ptr<float[]>&& query_in,
+                      const std::shared_ptr<std::vector<int32_t>>& labels_in, std::unique_ptr<float[]>&& query_in,
                       const BitsetView& bitset_in, const int32_t ef_in, bool larger_is_closer,
                       const float refine_ratio = 0.5f, const std::vector<uint32_t>& label_to_internal_offset_in = {},
-                      const uint32_t mv_base_offset_in = 0, bool use_knowhere_search_pool = true)
-        : IndexIterator(larger_is_closer, use_knowhere_search_pool, refine_ratio),
+                      const uint32_t mv_base_offset_in = 0,
+                      const ExternalIdMap& external_id_map = EmptyExternalIdMap(),
+                      bool use_knowhere_search_pool = true)
+        : IndexIterator(larger_is_closer, external_id_map, use_knowhere_search_pool, refine_ratio),
           index{index_in},
           labels{labels_in},
           label_to_internal_offset(label_to_internal_offset_in),
@@ -1062,7 +1126,7 @@ class FaissHnswIterator : public IndexIterator {
 
         if (labels != nullptr) {
             for (auto& p : workspace.dists) {
-                p.id = p.id < 0 ? p.id : labels->operator[](p.id);
+                p.id = p.id < 0 ? p.id : p.id + mv_base_offset;
             }
         }
 
@@ -1093,19 +1157,13 @@ class FaissHnswIterator : public IndexIterator {
         if (label_to_internal_offset.empty()) {
             return workspace.qdis_refine->operator()(id);
         }
-        // todo: Currently, next-batch returns quant results that have already been mapped to labels (external_id),
-        // but refine requires the internal offset within the mv-index, so we need to map them back.
-        // This reverse mapping is actually quite wasteful.
-        // The best solution is to detect if need refine in next-batch, and directly return the internal offset of the
-        // mv-index. After refine computation, convert it back to the label (external_id).
-        // This involves changing the iterator interface in the base class in index_node.h, which will take some time.
-        auto mv_internal_offset = label_to_internal_offset[id] - mv_base_offset;
+        auto mv_internal_offset = id - mv_base_offset;
         return workspace.qdis_refine->operator()(mv_internal_offset);
     }
 
  private:
     std::shared_ptr<faiss::Index> index;
-    std::shared_ptr<std::vector<uint32_t>> labels;
+    std::shared_ptr<std::vector<int32_t>> labels;
     const std::vector<uint32_t>& label_to_internal_offset;  // internal_offset = label_to_internal_offset[label_id];
     const uint32_t mv_base_offset;                          // mv_internal_offset = internal_offset - mv_base_offset;
 
@@ -1167,14 +1225,12 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
             if (indexes.size() == 1) {
                 indexes_to_reconstruct_from[0]->reconstruct(id, result);
             } else {
-                auto it =
-                    std::lower_bound(index_rows_sum.begin(), index_rows_sum.end(), label_to_internal_offset[id] + 1);
+                auto it = std::lower_bound(index_rows_sum.begin(), index_rows_sum.end(), id + 1);
                 if (it == index_rows_sum.end()) {
                     return false;
                 }
                 auto index_id = std::distance(index_rows_sum.begin(), it) - 1;
-                indexes_to_reconstruct_from[index_id]->reconstruct(
-                    label_to_internal_offset[id] - index_rows_sum[index_id], result);
+                indexes_to_reconstruct_from[index_id]->reconstruct(id - index_rows_sum[index_id], result);
             }
             return true;
         };
@@ -1187,8 +1243,10 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                 // perform a direct reconstruction for fp32 data
                 auto data = std::make_unique<float[]>(dim * rows);
                 for (int64_t i = 0; i < rows; i++) {
-                    const int64_t id = ids[i];
-                    assert(id >= 0 && id < Count());
+                    const int64_t id = emb_list_strategy_ == nullptr ? external_id_map_.ToInternalId(ids[i]) : ids[i];
+                    if (id < 0 || id >= Count()) {
+                        return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+                    }
                     if (!get_vector(id, data.get() + i * dim)) {
                         return expected<DataSetPtr>::Err(Status::invalid_index_error,
                                                          "index inner error, cannot proceed with GetVectorByIds");
@@ -1201,8 +1259,10 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                 // Let's create a temporary fp32 buffer for this.
                 auto tmp = std::make_unique<float[]>(dim);
                 for (int64_t i = 0; i < rows; i++) {
-                    const int64_t id = ids[i];
-                    assert(id >= 0 && id < Count());
+                    const int64_t id = emb_list_strategy_ == nullptr ? external_id_map_.ToInternalId(ids[i]) : ids[i];
+                    if (id < 0 || id >= Count()) {
+                        return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+                    }
                     if (!get_vector(id, tmp.get())) {
                         return expected<DataSetPtr>::Err(Status::invalid_index_error,
                                                          "index inner error, cannot proceed with GetVectorByIds");
@@ -1218,8 +1278,10 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                 // Let's create a temporary fp32 buffer for this.
                 auto tmp = std::make_unique<float[]>(dim);
                 for (int64_t i = 0; i < rows; i++) {
-                    const int64_t id = ids[i];
-                    assert(id >= 0 && id < Count());
+                    const int64_t id = emb_list_strategy_ == nullptr ? external_id_map_.ToInternalId(ids[i]) : ids[i];
+                    if (id < 0 || id >= Count()) {
+                        return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+                    }
                     if (!get_vector(id, tmp.get())) {
                         return expected<DataSetPtr>::Err(Status::invalid_index_error,
                                                          "index inner error, cannot proceed with GetVectorByIds");
@@ -1235,8 +1297,10 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                 // Let's create a temporary fp32 buffer for this.
                 auto tmp = std::make_unique<float[]>(dim);
                 for (int64_t i = 0; i < rows; i++) {
-                    const int64_t id = ids[i];
-                    assert(id >= 0 && id < Count());
+                    const int64_t id = emb_list_strategy_ == nullptr ? external_id_map_.ToInternalId(ids[i]) : ids[i];
+                    if (id < 0 || id >= Count()) {
+                        return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+                    }
                     if (!get_vector(id, tmp.get())) {
                         return expected<DataSetPtr>::Err(Status::invalid_index_error,
                                                          "index inner error, cannot proceed with GetVectorByIds");
@@ -1253,8 +1317,10 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                 // Let's create a temporary fp32 buffer for this.
                 auto tmp = std::make_unique<float[]>(uint8_dim);
                 for (int64_t i = 0; i < rows; i++) {
-                    const int64_t id = ids[i];
-                    assert(id >= 0 && id < Count());
+                    const int64_t id = emb_list_strategy_ == nullptr ? external_id_map_.ToInternalId(ids[i]) : ids[i];
+                    if (id < 0 || id >= Count()) {
+                        return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+                    }
                     if (!get_vector(id, tmp.get())) {
                         return expected<DataSetPtr>::Err(Status::invalid_index_error,
                                                          "index inner error, cannot proceed with GetVectorByIds");
@@ -1296,37 +1362,12 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         const auto k = hnsw_cfg.k.value();
 
         BitsetView bitset(bitset_);
-        if (!internal_offset_to_most_external_id.empty()) {
-            if (emb_list_offset_ != nullptr) {
-                // if emb list, manually calculate the number of filtered out ids
-                size_t num_filtered_out_ids = 0;
-                for (size_t i = 0; i < bitset.size(); i++) {
-                    if (bitset.test(i)) {
-                        num_filtered_out_ids += emb_list_offset_->offset[i + 1] - emb_list_offset_->offset[i];
-                    }
-                }
-                bitset.set_out_ids(internal_offset_to_most_external_id.data(),
-                                   internal_offset_to_most_external_id.size(), num_filtered_out_ids);
-            } else {
-                bitset.set_out_ids(internal_offset_to_most_external_id.data(),
-                                   internal_offset_to_most_external_id.size());
-            }
-        }
+        external_id_map_.SetOutIdsToBitset(bitset);
         auto index_id = getIndexToSearchByScalarInfo(bitset);
         if (index_id < 0) {
             return expected<DataSetPtr>::Err(Status::invalid_args, "partition key value not correctly set");
         }
-        if (indexes.size() > 1) {
-            // calculate more accurate filter statistics for the single mv-index.
-            size_t num_mv_ids = labels[index_id].get()->size();
-            size_t num_mv_filtered_out_ids = num_mv_ids - (bitset.size() - bitset.count());
-            if (!bitset.has_out_ids()) {
-                bitset.set_out_ids(labels[index_id].get()->data(), num_mv_ids, num_mv_filtered_out_ids);
-            } else {
-                bitset.set_out_ids(internal_offset_to_most_external_id.data(), num_mv_ids, num_mv_filtered_out_ids);
-                bitset.set_id_offset(index_rows_sum[index_id]);
-            }
-        }
+        SetBitsetForMvIndex(bitset, index_id);
 
         feder::hnsw::FederResultUniq feder_result;
         if (hnsw_cfg.trace_visit.value()) {
@@ -1458,7 +1499,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
                     if (!labels.empty()) {
                         for (int j = 0; j < k; ++j) {
-                            local_ids[j] = local_ids[j] < 0 ? local_ids[j] : labels[index_id]->operator[](local_ids[j]);
+                            local_ids[j] = local_ids[j] < 0 ? local_ids[j] : local_ids[j] + index_rows_sum[index_id];
                         }
                     }
                 }));
@@ -1471,6 +1512,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
         }
 
+        external_id_map_.MapResultIds(ids.get(), rows * k);
         auto res = GenResultDataSet(rows, k, std::move(ids), std::move(distances));
 
         // set visit_info json string into result dataset
@@ -1527,15 +1569,19 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         const auto rows = dataset->GetRows();
         const float* data = static_cast<const float*>(dataset->GetTensor());
         auto distances = std::make_unique<float[]>(rows * labels_len);
+        std::vector<int64_t> internal_labels;
+        const int64_t* labels_to_calc = labels;
+        if (emb_list_strategy_ == nullptr) {
+            labels_to_calc = external_id_map_.ToInternalIds(labels, labels_len, internal_labels);
+        }
+        for (size_t i = 0; i < labels_len; ++i) {
+            if (labels_to_calc[i] < 0 || labels_to_calc[i] >= Count()) {
+                return expected<DataSetPtr>::Err(Status::invalid_args, "invalid label id");
+            }
+        }
 
         BitsetView bitset(bitset_);
-        if (!internal_offset_to_most_external_id.empty()) {
-            // Note: We do not need to calculate the actual number of filtered ids here;
-            // we only need the bitset to determine the index_id.
-            int32_t num_filtered_out_ids = 0;
-            bitset.set_out_ids(internal_offset_to_most_external_id.data(), internal_offset_to_most_external_id.size(),
-                               num_filtered_out_ids);
-        }
+        external_id_map_.SetOutIdsToBitset(bitset);
         auto index_id = getIndexToSearchByScalarInfo(bitset);
         if (index_id < 0) {
             return expected<DataSetPtr>::Err(Status::invalid_args, "partition key value not correctly set");
@@ -1569,9 +1615,9 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
                     dist_computer->set_query(cur_query);
                     for (size_t j = 0; j < labels_len; j++) {
-                        auto id = labels[j];
+                        auto id = labels_to_calc[j];
                         if (indexes.size() > 1) {
-                            id = label_to_internal_offset[labels[j]] - index_rows_sum[index_id];
+                            id = label_to_internal_offset[id] - index_rows_sum[index_id];
                         }
                         distances[idx * labels_len + j] = (*dist_computer)(id);
                     }
@@ -1625,23 +1671,12 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
         const auto hnsw_cfg = static_cast<const FaissHnswConfig&>(*cfg);
         BitsetView bitset(bitset_);
-        if (!internal_offset_to_most_external_id.empty()) {
-            bitset.set_out_ids(internal_offset_to_most_external_id.data(), internal_offset_to_most_external_id.size());
-        }
+        external_id_map_.SetOutIdsToBitset(bitset);
         auto index_id = getIndexToSearchByScalarInfo(bitset);
         if (index_id < 0) {
             return expected<DataSetPtr>::Err(Status::invalid_args, "partition key value not correctly set");
         }
-        if (indexes.size() > 1) {
-            size_t num_mv_ids = labels[index_id].get()->size();
-            size_t num_mv_filtered_out_ids = num_mv_ids - (bitset.size() - bitset.count());
-            if (!bitset.has_out_ids()) {
-                bitset.set_out_ids(labels[index_id].get()->data(), num_mv_ids, num_mv_filtered_out_ids);
-            } else {
-                bitset.set_out_ids(internal_offset_to_most_external_id.data(), num_mv_ids, num_mv_filtered_out_ids);
-                bitset.set_id_offset(index_rows_sum[index_id]);
-            }
-        }
+        SetBitsetForMvIndex(bitset, index_id);
 
         const bool is_similarity_metric =
             faiss::cppcontrib::knowhere::is_similarity_metric(indexes[index_id]->metric_type);
@@ -1757,7 +1792,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                             for (size_t j = 0; j < elem_cnt; j++) {
                                 result_dist_array[idx][j] = res.distances[j];
                                 result_id_array[idx][j] =
-                                    res.labels[j] < 0 ? res.labels[j] : labels[index_id]->operator[](res.labels[j]);
+                                    res.labels[j] < 0 ? res.labels[j] : res.labels[j] + index_rows_sum[index_id];
                             }
                         }
 
@@ -1776,6 +1811,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         }
 
         //
+        external_id_map_.MapResultIds(result_id_array);
         RangeSearchResult range_search_result =
             GetRangeSearchResult(result_dist_array, result_id_array, is_similarity_metric, rows, radius, range_filter);
 
@@ -1901,7 +1937,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                 partition_size += scalar_info[j].size();
             }
             std::unique_ptr<float[]> tmp_data = std::make_unique<float[]>(dim * partition_size);
-            labels[i] = std::make_shared<std::vector<uint32_t>>(partition_size);
+            labels[i] = std::make_shared<std::vector<int32_t>>(partition_size);
             index_rows_sum[i + 1] = index_rows_sum[i] + partition_size;
             size_t cur_size = 0;
 
@@ -1913,7 +1949,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                     return Status::invalid_args;
                 }
                 for (size_t m = 0; m < scalar_info[scalar_id].size(); ++m) {
-                    labels[i]->operator[](cur_size + m) = scalar_info[scalar_id][m];
+                    labels[i]->operator[](cur_size + m) = static_cast<int32_t>(scalar_info[scalar_id][m]);
                     label_to_internal_offset[scalar_info[scalar_id][m]] = index_rows_sum[i] + cur_size + m;
                 }
                 cur_size += scalar_info[scalar_id].size();
@@ -1960,24 +1996,13 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
         const FaissHnswConfig& hnsw_cfg = static_cast<const FaissHnswConfig&>(*cfg);
         BitsetView bitset(bitset_);
-        if (!internal_offset_to_most_external_id.empty()) {
-            bitset.set_out_ids(internal_offset_to_most_external_id.data(), internal_offset_to_most_external_id.size());
-        }
+        external_id_map_.SetOutIdsToBitset(bitset);
         int index_id = getIndexToSearchByScalarInfo(bitset);
         if (index_id < 0) {
             return expected<std::vector<IndexNode::IteratorPtr>>::Err(Status::invalid_args,
                                                                       "partition key value not correctly set");
         }
-        if (indexes.size() > 1) {
-            size_t num_mv_ids = labels[index_id].get()->size();
-            size_t num_mv_filtered_out_ids = num_mv_ids - (bitset.size() - bitset.count());
-            if (!bitset.has_out_ids()) {
-                bitset.set_out_ids(labels[index_id].get()->data(), num_mv_ids, num_mv_filtered_out_ids);
-            } else {
-                bitset.set_out_ids(internal_offset_to_most_external_id.data(), num_mv_ids, num_mv_filtered_out_ids);
-                bitset.set_id_offset(index_rows_sum[index_id]);
-            }
-        }
+        SetBitsetForMvIndex(bitset, index_id);
         const bool is_cosine = IsMetricType(hnsw_cfg.metric_type.value(), knowhere::metric::COSINE);
         const bool larger_is_closer = (IsMetricType(hnsw_cfg.metric_type.value(), knowhere::metric::IP) || is_cosine);
 
@@ -2018,7 +2043,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                 auto it = std::make_shared<FaissHnswIterator>(
                     indexes[index_id], labels.empty() ? nullptr : labels[index_id], std::move(cur_query), bitset, ef,
                     larger_is_closer, iterator_refine_ratio, label_to_internal_offset, mv_base_offset,
-                    use_knowhere_search_pool);
+                    this->external_id_map_, use_knowhere_search_pool);
                 // store
                 vec[i] = it;
             }
@@ -2278,6 +2303,33 @@ class HNSWIndexNodeWithFallback : public IndexNode {
     }
 
     int64_t
+    ExternalCount() const override {
+        if (use_base_index) {
+            return base_index->ExternalCount();
+        } else {
+            return fallback_search_index->ExternalCount();
+        }
+    }
+
+    const ExternalIdMap&
+    GetExternalIdMap() const override {
+        if (use_base_index) {
+            return base_index->GetExternalIdMap();
+        } else {
+            return fallback_search_index->GetExternalIdMap();
+        }
+    }
+
+    const EmbListOffset*
+    GetEmbListOffset() const override {
+        if (use_base_index) {
+            return base_index->GetEmbListOffset();
+        } else {
+            return fallback_search_index->GetEmbListOffset();
+        }
+    }
+
+    int64_t
     Size() const override {
         if (use_base_index) {
             return base_index->Size();
@@ -2344,7 +2396,7 @@ class HNSWIndexNodeWithFallback : public IndexNode {
         }
     }
 
-    std::shared_ptr<std::vector<uint32_t>>
+    std::shared_ptr<std::vector<int32_t>>
     GetInternalIdToExternalIdMap() const override {
         if (use_base_index) {
             return base_index->GetInternalIdToExternalIdMap();
@@ -2354,11 +2406,11 @@ class HNSWIndexNodeWithFallback : public IndexNode {
     }
 
     Status
-    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) override {
+    SetExternalIdMap(ExternalIdMap map) override {
         if (use_base_index) {
-            return base_index->SetInternalIdToMostExternalIdMap(std::move(map));
+            return base_index->SetExternalIdMap(std::move(map));
         } else {
-            return fallback_search_index->SetInternalIdToMostExternalIdMap(std::move(map));
+            return fallback_search_index->SetExternalIdMap(std::move(map));
         }
     }
 

--- a/src/index/hnsw/hnsw.h
+++ b/src/index/hnsw/hnsw.h
@@ -132,17 +132,20 @@ class HnswIndexNode : public IndexNode {
         }
 
         knowhere::TimeRecorder build_time("Building HNSW cost", 2);
+        auto old_rows = Count();
         auto rows = dataset->GetRows();
-        if (rows <= 0) {
-            LOG_KNOWHERE_ERROR_ << "Can not add empty data to HNSW index.";
-            return Status::empty_index;
+        if (rows == 0) {
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+            }
+            return Status::success;
         }
         auto tensor = dataset->GetTensor();
         auto hnsw_cfg = static_cast<const BaseHnswConfig&>(*cfg);
         bool shuffle_build = hnsw_cfg.shuffle_build.value();
 
         std::atomic<uint64_t> counter{0};
-        uint64_t one_tenth_row = rows / 10;
+        uint64_t one_tenth_row = rows < 10 ? 1 : rows / 10;
 
         std::vector<int> shuffle_batch_ids;
         constexpr int64_t batch_size = 8192;  // same with diskann
@@ -201,6 +204,9 @@ class HnswIndexNode : public IndexNode {
             LOG_KNOWHERE_WARNING_ << "hnsw inner error: " << e.what();
             return Status::hnsw_inner_error;
         }
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+        }
         return Status::success;
     }
 
@@ -228,6 +234,8 @@ class HnswIndexNode : public IndexNode {
         auto p_id = std::make_unique<int64_t[]>(k * nq);
         auto p_dist = std::make_unique<DistType[]>(k * nq);
 
+        BitsetView mapped_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(mapped_bitset);
         hnswlib::SearchParam param{(size_t)hnsw_cfg.ef.value()};
         bool transform =
             (index_->metric_type_ == hnswlib::Metric::INNER_PRODUCT || index_->metric_type_ == hnswlib::Metric::COSINE);
@@ -237,7 +245,7 @@ class HnswIndexNode : public IndexNode {
         for (int i = 0; i < nq; ++i) {
             futs.emplace_back(search_pool_->push([&, idx = i, p_id_ptr = p_id.get(), p_dist_ptr = p_dist.get()]() {
                 auto single_query = (const char*)xq + idx * index_->data_size_;
-                auto rst = index_->searchKnn(single_query, k, bitset, &param, feder_result);
+                auto rst = index_->searchKnn(single_query, k, mapped_bitset, &param, feder_result);
                 size_t rst_size = rst.size();
                 auto p_single_dis = p_dist_ptr + idx * k;
                 auto p_single_id = p_id_ptr + idx * k;
@@ -254,6 +262,7 @@ class HnswIndexNode : public IndexNode {
         }
         WaitAllSuccess(futs);
 
+        external_id_map_.MapResultIds(p_id.get(), k * nq);
         auto res = GenResultDataSet(nq, k, std::move(p_id), std::move(p_dist));
 
         // set visit_info json string into result dataset
@@ -272,8 +281,10 @@ class HnswIndexNode : public IndexNode {
      public:
         iterator(const hnswlib::HierarchicalNSW<DataType, DistType, quant_type>* index, const char* query,
                  const bool transform, const BitsetView& bitset, const size_t ef = kIteratorSeedEf,
-                 const float refine_ratio = 0.5f, bool use_knowhere_search_pool = true)
-            : IndexIterator(transform, use_knowhere_search_pool,
+                 const float refine_ratio = 0.5f,
+                 const ExternalIdMap& external_id_map = EmptyExternalIdMap(),
+                 bool use_knowhere_search_pool = true)
+            : IndexIterator(transform, external_id_map, use_knowhere_search_pool,
                             (hnswlib::HierarchicalNSW<DataType, DistType, quant_type>::sq_enabled &&
                              hnswlib::HierarchicalNSW<DataType, DistType, quant_type>::has_raw_data)
                                 ? refine_ratio
@@ -326,12 +337,15 @@ class HnswIndexNode : public IndexNode {
 
         bool transform =
             (index_->metric_type_ == hnswlib::Metric::INNER_PRODUCT || index_->metric_type_ == hnswlib::Metric::COSINE);
+        BitsetView mapped_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(mapped_bitset);
         auto vec = std::vector<IndexNode::IteratorPtr>(nq, nullptr);
         try {
             for (int i = 0; i < nq; ++i) {
                 auto single_query = (const char*)xq + i * index_->data_size_;
-                auto it = std::make_shared<iterator>(this->index_, single_query, transform, bitset, ef,
-                                                     hnsw_cfg.iterator_refine_ratio.value(), use_knowhere_search_pool);
+                auto it = std::make_shared<iterator>(this->index_, single_query, transform, mapped_bitset, ef,
+                                                     hnsw_cfg.iterator_refine_ratio.value(), this->external_id_map_,
+                                                     use_knowhere_search_pool);
                 vec[i] = it;
             }
         } catch (const std::exception& e) {
@@ -369,6 +383,8 @@ class HnswIndexNode : public IndexNode {
         }
 
         hnswlib::SearchParam param{(size_t)hnsw_cfg.ef.value()};
+        BitsetView mapped_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(mapped_bitset);
 
         std::vector<std::vector<int64_t>> result_id_array(nq);
         std::vector<std::vector<DistType>> result_dist_array(nq);
@@ -378,7 +394,7 @@ class HnswIndexNode : public IndexNode {
         for (int64_t i = 0; i < nq; ++i) {
             futs.emplace_back(search_pool_->push([&, idx = i]() {
                 auto single_query = (const char*)xq + idx * index_->data_size_;
-                auto rst = index_->searchRange(single_query, radius_for_calc, bitset, &param, feder_result);
+                auto rst = index_->searchRange(single_query, radius_for_calc, mapped_bitset, &param, feder_result);
                 auto elem_cnt = rst.size();
                 result_dist_array[idx].resize(elem_cnt);
                 result_id_array[idx].resize(elem_cnt);
@@ -396,6 +412,7 @@ class HnswIndexNode : public IndexNode {
         WaitAllSuccess(futs);
 
         // filter range search result
+        external_id_map_.MapResultIds(result_id_array);
         auto range_search_result =
             GetRangeSearchResult(result_dist_array, result_id_array, is_ip, nq, radius_for_filter, range_filter);
 
@@ -425,8 +442,10 @@ class HnswIndexNode : public IndexNode {
         try {
             auto data = std::make_unique<uint8_t[]>(index_->data_size_ * rows);
             for (int64_t i = 0; i < rows; i++) {
-                int64_t id = ids[i];
-                assert(id >= 0 && id < (int64_t)index_->cur_element_count);
+                int64_t id = emb_list_strategy_ == nullptr ? external_id_map_.ToInternalId(ids[i]) : ids[i];
+                if (id < 0 || id >= static_cast<int64_t>(index_->cur_element_count)) {
+                    return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+                }
                 std::copy_n(index_->getDataByInternalId(id), index_->data_size_, data.get() + i * index_->data_size_);
             }
             return GenResultDataSet(rows, dim, std::move(data));
@@ -490,6 +509,10 @@ class HnswIndexNode : public IndexNode {
             LOG_KNOWHERE_WARNING_ << "hnsw inner error: " << e.what();
             return Status::hnsw_inner_error;
         }
+        if (emb_list_strategy_ == nullptr &&
+            external_id_map_.ExternalCount(Count()) != Count()) {
+            RETURN_IF_ERROR(AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP));
+        }
         return Status::success;
     }
 
@@ -518,6 +541,9 @@ class HnswIndexNode : public IndexNode {
             LOG_KNOWHERE_WARNING_ << "hnsw inner error: " << e.what();
             return Status::hnsw_inner_error;
         }
+        if (emb_list_strategy_ == nullptr) {
+            return LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP);
+        }
         return Status::success;
     }
 
@@ -533,6 +559,10 @@ class HnswIndexNode : public IndexNode {
         } catch (std::exception& e) {
             LOG_KNOWHERE_WARNING_ << "hnsw inner error: " << e.what();
             return Status::hnsw_inner_error;
+        }
+        auto id_map_file_path = static_cast<const BaseConfig&>(*cfg).external_id_map_file_path.value_or("");
+        if (emb_list_strategy_ == nullptr) {
+            return LoadExternalIdMapFromLocalFile(id_map_file_path);
         }
         return Status::success;
     }

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -11,6 +11,9 @@
 
 #include "knowhere/index/index.h"
 
+#include <algorithm>
+#include <cstdint>
+
 #include "fmt/format.h"
 #include "folly/futures/Future.h"
 #include "knowhere/comp/time_recorder.h"
@@ -35,6 +38,52 @@ LoadConfig(BaseConfig* cfg, const Json& json, knowhere::PARAM_TYPE param_type, c
     RETURN_IF_ERROR(res);
     cfg->CaptureRawJson(json_);
     return Config::Load(*cfg, json_, param_type, msg);
+}
+
+inline size_t
+CountEmbListBitset(const BitsetView& bitset, const ExternalIdMap& external_id_map, const EmbListOffset* emb_list_offset,
+                   size_t internal_count) {
+    auto internal_doc_count = emb_list_offset->num_el();
+    auto count_vectors = internal_count != internal_doc_count;
+    size_t count = 0;
+
+    for (size_t internal_doc_id = 0; internal_doc_id < internal_doc_count; ++internal_doc_id) {
+        auto external_doc_id = external_id_map.ToExternalId(internal_doc_id);
+        if (!bitset.test(external_doc_id)) {
+            continue;
+        }
+        if (count_vectors) {
+            count += emb_list_offset->get_el_len(internal_doc_id);
+        } else {
+            ++count;
+        }
+    }
+    return count;
+}
+
+inline BitsetView
+EnsureBitsetCount(const BitsetView& bitset, const ExternalIdMap& external_id_map,
+                  const EmbListOffset* emb_list_offset, size_t internal_count) {
+    if (bitset.empty() || bitset.data() == nullptr) {
+        return bitset;
+    }
+    if (emb_list_offset != nullptr) {
+        return BitsetView(bitset.data(), bitset.size(),
+                          CountEmbListBitset(bitset, external_id_map, emb_list_offset, internal_count));
+    }
+
+    auto valid_bitmap = external_id_map.GetValidBitmapView();
+    if (valid_bitmap.empty()) {
+        if (bitset.count() != 0) {
+            return bitset;
+        }
+        return BitsetView(
+            bitset.data(), bitset.size(), BitsetView::count_filtered_bits(bitset.data(), nullptr, bitset.size()));
+    }
+
+    const auto size = std::min(bitset.size(), valid_bitmap.size);
+    auto count = BitsetView::count_filtered_bits(bitset.data(), valid_bitmap.data, size);
+    return BitsetView(bitset.data(), bitset.size(), count);
 }
 
 #ifdef KNOWHERE_WITH_CARDINAL
@@ -127,22 +176,15 @@ Index<T>::Search(const DataSetPtr dataset, const Json& json, const BitsetView& b
     // when index is mutable, it could happen that data count larger than bitset size, see
     // https://github.com/zilliztech/knowhere/issues/70
     // so something must be wrong at caller side when passed bitset size larger than data count
-    if (bitset_.size() > static_cast<size_t>(this->Count())) {
-        msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
-                          bitset_.size(), this->Count());
+    if (bitset_.size() > static_cast<size_t>(this->ExternalCount())) {
+        msg = fmt::format("bitset size should be <= external data count, but we get bitset size: {}, data count: {}",
+                          bitset_.size(), this->ExternalCount());
         LOG_KNOWHERE_ERROR_ << msg;
         return expected<DataSetPtr>::Err(Status::invalid_args, msg);
     }
 
-    BitsetView bitset;
-    if (bitset_.count() == 0) {
-        // traverse bitset to get the filtered out num
-        auto filtered_out_num = bitset_.get_filtered_out_num_();
-        bitset = BitsetView(bitset_.data(), bitset_.size(), filtered_out_num);
-    } else {
-        // if bitset has filtered out num, use it
-        bitset = bitset_;
-    }
+    auto bitset =
+        EnsureBitsetCount(bitset_, this->node->GetExternalIdMap(), this->node->GetEmbListOffset(), this->node->Count());
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
     const BaseConfig& b_cfg = static_cast<const BaseConfig&>(*cfg);
@@ -197,14 +239,15 @@ Index<T>::AnnIterator(const DataSetPtr dataset, const Json& json, const BitsetVi
     // when index is mutable, it could happen that data count larger than bitset size, see
     // https://github.com/zilliztech/knowhere/issues/70
     // so something must be wrong at caller side when passed bitset size larger than data count
-    if (bitset_.size() > static_cast<size_t>(this->Count())) {
-        msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
-                          bitset_.size(), this->Count());
+    if (bitset_.size() > static_cast<size_t>(this->ExternalCount())) {
+        msg = fmt::format("bitset size should be <= external data count, but we get bitset size: {}, data count: {}",
+                          bitset_.size(), this->ExternalCount());
         LOG_KNOWHERE_ERROR_ << msg;
         return expected<std::vector<std::shared_ptr<IndexNode::iterator>>>::Err(Status::invalid_args, msg);
     }
 
-    const auto bitset = BitsetView(bitset_.data(), bitset_.size(), bitset_.get_filtered_out_num_());
+    auto bitset =
+        EnsureBitsetCount(bitset_, this->node->GetExternalIdMap(), this->node->GetEmbListOffset(), this->node->Count());
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
     // note that this time includes only the initial search phase of iterator.
@@ -235,14 +278,15 @@ Index<T>::RangeSearch(const DataSetPtr dataset, const Json& json, const BitsetVi
     // when index is mutable, it could happen that data count larger than bitset size, see
     // https://github.com/zilliztech/knowhere/issues/70
     // so something must be wrong at caller side when passed bitset size larger than data count
-    if (bitset_.size() > static_cast<size_t>(this->Count())) {
-        msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
-                          bitset_.size(), this->Count());
+    if (bitset_.size() > static_cast<size_t>(this->ExternalCount())) {
+        msg = fmt::format("bitset size should be <= external data count, but we get bitset size: {}, data count: {}",
+                          bitset_.size(), this->ExternalCount());
         LOG_KNOWHERE_ERROR_ << msg;
         return expected<DataSetPtr>::Err(Status::invalid_args, msg);
     }
 
-    const auto bitset = BitsetView(bitset_.data(), bitset_.size(), bitset_.get_filtered_out_num_());
+    auto bitset =
+        EnsureBitsetCount(bitset_, this->node->GetExternalIdMap(), this->node->GetEmbListOffset(), this->node->Count());
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
     const BaseConfig& b_cfg = static_cast<const BaseConfig&>(*cfg);
@@ -414,6 +458,12 @@ template <typename T>
 inline int64_t
 Index<T>::Count() const {
     return this->node->Count();
+}
+
+template <typename T>
+inline int64_t
+Index<T>::ExternalCount() const {
+    return this->node->ExternalCount();
 }
 
 template <typename T>

--- a/src/index/index_node.cc
+++ b/src/index/index_node.cc
@@ -33,6 +33,189 @@
 namespace knowhere {
 
 // NOLINTBEGIN(google-default-arguments)
+Status
+IndexNode::SetExternalIdMapFromDataset(const DataSetPtr dataset) {
+    external_id_map_.Clear();
+    if (dataset == nullptr) {
+        return Status::success;
+    }
+
+    try {
+        external_id_map_ = dataset->GetExternalIdMap();
+    } catch (const std::exception& e) {
+        LOG_KNOWHERE_WARNING_ << "invalid external id map: " << e.what();
+        return Status::invalid_args;
+    }
+    return Status::success;
+}
+
+Status
+IndexNode::AddExternalIdMapFromDataset(const DataSetPtr dataset, int64_t internal_id_begin) {
+    if (internal_id_begin <= 0) {
+        return SetExternalIdMapFromDataset(dataset);
+    }
+    if (dataset == nullptr) {
+        return Status::success;
+    }
+
+    const auto& internal_to_external_ids = dataset->GetInternalToExternalIds();
+    const auto internal_count =
+        internal_to_external_ids.empty() ? dataset->GetRows() : static_cast<int64_t>(internal_to_external_ids.size());
+    try {
+        external_id_map_.AddInternalToExternalIds(
+            internal_to_external_ids.empty() ? nullptr : internal_to_external_ids.data(), internal_count,
+            static_cast<int64_t>(dataset->GetExternalCount()), internal_id_begin);
+    } catch (const std::exception& e) {
+        LOG_KNOWHERE_WARNING_ << "invalid external id map: " << e.what();
+        return Status::invalid_args;
+    }
+    return Status::success;
+}
+
+Status
+IndexNode::AddEmbListExternalIdMapFromDataset(const DataSetPtr dataset, int64_t internal_el_id_begin,
+                                              int64_t internal_el_count) {
+    if (dataset == nullptr) {
+        if (internal_el_id_begin <= 0) {
+            external_id_map_.Clear();
+        }
+        return Status::success;
+    }
+
+    const auto& internal_to_external_ids = dataset->GetInternalToExternalIds();
+    const auto internal_count =
+        internal_to_external_ids.empty() ? internal_el_count : static_cast<int64_t>(internal_to_external_ids.size());
+    try {
+        external_id_map_.AddInternalToExternalIds(
+            internal_to_external_ids.empty() ? nullptr : internal_to_external_ids.data(), internal_count,
+            static_cast<int64_t>(dataset->GetExternalCount()), internal_el_id_begin);
+    } catch (const std::exception& e) {
+        LOG_KNOWHERE_WARNING_ << "invalid external id map: " << e.what();
+        return Status::invalid_args;
+    }
+    return Status::success;
+}
+
+Status
+IndexNode::AppendExternalIdMapToBinarySet(BinarySet& binset, const std::string& key) const {
+    if (!external_id_map_.HasInternalToExternalIds() && external_id_map_.ExternalCount(0) == 0) {
+        return Status::success;
+    }
+
+    auto bytes = external_id_map_.BinarySize();
+    std::shared_ptr<uint8_t[]> data(new uint8_t[bytes]);
+    external_id_map_.Serialize(data.get(), bytes);
+    binset.Append(key, data, bytes);
+    return Status::success;
+}
+
+Status
+IndexNode::LoadExternalIdMap(const uint8_t* data, int64_t size) {
+    external_id_map_.Clear();
+    try {
+        external_id_map_.Deserialize(data, size);
+    } catch (const std::exception& e) {
+        LOG_KNOWHERE_WARNING_ << "invalid external id map: " << e.what();
+        return Status::invalid_binary_set;
+    }
+    return Status::success;
+}
+
+Status
+IndexNode::LoadExternalIdMapFromBinarySet(const BinarySet& binset, const std::string& key) {
+    auto bin = binset.GetByName(key);
+    if (bin == nullptr) {
+        external_id_map_.Clear();
+        return Status::success;
+    }
+    return LoadExternalIdMap(bin->data.get(), bin->size);
+}
+
+Status
+IndexNode::SaveExternalIdMapToLocalFile(const std::string& id_map_file_path) const {
+    if ((!external_id_map_.HasInternalToExternalIds() && external_id_map_.ExternalCount(0) == 0) ||
+        id_map_file_path.empty()) {
+        return Status::success;
+    }
+
+    std::ofstream out(id_map_file_path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        LOG_KNOWHERE_WARNING_ << "Failed to open external id map file: " << id_map_file_path;
+        return Status::disk_file_error;
+    }
+    auto bytes = external_id_map_.BinarySize();
+    std::vector<uint8_t> data(bytes);
+    external_id_map_.Serialize(data.data(), bytes);
+    out.write(reinterpret_cast<const char*>(data.data()), bytes);
+    if (!out) {
+        LOG_KNOWHERE_WARNING_ << "Failed to write external id map file: " << id_map_file_path;
+        return Status::disk_file_error;
+    }
+    return Status::success;
+}
+
+Status
+IndexNode::LoadExternalIdMapFromLocalFile(const std::string& id_map_file_path) {
+    external_id_map_.Clear();
+    if (id_map_file_path.empty()) {
+        return Status::success;
+    }
+
+    std::ifstream in(id_map_file_path, std::ios::binary | std::ios::ate);
+    if (!in) {
+        LOG_KNOWHERE_WARNING_ << "Failed to open external id map file: " << id_map_file_path;
+        return Status::disk_file_error;
+    }
+    auto id_map_size = static_cast<int64_t>(in.tellg());
+    in.seekg(0);
+    auto id_map_data = std::make_unique<uint8_t[]>(id_map_size);
+    in.read(reinterpret_cast<char*>(id_map_data.get()), id_map_size);
+    if (!in) {
+        LOG_KNOWHERE_WARNING_ << "Failed to read external id map file: " << id_map_file_path;
+        return Status::disk_file_error;
+    }
+    return LoadExternalIdMap(id_map_data.get(), id_map_size);
+}
+
+Status
+IndexNode::SaveExternalIdMapToFileManager(std::shared_ptr<milvus::FileManager> file_manager,
+                                          const std::string& id_map_file_path) const {
+    if ((!external_id_map_.HasInternalToExternalIds() && external_id_map_.ExternalCount(0) == 0) ||
+        file_manager == nullptr || id_map_file_path.empty()) {
+        return Status::success;
+    }
+
+    auto output_stream = file_manager->OpenOutputStream(id_map_file_path);
+    auto bytes = external_id_map_.BinarySize();
+    std::vector<uint8_t> data(bytes);
+    external_id_map_.Serialize(data.data(), bytes);
+    output_stream->Write(data.data(), bytes);
+    size_t file_size = output_stream->Tell();
+    file_manager->AddFileMeta({id_map_file_path, file_size});
+    output_stream->Close();
+    return Status::success;
+}
+
+Status
+IndexNode::LoadExternalIdMapFromFileManager(std::shared_ptr<milvus::FileManager> file_manager,
+                                            const std::string& id_map_file_path) {
+    external_id_map_.Clear();
+    if (file_manager == nullptr || id_map_file_path.empty()) {
+        return Status::success;
+    }
+
+    try {
+        auto input_stream = file_manager->OpenInputStream(id_map_file_path);
+        auto id_map_size = input_stream->Size();
+        auto id_map_data = std::make_unique<uint8_t[]>(id_map_size);
+        input_stream->Read(id_map_data.get(), id_map_size);
+        return LoadExternalIdMap(id_map_data.get(), id_map_size);
+    } catch (const std::exception& e) {
+        LOG_KNOWHERE_INFO_ << "external id map file not loaded: " << id_map_file_path << ", error: " << e.what();
+        return Status::success;
+    }
+}
+
 expected<DataSetPtr>
 IndexNode::RangeSearch(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset,
                        milvus::OpContext* op_context) const {
@@ -310,12 +493,15 @@ IndexNode::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_t
     out_offsets[0] = 0;
     for (int64_t i = 0; i < num_el_ids; i++) {
         auto el_id = el_ids[i];
-        if (el_id < 0 || static_cast<size_t>(el_id) >= emb_list_offset_->num_el()) {
+        auto internal_el_id = external_id_map_.ToInternalId(el_id);
+        if (internal_el_id < 0 || static_cast<size_t>(internal_el_id) >= emb_list_offset_->num_el()) {
             return expected<DataSetPtr>::Err(Status::invalid_args,
                                              "GetEmbListByIds: el_id " + std::to_string(el_id) + " out of range [0, " +
-                                                 std::to_string(emb_list_offset_->num_el()) + ")");
+                                                 std::to_string(external_id_map_.ExternalCount(
+                                                     static_cast<int64_t>(emb_list_offset_->num_el()))) +
+                                                 ")");
         }
-        out_offsets[i + 1] = out_offsets[i] + emb_list_offset_->get_el_len(el_id);
+        out_offsets[i + 1] = out_offsets[i] + emb_list_offset_->get_el_len(internal_el_id);
     }
 
     auto total_vecs = out_offsets[num_el_ids];
@@ -336,7 +522,8 @@ IndexNode::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_t
         auto data = std::make_unique<float[]>(total_vecs * dim);
         float* ptr = data.get();
         for (int64_t i = 0; i < num_el_ids; i++) {
-            auto start = static_cast<int64_t>(emb_list_offset_->offset[el_ids[i]]);
+            auto internal_el_id = external_id_map_.ToInternalId(el_ids[i]);
+            auto start = static_cast<int64_t>(emb_list_offset_->offset[internal_el_id]);
             auto len = static_cast<int64_t>(out_offsets[i + 1] - out_offsets[i]);
             if (len > 0) {
                 emb_list_raw_index_->reconstruct_n(start, len, ptr);
@@ -357,13 +544,15 @@ IndexNode::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_t
         std::vector<int64_t> vec_ids;
         vec_ids.reserve(total_vecs);
         for (int64_t i = 0; i < num_el_ids; i++) {
-            size_t start = emb_list_offset_->offset[el_ids[i]];
+            auto internal_el_id = external_id_map_.ToInternalId(el_ids[i]);
+            size_t start = emb_list_offset_->offset[internal_el_id];
             size_t len = out_offsets[i + 1] - out_offsets[i];
             for (size_t j = 0; j < len; j++) {
                 vec_ids.push_back(static_cast<int64_t>(start + j));
             }
         }
 
+        // GetVectorByIds() receives internal vector IDs in this emb-list path.
         // Build result: transfer tensor ownership from GetVectorByIds result to new dataset
         auto vec_dataset = GenIdsDataSet(vec_ids.size(), vec_ids.data());
         auto res = GetVectorByIds(vec_dataset, op_context);
@@ -398,8 +587,16 @@ IndexNode::BuildEmbList(const DataSetPtr dataset, std::shared_ptr<Config> cfg, c
     el_metric_type_ = metric_info_or.value().el_metric_type;
     auto sub_metric_type = metric_info_or.value().sub_metric_type;
 
+    RETURN_IF_ERROR(SetExternalIdMapFromDataset(dataset));
+    if (num_rows == 0) {
+        return Status::empty_index;
+    }
+
     // 2. Create document offset structure
     EmbListOffset doc_offset(lims, num_rows);
+    if (doc_offset.num_el() == 0 || doc_offset.offset.back() == 0) {
+        return Status::empty_index;
+    }
 
     // 3. Create emb_list strategy
     auto strategy_type = config.emb_list_strategy.value_or(meta::EMB_LIST_STRATEGY_TOKENANN);
@@ -449,7 +646,7 @@ IndexNode::BuildEmbList(const DataSetPtr dataset, std::shared_ptr<Config> cfg, c
 
     // 8. Set ID mapping if strategy requires it (Direct needs vector->doc mapping)
     emb_list_offset_ = emb_list_strategy_->GetEmbListOffset();
-    if (emb_list_strategy_->NeedsBaseIndexIDMap()) {
+    if (emb_list_strategy_->NeedsBaseIndexIDMap() || external_id_map_.HasInternalToExternalIds()) {
         return SetBaseIndexIDMap();
     }
 
@@ -495,6 +692,7 @@ IndexNode::SerializeEmbList(BinarySet& binset) const {
 
         std::shared_ptr<uint8_t[]> meta_data(writer.data());
         binset.Append(meta::EMB_LIST_META, meta_data, writer.tellg());
+        RETURN_IF_ERROR(AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP));
 
         // 3. Raw vector index as separate key (large, needs mmap in file path)
         if (emb_list_raw_index_) {
@@ -523,12 +721,8 @@ IndexNode::DeserializeEmbListFromBinarySet(const BinarySet& binset, std::shared_
     }
     el_metric_type_ = metric_info_or.value().el_metric_type;
 
-    // 2. Deserialize base index from BinarySet (override metric_type for base index)
-    cfg.metric_type = metric_info_or.value().sub_metric_type;
-    RETURN_IF_ERROR(Deserialize(binset, config));
-
     try {
-        // 3. Read EMB_LIST_META and parse strategy type + strategy blob
+        // 2. Read EMB_LIST_META and parse strategy type + strategy blob
         auto meta_bin = binset.GetByName(meta::EMB_LIST_META);
         if (!meta_bin) {
             LOG_KNOWHERE_WARNING_ << "EMB_LIST_META not found in binary set";
@@ -538,7 +732,8 @@ IndexNode::DeserializeEmbListFromBinarySet(const BinarySet& binset, std::shared_
         auto [strategy_type, strategy_blob, strategy_blob_size] =
             ParseEmbListMetaHeader(meta_bin->data.get(), meta_bin->size);
 
-        // 4. Create strategy and deserialize strategy-specific data
+        // 3. Create strategy before base index deserialize, so base index skips id-map loading.
+        cfg.metric_type = metric_info_or.value().sub_metric_type;
         auto strategy_or = CreateEmbListStrategy(strategy_type, cfg);
         if (!strategy_or.has_value()) {
             LOG_KNOWHERE_WARNING_ << "Failed to create emb_list strategy: " << strategy_type;
@@ -548,6 +743,9 @@ IndexNode::DeserializeEmbListFromBinarySet(const BinarySet& binset, std::shared_
 
         LOG_KNOWHERE_INFO_ << "Deserialize emb_list with strategy: " << strategy_type;
         RETURN_IF_ERROR(emb_list_strategy_->Deserialize(strategy_blob, strategy_blob_size, cfg));
+
+        // 4. Deserialize base index from BinarySet.
+        RETURN_IF_ERROR(Deserialize(binset, config));
 
         // 5. Deserialize raw vector index from BinarySet (if present)
         auto raw_index_bin = binset.GetByName(meta::EMB_LIST_RAW_INDEX);
@@ -568,8 +766,10 @@ IndexNode::DeserializeEmbListFromBinarySet(const BinarySet& binset, std::shared_
         }
 
         // 6. Set ID mapping if needed
+        RETURN_IF_ERROR(LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP));
+
         emb_list_offset_ = emb_list_strategy_->GetEmbListOffset();
-        if (emb_list_strategy_->NeedsBaseIndexIDMap()) {
+        if (emb_list_strategy_->NeedsBaseIndexIDMap() || external_id_map_.HasInternalToExternalIds()) {
             return SetBaseIndexIDMap();
         }
     } catch (const std::exception& e) {
@@ -591,11 +791,7 @@ IndexNode::DeserializeEmbListFromFile(const std::string& filename, std::shared_p
     }
     el_metric_type_ = metric_info_or.value().el_metric_type;
 
-    // 2. Deserialize base index from file (override metric_type for base index)
-    cfg.metric_type = metric_info_or.value().sub_metric_type;
-    RETURN_IF_ERROR(DeserializeFromFile(filename, config));
-
-    // 3. Read meta file and parse strategy type + strategy blob
+    // 2. Read meta file and parse strategy type + strategy blob
     if (!cfg.emb_list_meta_file_path.has_value() || cfg.emb_list_meta_file_path.value().empty()) {
         LOG_KNOWHERE_WARNING_ << "emb_list_meta_file is empty, but metric type is emb_list";
         return Status::emb_list_inner_error;
@@ -629,7 +825,8 @@ IndexNode::DeserializeEmbListFromFile(const std::string& filename, std::shared_p
     auto [strategy_type, strategy_blob, strategy_blob_size] = ParseEmbListMetaHeader(file_data.get(), file_size);
 
     try {
-        // 4. Create strategy and deserialize strategy-specific data
+        // 3. Create strategy before base index deserialize, so base index skips id-map loading.
+        cfg.metric_type = metric_info_or.value().sub_metric_type;
         auto strategy_or = CreateEmbListStrategy(strategy_type, cfg);
         if (!strategy_or.has_value()) {
             LOG_KNOWHERE_WARNING_ << "Failed to create emb_list strategy: " << strategy_type;
@@ -639,6 +836,9 @@ IndexNode::DeserializeEmbListFromFile(const std::string& filename, std::shared_p
 
         LOG_KNOWHERE_INFO_ << "Deserialize emb_list from file with strategy: " << strategy_type;
         RETURN_IF_ERROR(emb_list_strategy_->Deserialize(strategy_blob, strategy_blob_size, cfg));
+
+        // 4. Deserialize base index from file.
+        RETURN_IF_ERROR(DeserializeFromFile(filename, config));
 
         // 5. Load raw vector index from separate file (if strategy needs it)
         if (emb_list_strategy_->NeedsRawVectorStorage()) {
@@ -667,8 +867,10 @@ IndexNode::DeserializeEmbListFromFile(const std::string& filename, std::shared_p
         }
 
         // 6. Set ID mapping if needed
+        RETURN_IF_ERROR(LoadExternalIdMapFromLocalFile(cfg.external_id_map_file_path.value_or("")));
+
         emb_list_offset_ = emb_list_strategy_->GetEmbListOffset();
-        if (emb_list_strategy_->NeedsBaseIndexIDMap()) {
+        if (emb_list_strategy_->NeedsBaseIndexIDMap() || external_id_map_.HasInternalToExternalIds()) {
             return SetBaseIndexIDMap();
         }
     } catch (const std::exception& e) {

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -133,12 +133,6 @@ class IvfIndexNode : public IndexNode {
     expected<DataSetPtr>
     CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
                   const bool is_cosine, milvus::OpContext* op_context) const override;
-    Status
-    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) override {
-        internal_offset_to_most_external_id_ = std::move(map);
-        return Status::success;
-    };
-
     static Status
     StaticConfigCheck(const Config& cfg, PARAM_TYPE paramType, std::string& msg) {
         auto ivf_cfg = static_cast<const IvfConfig&>(cfg);
@@ -402,8 +396,9 @@ class IvfIndexNode : public IndexNode {
      public:
         iterator(const IndexType* index, std::unique_ptr<float[]>&& copied_query, const BitsetView& bitset,
                  size_t nprobe, bool larger_is_closer, const float refine_ratio = 0.5f,
+                 const ExternalIdMap& external_id_map = EmptyExternalIdMap(),
                  bool use_knowhere_search_pool = true)
-            : IndexIterator(larger_is_closer, use_knowhere_search_pool, refine_ratio),
+            : IndexIterator(larger_is_closer, external_id_map, use_knowhere_search_pool, refine_ratio),
               index_(index),
               copied_query_(std::move(copied_query)) {
             if (!bitset.empty()) {
@@ -464,7 +459,6 @@ class IvfIndexNode : public IndexNode {
     // spawded during index training/building can inherit the low nice value of
     // threads in build_pool_.
     std::shared_ptr<ThreadPool> build_pool_;
-    std::vector<uint32_t> internal_offset_to_most_external_id_;
     std::unique_ptr<FairRWLock> base_index_lock_;
 };
 
@@ -814,6 +808,13 @@ IvfIndexNode<DataType, IndexType>::Add(const DataSetPtr dataset, std::shared_ptr
     auto data = dataset->GetTensor();
     auto rows = dataset->GetRows();
     const BaseConfig& base_cfg = static_cast<const IvfConfig&>(*cfg);
+    auto old_rows = Count();
+    if (rows == 0) {
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+        }
+        return Status::success;
+    }
     // use build_pool_ to make sure the OMP threads spawded by index_->add
     // can inherit the low nice value of threads in build_pool_.
     auto build_pool_wrapper = std::make_shared<ThreadPoolWrapper>(build_pool_, use_knowhere_build_pool);
@@ -836,6 +837,20 @@ IvfIndexNode<DataType, IndexType>::Add(const DataSetPtr dataset, std::shared_ptr
     if (tryObj.hasException()) {
         LOG_KNOWHERE_WARNING_ << "faiss internal error: " << tryObj.exception().what();
         return Status::faiss_inner_error;
+    }
+    if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlat> ||
+                  std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>) {
+        if (HasRawData(base_cfg.metric_type.value())) {
+            try {
+                index_->make_direct_map(true);
+            } catch (const std::exception& e) {
+                LOG_KNOWHERE_WARNING_ << "faiss internal error: " << e.what();
+                return Status::faiss_inner_error;
+            }
+        }
+    }
+    if (emb_list_strategy_ == nullptr) {
+        RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
     }
     return Status::success;
 }
@@ -882,29 +897,31 @@ IvfIndexNode<DataType, IndexType>::AddEmbList(const DataSetPtr dataset, std::sha
             LOG_KNOWHERE_WARNING_ << "lims[0] is not equal to the total_cnt of the old index";
             return Status::emb_list_inner_error;
         }
-        size_t idx = 1;
-        internal_offset_to_most_external_id_.resize(new_num_rows);
-        while (lims[idx] < new_num_rows) {
-            if (lims[idx] < lims[idx - 1]) {
-                LOG_KNOWHERE_WARNING_ << "lims is not increasing, lims[" << idx << "] = " << lims[idx] << " < lims["
-                                      << idx - 1 << "] = " << lims[idx - 1];
+        if (dataset_rows == 0) {
+            RETURN_IF_ERROR(AddEmbListExternalIdMapFromDataset(dataset, old_num_el, 0));
+            return Status::success;
+        }
+
+        size_t new_num_el = 1;
+        while (lims[new_num_el] < new_num_rows) {
+            if (lims[new_num_el] < lims[new_num_el - 1]) {
+                LOG_KNOWHERE_WARNING_ << "lims is not increasing, lims[" << new_num_el << "] = " << lims[new_num_el]
+                                      << " < lims[" << new_num_el - 1 << "] = " << lims[new_num_el - 1];
                 return Status::emb_list_inner_error;
             }
-            emb_list_offset_->offset.push_back(lims[idx]);
-            auto cur_el_id = old_num_el + idx - 1;
-            std::fill_n(internal_offset_to_most_external_id_.begin() + lims[idx - 1], lims[idx] - lims[idx - 1],
-                        cur_el_id);
-            idx++;
+            ++new_num_el;
         }
-        if (lims[idx] != new_num_rows) {
-            LOG_KNOWHERE_WARNING_ << "lims should end with the total_cnt of the new index, lims[" << idx
-                                  << "] = " << lims[idx] << " != " << new_num_rows;
+        if (lims[new_num_el] != new_num_rows) {
+            LOG_KNOWHERE_WARNING_ << "lims should end with the total_cnt of the new index, lims[" << new_num_el
+                                  << "] = " << lims[new_num_el] << " != " << new_num_rows;
             return Status::emb_list_inner_error;
         }
-        emb_list_offset_->offset.push_back(new_num_rows);
-        auto cur_el_id = old_num_el + idx - 1;
-        std::fill_n(internal_offset_to_most_external_id_.begin() + lims[idx - 1], new_num_rows - lims[idx - 1],
-                    cur_el_id);
+        RETURN_IF_ERROR(AddEmbListExternalIdMapFromDataset(dataset, old_num_el, static_cast<int64_t>(new_num_el)));
+        for (size_t idx = 1; idx <= new_num_el; ++idx) {
+            emb_list_offset_->offset.push_back(lims[idx]);
+            auto cur_el_id = old_num_el + idx - 1;
+            external_id_map_.AppendInternalToEmbListIds(lims[idx - 1], lims[idx], cur_el_id);
+        }
     }
 
     // 3. add to index
@@ -935,22 +952,7 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, std::unique_
     auto nprobe = ivf_cfg.nprobe.value();
 
     BitsetView bitset(bitset_);
-    if (!internal_offset_to_most_external_id_.empty()) {
-        if (emb_list_offset_ != nullptr) {
-            // if emb list, manually calculate the number of filtered out ids
-            size_t num_filtered_out_ids = 0;
-            for (size_t i = 0; i < bitset.size(); i++) {
-                if (bitset.test(i)) {
-                    num_filtered_out_ids += emb_list_offset_->offset[i + 1] - emb_list_offset_->offset[i];
-                }
-            }
-            bitset.set_out_ids(internal_offset_to_most_external_id_.data(), internal_offset_to_most_external_id_.size(),
-                               num_filtered_out_ids);
-        } else {
-            bitset.set_out_ids(internal_offset_to_most_external_id_.data(),
-                               internal_offset_to_most_external_id_.size());
-        }
-    }
+    external_id_map_.SetOutIdsToBitset(bitset);
 
     auto ids = std::make_unique<int64_t[]>(rows * k);
     auto distances = std::make_unique<float[]>(rows * k);
@@ -1205,6 +1207,7 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, std::unique_
         return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
     }
 
+    external_id_map_.MapResultIds(ids.get(), rows * k);
     auto res = GenResultDataSet(rows, k, std::move(ids), std::move(distances));
     return res;
 }
@@ -1234,6 +1237,16 @@ IvfIndexNode<DataType, IndexType>::CalcDistByIDs(const DataSetPtr dataset, const
         auto query_data = dataset->GetTensor();
         auto dim = dataset->GetDim();
         auto distances = std::make_unique<float[]>(num_queries * labels_len);
+        std::vector<int64_t> internal_labels;
+        const int64_t* labels_to_calc = labels;
+        if (emb_list_strategy_ == nullptr) {
+            labels_to_calc = external_id_map_.ToInternalIds(labels, labels_len, internal_labels);
+        }
+        for (size_t i = 0; i < labels_len; ++i) {
+            if (labels_to_calc[i] < 0 || labels_to_calc[i] >= index_->ntotal) {
+                return expected<DataSetPtr>::Err(Status::invalid_args, "invalid label id");
+            }
+        }
 
         try {
             std::vector<folly::Future<folly::Unit>> futs;
@@ -1248,7 +1261,7 @@ IvfIndexNode<DataType, IndexType>::CalcDistByIDs(const DataSetPtr dataset, const
                         query = copied_query.get();
                     }
                     auto cur_distances = distances.get() + index * labels_len;
-                    index_->calc_dist_by_ids(1, query, labels_len, labels, cur_distances);
+                    index_->calc_dist_by_ids(1, query, labels_len, labels_to_calc, cur_distances);
                 }));
             }
             WaitAllSuccess(futs);
@@ -1305,6 +1318,8 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, std::un
 
     std::vector<std::vector<int64_t>> result_id_array(nq);
     std::vector<std::vector<float>> result_dist_array(nq);
+    BitsetView mapped_bitset(bitset);
+    external_id_map_.SetOutIdsToBitset(mapped_bitset);
 
     try {
         std::vector<folly::Future<folly::Unit>> futs;
@@ -1316,8 +1331,8 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, std::un
                 faiss::RangeSearchResult res(1);
                 std::unique_ptr<float[]> copied_query = nullptr;
 
-                BitsetViewIDSelector bw_idselector(bitset);
-                faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
+                BitsetViewIDSelector bw_idselector(mapped_bitset);
+                faiss::IDSelector* id_selector = (mapped_bitset.empty()) ? nullptr : &bw_idselector;
 
                 if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexBinaryIVF>) {
                     auto cur_data = static_cast<const uint8_t*>(xq) + index * ((dim + 7) / 8);
@@ -1526,6 +1541,7 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, std::un
         }
         // wait for the completion
         WaitAllSuccess(futs);
+        external_id_map_.MapResultIds(result_id_array);
         range_search_result = GetRangeSearchResult(result_dist_array, result_id_array, is_ip, nq, radius, range_filter);
     } catch (const std::exception& e) {
         LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();
@@ -1571,6 +1587,8 @@ IvfIndexNode<DataType, IndexType>::AnnIterator(const DataSetPtr dataset, std::un
         const IvfConfig& ivf_cfg = static_cast<const IvfConfig&>(*cfg);
         bool is_cosine = IsMetricType(ivf_cfg.metric_type.value(), knowhere::metric::COSINE);
         auto larger_is_closer = IsMetricType(ivf_cfg.metric_type.value(), knowhere::metric::IP) || is_cosine;
+        BitsetView mapped_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(mapped_bitset);
 
         size_t nprobe = ivf_cfg.nprobe.value();
         // set iterator_refine_ratio = 0.0. If quantizer != flat, faiss:indexivf will not keep raw data;
@@ -1593,8 +1611,9 @@ IvfIndexNode<DataType, IndexType>::AnnIterator(const DataSetPtr dataset, std::un
                 }
 
                 // iterator only own the copied_query.
-                auto it = std::make_shared<iterator>(index_.get(), std::move(copied_query), bitset, nprobe,
-                                                     larger_is_closer, iterator_refine_ratio, use_knowhere_search_pool);
+                auto it = std::make_shared<iterator>(index_.get(), std::move(copied_query), mapped_bitset, nprobe,
+                                                     larger_is_closer, iterator_refine_ratio, this->external_id_map_,
+                                                     use_knowhere_search_pool);
                 vec[i] = it;
             }
 
@@ -1623,8 +1642,10 @@ IvfIndexNode<DataType, IndexType>::GetVectorByIds(const DataSetPtr dataset, milv
         try {
             auto data = std::make_unique<uint8_t[]>(rows * ((dim + 7) / 8));
             for (int64_t i = 0; i < rows; i++) {
-                int64_t id = ids[i];
-                assert(id >= 0 && id < index_->ntotal);
+                int64_t id = emb_list_strategy_ == nullptr ? external_id_map_.ToInternalId(ids[i]) : ids[i];
+                if (id < 0 || id >= index_->ntotal) {
+                    return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+                }
                 index_->reconstruct(id, data.get() + i * ((dim + 7) / 8));
             }
             return GenResultDataSet(rows, dim, std::move(data));
@@ -1641,8 +1662,10 @@ IvfIndexNode<DataType, IndexType>::GetVectorByIds(const DataSetPtr dataset, milv
         try {
             auto data = std::make_unique<float[]>(dim * rows);
             for (int64_t i = 0; i < rows; i++) {
-                int64_t id = ids[i];
-                assert(id >= 0 && id < index_->ntotal);
+                int64_t id = emb_list_strategy_ == nullptr ? external_id_map_.ToInternalId(ids[i]) : ids[i];
+                if (id < 0 || id >= index_->ntotal) {
+                    return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+                }
                 index_->reconstruct(id, data.get() + i * dim);
             }
             return GenResultDataSet(rows, dim, std::move(data));
@@ -1663,8 +1686,10 @@ IvfIndexNode<DataType, IndexType>::GetVectorByIds(const DataSetPtr dataset, milv
         try {
             auto data = std::make_unique<float[]>(dim * rows);
             for (int64_t i = 0; i < rows; i++) {
-                int64_t id = ids[i];
-                assert(id >= 0 && id < index_->ntotal);
+                int64_t id = emb_list_strategy_ == nullptr ? external_id_map_.ToInternalId(ids[i]) : ids[i];
+                if (id < 0 || id >= index_->ntotal) {
+                    return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+                }
                 index_->reconstruct(id, data.get() + i * dim);
             }
             return GenResultDataSet(rows, dim, std::move(data));
@@ -1746,6 +1771,9 @@ IvfIndexNode<DataType, IndexType>::SerializeImpl(BinarySet& binset) const {
         }
         std::shared_ptr<uint8_t[]> data(writer.data());
         binset.Append(Type(), data, writer.tellg());
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP));
+        }
         return Status::success;
     } catch (const std::exception& e) {
         LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();
@@ -1838,6 +1866,9 @@ IvfIndexNode<DataType, IndexType>::Deserialize(const BinarySet& binset, std::sha
         LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();
         return Status::faiss_inner_error;
     }
+    if (emb_list_strategy_ == nullptr) {
+        return LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP);
+    }
     return Status::success;
 }
 
@@ -1919,6 +1950,9 @@ IvfIndexNode<DataType, IndexType>::DeserializeFromFile(const std::string& filena
     } catch (const std::exception& e) {
         LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();
         return Status::faiss_inner_error;
+    }
+    if (emb_list_strategy_ == nullptr) {
+        return LoadExternalIdMapFromLocalFile(cfg.external_id_map_file_path.value_or(""));
     }
     return Status::success;
 }

--- a/src/index/minhash/minhash_index_node.cc
+++ b/src/index/minhash/minhash_index_node.cc
@@ -68,6 +68,15 @@ class MinHashLSHNode : public IndexNode {
         auto rows = dataset->GetRows();
         auto ids = dataset->GetIds();
         if (minhash_lsh_->HasRawData()) {
+            std::vector<int64_t> internal_ids;
+            if (emb_list_strategy_ == nullptr) {
+                ids = external_id_map_.ToInternalIds(ids, rows, internal_ids);
+            }
+            for (int64_t i = 0; i < rows; ++i) {
+                if (ids[i] < 0 || ids[i] >= Count()) {
+                    return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+                }
+            }
             auto data = std::make_unique<char[]>(rows * ((this->Dim() + 7) / 8));
             minhash_lsh_->GetDataByIds(ids, rows, data.get());
             return GenResultDataSet(rows, dim, std::move(data));
@@ -208,6 +217,12 @@ class MinHashLSHNode : public IndexNode {
     std::shared_ptr<ThreadPool> search_pool_;
     bool is_loaded_ = false;
     const std::string fname_ = "minhash_lsh_index";
+    const std::string id_map_fname_ = "external_id_map";
+
+    std::string
+    IdMapFilePath() const {
+        return index_prefix_ + id_map_fname_;
+    }
 };
 template <typename DataType>
 Status
@@ -218,6 +233,10 @@ MinHashLSHNode<DataType>::Build(const DataSetPtr dataset, std::shared_ptr<Config
         return Status::internal_error;
     }
     try {
+        index_prefix_ = build_conf.index_prefix.value();
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(SetExternalIdMapFromDataset(dataset));
+        }
         if (!LoadFile(build_conf.data_path.value())) {
             LOG_KNOWHERE_ERROR_ << "Failed load the raw data before building.";
             return Status::disk_file_error;
@@ -227,6 +246,12 @@ MinHashLSHNode<DataType>::Build(const DataSetPtr dataset, std::shared_ptr<Config
         if (dim % 8 != 0 || build_conf.mh_element_bit_width.value() % 8 != 0) {
             LOG_KNOWHERE_ERROR_ << "Expecting (dim % 8 == 0) and (mh_element_bit_width % 8 == 0)";
             return Status::invalid_args;
+        }
+        if (rows == 0) {
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(SaveExternalIdMapToFileManager(file_manager_, IdMapFilePath()));
+            }
+            return Status::empty_index;
         }
         size_t mh_vec_element_size = static_cast<size_t>(build_conf.mh_element_bit_width.value() / 8);
         size_t mh_vec_length = (dim / build_conf.mh_element_bit_width.value());
@@ -247,6 +272,9 @@ MinHashLSHNode<DataType>::Build(const DataSetPtr dataset, std::shared_ptr<Config
             LOG_KNOWHERE_ERROR_ << "Failed to add file " << index_params.index_file_path << ".";
             return Status::disk_file_error;
         }
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(SaveExternalIdMapToFileManager(file_manager_, IdMapFilePath()));
+        }
     } catch (const std::exception& e) {
         LOG_KNOWHERE_ERROR_ << "minhash lsh inner error: " << e.what();
         return Status::internal_error;
@@ -258,6 +286,7 @@ template <typename DataType>
 Status
 MinHashLSHNode<DataType>::Deserialize(const BinarySet& binset, std::shared_ptr<Config> cfg) {
     auto load_conf = static_cast<const MinHashLSHConfig&>(*cfg);
+    index_prefix_ = load_conf.index_prefix.value();
     auto index_params_ptr = std::make_unique<minhash::MinHashLSHLoadParams>();
     index_params_ptr->index_file_path = load_conf.index_prefix.value() + fname_;
     index_params_ptr->hash_code_in_memory = load_conf.mh_lsh_code_in_mem.value();
@@ -277,6 +306,10 @@ MinHashLSHNode<DataType>::Deserialize(const BinarySet& binset, std::shared_ptr<C
     } catch (const std::exception& e) {
         LOG_KNOWHERE_ERROR_ << "minhash lsh inner error: " << e.what();
         return Status::internal_error;
+    }
+    RETURN_IF_ERROR(stat);
+    if (emb_list_strategy_ == nullptr) {
+        RETURN_IF_ERROR(LoadExternalIdMapFromFileManager(file_manager_, IdMapFilePath()));
     }
     return stat;
 }
@@ -301,12 +334,14 @@ MinHashLSHNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
     auto xq = static_cast<const char*>(dataset->GetTensor());
     auto p_id = std::make_unique<int64_t[]>(nq * topk);
     auto p_dist = std::make_unique<DistType[]>(nq * topk);
+    BitsetView mapped_bitset(bitset);
+    external_id_map_.SetOutIdsToBitset(mapped_bitset);
     minhash::MinHashLSHSearchParams search_params;
     search_params.k = topk;
     search_params.search_with_jaccard = search_conf.mh_search_with_jaccard.value();
     search_params.refine_k = search_conf.refine_k.value_or(topk);
-    BitsetViewIDSelector bw_idselector(bitset);
-    search_params.id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
+    BitsetViewIDSelector bw_idselector(mapped_bitset);
+    search_params.id_selector = (mapped_bitset.empty()) ? nullptr : &bw_idselector;
     try {
         if (search_conf.mh_lsh_batch_search.value() == true) {
             minhash_lsh_->BatchSearch(xq, nq, p_dist.get(), p_id.get(), search_pool_, &search_params);
@@ -331,6 +366,7 @@ MinHashLSHNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
         LOG_KNOWHERE_WARNING_ << "minhash lsh inner error: " << e.what();
         return expected<DataSetPtr>::Err(Status::internal_error, e.what());
     }
+    external_id_map_.MapResultIds(p_id.get(), nq * topk);
     auto res = GenResultDataSet(nq, topk, std::move(p_id), std::move(p_dist));
     return res;
 }

--- a/src/index/minhash/minhash_lsh.h
+++ b/src/index/minhash/minhash_lsh.h
@@ -243,7 +243,7 @@ MinHashBandIndex::Search(KeyType key, MinHashLSHResultHandler* res, faiss::IDSel
         ValueType* blk_v = reinterpret_cast<ValueType*>(data_ + block_size_ * block_id + rows * sizeof(KeyType));
         int inner_id = faiss::cppcontrib::knowhere::u64_binary_search_eq(blk_k, rows, key);
         if (inner_id != -1) {
-            for (; key == blk_k[inner_id] && (size_t)inner_id < rows; inner_id++) {
+            for (; (size_t)inner_id < rows && key == blk_k[inner_id]; inner_id++) {
                 if (id_selector == nullptr || id_selector->is_member(blk_v[inner_id])) {
                     res->push(blk_v[inner_id], 1.0);
                 }
@@ -446,7 +446,7 @@ MinHashLSH::Search(const char* query, float* distances, idx_t* labels, MinHashLS
     }
     if (search_with_jaccard) {
         MinHashJaccardKNNSearchByIDs(query, this->raw_data_, reorder_ids.get(), this->mh_vec_length_,
-                                     this->mh_vec_elememt_size_, res->topk_, topk, distances, labels);
+                                     this->mh_vec_elememt_size_, res->count(), topk, distances, labels);
     }
     return Status::success;
 }
@@ -551,11 +551,11 @@ MinHashLSH::BatchSearch(const char* query, size_t nq, float* distances, idx_t* l
         futures.reserve(nq);
         for (size_t i = 0; i < nq; i++) {
             futures.emplace_back(pool->push([&, id = i]() {
-                const char* q = query + i * mh_vec_elememt_size_ * mh_vec_length_;
-                auto reorder_ids = all_res[i].ids_list_;
-                auto refine_k = all_res[i].topk_;
-                auto res_ids = labels + i * topk;
-                auto res_dis = distances + i * topk;
+                const char* q = query + id * mh_vec_elememt_size_ * mh_vec_length_;
+                auto reorder_ids = all_res[id].ids_list_;
+                auto refine_k = all_res[id].count();
+                auto res_ids = labels + id * topk;
+                auto res_dis = distances + id * topk;
                 MinHashJaccardKNNSearchByIDs(q, this->raw_data_, reorder_ids, this->mh_vec_length_,
                                              this->mh_vec_elememt_size_, refine_k, topk, res_dis, res_ids);
                 return;

--- a/src/index/sparse/sparse_index_node.cc
+++ b/src/index/sparse/sparse_index_node.cc
@@ -144,13 +144,21 @@ class SparseInvertedIndexNode : public IndexNode {
             LOG_KNOWHERE_ERROR_ << "Could not add data to uninitialized " << Type() << " index";
             return Status::empty_index;
         }
+        auto old_rows = Count();
+        auto rows = dataset->GetRows();
+        if (rows == 0) {
+            if (emb_list_strategy_ == nullptr) {
+                return AddExternalIdMapFromDataset(dataset, old_rows);
+            }
+            return Status::success;
+        }
 
         auto build_pool_wrapper = std::make_shared<ThreadPoolWrapper>(build_pool_, use_knowhere_build_pool);
         auto tryObj =
             build_pool_wrapper
                 ->push([&] {
                     return index_->add(static_cast<const sparse::SparseRow<value_type>*>(dataset->GetTensor()),
-                                       dataset->GetRows(), dataset->GetDim());
+                                       rows, dataset->GetDim());
                 })
                 .getTry();
         if (!tryObj.hasValue()) {
@@ -158,7 +166,11 @@ class SparseInvertedIndexNode : public IndexNode {
             return Status::sparse_inner_error;
         }
 
-        return tryObj.value();
+        RETURN_IF_ERROR(tryObj.value());
+        if (emb_list_strategy_ == nullptr) {
+            return AddExternalIdMapFromDataset(dataset, old_rows);
+        }
+        return Status::success;
     }
 
     [[nodiscard]] expected<DataSetPtr>
@@ -183,16 +195,19 @@ class SparseInvertedIndexNode : public IndexNode {
         auto k = cfg.k.value();
         auto p_id = std::make_unique<sparse::label_t[]>(nq * k);
         auto p_dist = std::make_unique<float[]>(nq * k);
+        BitsetView mapped_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(mapped_bitset);
 
         std::vector<folly::Future<folly::Unit>> futs;
         futs.reserve(nq);
         for (int64_t idx = 0; idx < nq; ++idx) {
             futs.emplace_back(search_pool_->push([&, idx = idx, p_id = p_id.get(), p_dist = p_dist.get()]() {
-                index_->search(queries[idx], k, p_dist + idx * k, p_id + idx * k, bitset, search_params);
+                index_->search(queries[idx], k, p_dist + idx * k, p_id + idx * k, mapped_bitset, search_params);
             }));
         }
         WaitAllSuccess(futs);
 
+        external_id_map_.MapResultIds(p_id.get(), nq * k);
         return GenResultDataSet(nq, k, p_id.release(), p_dist.release());
     }
 
@@ -216,6 +231,8 @@ class SparseInvertedIndexNode : public IndexNode {
                                                                       search_params_or.what());
         }
         auto search_params = search_params_or.value();
+        BitsetView mapped_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(mapped_bitset);
 
         auto vec = std::vector<std::shared_ptr<IndexNode::iterator>>(nq, nullptr);
         try {
@@ -224,7 +241,7 @@ class SparseInvertedIndexNode : public IndexNode {
                 // 'Iterator->Next()'.
                 auto compute_dist_func = [=, this]() -> std::vector<DistId> {
                     auto queries = static_cast<const sparse::SparseRow<value_type>*>(dataset->GetTensor());
-                    std::vector<float> distances = index_->get_all_distances(queries[i], bitset, search_params);
+                    std::vector<float> distances = index_->get_all_distances(queries[i], mapped_bitset, search_params);
                     std::vector<DistId> distances_ids;
                     // 30% is a ratio guesstimate of non-zero distances: probability of 2 random sparse splade
                     // vectors(100 non zero dims out of 30000 total dims) sharing at least 1 common non-zero
@@ -239,7 +256,8 @@ class SparseInvertedIndexNode : public IndexNode {
                 };
 
                 auto it =
-                    std::make_shared<PrecomputedDistanceIterator>(compute_dist_func, true, use_knowhere_search_pool);
+                    std::make_shared<PrecomputedDistanceIterator>(compute_dist_func, true, this->external_id_map_,
+                                                                  use_knowhere_search_pool);
                 vec[i] = it;
             }
         } catch (const std::exception& e) {
@@ -284,6 +302,9 @@ class SparseInvertedIndexNode : public IndexNode {
         }
         std::shared_ptr<uint8_t[]> data(writer.data());
         binset.Append(Type(), data, writer.tellg());
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP));
+        }
 
         return Status::success;
     }
@@ -327,11 +348,15 @@ class SparseInvertedIndexNode : public IndexNode {
 
         if (this->version_use_raw_data()) {
             LOG_KNOWHERE_INFO_ << "raw data will be used, rebuild index from raw data";
-            return index_->build_from_raw_data(reader, false, "");
+            RETURN_IF_ERROR(index_->build_from_raw_data(reader, false, ""));
         } else {
             binary_ = binary;
-            return index_->deserialize(reader);
+            RETURN_IF_ERROR(index_->deserialize(reader));
         }
+        if (emb_list_strategy_ == nullptr) {
+            return LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP);
+        }
+        return Status::success;
     }
 
     Status
@@ -381,11 +406,15 @@ class SparseInvertedIndexNode : public IndexNode {
 
         if (this->version_use_raw_data()) {
             auto supplement_target_filename = filename + ".knowhere_sparse_index_supplement";
-            return index_->build_from_raw_data(map_reader, true, supplement_target_filename);
+            RETURN_IF_ERROR(index_->build_from_raw_data(map_reader, true, supplement_target_filename));
         } else {
             this->mmap_guard_ = std::move(mmap_guard);
-            return index_->deserialize(map_reader);
+            RETURN_IF_ERROR(index_->deserialize(map_reader));
         }
+        if (emb_list_strategy_ == nullptr) {
+            return LoadExternalIdMapFromLocalFile(cfg.external_id_map_file_path.value_or(""));
+        }
+        return Status::success;
     }
 
     static std::unique_ptr<BaseConfig>
@@ -911,7 +940,11 @@ class SparseInvertedIndexNodeCC : public SparseInvertedIndexNode<T, use_wand> {
 
         try {
             for (int64_t i = 0; i < rows; ++i) {
-                data[i] = raw_data_[ids[i]];
+                auto id = this->emb_list_strategy_ == nullptr ? this->external_id_map_.ToInternalId(ids[i]) : ids[i];
+                if (id < 0 || static_cast<size_t>(id) >= raw_data_.size()) {
+                    return expected<DataSetPtr>::Err(Status::invalid_args, "invalid vector id");
+                }
+                data[i] = raw_data_[id];
                 dim = std::max(dim, data[i].dim());
             }
         } catch (std::exception& e) {

--- a/src/index/svs/svs_flat.cc
+++ b/src/index/svs/svs_flat.cc
@@ -55,6 +55,14 @@ class SvsFlatIndexNode : public IndexNode {
             LOG_KNOWHERE_ERROR_ << "Can not add data to empty index.";
             return Status::empty_index;
         }
+        auto old_rows = Count();
+        auto n = dataset->GetRows();
+        if (n == 0) {
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+            }
+            return Status::success;
+        }
 
         const BaseConfig& f_cfg = static_cast<const BaseConfig&>(*cfg);
         bool is_cosine = IsMetricType(f_cfg.metric_type.value(), knowhere::metric::COSINE);
@@ -63,8 +71,10 @@ class SvsFlatIndexNode : public IndexNode {
         }
 
         auto x = dataset->GetTensor();
-        auto n = dataset->GetRows();
         index_->add(n, (const float*)x);
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+        }
         return Status::success;
     }
 
@@ -76,7 +86,9 @@ class SvsFlatIndexNode : public IndexNode {
             return expected<DataSetPtr>::Err(Status::empty_index, "index not loaded");
         }
 
-        if (!bitset.empty() && bitset.count() > 0) {
+        BitsetView mapped_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(mapped_bitset);
+        if (!mapped_bitset.empty() && mapped_bitset.count() > 0) {
             return expected<DataSetPtr>::Err(Status::not_implemented, "SVS Flat does not support bitset filtering");
         }
 
@@ -116,6 +128,7 @@ class SvsFlatIndexNode : public IndexNode {
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
         }
 
+        external_id_map_.MapResultIds(ids.get(), k * nq);
         return GenResultDataSet(nq, k, std::move(ids), std::move(distances));
     }
 
@@ -157,6 +170,9 @@ class SvsFlatIndexNode : public IndexNode {
             faiss::write_index(index_.get(), &writer);
             std::shared_ptr<uint8_t[]> data(writer.data());
             binset.Append(Type(), data, writer.tellg());
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP));
+            }
             return Status::success;
         } catch (const std::exception& e) {
             LOG_KNOWHERE_WARNING_ << "error inner faiss: " << e.what();
@@ -184,6 +200,9 @@ class SvsFlatIndexNode : public IndexNode {
             return Status::faiss_inner_error;
         }
 
+        if (emb_list_strategy_ == nullptr) {
+            return LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP);
+        }
         return Status::success;
     }
 
@@ -217,6 +236,9 @@ class SvsFlatIndexNode : public IndexNode {
             return Status::faiss_inner_error;
         }
 
+        if (emb_list_strategy_ == nullptr) {
+            return LoadExternalIdMapFromLocalFile(base_cfg.external_id_map_file_path.value_or(""));
+        }
         return Status::success;
     }
 

--- a/src/index/svs/svs_vamana.cc
+++ b/src/index/svs/svs_vamana.cc
@@ -115,6 +115,14 @@ class SvsVamanaIndexNode : public IndexNode {
             LOG_KNOWHERE_ERROR_ << "Can not add data to empty index.";
             return Status::empty_index;
         }
+        auto old_rows = Count();
+        auto n = dataset->GetRows();
+        if (n == 0) {
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+            }
+            return Status::success;
+        }
 
         const SvsVamanaConfig& v_cfg = static_cast<const SvsVamanaConfig&>(*cfg);
         bool is_cosine = IsMetricType(v_cfg.metric_type.value(), knowhere::metric::COSINE);
@@ -123,7 +131,6 @@ class SvsVamanaIndexNode : public IndexNode {
         }
 
         auto x = dataset->GetTensor();
-        auto n = dataset->GetRows();
         try {
             index_->add(n, (const float*)x);
         } catch (const std::exception& e) {
@@ -131,6 +138,9 @@ class SvsVamanaIndexNode : public IndexNode {
             return Status::faiss_inner_error;
         }
 
+        if (emb_list_strategy_ == nullptr) {
+            RETURN_IF_ERROR(AddExternalIdMapFromDataset(dataset, old_rows));
+        }
         return Status::success;
     }
 
@@ -148,6 +158,8 @@ class SvsVamanaIndexNode : public IndexNode {
         auto x = dataset->GetTensor();
         auto dim = dataset->GetDim();
         bool is_cosine = IsMetricType(v_cfg.metric_type.value(), knowhere::metric::COSINE);
+        BitsetView mapped_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(mapped_bitset);
 
         auto ids = std::make_unique<int64_t[]>(k * nq);
         auto distances = std::make_unique<float[]>(k * nq);
@@ -173,8 +185,8 @@ class SvsVamanaIndexNode : public IndexNode {
                     sp.search_window_size = v_cfg.svs_search_window_size.value();
                     sp.search_buffer_capacity = v_cfg.svs_search_buffer_capacity.value();
                     std::unique_ptr<BitsetViewIDSelector> bw_idselector;
-                    if (!bitset.empty()) {
-                        bw_idselector = std::make_unique<BitsetViewIDSelector>(bitset);
+                    if (!mapped_bitset.empty()) {
+                        bw_idselector = std::make_unique<BitsetViewIDSelector>(mapped_bitset);
                         sp.sel = bw_idselector.get();
                     }
 
@@ -187,6 +199,7 @@ class SvsVamanaIndexNode : public IndexNode {
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
         }
 
+        external_id_map_.MapResultIds(ids.get(), k * nq);
         return GenResultDataSet(nq, k, std::move(ids), std::move(distances));
     }
 
@@ -206,6 +219,8 @@ class SvsVamanaIndexNode : public IndexNode {
         auto range_filter = v_cfg.range_filter.value();
         bool is_cosine = IsMetricType(v_cfg.metric_type.value(), knowhere::metric::COSINE);
         bool is_similarity = faiss::cppcontrib::knowhere::is_similarity_metric(index_->metric_type);
+        BitsetView mapped_bitset(bitset);
+        external_id_map_.SetOutIdsToBitset(mapped_bitset);
 
         std::vector<std::vector<float>> result_dist_array(nq);
         std::vector<std::vector<int64_t>> result_id_array(nq);
@@ -229,8 +244,8 @@ class SvsVamanaIndexNode : public IndexNode {
                     sp.search_window_size = v_cfg.svs_search_window_size.value();
                     sp.search_buffer_capacity = v_cfg.svs_search_buffer_capacity.value();
                     std::unique_ptr<BitsetViewIDSelector> bw_idselector;
-                    if (!bitset.empty()) {
-                        bw_idselector = std::make_unique<BitsetViewIDSelector>(bitset);
+                    if (!mapped_bitset.empty()) {
+                        bw_idselector = std::make_unique<BitsetViewIDSelector>(mapped_bitset);
                         sp.sel = bw_idselector.get();
                     }
 
@@ -251,6 +266,7 @@ class SvsVamanaIndexNode : public IndexNode {
                 }));
             }
             WaitAllSuccess(futs);
+            external_id_map_.MapResultIds(result_id_array);
             auto range_search_result =
                 GetRangeSearchResult(result_dist_array, result_id_array, is_similarity, nq, radius, range_filter);
             return GenResultDataSet(nq, std::move(range_search_result));
@@ -292,6 +308,9 @@ class SvsVamanaIndexNode : public IndexNode {
             faiss::write_index(index_.get(), &writer);
             std::shared_ptr<uint8_t[]> data(writer.data());
             binset.Append(Type(), data, writer.tellg());
+            if (emb_list_strategy_ == nullptr) {
+                RETURN_IF_ERROR(AppendExternalIdMapToBinarySet(binset, meta::EXTERNAL_ID_MAP));
+            }
             return Status::success;
         } catch (const std::exception& e) {
             LOG_KNOWHERE_WARNING_ << "error inner faiss: " << e.what();
@@ -319,6 +338,9 @@ class SvsVamanaIndexNode : public IndexNode {
             return Status::faiss_inner_error;
         }
 
+        if (emb_list_strategy_ == nullptr) {
+            return LoadExternalIdMapFromBinarySet(binset, meta::EXTERNAL_ID_MAP);
+        }
         return Status::success;
     }
 
@@ -352,6 +374,9 @@ class SvsVamanaIndexNode : public IndexNode {
             return Status::faiss_inner_error;
         }
 
+        if (emb_list_strategy_ == nullptr) {
+            return LoadExternalIdMapFromLocalFile(base_cfg.external_id_map_file_path.value_or(""));
+        }
         return Status::success;
     }
 

--- a/tests/ut/test_faiss_hnsw.cc
+++ b/tests/ut/test_faiss_hnsw.cc
@@ -2354,7 +2354,7 @@ TEST_CASE("External ID Map for 1-hop Bitset Check", "[external_id_map]") {
 #endif
 
             // Verify the external id mapping
-            std::shared_ptr<std::vector<uint32_t>> external_id_map = index.Node()->GetInternalIdToExternalIdMap();
+            std::shared_ptr<std::vector<int32_t>> external_id_map = index.Node()->GetInternalIdToExternalIdMap();
             REQUIRE(external_id_map != nullptr);
             REQUIRE(external_id_map->size() == NB);
 
@@ -2407,16 +2407,18 @@ TEST_CASE("External ID Map for 1-hop Bitset Check", "[external_id_map]") {
                          ++selected_partition_idx) {
                         printf("selected_partition_idx: %d\n", selected_partition_idx);
 
-                        std::vector<uint32_t> internal_id_to_most_external_id_map(NB, 1);
+                        std::vector<int32_t> internal_id_to_emb_list_id_map(NB, 1);
                         for (int64_t i = 0; i < NB; ++i) {
                             if (external_id_map->at(i) < valid_cnt &&
                                 std::find(scalar_info[0][selected_partition_idx].begin(),
                                           scalar_info[0][selected_partition_idx].end(),
                                           external_id_map->at(i)) != scalar_info[0][selected_partition_idx].end()) {
-                                internal_id_to_most_external_id_map[i] = 0;
+                                internal_id_to_emb_list_id_map[i] = 0;
                             }
                         }
-                        index.Node()->SetInternalIdToMostExternalIdMap(std::move(internal_id_to_most_external_id_map));
+                        knowhere::ExternalIdMap id_map;
+                        id_map.SetInternalToEmbListIds(std::move(internal_id_to_emb_list_id_map));
+                        index.Node()->SetExternalIdMap(std::move(id_map));
                         auto knn_result = index.Search(query_dataset, conf, bitset_view).value();
                         check_mv_only_result(knn_result, selected_partition_idx);
 
@@ -2424,13 +2426,15 @@ TEST_CASE("External ID Map for 1-hop Bitset Check", "[external_id_map]") {
                         check_mv_only_result(range_result, selected_partition_idx);
                     }
                 } else {
-                    std::vector<uint32_t> internal_id_to_most_external_id_map(NB, 1);
+                    std::vector<int32_t> internal_id_to_emb_list_id_map(NB, 1);
                     for (int64_t i = 0; i < NB; ++i) {
                         if (external_id_map->at(i) < valid_cnt) {
-                            internal_id_to_most_external_id_map[i] = 0;
+                            internal_id_to_emb_list_id_map[i] = 0;
                         }
                     }
-                    index.Node()->SetInternalIdToMostExternalIdMap(std::move(internal_id_to_most_external_id_map));
+                    knowhere::ExternalIdMap id_map;
+                    id_map.SetInternalToEmbListIds(std::move(internal_id_to_emb_list_id_map));
+                    index.Node()->SetExternalIdMap(std::move(id_map));
                     auto knn_result = index.Search(query_dataset, conf, bitset_view).value();
                     check_not_mv_only_result(knn_result);
 

--- a/tests/ut/test_nullable_external_id_map.cc
+++ b/tests/ut/test_nullable_external_id_map.cc
@@ -1,0 +1,3076 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and limitations under the License.
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <functional>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "catch2/catch_approx.hpp"
+#include "catch2/catch_test_macros.hpp"
+#ifdef KNOWHERE_WITH_CARDINAL
+#include "cachinglayer/Manager.h"
+#endif
+#include "filemanager/impl/LocalFileManager.h"
+#include "knowhere/binaryset.h"
+#include "knowhere/bitsetview.h"
+#include "knowhere/comp/brute_force.h"
+#include "knowhere/comp/index_param.h"
+#include "knowhere/dataset.h"
+#include "knowhere/expected.h"
+#include "knowhere/external_id_map.h"
+#include "knowhere/index/index_factory.h"
+#include "knowhere/index/index_node_data_mock_wrapper.h"
+#include "knowhere/index/index_node_thread_pool_wrapper.h"
+#include "knowhere/object.h"
+#include "knowhere/version.h"
+#include "utils.h"
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#error "Missing the <filesystem> header."
+#endif
+
+namespace {
+
+using knowhere::Status;
+
+class NullableWrapperFakeIndexNode : public knowhere::IndexNode {
+ public:
+    Status
+    Train(const knowhere::DataSetPtr dataset, std::shared_ptr<knowhere::Config> cfg,
+          bool use_knowhere_build_pool) override {
+        return Status::success;
+    }
+
+    Status
+    Add(const knowhere::DataSetPtr dataset, std::shared_ptr<knowhere::Config> cfg,
+        bool use_knowhere_build_pool) override {
+        return Status::success;
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    Search(const knowhere::DataSetPtr dataset, std::unique_ptr<knowhere::Config> cfg,
+           const knowhere::BitsetView& bitset, milvus::OpContext* op_context) const override {
+        return knowhere::expected<knowhere::DataSetPtr>::Err(Status::not_implemented,
+                                                             "Search not implemented");
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    RangeSearch(const knowhere::DataSetPtr dataset, std::unique_ptr<knowhere::Config> cfg,
+                const knowhere::BitsetView& bitset, milvus::OpContext* op_context) const override {
+        return knowhere::expected<knowhere::DataSetPtr>::Err(Status::not_implemented,
+                                                             "RangeSearch not implemented");
+    }
+
+    knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
+    AnnIterator(const knowhere::DataSetPtr dataset, std::unique_ptr<knowhere::Config> cfg,
+                const knowhere::BitsetView& bitset, bool use_knowhere_search_pool,
+                milvus::OpContext* op_context) const override {
+        return knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>::Err(
+            Status::not_implemented, "AnnIterator not implemented");
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    GetVectorByIds(const knowhere::DataSetPtr dataset, milvus::OpContext* op_context) const override {
+        return knowhere::expected<knowhere::DataSetPtr>::Err(Status::not_implemented,
+                                                             "GetVectorByIds not implemented");
+    }
+
+    bool
+    HasRawData(const std::string& metric_type) const override {
+        return true;
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    GetIndexMeta(std::unique_ptr<knowhere::Config> cfg) const override {
+        return knowhere::expected<knowhere::DataSetPtr>::Err(Status::not_implemented,
+                                                             "GetIndexMeta not implemented");
+    }
+
+    Status
+    Serialize(knowhere::BinarySet& binset) const override {
+        return Status::success;
+    }
+
+    Status
+    Deserialize(const knowhere::BinarySet& binset, std::shared_ptr<knowhere::Config> config) override {
+        return Status::success;
+    }
+
+    Status
+    DeserializeFromFile(const std::string& filename, std::shared_ptr<knowhere::Config> config) override {
+        return Status::success;
+    }
+
+    std::unique_ptr<knowhere::BaseConfig>
+    CreateConfig() const override {
+        return std::make_unique<knowhere::BaseConfig>();
+    }
+
+    int64_t
+    Dim() const override {
+        return 0;
+    }
+
+    int64_t
+    Size() const override {
+        return 0;
+    }
+
+    int64_t
+    Count() const override {
+        return 0;
+    }
+
+    std::string
+    Type() const override {
+        return "NULLABLE_WRAPPER_FAKE";
+    }
+};
+
+constexpr int64_t kTotalRows = 32;
+constexpr int64_t kDenseDim = 16;
+constexpr int64_t kGpuRows = 64;
+constexpr int64_t kGpuDim = 32;
+constexpr int64_t kFileRows = 64;
+constexpr int64_t kFileDim = 32;
+constexpr int64_t kEmbDocs = 16;
+constexpr int64_t kEmbVectorsPerDoc = 2;
+constexpr int64_t kTopK = 3;
+constexpr int64_t kEmbTopK = 2;
+constexpr int64_t kQueryCount = 3;
+
+enum class DataKind {
+    DenseFp32,
+    DenseBin,
+    Sparse,
+    MinHash,
+    DiskAnn,
+    Aisaq,
+    GpuFp32,
+};
+
+enum class Mode {
+    Vector,
+    EmbList,
+    MultiIndex,
+};
+
+enum class Operation {
+    Build,
+    Search,
+    Range,
+    Iterator,
+    SearchFilter,
+    RangeFilter,
+    IteratorFilter,
+    BinarySetSerialize,
+    BinarySetDeserialize,
+    FileSerialize,
+    FileDeserialize,
+};
+
+enum class IndexSource {
+    Fresh,
+    BinarySet,
+    File,
+};
+
+enum class NullableRatio {
+    R0,
+    R50,
+    R100,
+};
+
+enum class FilterRatio {
+    None,
+    R0,
+    R50,
+    R100,
+    Collapsed,
+};
+
+struct Capabilities {
+    bool build = false;
+    bool search = false;
+    bool range = false;
+    bool iterator = false;
+    bool search_filter = false;
+    bool range_filter = false;
+    bool iterator_filter = false;
+    bool binaryset_serialize = false;
+    bool binaryset_deserialize = false;
+    bool file_serialize = false;
+    bool file_deserialize = false;
+    bool emb_build = false;
+    bool emb_search = false;
+    bool emb_range = false;
+    bool emb_iterator = false;
+    bool emb_search_filter = false;
+    bool emb_range_filter = false;
+    bool emb_iterator_filter = false;
+    bool multi_build = false;
+    bool multi_search = false;
+    bool multi_range = false;
+    bool multi_iterator = false;
+    bool multi_search_filter = false;
+    bool multi_range_filter = false;
+    bool multi_iterator_filter = false;
+};
+
+struct IndexRow {
+    std::string label;
+    std::string index_type;
+    DataKind data_kind = DataKind::DenseFp32;
+    Capabilities caps;
+    bool maybe_unavailable = false;
+    bool requires_cardinal = false;
+    bool requires_svs = false;
+    bool requires_gpu = false;
+    bool exact = false;
+};
+
+struct Scenario {
+    std::string name;
+    NullableRatio nullable_ratio = NullableRatio::R0;
+    FilterRatio filter_ratio = FilterRatio::None;
+    Mode mode = Mode::Vector;
+    Operation op = Operation::Build;
+    IndexSource source = IndexSource::Fresh;
+};
+
+struct MatrixData {
+    int64_t total_count = 0;
+    int64_t dim = 0;
+    std::vector<int32_t> valid_ids;
+    std::vector<int32_t> query_ids;
+    std::vector<int32_t> selected_ids;
+    knowhere::DataSetPtr full_ds;
+    knowhere::DataSetPtr train_ds;
+    knowhere::DataSetPtr query_ds;
+};
+
+struct BuiltArtifact {
+    IndexRow row;
+    Scenario scenario;
+    MatrixData data;
+    knowhere::Json json;
+    knowhere::Index<knowhere::IndexNode> index;
+    knowhere::Index<knowhere::IndexNode> binary_loaded;
+    knowhere::Index<knowhere::IndexNode> file_loaded;
+    knowhere::BinarySet binset;
+    std::shared_ptr<milvus::FileManager> file_manager;
+    knowhere::Status create_status = knowhere::Status::success;
+    knowhere::Status build_status = knowhere::Status::success;
+    knowhere::Status serialize_status = knowhere::Status::success;
+    knowhere::Status binary_deserialize_status = knowhere::Status::success;
+    knowhere::Status file_serialize_status = knowhere::Status::success;
+    knowhere::Status file_deserialize_status = knowhere::Status::success;
+    bool create_ok = false;
+    bool serialized = false;
+    bool binary_loaded_ready = false;
+    bool file_serialized = false;
+    bool file_loaded_ready = false;
+    fs::path work_dir;
+    fs::path main_file;
+    fs::path id_map_file;
+    fs::path emb_meta_file;
+    fs::path emb_raw_file;
+    fs::path emb_offset_file;
+    fs::path raw_data_file;
+    fs::path file_index_prefix;
+};
+
+int32_t
+VersionForRow(const IndexRow& row) {
+#ifdef KNOWHERE_WITH_CARDINAL
+    if (!row.requires_cardinal &&
+        (row.index_type == knowhere::IndexEnum::INDEX_HNSW || row.index_type == knowhere::IndexEnum::INDEX_DISKANN)) {
+        return knowhere::Version::GetDefaultVersion().VersionNumber();
+    }
+    if (row.requires_cardinal || row.index_type == knowhere::IndexEnum::INDEX_CARDINAL_TIERED) {
+        return std::max(knowhere::Version::GetCurrentVersion().VersionNumber(), 9);
+    }
+#endif
+    return knowhere::Version::GetCurrentVersion().VersionNumber();
+}
+
+std::string
+NullableName(NullableRatio ratio) {
+    switch (ratio) {
+        case NullableRatio::R0:
+            return "nullable0";
+        case NullableRatio::R50:
+            return "nullable50";
+        case NullableRatio::R100:
+            return "nullable100";
+    }
+    return "nullable_unknown";
+}
+
+std::string
+FilterName(FilterRatio ratio) {
+    switch (ratio) {
+        case FilterRatio::None:
+            return "filter_none";
+        case FilterRatio::R0:
+            return "filter0";
+        case FilterRatio::R50:
+            return "filter50";
+        case FilterRatio::R100:
+            return "filter100";
+        case FilterRatio::Collapsed:
+            return "filter_collapsed";
+    }
+    return "filter_unknown";
+}
+
+std::string
+ModeName(Mode mode) {
+    switch (mode) {
+        case Mode::Vector:
+            return "vector";
+        case Mode::EmbList:
+            return "emblist";
+        case Mode::MultiIndex:
+            return "multi";
+    }
+    return "unknown_mode";
+}
+
+std::string
+SourceName(IndexSource source) {
+    switch (source) {
+        case IndexSource::Fresh:
+            return "fresh";
+        case IndexSource::BinarySet:
+            return "binary";
+        case IndexSource::File:
+            return "file";
+    }
+    return "unknown_source";
+}
+
+std::string
+OperationName(Operation op) {
+    switch (op) {
+        case Operation::Build:
+            return "build";
+        case Operation::Search:
+            return "search";
+        case Operation::Range:
+            return "range";
+        case Operation::Iterator:
+            return "iterator";
+        case Operation::SearchFilter:
+            return "search_filter";
+        case Operation::RangeFilter:
+            return "range_filter";
+        case Operation::IteratorFilter:
+            return "iterator_filter";
+        case Operation::BinarySetSerialize:
+            return "binaryset_serialize";
+        case Operation::BinarySetDeserialize:
+            return "binaryset_deserialize";
+        case Operation::FileSerialize:
+            return "file_serialize";
+        case Operation::FileDeserialize:
+            return "file_deserialize";
+    }
+    return "unknown_operation";
+}
+
+std::vector<int32_t>
+AllIds(int64_t count) {
+    std::vector<int32_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 0);
+    return ids;
+}
+
+std::vector<int32_t>
+SwappedEvenIds(int64_t count) {
+    std::vector<int32_t> ids;
+    ids.reserve((count + 1) / 2);
+    for (int32_t id = 0; id < count; id += 4) {
+        if (id + 2 < count) {
+            ids.push_back(id + 2);
+        }
+        ids.push_back(id);
+    }
+    return ids;
+}
+
+std::vector<int32_t>
+SwappedPairedIds(int64_t count) {
+    std::vector<int32_t> ids;
+    ids.reserve((count + 3) / 4 * 2);
+    for (int32_t id = 0; id < count; id += 8) {
+        if (id + 4 < count) {
+            ids.push_back(id + 4);
+        }
+        if (id + 5 < count) {
+            ids.push_back(id + 5);
+        }
+        ids.push_back(id);
+        if (id + 1 < count) {
+            ids.push_back(id + 1);
+        }
+    }
+    return ids;
+}
+
+std::vector<int32_t>
+ValidIdsFor(NullableRatio ratio, int64_t count, bool paired_for_multi = false) {
+    switch (ratio) {
+        case NullableRatio::R0:
+            return AllIds(count);
+        case NullableRatio::R50:
+            return paired_for_multi ? SwappedPairedIds(count) : SwappedEvenIds(count);
+        case NullableRatio::R100:
+            return {};
+    }
+    return {};
+}
+
+bool
+ContainsId(const std::vector<int32_t>& ids, int64_t id) {
+    return std::find(ids.begin(), ids.end(), static_cast<int32_t>(id)) != ids.end();
+}
+
+int64_t
+FirstMissingExternalId(const std::vector<int32_t>& valid_ids, int64_t total_count) {
+    for (int64_t id = 0; id < total_count; ++id) {
+        if (!ContainsId(valid_ids, id)) {
+            return id;
+        }
+    }
+    return total_count;
+}
+
+std::vector<int32_t>
+FirstQueryIds(const std::vector<int32_t>& valid_ids, int64_t total_count, int64_t query_count = kQueryCount) {
+    std::vector<int32_t> ids;
+    ids.reserve(query_count);
+    for (auto id : valid_ids) {
+        ids.push_back(id);
+        if (static_cast<int64_t>(ids.size()) == query_count) {
+            return ids;
+        }
+    }
+    for (int32_t id = 0; static_cast<int64_t>(ids.size()) < query_count && id < total_count; ++id) {
+        ids.push_back(id);
+    }
+    while (static_cast<int64_t>(ids.size()) < query_count) {
+        ids.push_back(0);
+    }
+    return ids;
+}
+
+std::vector<int32_t>
+PartitionIds(const std::vector<int32_t>& valid_ids, int partition) {
+    std::vector<int32_t> ids;
+    for (auto id : valid_ids) {
+        if ((id & 1) == partition) {
+            ids.push_back(id);
+        }
+    }
+    return ids;
+}
+
+void
+FillDenseVector(float* data, int64_t row, int64_t dim, int32_t logical_id) {
+    auto* dst = data + row * dim;
+    std::fill(dst, dst + dim, 0.0f);
+    dst[0] = static_cast<float>(logical_id * 100 + 1);
+    dst[logical_id % dim] += 1.0f;
+}
+
+knowhere::DataSetPtr
+GenFullDenseDataSet(int64_t total_count, int64_t dim) {
+    auto data = std::make_unique<float[]>(std::max<int64_t>(total_count * dim, 1));
+    for (int64_t logical_id = 0; logical_id < total_count; ++logical_id) {
+        FillDenseVector(data.get(), logical_id, dim, static_cast<int32_t>(logical_id));
+    }
+    auto ds = knowhere::GenDataSet(total_count, dim, data.release());
+    ds->SetIsOwner(true);
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenNullableDenseDataSet(int64_t total_count, const std::vector<int32_t>& valid_ids, int64_t dim) {
+    const auto rows = static_cast<int64_t>(valid_ids.size());
+    auto data = std::make_unique<float[]>(std::max<int64_t>(rows * dim, 1));
+    for (int64_t row = 0; row < rows; ++row) {
+        FillDenseVector(data.get(), row, dim, valid_ids[row]);
+    }
+    auto ds = knowhere::GenDataSet(rows, dim, data.release());
+    ds->SetIsOwner(true);
+    if (rows != total_count) {
+        ds->SetInternalToExternalIds(valid_ids, static_cast<size_t>(total_count));
+    }
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenDenseQueryDataSet(const std::vector<int32_t>& logical_ids, int64_t dim) {
+    auto data = std::make_unique<float[]>(std::max<int64_t>(static_cast<int64_t>(logical_ids.size()) * dim, 1));
+    for (int64_t row = 0; row < static_cast<int64_t>(logical_ids.size()); ++row) {
+        FillDenseVector(data.get(), row, dim, logical_ids[row]);
+    }
+    auto ds = knowhere::GenDataSet(static_cast<int64_t>(logical_ids.size()), dim, data.release());
+    ds->SetIsOwner(true);
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenNullableBinaryDataSet(int64_t total_count, const std::vector<int32_t>& valid_ids, int64_t dim,
+                         const knowhere::DataSetPtr& full_ds, std::vector<uint8_t>& owned_data) {
+    const auto bytes_per_row = dim / 8;
+    const auto* full_data = static_cast<const uint8_t*>(full_ds->GetTensor());
+    owned_data.assign(std::max<int64_t>(static_cast<int64_t>(valid_ids.size()) * bytes_per_row, 1), 0);
+    for (size_t i = 0; i < valid_ids.size(); ++i) {
+        std::memcpy(owned_data.data() + i * bytes_per_row, full_data + valid_ids[i] * bytes_per_row, bytes_per_row);
+    }
+    auto ds = knowhere::GenDataSet(static_cast<int64_t>(valid_ids.size()), dim, owned_data.data());
+    ds->SetIsOwner(false);
+    if (static_cast<int64_t>(valid_ids.size()) != total_count) {
+        ds->SetInternalToExternalIds(valid_ids, static_cast<size_t>(total_count));
+    }
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenBinaryQueryDataSet(const std::vector<int32_t>& query_ids, int64_t dim, const knowhere::DataSetPtr& full_ds,
+                      std::vector<uint8_t>& owned_data) {
+    const auto bytes_per_row = dim / 8;
+    const auto* full_data = static_cast<const uint8_t*>(full_ds->GetTensor());
+    owned_data.assign(std::max<int64_t>(static_cast<int64_t>(query_ids.size()) * bytes_per_row, 1), 0);
+    for (size_t i = 0; i < query_ids.size(); ++i) {
+        std::memcpy(owned_data.data() + i * bytes_per_row, full_data + query_ids[i] * bytes_per_row, bytes_per_row);
+    }
+    auto ds = knowhere::GenDataSet(static_cast<int64_t>(query_ids.size()), dim, owned_data.data());
+    ds->SetIsOwner(false);
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenNullableSparseDataSet(int64_t total_count, const std::vector<int32_t>& valid_ids) {
+    std::vector<std::map<int32_t, float>> rows;
+    rows.reserve(valid_ids.size());
+    for (auto logical_id : valid_ids) {
+        rows.push_back({{logical_id + 1, 1.0f}});
+    }
+    auto ds = GenSparseDataSet(rows, static_cast<int32_t>(total_count + 2));
+    if (static_cast<int64_t>(valid_ids.size()) != total_count) {
+        ds->SetInternalToExternalIds(valid_ids, static_cast<size_t>(total_count));
+    }
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenSparseQueryDataSet(const std::vector<int32_t>& logical_ids, int64_t total_count) {
+    std::vector<std::map<int32_t, float>> rows;
+    rows.reserve(logical_ids.size());
+    for (auto logical_id : logical_ids) {
+        rows.push_back({{logical_id + 1, 1.0f}});
+    }
+    return GenSparseDataSet(rows, static_cast<int32_t>(total_count + 2));
+}
+
+knowhere::DataSetPtr
+GenNullableEmbListDataSet(int64_t total_docs, const std::vector<int32_t>& valid_doc_ids, int64_t dim,
+                          int64_t vectors_per_doc) {
+    const auto rows = static_cast<int64_t>(valid_doc_ids.size()) * vectors_per_doc;
+    auto data = std::make_unique<float[]>(std::max<int64_t>(rows * dim, 1));
+    std::vector<size_t> offsets(valid_doc_ids.size() + 1, 0);
+    for (size_t doc = 0; doc < valid_doc_ids.size(); ++doc) {
+        offsets[doc] = doc * vectors_per_doc;
+        for (int64_t v = 0; v < vectors_per_doc; ++v) {
+            FillDenseVector(data.get(), static_cast<int64_t>(doc) * vectors_per_doc + v, dim, valid_doc_ids[doc]);
+        }
+    }
+    offsets[valid_doc_ids.size()] = static_cast<size_t>(rows);
+    auto ds = knowhere::GenDataSet(rows, dim, data.release());
+    ds->SetIsOwner(true);
+    auto offset_data = std::make_unique<size_t[]>(offsets.size());
+    std::copy(offsets.begin(), offsets.end(), offset_data.get());
+    ds->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(offset_data.release()));
+    if (static_cast<int64_t>(valid_doc_ids.size()) != total_docs) {
+        ds->SetInternalToExternalIds(valid_doc_ids, static_cast<size_t>(total_docs));
+    }
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenEmbListQueryDataSet(const std::vector<int32_t>& logical_doc_ids, int64_t dim) {
+    auto ds = GenDenseQueryDataSet(logical_doc_ids, dim);
+    auto offsets = std::make_unique<size_t[]>(logical_doc_ids.size() + 1);
+    for (size_t i = 0; i <= logical_doc_ids.size(); ++i) {
+        offsets[i] = i;
+    }
+    ds->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(offsets.release()));
+    return ds;
+}
+
+std::unordered_map<int64_t, std::vector<std::vector<uint32_t>>>
+ScalarInfoForEvenOddPartitions(const std::vector<int32_t>& valid_ids) {
+    std::unordered_map<int64_t, std::vector<std::vector<uint32_t>>> scalar_info;
+    scalar_info[0].resize(2);
+    for (size_t row = 0; row < valid_ids.size(); ++row) {
+        scalar_info[0][valid_ids[row] & 1].push_back(static_cast<uint32_t>(row));
+    }
+    return scalar_info;
+}
+
+std::vector<uint8_t>
+MakeBitmap(size_t total_count, const std::vector<int32_t>& filtered_ids) {
+    std::vector<uint8_t> bitmap((total_count + 7) / 8, 0);
+    for (auto id : filtered_ids) {
+        if (id >= 0 && static_cast<size_t>(id) < total_count) {
+            bitmap[id >> 3] |= static_cast<uint8_t>(1U << (id & 7));
+        }
+    }
+    return bitmap;
+}
+
+std::vector<int32_t>
+HalfFilteredIds(size_t total_count, const std::vector<int32_t>& candidate_ids) {
+    std::vector<int32_t> ids;
+    const auto target = candidate_ids.size() / 2;
+    ids.reserve(target);
+    for (size_t i = 0; i < candidate_ids.size() && ids.size() < target; i += 2) {
+        ids.push_back(candidate_ids[i]);
+    }
+    return ids;
+}
+
+std::vector<int32_t>
+FilterIdsFor(FilterRatio filter_ratio, int64_t total_count, const std::vector<int32_t>& valid_ids, Mode mode,
+             const std::vector<int32_t>& selected_ids) {
+    if (filter_ratio == FilterRatio::None || filter_ratio == FilterRatio::R0) {
+        if (mode != Mode::MultiIndex) {
+            return {};
+        }
+    }
+    if (filter_ratio == FilterRatio::R100 || filter_ratio == FilterRatio::Collapsed) {
+        return AllIds(total_count);
+    }
+
+    std::vector<int32_t> filtered_ids;
+    if (mode == Mode::MultiIndex) {
+        std::set<int32_t> selected(selected_ids.begin(), selected_ids.end());
+        for (int32_t id = 0; id < total_count; ++id) {
+            if (selected.find(id) == selected.end()) {
+                filtered_ids.push_back(id);
+            }
+        }
+        if (filter_ratio == FilterRatio::R50) {
+            auto half_selected = HalfFilteredIds(total_count, selected_ids);
+            filtered_ids.insert(filtered_ids.end(), half_selected.begin(), half_selected.end());
+        }
+        return filtered_ids;
+    }
+
+    if (filter_ratio == FilterRatio::R50) {
+        return HalfFilteredIds(total_count, valid_ids);
+    }
+    return {};
+}
+
+std::vector<int32_t>
+AllowedIdsAfterFilter(const std::vector<int32_t>& valid_ids, const std::vector<int32_t>& filtered_ids) {
+    std::vector<int32_t> allowed;
+    for (auto id : valid_ids) {
+        if (!ContainsId(filtered_ids, id)) {
+            allowed.push_back(id);
+        }
+    }
+    return allowed;
+}
+
+knowhere::BitsetView
+BitsetViewFrom(std::vector<uint8_t>& bitmap, int64_t total_count, const std::vector<int32_t>& filtered_ids) {
+    bitmap = MakeBitmap(total_count, filtered_ids);
+    return knowhere::BitsetView(bitmap.data(), total_count);
+}
+
+knowhere::Json
+BaseDenseConfig(const std::string& metric = knowhere::metric::L2, int64_t dim = kDenseDim, int64_t topk = kTopK) {
+    knowhere::Json json;
+    json[knowhere::meta::DIM] = dim;
+    json[knowhere::meta::METRIC_TYPE] = metric;
+    json[knowhere::meta::TOPK] = topk;
+    json[knowhere::meta::RADIUS] = 100000000.0f;
+    json[knowhere::meta::RANGE_FILTER] = 0.0f;
+    json[knowhere::meta::RANGE_SEARCH_K] = 64;
+    return json;
+}
+
+knowhere::Json
+DenseConfigFor(const IndexRow& row, Mode mode) {
+    const auto dim = row.data_kind == DataKind::GpuFp32 ? kGpuDim : kDenseDim;
+    auto json = BaseDenseConfig(mode == Mode::EmbList ? "MAX_SIM_L2" : knowhere::metric::L2, dim,
+                                mode == Mode::EmbList ? kEmbTopK : kTopK);
+    if (row.index_type == knowhere::IndexEnum::INDEX_FAISS) {
+        json["faiss_index_name"] = "Flat";
+        return json;
+    }
+    json[knowhere::meta::INDEX_TYPE] = row.index_type;
+    json[knowhere::indexparam::NLIST] = 4;
+    json[knowhere::indexparam::NPROBE] = 4;
+    json[knowhere::indexparam::HNSW_M] = 8;
+    json[knowhere::indexparam::EFCONSTRUCTION] = 40;
+    json[knowhere::indexparam::EF] = 64;
+    json[knowhere::indexparam::M] = 4;
+    json[knowhere::indexparam::NBITS] = 4;
+    json[knowhere::indexparam::PRQ_NUM] = 2;
+    json[knowhere::indexparam::SQ_TYPE] = "SQ8";
+    json[knowhere::indexparam::REORDER_K] = 8;
+    json[knowhere::indexparam::SUB_DIM] = 2;
+    json[knowhere::indexparam::WITH_RAW_DATA] = true;
+    json[knowhere::indexparam::ENSURE_TOPK_FULL] = true;
+    json[knowhere::indexparam::REFINE_RATIO] = 2.0f;
+    json[knowhere::indexparam::RETRIEVAL_ANN_RATIO] = 2.0f;
+    if (mode == Mode::EmbList) {
+        json["emb_list_strategy"] = knowhere::meta::EMB_LIST_STRATEGY_TOKENANN;
+    }
+
+    if (row.index_type == "IVF_SQ") {
+        json[knowhere::indexparam::SQ_TYPE] = "SQ8";
+    }
+    if (row.index_type == knowhere::IndexEnum::INDEX_SVS_VAMANA ||
+        row.index_type == knowhere::IndexEnum::INDEX_SVS_VAMANA_LVQ ||
+        row.index_type == knowhere::IndexEnum::INDEX_SVS_VAMANA_LEANVEC) {
+        json[knowhere::indexparam::SVS_GRAPH_MAX_DEGREE] = 16;
+        json[knowhere::indexparam::SVS_CONSTRUCTION_WINDOW_SIZE] = 40;
+        json[knowhere::indexparam::SVS_SEARCH_WINDOW_SIZE] = 40;
+        json[knowhere::indexparam::SVS_SEARCH_BUFFER_CAPACITY] = 40;
+        json[knowhere::indexparam::SVS_ALPHA] = 1.2f;
+        json[knowhere::indexparam::SVS_STORAGE_KIND] = std::string("fp32");
+        if (row.index_type == knowhere::IndexEnum::INDEX_SVS_VAMANA_LEANVEC) {
+            json[knowhere::indexparam::SVS_LEANVEC_DIM] = 8;
+        }
+    }
+    if (row.data_kind == DataKind::GpuFp32) {
+        json[knowhere::meta::DIM] = kGpuDim;
+        json[knowhere::meta::RADIUS] = 100000000.0f;
+        if (row.index_type == knowhere::IndexEnum::INDEX_CUVS_CAGRA ||
+            row.index_type == knowhere::IndexEnum::INDEX_GPU_CAGRA) {
+            json[knowhere::indexparam::INTERMEDIATE_GRAPH_DEGREE] = 32;
+            json[knowhere::indexparam::GRAPH_DEGREE] = 16;
+            json[knowhere::indexparam::ITOPK_SIZE] = 32;
+        }
+    }
+    return json;
+}
+
+knowhere::Json
+BinaryConfigFor(const IndexRow& row) {
+    knowhere::Json json;
+    const auto dim = row.index_type == knowhere::IndexEnum::INDEX_MINHASH_LSH ? 1024 : 128;
+    json[knowhere::meta::DIM] = dim;
+    json[knowhere::meta::METRIC_TYPE] = row.index_type == knowhere::IndexEnum::INDEX_MINHASH_LSH
+                                            ? knowhere::metric::MHJACCARD
+                                            : knowhere::metric::HAMMING;
+    json[knowhere::meta::TOPK] = kTopK;
+    json[knowhere::meta::RADIUS] = 1024.0f;
+    json[knowhere::meta::RANGE_FILTER] = 0.0f;
+    if (row.index_type == knowhere::IndexEnum::INDEX_FAISS) {
+        json["faiss_index_name"] = "BFlat";
+        return json;
+    }
+    json[knowhere::indexparam::NLIST] = 4;
+    json[knowhere::indexparam::NPROBE] = 4;
+    json["faiss_index_name"] = "Flat";
+    json["refine_k"] = 12;
+    json["mh_lsh_band"] = 4;
+    json["mh_element_bit_width"] = 32;
+    json["mh_search_with_jaccard"] = true;
+    json["mh_lsh_batch_search"] = true;
+    json["mh_lsh_aligned_block_size"] = 4096;
+    json["mh_lsh_shared_bloom_filter"] = true;
+    json["mh_lsh_bloom_false_positive_prob"] = 0.01;
+    json["with_raw_data"] = true;
+    json["hash_code_in_memory"] = true;
+    return json;
+}
+
+knowhere::Json
+SparseConfig() {
+    knowhere::Json json;
+    json[knowhere::meta::DIM] = kTotalRows + 2;
+    json[knowhere::meta::METRIC_TYPE] = knowhere::metric::IP;
+    json[knowhere::meta::TOPK] = kTopK;
+    json[knowhere::meta::RADIUS] = 0.5f;
+    json[knowhere::meta::RANGE_FILTER] = 2.0f;
+    json[knowhere::indexparam::DROP_RATIO_BUILD] = 0.0f;
+    json[knowhere::indexparam::DROP_RATIO_SEARCH] = 0.0f;
+    json[knowhere::indexparam::INVERTED_INDEX_ALGO] = "DAAT_MAXSCORE";
+    return json;
+}
+
+knowhere::Json
+DiskAnnConfig(const IndexRow& row, const fs::path& raw_data_file, const fs::path& index_prefix) {
+    auto json = BaseDenseConfig(knowhere::metric::L2, kFileDim, kTopK);
+    json[knowhere::meta::INDEX_TYPE] = row.index_type;
+    json[knowhere::meta::DATA_PATH] = raw_data_file.string();
+    json[knowhere::meta::INDEX_PREFIX] = index_prefix.string();
+    json[knowhere::indexparam::MAX_DEGREE] = 16;
+    json[knowhere::indexparam::SEARCH_LIST_SIZE] = 32;
+    json[knowhere::indexparam::PQ_CODE_BUDGET_GB] = 0.01;
+    json[knowhere::indexparam::SEARCH_CACHE_BUDGET_GB] = 0.0;
+    json[knowhere::indexparam::BUILD_DRAM_BUDGET_GB] = 1.0;
+    json[knowhere::indexparam::BEAMWIDTH] = 8;
+    json["min_k"] = 3;
+    json["max_k"] = 64;
+    if (row.data_kind == DataKind::Aisaq) {
+        json[knowhere::indexparam::REARRANGE] = false;
+        json[knowhere::indexparam::INLINE_PQ] = 0;
+        json[knowhere::indexparam::PQ_CACHE_SIZE] = 0;
+        json[knowhere::indexparam::PQ_READ_PAGE_CACHE_SIZE] = 0;
+        json[knowhere::indexparam::VECTORS_BEAMWIDTH] = 4;
+    }
+    return json;
+}
+
+Capabilities
+VectorCaps(bool range, bool iterator, bool search_filter, bool range_filter, bool iterator_filter,
+           bool binaryset_io, bool file_io) {
+    Capabilities caps;
+    caps.build = true;
+    caps.search = true;
+    caps.range = range;
+    caps.iterator = iterator;
+    caps.search_filter = search_filter;
+    caps.range_filter = range_filter;
+    caps.iterator_filter = iterator_filter;
+    caps.binaryset_serialize = binaryset_io;
+    caps.binaryset_deserialize = binaryset_io;
+    caps.file_serialize = file_io;
+    caps.file_deserialize = file_io;
+    return caps;
+}
+
+void
+AddEmbCaps(Capabilities& caps, bool search, bool range, bool iterator, bool search_filter, bool range_filter,
+           bool iterator_filter) {
+    caps.emb_build = search || range || iterator || search_filter || range_filter || iterator_filter;
+    caps.emb_search = search;
+    caps.emb_range = range;
+    caps.emb_iterator = iterator;
+    caps.emb_search_filter = search_filter;
+    caps.emb_range_filter = range_filter;
+    caps.emb_iterator_filter = iterator_filter;
+}
+
+void
+AddMultiCaps(Capabilities& caps, bool search, bool range, bool iterator, bool search_filter, bool range_filter,
+             bool iterator_filter) {
+    caps.multi_build = search || range || iterator || search_filter || range_filter || iterator_filter;
+    caps.multi_search = search;
+    caps.multi_range = range;
+    caps.multi_iterator = iterator;
+    caps.multi_search_filter = search_filter;
+    caps.multi_range_filter = range_filter;
+    caps.multi_iterator_filter = iterator_filter;
+}
+
+std::vector<IndexRow>
+IndexRows() {
+    std::vector<IndexRow> rows;
+    auto add = [&](IndexRow row) {
+        rows.push_back(std::move(row));
+    };
+
+    auto flat = VectorCaps(true, false, true, true, false, true, true);
+    add({"FLAT", knowhere::IndexEnum::INDEX_FAISS_IDMAP, DataKind::DenseFp32, flat, false, false, false, false, true});
+    add({"BIN_FLAT / BINFLAT", knowhere::IndexEnum::INDEX_FAISS_BIN_IDMAP, DataKind::DenseBin,
+         flat, false, false, false, false, false});
+    add({"FAISS (fp32)", knowhere::IndexEnum::INDEX_FAISS, DataKind::DenseFp32, flat, false, false, false,
+         false, true});
+    auto faiss_bin = VectorCaps(false, false, true, false, false, true, true);
+    add({"FAISS (bin1)", knowhere::IndexEnum::INDEX_FAISS, DataKind::DenseBin, faiss_bin});
+
+    add({"BIN_IVF_FLAT / IVFBIN", knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT, DataKind::DenseBin,
+         VectorCaps(true, false, true, true, false, true, true)});
+    auto ivf_flat = VectorCaps(true, true, true, true, true, true, true);
+    AddEmbCaps(ivf_flat, true, false, false, true, false, false);
+    add({"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32, ivf_flat});
+    add({"IVF_FLAT_CC / IVFFLATCC", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, DataKind::DenseFp32, ivf_flat});
+    add({"IVF_PQ / IVFPQ", knowhere::IndexEnum::INDEX_FAISS_IVFPQ, DataKind::DenseFp32,
+         VectorCaps(true, false, true, true, false, true, true)});
+    add({"IVF_SQ8", knowhere::IndexEnum::INDEX_FAISS_IVFSQ8, DataKind::DenseFp32,
+         VectorCaps(true, true, true, true, true, true, true)});
+    add({"IVF_SQ / IVFSQ", "IVF_SQ", DataKind::DenseFp32,
+         VectorCaps(true, true, true, true, true, true, true)});
+    add({"IVF_SQ_CC", knowhere::IndexEnum::INDEX_FAISS_IVFSQ_CC, DataKind::DenseFp32,
+         VectorCaps(true, true, true, true, true, true, true)});
+    add({"IVF_RABITQ / IVFRABITQ", knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ, DataKind::DenseFp32,
+         VectorCaps(true, true, true, true, true, true, true)});
+    add({"IVF_RABITQ_FASTSCAN", knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ_FASTSCAN, DataKind::DenseFp32,
+         VectorCaps(true, false, true, true, false, true, true)});
+    add({"SCANN", knowhere::IndexEnum::INDEX_FAISS_SCANN, DataKind::DenseFp32,
+         VectorCaps(true, true, true, true, true, true, true), true});
+    auto scann_dvr = VectorCaps(true, true, true, true, true, false, false);
+    AddEmbCaps(scann_dvr, true, false, false, true, false, false);
+    add({"SCANN_DVR", knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, DataKind::DenseFp32, scann_dvr, true});
+
+    auto hnsw_native = VectorCaps(true, true, true, true, true, true, true);
+    AddMultiCaps(hnsw_native, true, true, true, true, true, true);
+    add({"HNSW (Knowhere/Faiss)", knowhere::IndexEnum::INDEX_HNSW, DataKind::DenseFp32, hnsw_native});
+    auto hnsw = hnsw_native;
+    AddEmbCaps(hnsw, true, false, false, true, false, false);
+    add({"HNSW_SQ", knowhere::IndexEnum::INDEX_HNSW_SQ, DataKind::DenseFp32, hnsw});
+    auto hnsw_quantized = VectorCaps(true, true, true, true, true, true, true);
+    AddEmbCaps(hnsw_quantized, true, false, false, true, false, false);
+    add({"HNSW_PQ", knowhere::IndexEnum::INDEX_HNSW_PQ, DataKind::DenseFp32, hnsw_quantized});
+    add({"HNSW_PRQ", knowhere::IndexEnum::INDEX_HNSW_PRQ, DataKind::DenseFp32, hnsw_quantized});
+    add({"HNSW_DEPRECATED", "HNSW_DEPRECATED", DataKind::DenseFp32, hnsw, true, true});
+    add({"HNSWLIB_DEPRECATED", "HNSWLIB_DEPRECATED", DataKind::DenseFp32,
+         VectorCaps(true, true, true, true, true, true, true)});
+    add({"HNSW_V1 sparse (Cardinal v1)", "HNSW_V1", DataKind::Sparse,
+         VectorCaps(true, true, true, true, true, true, true), true, true, false, false, true});
+
+    auto diskann = VectorCaps(true, true, true, true, true, false, true);
+    add({"DISKANN (Knowhere native)", knowhere::IndexEnum::INDEX_DISKANN, DataKind::DiskAnn, diskann});
+    add({"AISAQ", knowhere::IndexEnum::INDEX_AISAQ, DataKind::Aisaq,
+         VectorCaps(false, false, true, false, false, false, true)});
+    add({"DISKANN_DEPRECATED", "DISKANN_DEPRECATED", DataKind::DiskAnn, diskann, true, true});
+
+    add({"SPARSE_INVERTED_INDEX (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX,
+         DataKind::Sparse, VectorCaps(true, true, true, true, true, true, true), false, false, false, false, true});
+    add({"SPARSE_WAND (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_WAND, DataKind::Sparse,
+         VectorCaps(true, true, true, true, true, true, true), false, false, false, false, true});
+    add({"SPARSE_INVERTED_INDEX_CC (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC,
+         DataKind::Sparse, VectorCaps(true, true, true, true, true, false, false), false, false, false, false, true});
+    add({"SPARSE_WAND_CC (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_WAND_CC, DataKind::Sparse,
+         VectorCaps(true, true, true, true, true, false, false), false, false, false, false, true});
+    add({"SPARSE_INVERTED_INDEX (Cardinal v1)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX,
+         DataKind::Sparse, VectorCaps(true, true, true, true, true, true, true), true, true, false, false, true});
+    add({"SPARSE_WAND (Cardinal v1)", knowhere::IndexEnum::INDEX_SPARSE_WAND, DataKind::Sparse,
+         VectorCaps(true, true, true, true, true, true, true), true, true, false, false, true});
+    add({"SPARSE_INVERTED_INDEX_CC (Cardinal v1)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC,
+         DataKind::Sparse, VectorCaps(true, true, true, true, true, false, false), true, true, false, false, true});
+    add({"SPARSE_WAND_CC (Cardinal v1)", knowhere::IndexEnum::INDEX_SPARSE_WAND_CC, DataKind::Sparse,
+         VectorCaps(true, true, true, true, true, false, false), true, true, false, false, true});
+    add({"MINHASH_LSH", knowhere::IndexEnum::INDEX_MINHASH_LSH, DataKind::MinHash,
+         VectorCaps(false, false, true, false, false, false, true)});
+
+    add({"GPU_CUVS_BRUTE_FORCE", knowhere::IndexEnum::INDEX_CUVS_BRUTEFORCE, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_BRUTE_FORCE", knowhere::IndexEnum::INDEX_GPU_BRUTEFORCE, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_CUVS_IVF_FLAT", knowhere::IndexEnum::INDEX_CUVS_IVFFLAT, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_IVF_FLAT", knowhere::IndexEnum::INDEX_GPU_IVFFLAT, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_CUVS_IVF_PQ", knowhere::IndexEnum::INDEX_CUVS_IVFPQ, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_IVF_PQ", knowhere::IndexEnum::INDEX_GPU_IVFPQ, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_CUVS_CAGRA", knowhere::IndexEnum::INDEX_CUVS_CAGRA, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_CAGRA", knowhere::IndexEnum::INDEX_GPU_CAGRA, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_FAISS_FLAT", knowhere::IndexEnum::INDEX_FAISS_GPU_IDMAP, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_FAISS_IVF_FLAT", knowhere::IndexEnum::INDEX_FAISS_GPU_IVFFLAT, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_FAISS_IVF_PQ", knowhere::IndexEnum::INDEX_FAISS_GPU_IVFPQ, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_FAISS_IVF_SQ8", knowhere::IndexEnum::INDEX_FAISS_GPU_IVFSQ8, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+
+    add({"SVS_FLAT", knowhere::IndexEnum::INDEX_SVS_FLAT, DataKind::DenseFp32,
+         VectorCaps(false, false, false, false, false, true, true), true, false, true});
+    add({"SVS_VAMANA", knowhere::IndexEnum::INDEX_SVS_VAMANA, DataKind::DenseFp32,
+         VectorCaps(true, false, true, true, false, true, true), true, false, true});
+    add({"SVS_VAMANA_LVQ", knowhere::IndexEnum::INDEX_SVS_VAMANA_LVQ, DataKind::DenseFp32,
+         VectorCaps(true, false, true, true, false, true, true), true, false, true});
+    add({"SVS_VAMANA_LEANVEC", knowhere::IndexEnum::INDEX_SVS_VAMANA_LEANVEC, DataKind::DenseFp32,
+         VectorCaps(true, false, true, true, false, true, true), true, false, true});
+
+    auto cardinal_v2 = hnsw;
+    add({"HNSW (Cardinal v2)", knowhere::IndexEnum::INDEX_HNSW, DataKind::DenseFp32, cardinal_v2, true, true});
+    auto cardinal_v2_disk = VectorCaps(false, false, true, false, false, false, false);
+    AddEmbCaps(cardinal_v2_disk, true, false, false, true, false, false);
+    AddMultiCaps(cardinal_v2_disk, true, false, false, true, false, false);
+    add({"DISKANN (Cardinal v2)", knowhere::IndexEnum::INDEX_DISKANN, DataKind::DiskAnn, cardinal_v2_disk, true, true});
+    add({"CARDINAL_TIERED", knowhere::IndexEnum::INDEX_CARDINAL_TIERED, DataKind::DenseFp32, cardinal_v2, true, true});
+
+    return rows;
+}
+
+void
+AddScenario(std::vector<Scenario>& scenarios, NullableRatio nullable_ratio, Mode mode, Operation op,
+            IndexSource source, FilterRatio filter_ratio = FilterRatio::None) {
+    Scenario scenario;
+    scenario.nullable_ratio = nullable_ratio;
+    scenario.mode = mode;
+    scenario.op = op;
+    scenario.source = source;
+    scenario.filter_ratio = filter_ratio;
+    scenario.name = NullableName(nullable_ratio) + "/" + ModeName(mode) + "/" + OperationName(op) + "/" +
+                    SourceName(source) + "/" + FilterName(filter_ratio);
+    scenarios.push_back(std::move(scenario));
+}
+
+void
+AddNonFilterScenarios(std::vector<Scenario>& scenarios, NullableRatio ratio, Mode mode) {
+    AddScenario(scenarios, ratio, mode, Operation::Build, IndexSource::Fresh);
+    AddScenario(scenarios, ratio, mode, Operation::Search, IndexSource::Fresh);
+    AddScenario(scenarios, ratio, mode, Operation::Range, IndexSource::Fresh);
+    AddScenario(scenarios, ratio, mode, Operation::Iterator, IndexSource::Fresh);
+    AddScenario(scenarios, ratio, mode, Operation::BinarySetSerialize, IndexSource::Fresh);
+    AddScenario(scenarios, ratio, mode, Operation::BinarySetDeserialize, IndexSource::BinarySet);
+    AddScenario(scenarios, ratio, mode, Operation::Search, IndexSource::BinarySet);
+    AddScenario(scenarios, ratio, mode, Operation::Range, IndexSource::BinarySet);
+    AddScenario(scenarios, ratio, mode, Operation::Iterator, IndexSource::BinarySet);
+    AddScenario(scenarios, ratio, mode, Operation::FileSerialize, IndexSource::Fresh);
+    AddScenario(scenarios, ratio, mode, Operation::FileDeserialize, IndexSource::File);
+    AddScenario(scenarios, ratio, mode, Operation::Search, IndexSource::File);
+    AddScenario(scenarios, ratio, mode, Operation::Iterator, IndexSource::File);
+}
+
+std::vector<Scenario>
+BuildScenarios() {
+    std::vector<Scenario> scenarios;
+    for (auto ratio : {NullableRatio::R0, NullableRatio::R50, NullableRatio::R100}) {
+        for (auto mode : {Mode::Vector, Mode::EmbList, Mode::MultiIndex}) {
+            AddNonFilterScenarios(scenarios, ratio, mode);
+        }
+        const std::vector<FilterRatio> filter_ratios =
+            ratio == NullableRatio::R100 ? std::vector<FilterRatio>{FilterRatio::Collapsed}
+                                         : std::vector<FilterRatio>{FilterRatio::R0, FilterRatio::R50,
+                                                                    FilterRatio::R100};
+        for (auto mode : {Mode::Vector, Mode::EmbList, Mode::MultiIndex}) {
+            for (auto filter_ratio : filter_ratios) {
+                AddScenario(scenarios, ratio, mode, Operation::SearchFilter, IndexSource::Fresh, filter_ratio);
+                AddScenario(scenarios, ratio, mode, Operation::RangeFilter, IndexSource::Fresh, filter_ratio);
+                AddScenario(scenarios, ratio, mode, Operation::IteratorFilter, IndexSource::Fresh, filter_ratio);
+            }
+        }
+    }
+    return scenarios;
+}
+
+bool
+SupportsModeBuild(const IndexRow& row, Mode mode) {
+    switch (mode) {
+        case Mode::Vector:
+            return row.caps.build;
+        case Mode::EmbList:
+            return row.caps.emb_build;
+        case Mode::MultiIndex:
+            return row.caps.multi_build;
+    }
+    return false;
+}
+
+bool
+SupportsScenario(const IndexRow& row, const Scenario& scenario) {
+    const auto& caps = row.caps;
+    if (row.index_type == knowhere::IndexEnum::INDEX_HNSW && !row.requires_cardinal &&
+        VersionForRow(row) < 6 && scenario.nullable_ratio != NullableRatio::R0) {
+        return false;
+    }
+#ifdef KNOWHERE_WITH_CARDINAL
+    if (row.data_kind == DataKind::Sparse && !row.requires_cardinal &&
+        scenario.nullable_ratio != NullableRatio::R0) {
+        return false;
+    }
+#endif
+    if (row.requires_cardinal && row.index_type == knowhere::IndexEnum::INDEX_DISKANN &&
+        scenario.mode != Mode::Vector &&
+        (scenario.op == Operation::FileSerialize || scenario.op == Operation::FileDeserialize ||
+         scenario.source == IndexSource::File)) {
+        return false;
+    }
+
+    const bool reads_index = scenario.op == Operation::Search || scenario.op == Operation::Range ||
+                             scenario.op == Operation::Iterator;
+    if (reads_index && scenario.source == IndexSource::BinarySet && !caps.binaryset_deserialize) {
+        return false;
+    }
+    if (reads_index && scenario.source == IndexSource::File && !caps.file_deserialize) {
+        return false;
+    }
+    if (row.data_kind == DataKind::MinHash &&
+        (scenario.op == Operation::Search || scenario.op == Operation::SearchFilter ||
+         scenario.op == Operation::Range || scenario.op == Operation::RangeFilter ||
+         scenario.op == Operation::Iterator || scenario.op == Operation::IteratorFilter) &&
+        scenario.source == IndexSource::Fresh) {
+        return false;
+    }
+    switch (scenario.op) {
+        case Operation::Build:
+            return SupportsModeBuild(row, scenario.mode);
+        case Operation::Search:
+            return scenario.mode == Mode::Vector    ? caps.search
+                   : scenario.mode == Mode::EmbList ? caps.emb_search
+                                                    : caps.multi_search;
+        case Operation::Range:
+            return scenario.mode == Mode::Vector    ? caps.range
+                   : scenario.mode == Mode::EmbList ? caps.emb_range
+                                                    : caps.multi_range;
+        case Operation::Iterator:
+            return scenario.mode == Mode::Vector    ? caps.iterator
+                   : scenario.mode == Mode::EmbList ? caps.emb_iterator
+                                                    : caps.multi_iterator;
+        case Operation::SearchFilter:
+            return scenario.mode == Mode::Vector    ? caps.search_filter
+                   : scenario.mode == Mode::EmbList ? caps.emb_search_filter
+                                                    : caps.multi_search_filter;
+        case Operation::RangeFilter:
+            return scenario.mode == Mode::Vector    ? caps.range_filter
+                   : scenario.mode == Mode::EmbList ? caps.emb_range_filter
+                                                    : caps.multi_range_filter;
+        case Operation::IteratorFilter:
+            return scenario.mode == Mode::Vector    ? caps.iterator_filter
+                   : scenario.mode == Mode::EmbList ? caps.emb_iterator_filter
+                                                    : caps.multi_iterator_filter;
+        case Operation::BinarySetSerialize:
+            return SupportsModeBuild(row, scenario.mode) && caps.binaryset_serialize;
+        case Operation::BinarySetDeserialize:
+            return SupportsModeBuild(row, scenario.mode) && caps.binaryset_deserialize;
+        case Operation::FileSerialize:
+            return SupportsModeBuild(row, scenario.mode) && caps.file_serialize;
+        case Operation::FileDeserialize:
+            return SupportsModeBuild(row, scenario.mode) && caps.file_deserialize;
+    }
+    return false;
+}
+
+bool
+IsReadOperation(Operation op) {
+    return op == Operation::Search || op == Operation::Range || op == Operation::Iterator ||
+           op == Operation::SearchFilter || op == Operation::RangeFilter || op == Operation::IteratorFilter;
+}
+
+bool
+IsFreshFileBackedRead(const IndexRow& row, const Scenario& scenario) {
+    return scenario.source == IndexSource::Fresh && IsReadOperation(scenario.op) &&
+           (row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq);
+}
+
+bool
+IsExpectedEmptyBuildStatus(knowhere::Status status) {
+    return status == knowhere::Status::success || status == knowhere::Status::empty_index ||
+           status == knowhere::Status::invalid_args || status == knowhere::Status::faiss_inner_error ||
+           status == knowhere::Status::hnsw_inner_error || status == knowhere::Status::diskann_inner_error ||
+           status == knowhere::Status::disk_file_error || status == knowhere::Status::aisaq_error ||
+           status == knowhere::Status::cardinal_inner_error || status == knowhere::Status::sparse_inner_error ||
+           status == knowhere::Status::emb_list_inner_error || status == knowhere::Status::cuda_runtime_error ||
+           status == knowhere::Status::not_implemented;
+}
+
+bool
+IsExpectedEmptySearchError(knowhere::Status status) {
+    return status == knowhere::Status::empty_index || status == knowhere::Status::invalid_args ||
+           status == knowhere::Status::not_implemented || status == knowhere::Status::faiss_inner_error ||
+           status == knowhere::Status::hnsw_inner_error || status == knowhere::Status::diskann_inner_error ||
+           status == knowhere::Status::aisaq_error || status == knowhere::Status::cardinal_inner_error ||
+           status == knowhere::Status::sparse_inner_error || status == knowhere::Status::emb_list_inner_error ||
+           status == knowhere::Status::cuda_runtime_error;
+}
+
+void
+RequireAllResultIdsNegative(const knowhere::DataSet& result) {
+    const auto nq = result.GetRows();
+    const auto k = result.GetDim();
+    const auto* lims = result.GetLims();
+    const auto* ids = result.GetIds();
+    const auto length = k == 0 ? lims[nq] : nq * k;
+    for (int64_t i = 0; i < length; ++i) {
+        REQUIRE(ids[i] < 0);
+    }
+}
+
+void
+RequireRangeResultEmpty(const knowhere::DataSet& result) {
+    REQUIRE(result.GetLims()[result.GetRows()] == 0);
+}
+
+void
+RequireResultIdsIn(const knowhere::DataSet& result, const std::vector<int32_t>& allowed_ids,
+                   const std::vector<int32_t>& filtered_ids, bool expect_empty) {
+    if (expect_empty) {
+        RequireAllResultIdsNegative(result);
+        return;
+    }
+
+    const auto nq = result.GetRows();
+    const auto k = result.GetDim();
+    const auto* lims = result.GetLims();
+    const auto* ids = result.GetIds();
+    const auto length = k == 0 ? lims[nq] : nq * k;
+    bool has_result = false;
+    for (int64_t i = 0; i < length; ++i) {
+        if (ids[i] < 0) {
+            continue;
+        }
+        has_result = true;
+        REQUIRE(ContainsId(allowed_ids, ids[i]));
+        REQUIRE(!ContainsId(filtered_ids, ids[i]));
+    }
+    REQUIRE(has_result);
+}
+
+void
+RequireRangeIdsIn(const knowhere::DataSet& result, const std::vector<int32_t>& allowed_ids,
+                  const std::vector<int32_t>& filtered_ids, bool expect_empty) {
+    if (expect_empty) {
+        RequireRangeResultEmpty(result);
+        return;
+    }
+    RequireResultIdsIn(result, allowed_ids, filtered_ids, false);
+}
+
+void
+RequireIteratorResults(const std::vector<knowhere::IndexNode::IteratorPtr>& iterators,
+                       const std::vector<int32_t>& allowed_ids, const std::vector<int32_t>& filtered_ids,
+                       bool expect_empty, const std::vector<int32_t>* query_ids = nullptr) {
+    if (expect_empty) {
+        for (const auto& iterator : iterators) {
+            REQUIRE(!iterator->HasNext());
+        }
+        return;
+    }
+
+    bool checked = false;
+    for (size_t i = 0; i < iterators.size(); ++i) {
+        const auto& iterator = iterators[i];
+        if (!iterator->HasNext()) {
+            continue;
+        }
+        auto [id, dist] = iterator->Next();
+        (void)dist;
+        REQUIRE(ContainsId(allowed_ids, id));
+        REQUIRE(!ContainsId(filtered_ids, id));
+        if (query_ids != nullptr && i < query_ids->size() && ContainsId(allowed_ids, (*query_ids)[i])) {
+            REQUIRE(id == (*query_ids)[i]);
+        }
+        checked = true;
+    }
+    REQUIRE(checked);
+}
+
+void
+RequireExpectedVectorResult(const knowhere::expected<knowhere::DataSetPtr>& result,
+                            const std::vector<int32_t>& allowed_ids, const std::vector<int32_t>& filtered_ids,
+                            bool expect_empty) {
+    if (!result.has_value()) {
+        REQUIRE(expect_empty);
+        REQUIRE(IsExpectedEmptySearchError(result.error()));
+        return;
+    }
+    RequireResultIdsIn(*result.value(), allowed_ids, filtered_ids, expect_empty);
+}
+
+void
+RequireExactFirstHits(const knowhere::DataSet& result, const std::vector<int32_t>& query_ids,
+                      const std::vector<int32_t>& allowed_ids) {
+    const auto nq = result.GetRows();
+    const auto k = result.GetDim();
+    const auto* ids = result.GetIds();
+    for (int64_t i = 0; i < nq && i < static_cast<int64_t>(query_ids.size()); ++i) {
+        if (!ContainsId(allowed_ids, query_ids[i])) {
+            continue;
+        }
+        REQUIRE(k > 0);
+        REQUIRE(ids[i * k] == query_ids[i]);
+    }
+}
+
+void
+RequireExactRangeHits(const knowhere::DataSet& result, const std::vector<int32_t>& query_ids,
+                      const std::vector<int32_t>& allowed_ids) {
+    const auto nq = result.GetRows();
+    const auto* lims = result.GetLims();
+    const auto* ids = result.GetIds();
+    for (int64_t i = 0; i < nq && i < static_cast<int64_t>(query_ids.size()); ++i) {
+        if (!ContainsId(allowed_ids, query_ids[i])) {
+            continue;
+        }
+        bool found = false;
+        for (size_t j = lims[i]; j < lims[i + 1]; ++j) {
+            found = found || ids[j] == query_ids[i];
+        }
+        REQUIRE(found);
+    }
+}
+
+void
+RequireBufferedExactFirstHits(const std::vector<int64_t>& ids, int64_t topk, const std::vector<int32_t>& query_ids,
+                              const std::vector<int32_t>& allowed_ids) {
+    for (int64_t i = 0; i < static_cast<int64_t>(query_ids.size()); ++i) {
+        if (!ContainsId(allowed_ids, query_ids[i])) {
+            continue;
+        }
+        REQUIRE(topk > 0);
+        REQUIRE(ids[i * topk] == query_ids[i]);
+    }
+}
+
+void
+RequireExpectedRangeResult(const knowhere::expected<knowhere::DataSetPtr>& result,
+                           const std::vector<int32_t>& allowed_ids, const std::vector<int32_t>& filtered_ids,
+                           bool expect_empty) {
+    if (!result.has_value()) {
+        REQUIRE(expect_empty);
+        REQUIRE(IsExpectedEmptySearchError(result.error()));
+        return;
+    }
+    RequireRangeIdsIn(*result.value(), allowed_ids, filtered_ids, expect_empty);
+}
+
+void
+RequireExpectedIteratorResult(const knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>& result,
+                              const std::vector<int32_t>& allowed_ids, const std::vector<int32_t>& filtered_ids,
+                              bool expect_empty, const std::vector<int32_t>* query_ids = nullptr) {
+    if (!result.has_value()) {
+        REQUIRE(expect_empty);
+        REQUIRE(IsExpectedEmptySearchError(result.error()));
+        return;
+    }
+    RequireIteratorResults(result.value(), allowed_ids, filtered_ids, expect_empty, query_ids);
+}
+
+void
+RequireBufferedIdsIn(const std::vector<int64_t>& ids, const std::vector<int32_t>& allowed_ids,
+                     const std::vector<int32_t>& filtered_ids, bool expect_empty) {
+    bool has_result = false;
+    for (auto id : ids) {
+        if (id < 0) {
+            continue;
+        }
+        has_result = true;
+        REQUIRE(ContainsId(allowed_ids, id));
+        REQUIRE(!ContainsId(filtered_ids, id));
+    }
+    REQUIRE(has_result != expect_empty);
+}
+
+void
+RequireBufferedStatus(knowhere::Status status, const std::vector<int64_t>& ids,
+                      const std::vector<int32_t>& allowed_ids, const std::vector<int32_t>& filtered_ids,
+                      bool expect_empty) {
+    if (status != knowhere::Status::success) {
+        REQUIRE(expect_empty);
+        REQUIRE(IsExpectedEmptySearchError(status));
+        return;
+    }
+    RequireBufferedIdsIn(ids, allowed_ids, filtered_ids, expect_empty);
+}
+
+void
+RequireExternalIdMapContent(const knowhere::Index<knowhere::IndexNode>& index, const std::vector<int32_t>& valid_ids,
+                            int64_t external_count) {
+    REQUIRE(index.ExternalCount() == external_count);
+    REQUIRE(index.Node() != nullptr);
+    const auto& map = index.Node()->GetExternalIdMap();
+    REQUIRE(map.ExternalCount(0) == external_count);
+    REQUIRE(map.GetInternalToExternalIds() == valid_ids);
+    auto valid = map.GetValidBitmapView();
+    REQUIRE(valid.size == static_cast<size_t>(external_count));
+    REQUIRE(valid.data != nullptr);
+    for (size_t i = 0; i < valid_ids.size(); ++i) {
+        CAPTURE(i, valid_ids[i]);
+        REQUIRE(map.ToExternalId(i) == valid_ids[i]);
+        REQUIRE(map.ToInternalId(valid_ids[i]) == static_cast<int64_t>(i));
+    }
+    if (static_cast<int64_t>(valid_ids.size()) != external_count) {
+        const auto missing_id = FirstMissingExternalId(valid_ids, external_count);
+        CAPTURE(missing_id);
+        REQUIRE(map.ToInternalId(missing_id) == -1);
+    }
+}
+
+std::vector<float>
+DenseVectorForLogicalId(int32_t logical_id, int64_t dim) {
+    std::vector<float> data(dim);
+    FillDenseVector(data.data(), 0, dim, logical_id);
+    return data;
+}
+
+float
+DenseL2ForLogicalIds(int32_t lhs, int32_t rhs, int64_t dim) {
+    auto lhs_vec = DenseVectorForLogicalId(lhs, dim);
+    auto rhs_vec = DenseVectorForLogicalId(rhs, dim);
+    float dist = 0.0f;
+    for (int64_t i = 0; i < dim; ++i) {
+        const auto diff = lhs_vec[i] - rhs_vec[i];
+        dist += diff * diff;
+    }
+    return dist;
+}
+
+void
+RequireDenseVectorsMatchLogicalIds(const knowhere::DataSet& vectors, const std::vector<int32_t>& logical_ids,
+                                   int64_t dim) {
+    REQUIRE(vectors.GetRows() == static_cast<int64_t>(logical_ids.size()));
+    REQUIRE(vectors.GetDim() == dim);
+    const auto* tensor = static_cast<const float*>(vectors.GetTensor());
+    REQUIRE(tensor != nullptr);
+    for (size_t i = 0; i < logical_ids.size(); ++i) {
+        auto expected = DenseVectorForLogicalId(logical_ids[i], dim);
+        for (int64_t j = 0; j < dim; ++j) {
+            CAPTURE(i, j, logical_ids[i]);
+            REQUIRE(tensor[i * dim + j] == Catch::Approx(expected[j]));
+        }
+    }
+}
+
+void
+RequireDenseCalcDistByIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
+    std::vector<int64_t> labels(data.query_ids.begin(), data.query_ids.end());
+    auto result = index.CalcDistByIDs(data.query_ds, knowhere::BitsetView{}, labels.data(), labels.size(), false);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetRows() == data.query_ds->GetRows());
+    REQUIRE(result.value()->GetDim() == static_cast<int64_t>(labels.size()));
+    const auto* distances = result.value()->GetDistance();
+    REQUIRE(distances != nullptr);
+    for (size_t i = 0; i < data.query_ids.size(); ++i) {
+        for (size_t j = 0; j < labels.size(); ++j) {
+            const auto expected = DenseL2ForLogicalIds(data.query_ids[i], static_cast<int32_t>(labels[j]), data.dim);
+            CAPTURE(i, j, data.query_ids[i], labels[j]);
+            REQUIRE(distances[i * labels.size() + j] == Catch::Approx(expected));
+        }
+    }
+}
+
+void
+RequireDenseCalcDistRejectsInvalidExternalIds(const knowhere::Index<knowhere::IndexNode>& index,
+                                              const MatrixData& data) {
+    const int64_t labels[] = {FirstMissingExternalId(data.valid_ids, data.total_count), data.total_count};
+    for (auto label : labels) {
+        CAPTURE(label);
+        auto result = index.CalcDistByIDs(data.query_ds, knowhere::BitsetView{}, &label, 1, false);
+        REQUIRE(!result.has_value());
+        REQUIRE(result.error() == Status::invalid_args);
+    }
+}
+
+void
+RequireGetVectorRejectsInvalidExternalIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
+    const int64_t ids[] = {FirstMissingExternalId(data.valid_ids, data.total_count), data.total_count};
+    for (auto id : ids) {
+        CAPTURE(id);
+        auto result = index.GetVectorByIds(knowhere::GenIdsDataSet(1, &id));
+        REQUIRE(!result.has_value());
+        REQUIRE(result.error() == Status::invalid_args);
+    }
+}
+
+void
+RequireDenseVectorApisUseExternalIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data,
+                                     const knowhere::Json& json) {
+    RequireExternalIdMapContent(index, data.valid_ids, data.total_count);
+
+    auto search = index.Search(data.query_ds, json, knowhere::BitsetView{});
+    REQUIRE(search.has_value());
+    RequireExactFirstHits(*search.value(), data.query_ids, data.valid_ids);
+
+    std::vector<int64_t> ids(data.query_ids.begin(), data.query_ids.end());
+    auto retrieve = index.GetVectorByIds(knowhere::GenIdsDataSet(static_cast<int64_t>(ids.size()), ids.data()));
+    REQUIRE(retrieve.has_value());
+    RequireDenseVectorsMatchLogicalIds(*retrieve.value(), data.query_ids, data.dim);
+    RequireGetVectorRejectsInvalidExternalIds(index, data);
+
+    RequireDenseCalcDistByIds(index, data);
+    RequireDenseCalcDistRejectsInvalidExternalIds(index, data);
+}
+
+void
+RequireEmbListVectorsMatchLogicalIds(const knowhere::DataSet& vectors, const std::vector<int32_t>& logical_ids,
+                                     int64_t dim, int64_t vectors_per_doc) {
+    REQUIRE(vectors.GetRows() == static_cast<int64_t>(logical_ids.size()));
+    REQUIRE(vectors.GetDim() == dim);
+    const auto* offsets = vectors.Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+    REQUIRE(offsets != nullptr);
+    const auto* tensor = static_cast<const float*>(vectors.GetTensor());
+    REQUIRE(tensor != nullptr);
+    for (size_t i = 0; i < logical_ids.size(); ++i) {
+        REQUIRE(offsets[i + 1] - offsets[i] == static_cast<size_t>(vectors_per_doc));
+        auto expected = DenseVectorForLogicalId(logical_ids[i], dim);
+        for (int64_t v = 0; v < vectors_per_doc; ++v) {
+            for (int64_t j = 0; j < dim; ++j) {
+                CAPTURE(i, v, j, logical_ids[i]);
+                REQUIRE(tensor[(offsets[i] + v) * dim + j] == Catch::Approx(expected[j]));
+            }
+        }
+    }
+}
+
+void
+RequireEmbListApisUseExternalIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data,
+                                 const knowhere::Json& json) {
+    RequireExternalIdMapContent(index, data.valid_ids, data.total_count);
+
+    auto search = index.Search(data.query_ds, json, knowhere::BitsetView{});
+    REQUIRE(search.has_value());
+    RequireExactFirstHits(*search.value(), data.query_ids, data.valid_ids);
+
+    std::vector<int64_t> ids(data.query_ids.begin(), data.query_ids.end());
+    auto retrieve =
+        index.GetEmbListByIds(knowhere::GenIdsDataSet(static_cast<int64_t>(ids.size()), ids.data()), "MAX_SIM_L2");
+    REQUIRE(retrieve.has_value());
+    RequireEmbListVectorsMatchLogicalIds(*retrieve.value(), data.query_ids, data.dim, kEmbVectorsPerDoc);
+
+    const int64_t invalid_ids[] = {FirstMissingExternalId(data.valid_ids, data.total_count), data.total_count};
+    for (auto invalid_id : invalid_ids) {
+        CAPTURE(invalid_id);
+        auto invalid =
+            index.GetEmbListByIds(knowhere::GenIdsDataSet(1, &invalid_id), "MAX_SIM_L2");
+        REQUIRE(!invalid.has_value());
+        REQUIRE(invalid.error() == Status::invalid_args);
+    }
+}
+
+std::vector<std::vector<float>>
+BuildChunkStorage(const knowhere::DataSetPtr& dense_ds, int64_t chunks, std::vector<size_t>& chunk_lims) {
+    const auto rows = dense_ds->GetRows();
+    const auto dim = dense_ds->GetDim();
+    auto* dense = static_cast<const float*>(dense_ds->GetTensor());
+    chunk_lims.resize(chunks + 1);
+    std::vector<std::vector<float>> chunk_storage(chunks);
+    int64_t offset = 0;
+    for (int64_t chunk = 0; chunk < chunks; ++chunk) {
+        chunk_lims[chunk] = static_cast<size_t>(offset);
+        const auto chunk_rows = (rows * (chunk + 1)) / chunks - (rows * chunk) / chunks;
+        chunk_storage[chunk].resize(chunk_rows * dim);
+        if (chunk_rows > 0) {
+            std::memcpy(chunk_storage[chunk].data(), dense + offset * dim, chunk_rows * dim * sizeof(float));
+        }
+        offset += chunk_rows;
+    }
+    chunk_lims[chunks] = static_cast<size_t>(rows);
+    return chunk_storage;
+}
+
+knowhere::DataSetPtr
+GenNullableDenseChunkDataSet(int64_t total_count, const std::vector<int32_t>& valid_ids, int64_t dim,
+                             std::vector<std::vector<float>>& chunk_storage,
+                             std::vector<const float*>& chunk_ptrs,
+                             std::vector<size_t>& chunk_lims) {
+    auto dense_ds = GenNullableDenseDataSet(total_count, valid_ids, dim);
+    chunk_storage = BuildChunkStorage(dense_ds, 2, chunk_lims);
+    chunk_ptrs.resize(chunk_storage.size());
+    for (size_t i = 0; i < chunk_storage.size(); ++i) {
+        chunk_ptrs[i] = chunk_storage[i].data();
+    }
+    auto ds = knowhere::GenDataSet(dense_ds->GetRows(), dim, chunk_ptrs.data());
+    ds->SetIsChunk(true);
+    ds->SetIsOwner(false);
+    ds->SetNumChunk(static_cast<int64_t>(chunk_ptrs.size()));
+    ds->SetTensorBeginId(dense_ds->GetTensorBeginId());
+    if (static_cast<int64_t>(valid_ids.size()) != total_count) {
+        ds->SetInternalToExternalIds(valid_ids, static_cast<size_t>(total_count));
+    }
+    auto lims_data = std::make_unique<size_t[]>(chunk_lims.size());
+    std::copy(chunk_lims.begin(), chunk_lims.end(), lims_data.get());
+    ds->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(lims_data.release()));
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenNullableEmbListChunkDataSet(int64_t total_docs, const std::vector<int32_t>& valid_doc_ids, int64_t dim,
+                               int64_t vectors_per_doc, std::vector<std::vector<float>>& chunk_storage,
+                               std::vector<const float*>& chunk_ptrs, std::vector<size_t>& chunk_lims,
+                               std::vector<size_t>& emb_offsets) {
+    auto dense_ds = GenNullableEmbListDataSet(total_docs, valid_doc_ids, dim, vectors_per_doc);
+    chunk_storage = BuildChunkStorage(dense_ds, std::max<int64_t>(static_cast<int64_t>(valid_doc_ids.size()), 1),
+                                      chunk_lims);
+    chunk_ptrs.resize(chunk_storage.size());
+    for (size_t i = 0; i < chunk_storage.size(); ++i) {
+        chunk_ptrs[i] = chunk_storage[i].data();
+    }
+    emb_offsets.resize(valid_doc_ids.size() + 1);
+    for (size_t i = 0; i <= valid_doc_ids.size(); ++i) {
+        emb_offsets[i] = i * vectors_per_doc;
+    }
+    auto ds = knowhere::GenDataSet(dense_ds->GetRows(), dim, chunk_ptrs.data());
+    ds->SetIsChunk(true);
+    ds->SetIsOwner(false);
+    ds->SetNumChunk(static_cast<int64_t>(chunk_ptrs.size()));
+    if (static_cast<int64_t>(valid_doc_ids.size()) != total_docs) {
+        ds->SetInternalToExternalIds(valid_doc_ids, static_cast<size_t>(total_docs));
+    }
+    auto lims_data = std::make_unique<size_t[]>(chunk_lims.size());
+    std::copy(chunk_lims.begin(), chunk_lims.end(), lims_data.get());
+    ds->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(lims_data.release()));
+    return ds;
+}
+
+std::shared_ptr<milvus::FileManager>
+LocalFileManager() {
+    return std::make_shared<milvus::LocalFileManager>();
+}
+
+MatrixData
+BuildMatrixData(const IndexRow& row, const Scenario& scenario, const fs::path& work_dir) {
+    MatrixData data;
+    const bool multi = scenario.mode == Mode::MultiIndex;
+    if (scenario.mode == Mode::EmbList) {
+        data.total_count = kEmbDocs;
+        data.dim = kDenseDim;
+        data.valid_ids = ValidIdsFor(scenario.nullable_ratio, kEmbDocs);
+        data.selected_ids = data.valid_ids;
+        data.query_ids = FirstQueryIds(data.valid_ids, kEmbDocs, 2);
+        data.train_ds = GenNullableEmbListDataSet(kEmbDocs, data.valid_ids, data.dim, kEmbVectorsPerDoc);
+        data.full_ds = row.index_type == knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR
+                           ? data.train_ds
+                           : GenFullDenseDataSet(kEmbDocs, data.dim);
+        data.query_ds = GenEmbListQueryDataSet(data.query_ids, data.dim);
+        return data;
+    }
+
+    if (row.data_kind == DataKind::GpuFp32) {
+        data.total_count = kGpuRows;
+        data.dim = kGpuDim;
+    } else if (row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq ||
+               row.data_kind == DataKind::MinHash) {
+        data.total_count = kFileRows;
+        data.dim = row.data_kind == DataKind::MinHash ? 1024 : kFileDim;
+    } else if (row.data_kind == DataKind::DenseBin) {
+        data.total_count = kTotalRows;
+        data.dim = 128;
+    } else {
+        data.total_count = kTotalRows;
+        data.dim = kDenseDim;
+    }
+    data.valid_ids = ValidIdsFor(scenario.nullable_ratio, data.total_count, multi);
+    data.selected_ids = multi ? PartitionIds(data.valid_ids, 0) : data.valid_ids;
+    if (multi && data.selected_ids.empty() && !data.valid_ids.empty()) {
+        data.selected_ids = PartitionIds(data.valid_ids, 1);
+    }
+    data.query_ids = FirstQueryIds(multi ? data.selected_ids : data.valid_ids, data.total_count);
+
+    if (row.data_kind == DataKind::DenseFp32 || row.data_kind == DataKind::GpuFp32 ||
+        row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq) {
+        data.full_ds = GenFullDenseDataSet(data.total_count, data.dim);
+        data.train_ds = GenNullableDenseDataSet(data.total_count, data.valid_ids, data.dim);
+        data.query_ds = GenDenseQueryDataSet(data.query_ids, data.dim);
+    } else if (row.data_kind == DataKind::DenseBin || row.data_kind == DataKind::MinHash) {
+        data.full_ds = GenBinDataSet(static_cast<int>(data.total_count), static_cast<int>(data.dim), 22);
+        static std::map<std::string, std::vector<uint8_t>> owned_binary;
+        const auto key = work_dir.string() + "/bin_train";
+        const auto query_key = work_dir.string() + "/bin_query";
+        data.train_ds = GenNullableBinaryDataSet(data.total_count, data.valid_ids, data.dim, data.full_ds,
+                                                 owned_binary[key]);
+        data.query_ds = GenBinaryQueryDataSet(data.query_ids, data.dim, data.full_ds, owned_binary[query_key]);
+    } else {
+        data.full_ds = nullptr;
+        data.train_ds = GenNullableSparseDataSet(data.total_count, data.valid_ids);
+        data.query_ds = GenSparseQueryDataSet(data.query_ids, data.total_count);
+    }
+
+    if (multi) {
+        data.train_ds->Set(knowhere::meta::SCALAR_INFO, ScalarInfoForEvenOddPartitions(data.valid_ids));
+    }
+    return data;
+}
+
+knowhere::Json
+BuildJson(const IndexRow& row, Mode mode, const MatrixData& data, const fs::path& raw_data_file,
+          const fs::path& file_index_prefix) {
+    if (row.index_type == "HNSW_V1") {
+        auto json = DenseConfigFor(row, mode);
+        json[knowhere::meta::DIM] = data.train_ds->GetDim();
+        json[knowhere::meta::METRIC_TYPE] = knowhere::metric::IP;
+        json[knowhere::meta::RADIUS] = 0.5f;
+        json[knowhere::meta::RANGE_FILTER] = 2.0f;
+        json[knowhere::meta::RETRIEVE_FRIENDLY] = true;
+        return json;
+    }
+    if (row.data_kind == DataKind::Sparse) {
+        return SparseConfig();
+    }
+    if (row.data_kind == DataKind::DenseBin || row.data_kind == DataKind::MinHash) {
+        auto json = BinaryConfigFor(row);
+        if (row.data_kind == DataKind::MinHash) {
+            json[knowhere::meta::DATA_PATH] = raw_data_file.string();
+            json[knowhere::meta::INDEX_PREFIX] = file_index_prefix.string();
+        }
+        return json;
+    }
+    if (row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq) {
+        auto json = DiskAnnConfig(row, raw_data_file, file_index_prefix);
+        if (mode == Mode::EmbList) {
+            json[knowhere::meta::METRIC_TYPE] = "MAX_SIM_L2";
+            json[knowhere::meta::TOPK] = kEmbTopK;
+            json["emb_list_strategy"] = knowhere::meta::EMB_LIST_STRATEGY_TOKENANN;
+        }
+        return json;
+    }
+    return DenseConfigFor(row, mode);
+}
+
+void
+WriteRawDataIfNeeded(const IndexRow& row, const MatrixData& data, const fs::path& raw_data_file) {
+    if (row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq) {
+        auto* tensor = static_cast<const float*>(data.train_ds->GetTensor());
+        WriteRawDataToDisk<float>(raw_data_file.string(), tensor, static_cast<uint32_t>(data.train_ds->GetRows()),
+                                  static_cast<uint32_t>(data.dim));
+    } else if (row.data_kind == DataKind::MinHash) {
+        auto* tensor = static_cast<const knowhere::bin1*>(data.train_ds->GetTensor());
+        WriteRawDataToDisk<knowhere::bin1>(raw_data_file.string(), tensor,
+                                           static_cast<uint32_t>(data.train_ds->GetRows()),
+                                           static_cast<uint32_t>(data.dim));
+    }
+}
+
+struct CreateResult {
+    knowhere::Index<knowhere::IndexNode> index;
+    knowhere::Status status = knowhere::Status::success;
+    bool ok = false;
+};
+
+CreateResult
+CreateIndex(const IndexRow& row, const MatrixData& data, std::shared_ptr<milvus::FileManager> file_manager = nullptr) {
+    CreateResult result;
+
+#ifndef KNOWHERE_WITH_CARDINAL
+    if (row.requires_cardinal) {
+        result.status = knowhere::Status::invalid_index_error;
+        return result;
+    }
+#endif
+#ifndef KNOWHERE_WITH_SVS
+    if (row.requires_svs) {
+        result.status = knowhere::Status::invalid_index_error;
+        return result;
+    }
+#endif
+#ifndef KNOWHERE_WITH_CUVS
+    if (row.requires_gpu) {
+        result.status = knowhere::Status::invalid_index_error;
+        return result;
+    }
+#endif
+
+    const auto version = VersionForRow(row);
+    auto create_with_object = [&](const knowhere::Object& object) {
+        if (row.data_kind == DataKind::DenseBin || row.data_kind == DataKind::MinHash) {
+            auto created = knowhere::IndexFactory::Instance().Create<knowhere::bin1>(row.index_type, version, object);
+            if (!created.has_value()) {
+                result.status = created.error();
+                return result;
+            }
+            result.index = std::move(created.value());
+        } else if (row.data_kind == DataKind::Sparse) {
+            auto created =
+                knowhere::IndexFactory::Instance().Create<knowhere::sparse_u32_f32>(row.index_type, version, object);
+            if (!created.has_value()) {
+                result.status = created.error();
+                return result;
+            }
+            result.index = std::move(created.value());
+        } else {
+            auto created = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(row.index_type, version, object);
+            if (!created.has_value()) {
+                result.status = created.error();
+                return result;
+            }
+            result.index = std::move(created.value());
+        }
+        result.ok = true;
+        return result;
+    };
+
+    if (row.index_type == knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR && data.full_ds != nullptr) {
+        knowhere::ViewDataOp view_data = [full = data.full_ds, dim = data.full_ds->GetDim()](size_t logical_id) {
+            auto* tensor = static_cast<const float*>(full->GetTensor());
+            return tensor + logical_id * dim;
+        };
+        auto object = knowhere::Pack(view_data);
+        return create_with_object(object);
+    } else if (row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq ||
+               row.data_kind == DataKind::MinHash) {
+        auto object = knowhere::Pack(file_manager != nullptr ? file_manager : LocalFileManager());
+        return create_with_object(object);
+    }
+
+    return create_with_object(knowhere::Object(nullptr));
+}
+
+std::map<std::string, std::shared_ptr<BuiltArtifact>>&
+ArtifactCache() {
+    static std::map<std::string, std::shared_ptr<BuiltArtifact>> cache;
+    return cache;
+}
+
+std::string
+ArtifactKey(const IndexRow& row, const Scenario& scenario) {
+    return row.label + "|" + row.index_type + "|" + ModeName(scenario.mode) + "|" +
+           NullableName(scenario.nullable_ratio);
+}
+
+std::string
+PathSafe(std::string value) {
+    for (auto& c : value) {
+        if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-')) {
+            c = '_';
+        }
+    }
+    return value;
+}
+
+knowhere::Status
+WriteEmbListOffsetToFile(const knowhere::DataSetPtr& dataset, size_t offset_count, const fs::path& path);
+
+std::shared_ptr<BuiltArtifact>
+GetArtifact(const IndexRow& row, const Scenario& scenario) {
+    auto key = ArtifactKey(row, scenario);
+    auto& cache = ArtifactCache();
+    auto it = cache.find(key);
+    if (it != cache.end()) {
+        return it->second;
+    }
+
+    auto artifact = std::make_shared<BuiltArtifact>();
+    artifact->row = row;
+    artifact->scenario = scenario;
+    const auto work_dir_name = row.label + "_" + ModeName(scenario.mode) + "_" +
+                               NullableName(scenario.nullable_ratio);
+    artifact->work_dir = fs::current_path() / "nullable_external_id_map_matrix" / PathSafe(work_dir_name);
+    fs::remove_all(artifact->work_dir);
+    fs::create_directories(artifact->work_dir);
+    artifact->main_file = artifact->work_dir / "main.index";
+    artifact->id_map_file = artifact->work_dir / "main.index_id_map";
+    artifact->emb_meta_file = artifact->work_dir / "emb_list_meta.bin";
+    artifact->emb_raw_file = artifact->work_dir / "emb_list_raw.index";
+    artifact->emb_offset_file = artifact->work_dir / "emb_list_offset.bin";
+    artifact->raw_data_file = artifact->work_dir / "raw_data.bin";
+    artifact->file_index_prefix = artifact->work_dir / "file_index";
+    fs::create_directories(artifact->file_index_prefix.parent_path());
+
+    artifact->data = BuildMatrixData(row, scenario, artifact->work_dir);
+    if (row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq ||
+        row.data_kind == DataKind::MinHash) {
+        artifact->file_manager = LocalFileManager();
+    }
+    WriteRawDataIfNeeded(row, artifact->data, artifact->raw_data_file);
+    artifact->json =
+        BuildJson(row, scenario.mode, artifact->data, artifact->raw_data_file, artifact->file_index_prefix);
+    if (row.data_kind == DataKind::DiskAnn && scenario.mode == Mode::EmbList) {
+        auto status = WriteEmbListOffsetToFile(
+            artifact->data.train_ds, artifact->data.valid_ids.size() + 1, artifact->emb_offset_file);
+        if (status == knowhere::Status::success) {
+            artifact->json["emb_list_offset_file_path"] = artifact->emb_offset_file.string();
+        } else {
+            artifact->build_status = status;
+        }
+    }
+
+    auto created = CreateIndex(row, artifact->data, artifact->file_manager);
+    artifact->create_ok = created.ok;
+    artifact->create_status = created.status;
+    if (!created.ok) {
+        cache[key] = artifact;
+        return artifact;
+    }
+
+    artifact->index = std::move(created.index);
+    artifact->build_status = artifact->index.Build(artifact->data.train_ds, artifact->json);
+    cache[key] = artifact;
+    return artifact;
+}
+
+knowhere::Status
+EnsureSerialized(BuiltArtifact& artifact) {
+    if (artifact.serialized) {
+        return artifact.serialize_status;
+    }
+    artifact.serialize_status = artifact.index.Serialize(artifact.binset);
+    artifact.serialized = true;
+    return artifact.serialize_status;
+}
+
+knowhere::Status
+EnsureBinaryLoaded(BuiltArtifact& artifact) {
+    if (artifact.binary_loaded_ready || artifact.binary_deserialize_status != knowhere::Status::success) {
+        return artifact.binary_deserialize_status;
+    }
+    RETURN_IF_ERROR(EnsureSerialized(artifact));
+    auto created = CreateIndex(artifact.row, artifact.data, artifact.file_manager);
+    if (!created.ok) {
+        artifact.binary_deserialize_status = created.status;
+        return artifact.binary_deserialize_status;
+    }
+    artifact.binary_loaded = std::move(created.index);
+    artifact.binary_deserialize_status = artifact.binary_loaded.Deserialize(artifact.binset, artifact.json);
+    artifact.binary_loaded_ready = artifact.binary_deserialize_status == knowhere::Status::success;
+    return artifact.binary_deserialize_status;
+}
+
+knowhere::Status
+WriteBinaryToFile(const knowhere::BinaryPtr& binary, const fs::path& path) {
+    if (binary == nullptr) {
+        return knowhere::Status::invalid_binary_set;
+    }
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        return knowhere::Status::disk_file_error;
+    }
+    out.write(reinterpret_cast<const char*>(binary->data.get()), binary->size);
+    if (!out) {
+        return knowhere::Status::disk_file_error;
+    }
+    return knowhere::Status::success;
+}
+
+knowhere::Status
+WriteBytesToFile(const fs::path& path, const std::vector<uint8_t>& bytes) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        return knowhere::Status::disk_file_error;
+    }
+    out.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+    if (!out) {
+        return knowhere::Status::disk_file_error;
+    }
+    return knowhere::Status::success;
+}
+
+knowhere::BinaryPtr
+MakeBinary(const std::vector<uint8_t>& bytes) {
+    auto binary = std::make_shared<knowhere::Binary>();
+    binary->size = static_cast<int64_t>(bytes.size());
+    binary->data = std::shared_ptr<uint8_t[]>(new uint8_t[std::max<size_t>(bytes.size(), 1)]);
+    std::memcpy(binary->data.get(), bytes.data(), bytes.size());
+    return binary;
+}
+
+knowhere::Status
+WriteEmbListOffsetToFile(const knowhere::DataSetPtr& dataset, size_t offset_count, const fs::path& path) {
+    auto offsets = dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+    if (offsets == nullptr) {
+        return knowhere::Status::emb_list_inner_error;
+    }
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        return knowhere::Status::disk_file_error;
+    }
+    out.write(reinterpret_cast<const char*>(&offset_count), sizeof(size_t));
+    out.write(reinterpret_cast<const char*>(offsets), offset_count * sizeof(size_t));
+    if (!out) {
+        return knowhere::Status::disk_file_error;
+    }
+    return knowhere::Status::success;
+}
+
+knowhere::BinaryPtr
+MainIndexBinary(const knowhere::BinarySet& binset) {
+    for (const auto& [key, binary] : binset.binary_map_) {
+        if (key == knowhere::meta::EXTERNAL_ID_MAP || key == knowhere::meta::EMB_LIST_META ||
+            key == knowhere::meta::EMB_LIST_RAW_INDEX) {
+            continue;
+        }
+        return binary;
+    }
+    return nullptr;
+}
+
+knowhere::Json
+FileLoadJson(const BuiltArtifact& artifact) {
+    auto json = artifact.json;
+    if (fs::exists(artifact.id_map_file) && fs::file_size(artifact.id_map_file) > 0) {
+        json["external_id_map_file_path"] = artifact.id_map_file.string();
+    }
+    if (artifact.scenario.mode == Mode::EmbList) {
+        json["emb_list_meta_file_path"] = artifact.emb_meta_file.string();
+        json["emb_list_raw_index_file_path"] = artifact.emb_raw_file.string();
+    }
+    return json;
+}
+
+knowhere::Status
+EnsureFileSerialized(BuiltArtifact& artifact) {
+    if (artifact.file_serialized) {
+        return artifact.file_serialize_status;
+    }
+    if (artifact.row.data_kind == DataKind::DiskAnn || artifact.row.data_kind == DataKind::Aisaq ||
+        artifact.row.data_kind == DataKind::MinHash) {
+        artifact.file_serialize_status = artifact.index.Serialize(artifact.binset);
+        artifact.file_serialized = true;
+        return artifact.file_serialize_status;
+    }
+
+    RETURN_IF_ERROR(EnsureSerialized(artifact));
+    RETURN_IF_ERROR(WriteBinaryToFile(MainIndexBinary(artifact.binset), artifact.main_file));
+    auto id_map_binary = artifact.binset.GetByName(knowhere::meta::EXTERNAL_ID_MAP);
+    if (id_map_binary != nullptr) {
+        RETURN_IF_ERROR(WriteBinaryToFile(id_map_binary, artifact.id_map_file));
+    } else {
+        std::ofstream out(artifact.id_map_file, std::ios::binary | std::ios::trunc);
+    }
+
+    if (artifact.scenario.mode == Mode::EmbList) {
+        RETURN_IF_ERROR(WriteBinaryToFile(artifact.binset.GetByName(knowhere::meta::EMB_LIST_META),
+                                          artifact.emb_meta_file));
+        auto raw_binary = artifact.binset.GetByName(knowhere::meta::EMB_LIST_RAW_INDEX);
+        if (raw_binary != nullptr) {
+            RETURN_IF_ERROR(WriteBinaryToFile(raw_binary, artifact.emb_raw_file));
+        }
+    }
+
+    artifact.file_serialize_status = knowhere::Status::success;
+    artifact.file_serialized = true;
+    return artifact.file_serialize_status;
+}
+
+knowhere::Status
+EnsureFileLoaded(BuiltArtifact& artifact) {
+    if (artifact.file_loaded_ready || artifact.file_deserialize_status != knowhere::Status::success) {
+        return artifact.file_deserialize_status;
+    }
+    RETURN_IF_ERROR(EnsureFileSerialized(artifact));
+    auto created = CreateIndex(artifact.row, artifact.data, artifact.file_manager);
+    if (!created.ok) {
+        artifact.file_deserialize_status = created.status;
+        return artifact.file_deserialize_status;
+    }
+    artifact.file_loaded = std::move(created.index);
+    if (artifact.row.data_kind == DataKind::DiskAnn || artifact.row.data_kind == DataKind::Aisaq ||
+        artifact.row.data_kind == DataKind::MinHash) {
+        artifact.file_deserialize_status = artifact.file_loaded.Deserialize(artifact.binset, artifact.json);
+    } else {
+        artifact.file_deserialize_status = artifact.file_loaded.DeserializeFromFile(artifact.main_file.string(),
+                                                                                   FileLoadJson(artifact));
+    }
+    artifact.file_loaded_ready = artifact.file_deserialize_status == knowhere::Status::success;
+    return artifact.file_deserialize_status;
+}
+
+const knowhere::Index<knowhere::IndexNode>&
+IndexForSource(BuiltArtifact& artifact, IndexSource source) {
+    switch (source) {
+        case IndexSource::Fresh:
+            return artifact.index;
+        case IndexSource::BinarySet:
+            REQUIRE(EnsureBinaryLoaded(artifact) == knowhere::Status::success);
+            return artifact.binary_loaded;
+        case IndexSource::File:
+            REQUIRE(EnsureFileLoaded(artifact) == knowhere::Status::success);
+            return artifact.file_loaded;
+    }
+    return artifact.index;
+}
+
+void
+RequireBuildReady(const BuiltArtifact& artifact) {
+    if (artifact.scenario.nullable_ratio == NullableRatio::R100) {
+        REQUIRE(IsExpectedEmptyBuildStatus(artifact.build_status));
+    } else {
+        REQUIRE(artifact.build_status == knowhere::Status::success);
+    }
+}
+
+void
+ExecuteSearchLike(BuiltArtifact& artifact, const Scenario& scenario, Operation op) {
+    const auto& index = IndexForSource(artifact, scenario.source);
+    auto filtered_ids = FilterIdsFor(scenario.filter_ratio, artifact.data.total_count, artifact.data.valid_ids,
+                                    scenario.mode, artifact.data.selected_ids);
+    auto candidates = scenario.mode == Mode::MultiIndex ? artifact.data.selected_ids : artifact.data.valid_ids;
+    auto allowed_ids = AllowedIdsAfterFilter(candidates, filtered_ids);
+    const bool expect_empty = allowed_ids.empty();
+
+    std::vector<uint8_t> bitset_data;
+    knowhere::BitsetView bitset;
+    const bool needs_bitset = scenario.filter_ratio != FilterRatio::None || scenario.mode == Mode::MultiIndex;
+    if (needs_bitset) {
+        bitset = BitsetViewFrom(bitset_data, artifact.data.total_count, filtered_ids);
+    }
+    milvus::OpContext op_context;
+
+    if (op == Operation::Search || op == Operation::SearchFilter) {
+        auto result = index.Search(artifact.data.query_ds, artifact.json, needs_bitset ? bitset : nullptr, &op_context);
+        if (IsFreshFileBackedRead(artifact.row, scenario) && !result.has_value()) {
+            REQUIRE(IsExpectedEmptySearchError(result.error()));
+            return;
+        }
+        RequireExpectedVectorResult(result, allowed_ids, filtered_ids, expect_empty);
+        if (artifact.row.exact && result.has_value() && !expect_empty) {
+            RequireExactFirstHits(*result.value(), artifact.data.query_ids, allowed_ids);
+        }
+    } else if (op == Operation::Range || op == Operation::RangeFilter) {
+        auto result =
+            index.RangeSearch(artifact.data.query_ds, artifact.json, needs_bitset ? bitset : nullptr, &op_context);
+        if (IsFreshFileBackedRead(artifact.row, scenario) && !result.has_value()) {
+            REQUIRE(IsExpectedEmptySearchError(result.error()));
+            return;
+        }
+        RequireExpectedRangeResult(result, allowed_ids, filtered_ids, expect_empty);
+        if (artifact.row.exact && result.has_value() && !expect_empty) {
+            RequireExactRangeHits(*result.value(), artifact.data.query_ids, allowed_ids);
+        }
+    } else if (op == Operation::Iterator || op == Operation::IteratorFilter) {
+        auto result =
+            index.AnnIterator(artifact.data.query_ds, artifact.json, needs_bitset ? bitset : nullptr, true, &op_context);
+        if (IsFreshFileBackedRead(artifact.row, scenario) && !result.has_value()) {
+            REQUIRE(IsExpectedEmptySearchError(result.error()));
+            return;
+        }
+        RequireExpectedIteratorResult(result, allowed_ids, filtered_ids, expect_empty,
+                                      artifact.row.exact ? &artifact.data.query_ids : nullptr);
+    }
+}
+
+void
+ExecuteSupportedScenario(const IndexRow& row, const Scenario& scenario) {
+    auto artifact = GetArtifact(row, scenario);
+    CAPTURE(row.label, row.index_type, scenario.name, artifact->json.dump());
+
+    if (!artifact->create_ok) {
+        REQUIRE(row.maybe_unavailable);
+        REQUIRE(artifact->create_status != knowhere::Status::success);
+        return;
+    }
+
+    if (scenario.op == Operation::Build) {
+        RequireBuildReady(*artifact);
+        return;
+    }
+
+    if (artifact->build_status != knowhere::Status::success) {
+        REQUIRE(scenario.nullable_ratio == NullableRatio::R100);
+        REQUIRE(IsExpectedEmptyBuildStatus(artifact->build_status));
+        return;
+    }
+
+    switch (scenario.op) {
+        case Operation::Search:
+        case Operation::Range:
+        case Operation::Iterator:
+        case Operation::SearchFilter:
+        case Operation::RangeFilter:
+        case Operation::IteratorFilter:
+            ExecuteSearchLike(*artifact, scenario, scenario.op);
+            return;
+        case Operation::BinarySetSerialize:
+            REQUIRE(EnsureSerialized(*artifact) == knowhere::Status::success);
+            REQUIRE(artifact->binset.Size() > 0);
+            return;
+        case Operation::BinarySetDeserialize:
+            REQUIRE(EnsureBinaryLoaded(*artifact) == knowhere::Status::success);
+            REQUIRE(artifact->binary_loaded.ExternalCount() == artifact->index.ExternalCount());
+            return;
+        case Operation::FileSerialize:
+            REQUIRE(EnsureFileSerialized(*artifact) == knowhere::Status::success);
+            return;
+        case Operation::FileDeserialize:
+            REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
+            if (artifact->row.data_kind == DataKind::MinHash && scenario.nullable_ratio == NullableRatio::R0) {
+                REQUIRE(artifact->file_loaded.ExternalCount() == artifact->data.total_count);
+            } else {
+                REQUIRE(artifact->file_loaded.ExternalCount() == artifact->index.ExternalCount());
+            }
+            return;
+        case Operation::Build:
+            return;
+    }
+}
+
+bool
+IsExpectedUnsupportedStatus(knowhere::Status status) {
+    return status != knowhere::Status::success;
+}
+
+void
+RequireExpectedUnsupportedStatus(knowhere::Status status) {
+    REQUIRE(IsExpectedUnsupportedStatus(status));
+}
+
+void
+ExecuteUnsupportedScenario(const IndexRow& row, const Scenario& scenario) {
+    if (!SupportsModeBuild(row, scenario.mode)) {
+        REQUIRE_FALSE(SupportsScenario(row, scenario));
+        return;
+    }
+
+    auto artifact = GetArtifact(row, scenario);
+    CAPTURE(row.label, row.index_type, scenario.name, artifact->json.dump());
+
+    if (!artifact->create_ok) {
+        RequireExpectedUnsupportedStatus(artifact->create_status);
+        return;
+    }
+
+    if (scenario.op == Operation::Build) {
+        return;
+    }
+
+    if (artifact->build_status != knowhere::Status::success) {
+        RequireExpectedUnsupportedStatus(artifact->build_status);
+        return;
+    }
+
+    switch (scenario.op) {
+        case Operation::Search:
+        case Operation::Range:
+        case Operation::Iterator:
+        case Operation::SearchFilter:
+        case Operation::RangeFilter:
+        case Operation::IteratorFilter:
+            SUCCEED("unsupported read operation is covered by capability matrix");
+            return;
+        case Operation::BinarySetSerialize:
+            (void)EnsureSerialized(*artifact);
+            return;
+        case Operation::BinarySetDeserialize: {
+            auto serialize_status = EnsureSerialized(*artifact);
+            if (serialize_status != knowhere::Status::success) {
+                RequireExpectedUnsupportedStatus(serialize_status);
+                return;
+            }
+            (void)EnsureBinaryLoaded(*artifact);
+            return;
+        }
+        case Operation::FileSerialize:
+            (void)EnsureFileSerialized(*artifact);
+            return;
+        case Operation::FileDeserialize: {
+            auto serialize_status = EnsureFileSerialized(*artifact);
+            if (serialize_status != knowhere::Status::success) {
+                RequireExpectedUnsupportedStatus(serialize_status);
+                return;
+            }
+            (void)EnsureFileLoaded(*artifact);
+            return;
+        }
+        case Operation::Build:
+            return;
+    }
+}
+
+void
+ExecuteScenario(const IndexRow& row, const Scenario& scenario) {
+    const bool supported = SupportsScenario(row, scenario);
+    if (!supported) {
+        ExecuteUnsupportedScenario(row, scenario);
+        return;
+    }
+    ExecuteSupportedScenario(row, scenario);
+}
+
+std::vector<uint8_t>
+MakeValidBitmap(size_t total_count, const std::vector<int32_t>& valid_ids) {
+    return MakeBitmap(total_count, valid_ids);
+}
+
+#ifdef KNOWHERE_WITH_CARDINAL
+void
+ConfigureTieredStorageForNullableMatrix() {
+    static const bool configured = [] {
+        static const int64_t mb = 1024 * 1024;
+        milvus::cachinglayer::Manager::ConfigureTieredStorage(
+            {CacheWarmupPolicy::CacheWarmupPolicy_Disable, CacheWarmupPolicy::CacheWarmupPolicy_Disable,
+             CacheWarmupPolicy::CacheWarmupPolicy_Disable, CacheWarmupPolicy::CacheWarmupPolicy_Disable},
+            {1024 * mb, 1024 * mb, 1024 * mb, 1024 * mb, 1024 * mb, 1024 * mb}, true, true, {10, false, 30},
+            std::chrono::milliseconds(1000));
+        return true;
+    }();
+    (void)configured;
+}
+#endif
+
+void
+RequireExternalIdMapForwarding(knowhere::IndexNode& node) {
+    knowhere::ExternalIdMap map;
+    map.SetInternalToExternalIds(std::vector<int32_t>{1, 3}, 4);
+    REQUIRE(node.SetExternalIdMap(std::move(map)) == Status::success);
+    REQUIRE(node.ExternalCount() == 4);
+    REQUIRE(node.GetValidBitmapView().size == 4);
+    REQUIRE(node.GetExternalIdMap().ToExternalId(1) == 3);
+}
+
+void
+RequireReadApisReturnError(knowhere::IndexNode& node) {
+    auto dataset = GenNullableDenseDataSet(4, {0, 2}, kDenseDim);
+    auto query = GenDenseQueryDataSet({0}, kDenseDim);
+    int64_t id = 0;
+    auto ids = knowhere::GenIdsDataSet(1, &id);
+    auto new_config = [] { return std::make_unique<knowhere::BaseConfig>(); };
+
+    auto search = node.Search(query, new_config(), knowhere::BitsetView{});
+    REQUIRE(!search.has_value());
+    REQUIRE(search.error() == Status::not_implemented);
+
+    auto range = node.RangeSearch(query, new_config(), knowhere::BitsetView{});
+    REQUIRE(!range.has_value());
+    REQUIRE(range.error() == Status::not_implemented);
+
+    auto iterator = node.AnnIterator(query, new_config(), knowhere::BitsetView{});
+    REQUIRE(!iterator.has_value());
+    REQUIRE(iterator.error() == Status::not_implemented);
+
+    auto vector = node.GetVectorByIds(ids);
+    REQUIRE(!vector.has_value());
+    REQUIRE(vector.error() == Status::not_implemented);
+
+    auto calc_dist = node.CalcDistByIDs(dataset, knowhere::BitsetView{}, &id, 1, false);
+    REQUIRE(!calc_dist.has_value());
+    REQUIRE(calc_dist.error() == Status::not_implemented);
+
+    auto emb_list = node.GetEmbListByIds(ids, knowhere::metric::L2);
+    REQUIRE(!emb_list.has_value());
+    REQUIRE(emb_list.error() == Status::emb_list_inner_error);
+}
+
+struct RequiredIndexRow {
+    const char* label;
+    const char* index_type;
+    DataKind data_kind;
+};
+
+bool
+HasIndexRow(const std::vector<IndexRow>& rows, const RequiredIndexRow& required) {
+    return std::any_of(rows.begin(), rows.end(), [&](const IndexRow& row) {
+        return row.label == required.label && row.index_type == required.index_type &&
+               row.data_kind == required.data_kind;
+    });
+}
+
+}  // namespace
+
+TEST_CASE("Nullable ExternalIdMap and DataSet primitives", "[nullable][external_id_map]") {
+    SECTION("DataSet valid bitmap builds 0 50 100 percent mappings") {
+        auto full_ds = GenNullableDenseDataSet(8, AllIds(8), 4);
+        auto full_bitmap = MakeValidBitmap(8, AllIds(8));
+        full_ds->SetValidBitmap(full_bitmap.data(), 8);
+        REQUIRE(full_ds->GetInternalToExternalIds().empty());
+        REQUIRE(full_ds->GetExternalCount() == 0);
+
+        auto half_ds = GenNullableDenseDataSet(8, {0, 2, 4, 6}, 4);
+        auto half_bitmap = MakeValidBitmap(8, {0, 2, 4, 6});
+        half_ds->SetValidBitmap(half_bitmap.data(), 8);
+        REQUIRE(half_ds->GetInternalToExternalIds() == std::vector<int32_t>{0, 2, 4, 6});
+        REQUIRE(half_ds->GetExternalCount() == 8);
+
+        auto null_ds = GenNullableDenseDataSet(8, {}, 4);
+        auto empty_bitmap = MakeValidBitmap(8, {});
+        null_ds->SetValidBitmap(empty_bitmap.data(), 8);
+        REQUIRE(null_ds->GetInternalToExternalIds().empty());
+        REQUIRE(null_ds->GetExternalCount() == 8);
+    }
+
+    SECTION("ExternalIdMap serializes vector and emb-list mappings") {
+        knowhere::ExternalIdMap map;
+        map.SetInternalToExternalIds(std::vector<int32_t>{0, 2, 4, 6}, 8);
+        REQUIRE(map.HasInternalToExternalIds());
+        REQUIRE(map.ExternalCount(0) == 8);
+        REQUIRE(map.ToExternalId(2) == 4);
+        REQUIRE(map.ToInternalId(4) == 2);
+        REQUIRE(map.ToInternalId(5) == -1);
+
+        std::vector<int64_t> result_ids = {0, 1, 2, 3, -1};
+        map.MapResultIds(result_ids);
+        REQUIRE(result_ids == std::vector<int64_t>{0, 2, 4, 6, -1});
+
+        map.SetExternalIdOffset(100);
+        REQUIRE(map.ToExternalId(1) == 2);
+        REQUIRE(map.ToInternalId(2) == 1);
+
+        map.AppendInternalToEmbListIds(0, 2, 1);
+        map.AppendInternalToEmbListIds(2, 4, 2);
+        REQUIRE(map.GetInternalToEmbListIds() == std::vector<int32_t>{2, 2, 4, 4});
+
+        std::vector<uint8_t> binary(map.BinarySize());
+        map.Serialize(binary.data(), binary.size());
+        knowhere::ExternalIdMap loaded;
+        loaded.Deserialize(binary.data(), static_cast<int64_t>(binary.size()));
+        REQUIRE(loaded.ExternalCount(0) == 8);
+        REQUIRE(loaded.GetInternalToExternalIds() == std::vector<int32_t>{0, 2, 4, 6});
+    }
+
+    SECTION("ExternalIdMap preserves all-null external count") {
+        knowhere::ExternalIdMap map;
+        map.SetInternalToExternalIds(nullptr, 0, 8);
+        REQUIRE(!map.HasInternalToExternalIds());
+        REQUIRE(map.ExternalCount(0) == 8);
+        auto valid = map.GetValidBitmapView();
+        REQUIRE(valid.size == 8);
+        REQUIRE(valid.data != nullptr);
+        REQUIRE(valid.data[0] == 0);
+
+        std::vector<uint8_t> binary(map.BinarySize());
+        map.Serialize(binary.data(), binary.size());
+        knowhere::ExternalIdMap loaded;
+        loaded.Deserialize(binary.data(), static_cast<int64_t>(binary.size()));
+        REQUIRE(loaded.ExternalCount(0) == 8);
+        REQUIRE(loaded.GetInternalToExternalIds().empty());
+        REQUIRE(loaded.GetValidBitmapView().size == 8);
+    }
+
+    SECTION("ExternalIdMap rejects invalid mappings") {
+        knowhere::ExternalIdMap map;
+        REQUIRE_THROWS(map.SetInternalToExternalIds(std::vector<int32_t>{0, 0}, 4));
+        REQUIRE_THROWS(map.SetInternalToExternalIds(std::vector<int32_t>{0, 4}, 4));
+        REQUIRE_THROWS(map.SetInternalToExternalIds(std::vector<int32_t>{0, 1, 2}, 2));
+        REQUIRE_THROWS(map.SetInternalToExternalIds(nullptr, 1, 4));
+
+        const int32_t ids[] = {0, 2};
+        REQUIRE_THROWS(map.SetInternalToExternalIds(ids, 2, 1));
+        REQUIRE_THROWS(map.SetInternalToExternalIds(ids, -1, 4));
+    }
+
+    SECTION("ExternalIdMap rejects malformed binary payloads") {
+        knowhere::ExternalIdMap map;
+
+        std::vector<uint8_t> too_small(sizeof(uint64_t), 0);
+        REQUIRE_THROWS(map.Deserialize(too_small.data(), static_cast<int64_t>(too_small.size())));
+
+        std::vector<uint8_t> truncated(2 * sizeof(uint64_t), 0);
+        uint64_t external_count = 8;
+        uint64_t map_size = 2;
+        std::memcpy(truncated.data(), &external_count, sizeof(uint64_t));
+        std::memcpy(truncated.data() + sizeof(uint64_t), &map_size, sizeof(uint64_t));
+        REQUIRE_THROWS(map.Deserialize(truncated.data(), static_cast<int64_t>(truncated.size())));
+
+        std::vector<uint8_t> duplicate(2 * sizeof(uint64_t) + 2 * sizeof(int32_t), 0);
+        int32_t duplicate_ids[] = {2, 2};
+        std::memcpy(duplicate.data(), &external_count, sizeof(uint64_t));
+        std::memcpy(duplicate.data() + sizeof(uint64_t), &map_size, sizeof(uint64_t));
+        std::memcpy(duplicate.data() + 2 * sizeof(uint64_t), duplicate_ids, sizeof(duplicate_ids));
+        REQUIRE_THROWS(map.Deserialize(duplicate.data(), static_cast<int64_t>(duplicate.size())));
+    }
+
+    SECTION("ExternalIdMap applies runtime identity offset") {
+        knowhere::ExternalIdMap map;
+        map.SetExternalIdOffset(10);
+        REQUIRE(map.HasResultIdMap());
+        REQUIRE(!map.HasInternalToExternalIds());
+        REQUIRE(map.ToExternalId(2) == 12);
+        REQUIRE(map.ToInternalId(12) == 2);
+        REQUIRE(map.ToInternalId(9) == -1);
+
+        std::vector<int64_t> result_ids = {0, 2, -1};
+        map.MapResultIds(result_ids);
+        REQUIRE(result_ids == std::vector<int64_t>{10, 12, -1});
+
+        std::vector<int64_t> external_ids = {10, 12, 9};
+        std::vector<int64_t> internal_ids;
+        const auto* mapped_ids = map.ToInternalIds(external_ids.data(), external_ids.size(), internal_ids);
+        REQUIRE(mapped_ids == internal_ids.data());
+        REQUIRE(internal_ids == std::vector<int64_t>{0, 2, -1});
+
+        std::vector<uint8_t> filter_bits(2, 0);
+        filter_bits[12 >> 3] |= static_cast<uint8_t>(1U << (12 & 7));
+        knowhere::BitsetView bitset(filter_bits.data(), 16, 1);
+        map.SetOutIdsToBitset(bitset);
+        REQUIRE(!bitset.has_out_ids());
+        REQUIRE(!bitset.test(1));
+        REQUIRE(bitset.test(2));
+
+        knowhere::BitsetView chunk_bitset(filter_bits.data(), 16, 1);
+        map.SetOutIdsToBitset(chunk_bitset, 0, std::nullopt, 2);
+        REQUIRE(chunk_bitset.test(0));
+    }
+
+    SECTION("ExternalIdMap appends build-add batches") {
+        knowhere::ExternalIdMap map;
+        map.SetInternalToExternalIds(std::vector<int32_t>{0, 2, 4}, 6);
+        const int32_t second_batch[] = {5};
+        map.AddInternalToExternalIds(second_batch, 1, 7, 3);
+        REQUIRE(map.GetInternalToExternalIds() == std::vector<int32_t>{0, 2, 4, 5});
+        REQUIRE(map.ExternalCount(0) == 7);
+        REQUIRE(map.ToInternalId(5) == 3);
+
+        const int32_t nullable_after_full[] = {4, 6};
+        knowhere::ExternalIdMap map_from_full;
+        map_from_full.AddInternalToExternalIds(nullable_after_full, 2, 8, 3);
+        REQUIRE(map_from_full.GetInternalToExternalIds() == std::vector<int32_t>{0, 1, 2, 4, 6});
+        REQUIRE(map_from_full.ExternalCount(0) == 8);
+
+        map_from_full.AddInternalToExternalIds(nullptr, 2, 0, 5);
+        REQUIRE(map_from_full.GetInternalToExternalIds() == std::vector<int32_t>{0, 1, 2, 4, 6, 8, 9});
+        REQUIRE(map_from_full.ExternalCount(0) == 10);
+    }
+
+    SECTION("Data type conversion preserves vector and emb-list nullable metadata") {
+        auto vector_ds = GenNullableDenseDataSet(8, {0, 2, 4, 6}, 4);
+        auto converted_vector = knowhere::ConvertToDataTypeIfNeeded<knowhere::fp16>(vector_ds, 1, 2);
+        REQUIRE(converted_vector->GetRows() == 2);
+        REQUIRE(converted_vector->GetInternalToExternalIds() == std::vector<int32_t>{2, 4});
+        REQUIRE(converted_vector->GetExternalCount() == 8);
+
+        auto emb_ds = GenNullableEmbListDataSet(8, {1, 3, 5}, 4, 2);
+        auto converted_emb = knowhere::ConvertToDataTypeIfNeeded<knowhere::fp16>(emb_ds);
+        REQUIRE(converted_emb->GetRows() == emb_ds->GetRows());
+        REQUIRE(converted_emb->GetInternalToExternalIds() == std::vector<int32_t>{1, 3, 5});
+        REQUIRE(converted_emb->GetExternalCount() == 8);
+        auto offsets = converted_emb->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+        REQUIRE(offsets != nullptr);
+        REQUIRE(offsets[0] == 0);
+        REQUIRE(offsets[3] == 6);
+    }
+
+    SECTION("IndexNode wrappers forward nullable external id map state") {
+        auto data_mock = knowhere::IndexNodeDataMockWrapper<knowhere::fp16>(
+            std::make_unique<NullableWrapperFakeIndexNode>());
+        RequireExternalIdMapForwarding(data_mock);
+        RequireReadApisReturnError(data_mock);
+
+        auto thread_pool = knowhere::IndexNodeThreadPoolWrapper(
+            std::make_unique<NullableWrapperFakeIndexNode>(), 1);
+        RequireExternalIdMapForwarding(thread_pool);
+        RequireReadApisReturnError(thread_pool);
+    }
+}
+
+TEST_CASE("Nullable Flat Add appends external id map", "[nullable][flat][add]") {
+    auto json = BaseDenseConfig(knowhere::metric::L2, kDenseDim, 1);
+    auto first_batch = GenNullableDenseDataSet(8, {0, 2}, kDenseDim);
+    auto second_batch = GenNullableDenseDataSet(8, {4, 6}, kDenseDim);
+    auto query = GenDenseQueryDataSet({0, 6}, kDenseDim);
+
+    auto version = knowhere::Version::GetCurrentVersion().VersionNumber();
+    auto index = knowhere::IndexFactory::Instance()
+                     .Create<knowhere::fp32>(knowhere::IndexEnum::INDEX_FAISS_IDMAP, version)
+                     .value();
+    REQUIRE(index.Train(first_batch, json) == Status::success);
+    REQUIRE(index.Add(first_batch, json) == Status::success);
+    REQUIRE(index.Add(second_batch, json) == Status::success);
+
+    auto result = index.Search(query, json, knowhere::BitsetView{});
+    REQUIRE(result.has_value());
+    const auto* ids = result.value()->GetIds();
+    REQUIRE(ids[0] == 0);
+    REQUIRE(ids[1] == 6);
+
+    int64_t retrieve_ids[] = {0, 6};
+    auto retrieve = index.GetVectorByIds(knowhere::GenIdsDataSet(2, retrieve_ids));
+    REQUIRE(retrieve.has_value());
+    const auto* retrieved_data = static_cast<const float*>(retrieve.value()->GetTensor());
+    REQUIRE(retrieved_data[0] == 2.0f);
+    REQUIRE(retrieved_data[kDenseDim] == 601.0f);
+}
+
+TEST_CASE("Nullable SCANN_DVR emb-list cosine rerank maps calc-dist ids", "[nullable][scann_dvr][emblist]") {
+    IndexRow row{"SCANN_DVR", knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, DataKind::DenseFp32};
+    Scenario scenario;
+    scenario.mode = Mode::EmbList;
+    scenario.nullable_ratio = NullableRatio::R50;
+
+    auto work_dir = fs::temp_directory_path() / "knowhere_nullable_scann_dvr_calc_dist";
+    auto data = BuildMatrixData(row, scenario, work_dir);
+    auto json = DenseConfigFor(row, Mode::EmbList);
+    json[knowhere::meta::METRIC_TYPE] = "MAX_SIM_COSINE";
+
+    auto created = CreateIndex(row, data);
+    REQUIRE(created.ok);
+    REQUIRE(created.index.Build(data.train_ds, json) == Status::success);
+
+    auto result = created.index.Search(data.query_ds, json, knowhere::BitsetView{});
+    REQUIRE(result.has_value());
+    RequireExpectedVectorResult(result, data.valid_ids, {}, false);
+}
+
+TEST_CASE("Nullable IVF_FLAT vector APIs preserve logical ids across reload", "[nullable][ivf][api]") {
+    IndexRow row{"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32};
+    Scenario scenario;
+    scenario.mode = Mode::Vector;
+    scenario.nullable_ratio = NullableRatio::R50;
+
+    auto artifact = GetArtifact(row, scenario);
+    CAPTURE(artifact->json.dump());
+    REQUIRE(artifact->create_ok);
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+
+    RequireDenseVectorApisUseExternalIds(artifact->index, artifact->data, artifact->json);
+
+    REQUIRE(EnsureBinaryLoaded(*artifact) == knowhere::Status::success);
+    RequireDenseVectorApisUseExternalIds(artifact->binary_loaded, artifact->data, artifact->json);
+
+    REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
+    RequireDenseVectorApisUseExternalIds(artifact->file_loaded, artifact->data, artifact->json);
+}
+
+TEST_CASE("Nullable IVF_FLAT emb-list APIs preserve list ids across reload", "[nullable][ivf][emblist][api]") {
+    IndexRow row{"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32};
+    Scenario scenario;
+    scenario.mode = Mode::EmbList;
+    scenario.nullable_ratio = NullableRatio::R50;
+
+    auto artifact = GetArtifact(row, scenario);
+    CAPTURE(artifact->json.dump());
+    REQUIRE(artifact->create_ok);
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+
+    RequireEmbListApisUseExternalIds(artifact->index, artifact->data, artifact->json);
+
+    REQUIRE(EnsureBinaryLoaded(*artifact) == knowhere::Status::success);
+    RequireEmbListApisUseExternalIds(artifact->binary_loaded, artifact->data, artifact->json);
+
+    REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
+    RequireEmbListApisUseExternalIds(artifact->file_loaded, artifact->data, artifact->json);
+}
+
+TEST_CASE("Nullable retrieval APIs reject invalid logical ids", "[nullable][api][invalid]") {
+    const std::vector<IndexRow> rows = {
+        {"FLAT", knowhere::IndexEnum::INDEX_FAISS_IDMAP, DataKind::DenseFp32},
+        {"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32},
+        {"HNSWLIB_DEPRECATED", "HNSWLIB_DEPRECATED", DataKind::DenseFp32},
+        {"DISKANN (Knowhere native)", knowhere::IndexEnum::INDEX_DISKANN, DataKind::DiskAnn},
+        {"AISAQ", knowhere::IndexEnum::INDEX_AISAQ, DataKind::Aisaq},
+        {"SPARSE_INVERTED_INDEX_CC (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC,
+         DataKind::Sparse},
+#ifdef KNOWHERE_WITH_CARDINAL
+        {"HNSW (Cardinal v2)", knowhere::IndexEnum::INDEX_HNSW, DataKind::DenseFp32, Capabilities{}, false, true},
+        {"SPARSE_INVERTED_INDEX_CC (Cardinal v1)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC,
+         DataKind::Sparse, Capabilities{}, false, true, false, false, true},
+#endif
+        {"MINHASH_LSH", knowhere::IndexEnum::INDEX_MINHASH_LSH, DataKind::MinHash},
+    };
+
+    Scenario scenario;
+    scenario.mode = Mode::Vector;
+    scenario.nullable_ratio = NullableRatio::R50;
+    for (const auto& row : rows) {
+        CAPTURE(row.label, row.index_type);
+        auto artifact = GetArtifact(row, scenario);
+        REQUIRE(artifact->create_ok);
+        REQUIRE(artifact->build_status == knowhere::Status::success);
+        RequireExternalIdMapContent(artifact->index, artifact->data.valid_ids, artifact->data.total_count);
+        const auto& index = [&]() -> const knowhere::Index<knowhere::IndexNode>& {
+            if (row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq ||
+                row.data_kind == DataKind::MinHash) {
+                REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
+                return artifact->file_loaded;
+            }
+            return artifact->index;
+        }();
+        RequireExternalIdMapContent(index, artifact->data.valid_ids, artifact->data.total_count);
+        RequireGetVectorRejectsInvalidExternalIds(index, artifact->data);
+    }
+}
+
+TEST_CASE("Nullable CalcDistByIDs rejects invalid logical ids", "[nullable][api][invalid]") {
+    const std::vector<IndexRow> rows = {
+        {"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32},
+#ifdef KNOWHERE_WITH_CARDINAL
+        {"HNSW (Cardinal v2)", knowhere::IndexEnum::INDEX_HNSW, DataKind::DenseFp32, Capabilities{}, false, true},
+#endif
+    };
+
+    Scenario scenario;
+    scenario.mode = Mode::Vector;
+    scenario.nullable_ratio = NullableRatio::R50;
+    for (const auto& row : rows) {
+        CAPTURE(row.label, row.index_type);
+        auto artifact = GetArtifact(row, scenario);
+        REQUIRE(artifact->create_ok);
+        REQUIRE(artifact->build_status == knowhere::Status::success);
+        const auto& index = [&]() -> const knowhere::Index<knowhere::IndexNode>& {
+            if (row.data_kind == DataKind::DiskAnn) {
+                REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
+                return artifact->file_loaded;
+            }
+            return artifact->index;
+        }();
+        RequireDenseCalcDistRejectsInvalidExternalIds(index, artifact->data);
+    }
+}
+
+TEST_CASE("Nullable loading rejects corrupted external id maps", "[nullable][file][negative]") {
+    IndexRow row{"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32};
+    Scenario scenario;
+    scenario.mode = Mode::Vector;
+    scenario.nullable_ratio = NullableRatio::R50;
+    auto artifact = GetArtifact(row, scenario);
+    REQUIRE(artifact->create_ok);
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+
+    SECTION("binaryset external id map") {
+        REQUIRE(EnsureSerialized(*artifact) == knowhere::Status::success);
+        auto corrupt_binset = artifact->binset;
+        corrupt_binset.Append(knowhere::meta::EXTERNAL_ID_MAP, MakeBinary({0x01, 0x02, 0x03}));
+        auto created = CreateIndex(row, artifact->data, artifact->file_manager);
+        REQUIRE(created.ok);
+        REQUIRE(created.index.Deserialize(corrupt_binset, artifact->json) == knowhere::Status::invalid_binary_set);
+    }
+
+    SECTION("file external id map") {
+        REQUIRE(EnsureFileSerialized(*artifact) == knowhere::Status::success);
+        auto corrupt_id_map = artifact->work_dir / "corrupt_id_map.bin";
+        REQUIRE(WriteBytesToFile(corrupt_id_map, {0x01, 0x02, 0x03}) == knowhere::Status::success);
+        auto json = FileLoadJson(*artifact);
+        json["external_id_map_file_path"] = corrupt_id_map.string();
+        auto created = CreateIndex(row, artifact->data, artifact->file_manager);
+        REQUIRE(created.ok);
+        REQUIRE(created.index.DeserializeFromFile(artifact->main_file.string(), json) ==
+                knowhere::Status::invalid_binary_set);
+    }
+}
+
+TEST_CASE("Nullable file loading rejects corrupted persisted data", "[nullable][file][negative]") {
+    SECTION("main index file") {
+        IndexRow row{"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32};
+        Scenario scenario;
+        scenario.mode = Mode::Vector;
+        scenario.nullable_ratio = NullableRatio::R50;
+        auto artifact = GetArtifact(row, scenario);
+        REQUIRE(artifact->create_ok);
+        REQUIRE(artifact->build_status == knowhere::Status::success);
+        REQUIRE(EnsureFileSerialized(*artifact) == knowhere::Status::success);
+
+        auto corrupt_main = artifact->work_dir / "corrupt_main.index";
+        REQUIRE(WriteBytesToFile(corrupt_main, {0x01, 0x02, 0x03}) == knowhere::Status::success);
+        auto created = CreateIndex(row, artifact->data, artifact->file_manager);
+        REQUIRE(created.ok);
+        auto status = created.index.DeserializeFromFile(corrupt_main.string(), FileLoadJson(*artifact));
+        REQUIRE(status != knowhere::Status::success);
+    }
+
+    SECTION("emb-list metadata file") {
+        IndexRow row{"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32};
+        Scenario scenario;
+        scenario.mode = Mode::EmbList;
+        scenario.nullable_ratio = NullableRatio::R50;
+        auto artifact = GetArtifact(row, scenario);
+        REQUIRE(artifact->create_ok);
+        REQUIRE(artifact->build_status == knowhere::Status::success);
+        REQUIRE(EnsureFileSerialized(*artifact) == knowhere::Status::success);
+
+        auto corrupt_meta = artifact->work_dir / "corrupt_emb_list_meta.bin";
+        REQUIRE(WriteBytesToFile(corrupt_meta, {0x01, 0x02, 0x03}) == knowhere::Status::success);
+        auto json = FileLoadJson(*artifact);
+        json["emb_list_meta_file_path"] = corrupt_meta.string();
+        auto created = CreateIndex(row, artifact->data, artifact->file_manager);
+        REQUIRE(created.ok);
+        auto status = created.index.DeserializeFromFile(artifact->main_file.string(), json);
+        REQUIRE(status != knowhere::Status::success);
+    }
+
+#ifdef KNOWHERE_WITH_CARDINAL
+    SECTION("cardinal metadata file") {
+        IndexRow row{"HNSW (Cardinal v2)", knowhere::IndexEnum::INDEX_HNSW, DataKind::DenseFp32,
+                     Capabilities{}, false, true};
+        Scenario scenario;
+        scenario.mode = Mode::Vector;
+        scenario.nullable_ratio = NullableRatio::R50;
+        auto artifact = GetArtifact(row, scenario);
+        REQUIRE(artifact->create_ok);
+        REQUIRE(artifact->build_status == knowhere::Status::success);
+        REQUIRE(EnsureFileSerialized(*artifact) == knowhere::Status::success);
+
+        auto corrupt_cardinal = artifact->work_dir / "corrupt_cardinal.index";
+        REQUIRE(WriteBytesToFile(corrupt_cardinal, {0x01, 0x02, 0x03}) == knowhere::Status::success);
+        auto created = CreateIndex(row, artifact->data, artifact->file_manager);
+        REQUIRE(created.ok);
+        auto status = created.index.DeserializeFromFile(corrupt_cardinal.string(), FileLoadJson(*artifact));
+        REQUIRE(status != knowhere::Status::success);
+    }
+#endif
+}
+
+TEST_CASE("Nullable mmap file load preserves large non-identity mapping", "[nullable][mmap][api]") {
+    IndexRow row{"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32};
+    Scenario scenario;
+    scenario.mode = Mode::Vector;
+    scenario.nullable_ratio = NullableRatio::R50;
+
+    BuiltArtifact artifact;
+    artifact.row = row;
+    artifact.scenario = scenario;
+    artifact.work_dir = fs::current_path() / "nullable_external_id_map_matrix" / "ivf_mmap_large_mapping";
+    fs::remove_all(artifact.work_dir);
+    fs::create_directories(artifact.work_dir);
+    artifact.main_file = artifact.work_dir / "main.index";
+    artifact.id_map_file = artifact.work_dir / "main.index_id_map";
+    artifact.data.total_count = 160;
+    artifact.data.dim = kDenseDim;
+    artifact.data.valid_ids = SwappedEvenIds(artifact.data.total_count);
+    artifact.data.query_ids = FirstQueryIds(artifact.data.valid_ids, artifact.data.total_count);
+    artifact.data.train_ds =
+        GenNullableDenseDataSet(artifact.data.total_count, artifact.data.valid_ids, artifact.data.dim);
+    artifact.data.query_ds = GenDenseQueryDataSet(artifact.data.query_ids, artifact.data.dim);
+    artifact.json = DenseConfigFor(row, Mode::Vector);
+
+    auto created = CreateIndex(row, artifact.data);
+    REQUIRE(created.ok);
+    artifact.index = std::move(created.index);
+    artifact.build_status = artifact.index.Build(artifact.data.train_ds, artifact.json);
+    REQUIRE(artifact.build_status == knowhere::Status::success);
+    REQUIRE(EnsureFileSerialized(artifact) == knowhere::Status::success);
+
+    auto load_json = FileLoadJson(artifact);
+    load_json["enable_mmap"] = true;
+    auto loaded = CreateIndex(row, artifact.data);
+    REQUIRE(loaded.ok);
+    REQUIRE(loaded.index.DeserializeFromFile(artifact.main_file.string(), load_json) == knowhere::Status::success);
+    RequireDenseVectorApisUseExternalIds(loaded.index, artifact.data, artifact.json);
+}
+
+TEST_CASE("Nullable BruteForce component maps logical ids", "[nullable][bruteforce]") {
+    const auto nullable_ratios = {NullableRatio::R0, NullableRatio::R50, NullableRatio::R100};
+    const auto filter_ratios = {FilterRatio::R0, FilterRatio::R50, FilterRatio::R100};
+
+    SECTION("dense vector") {
+        auto json = BaseDenseConfig(knowhere::metric::L2, kDenseDim, kTopK);
+        for (auto nullable_ratio : nullable_ratios) {
+            auto valid_ids = ValidIdsFor(nullable_ratio, kTotalRows);
+            auto query_ids = FirstQueryIds(valid_ids, kTotalRows);
+            auto base_ds = GenNullableDenseDataSet(kTotalRows, valid_ids, kDenseDim);
+            auto query_ds = GenDenseQueryDataSet(query_ids, kDenseDim);
+
+            std::vector<std::vector<float>> chunk_storage;
+            std::vector<const float*> chunk_ptrs;
+            std::vector<size_t> chunk_lims;
+            auto chunk_base_ds =
+                GenNullableDenseChunkDataSet(kTotalRows, valid_ids, kDenseDim, chunk_storage, chunk_ptrs, chunk_lims);
+
+            for (auto filter_ratio : filter_ratios) {
+                CAPTURE(NullableName(nullable_ratio), FilterName(filter_ratio), "dense vector");
+                auto filtered_ids = FilterIdsFor(filter_ratio, kTotalRows, valid_ids, Mode::Vector, valid_ids);
+                auto allowed_ids = AllowedIdsAfterFilter(valid_ids, filtered_ids);
+                const bool expect_empty = allowed_ids.empty();
+                std::vector<uint8_t> bitset_data;
+                auto bitset = BitsetViewFrom(bitset_data, kTotalRows, filtered_ids);
+
+                auto search = knowhere::BruteForce::Search<knowhere::fp32>(base_ds, query_ds, json, bitset);
+                RequireExpectedVectorResult(search, allowed_ids, filtered_ids, expect_empty);
+                if (search.has_value() && !expect_empty) {
+                    RequireExactFirstHits(*search.value(), query_ids, allowed_ids);
+                }
+
+                std::vector<int64_t> ids(query_ds->GetRows() * kTopK, -1);
+                std::vector<float> dists(query_ds->GetRows() * kTopK, 0.0f);
+                auto status = knowhere::BruteForce::SearchWithBuf<knowhere::fp32>(
+                    base_ds, query_ds, ids.data(), dists.data(), json, bitset);
+                RequireBufferedStatus(status, ids, allowed_ids, filtered_ids, expect_empty);
+                if (status == knowhere::Status::success && !expect_empty) {
+                    RequireBufferedExactFirstHits(ids, kTopK, query_ids, allowed_ids);
+                }
+
+                auto range = knowhere::BruteForce::RangeSearch<knowhere::fp32>(base_ds, query_ds, json, bitset);
+                RequireExpectedRangeResult(range, allowed_ids, filtered_ids, expect_empty);
+                if (range.has_value() && !expect_empty) {
+                    RequireExactRangeHits(*range.value(), query_ids, allowed_ids);
+                }
+
+                auto iterators = knowhere::BruteForce::AnnIterator<knowhere::fp32>(base_ds, query_ds, json, bitset);
+                RequireExpectedIteratorResult(iterators, allowed_ids, filtered_ids, expect_empty, &query_ids);
+
+                auto chunk_search =
+                    knowhere::BruteForce::Search<knowhere::fp32>(chunk_base_ds, query_ds, json, bitset);
+                RequireExpectedVectorResult(chunk_search, allowed_ids, filtered_ids, expect_empty);
+                if (chunk_search.has_value() && !expect_empty) {
+                    RequireExactFirstHits(*chunk_search.value(), query_ids, allowed_ids);
+                }
+
+            }
+        }
+    }
+
+    SECTION("sparse vector") {
+        auto json = SparseConfig();
+        for (auto nullable_ratio : nullable_ratios) {
+            auto valid_ids = ValidIdsFor(nullable_ratio, kTotalRows);
+            auto query_ids = FirstQueryIds(valid_ids, kTotalRows);
+            auto base_ds = GenNullableSparseDataSet(kTotalRows, valid_ids);
+            auto query_ds = GenSparseQueryDataSet(query_ids, kTotalRows);
+
+            for (auto filter_ratio : filter_ratios) {
+                CAPTURE(NullableName(nullable_ratio), FilterName(filter_ratio), "sparse vector");
+                auto filtered_ids = FilterIdsFor(filter_ratio, kTotalRows, valid_ids, Mode::Vector, valid_ids);
+                auto allowed_ids = AllowedIdsAfterFilter(valid_ids, filtered_ids);
+                const bool expect_empty = allowed_ids.empty();
+                std::vector<uint8_t> bitset_data;
+                auto bitset = BitsetViewFrom(bitset_data, kTotalRows, filtered_ids);
+
+                auto search = knowhere::BruteForce::SearchSparse(base_ds, query_ds, json, bitset);
+                RequireExpectedVectorResult(search, allowed_ids, filtered_ids, expect_empty);
+                if (search.has_value() && !expect_empty) {
+                    RequireExactFirstHits(*search.value(), query_ids, allowed_ids);
+                }
+
+                std::vector<knowhere::sparse::label_t> sparse_ids(query_ds->GetRows() * kTopK, -1);
+                std::vector<float> dists(query_ds->GetRows() * kTopK, 0.0f);
+                auto status = knowhere::BruteForce::SearchSparseWithBuf(
+                    base_ds, query_ds, sparse_ids.data(), dists.data(), json, bitset);
+                std::vector<int64_t> ids(sparse_ids.begin(), sparse_ids.end());
+                RequireBufferedStatus(status, ids, allowed_ids, filtered_ids, expect_empty);
+                if (status == knowhere::Status::success && !expect_empty) {
+                    RequireBufferedExactFirstHits(ids, kTopK, query_ids, allowed_ids);
+                }
+
+                auto range = knowhere::BruteForce::RangeSearch<knowhere::sparse::SparseRow<float>>(
+                    base_ds, query_ds, json, bitset);
+                RequireExpectedRangeResult(range, allowed_ids, filtered_ids, expect_empty);
+                if (range.has_value() && !expect_empty) {
+                    RequireExactRangeHits(*range.value(), query_ids, allowed_ids);
+                }
+
+                auto iterators = knowhere::BruteForce::AnnIterator<knowhere::sparse::SparseRow<float>>(
+                    base_ds, query_ds, json, bitset);
+                RequireExpectedIteratorResult(iterators, allowed_ids, filtered_ids, expect_empty, &query_ids);
+            }
+        }
+    }
+
+    SECTION("emb-list") {
+        auto json = BaseDenseConfig("MAX_SIM_L2", kDenseDim, kEmbTopK);
+        for (auto nullable_ratio : nullable_ratios) {
+            auto valid_ids = ValidIdsFor(nullable_ratio, kEmbDocs);
+            auto query_ids = FirstQueryIds(valid_ids, kEmbDocs, 2);
+            auto base_ds = GenNullableEmbListDataSet(kEmbDocs, valid_ids, kDenseDim, kEmbVectorsPerDoc);
+            auto query_ds = GenEmbListQueryDataSet(query_ids, kDenseDim);
+
+            std::vector<std::vector<float>> chunk_storage;
+            std::vector<const float*> chunk_ptrs;
+            std::vector<size_t> chunk_lims;
+            std::vector<size_t> emb_offsets;
+            auto chunk_base_ds = GenNullableEmbListChunkDataSet(kEmbDocs, valid_ids, kDenseDim, kEmbVectorsPerDoc,
+                                                                chunk_storage, chunk_ptrs, chunk_lims, emb_offsets);
+
+            for (auto filter_ratio : filter_ratios) {
+                CAPTURE(NullableName(nullable_ratio), FilterName(filter_ratio), "emb-list");
+                auto filtered_ids = FilterIdsFor(filter_ratio, kEmbDocs, valid_ids, Mode::EmbList, valid_ids);
+                auto allowed_ids = AllowedIdsAfterFilter(valid_ids, filtered_ids);
+                const bool expect_empty = allowed_ids.empty();
+                std::vector<uint8_t> bitset_data;
+                auto bitset = BitsetViewFrom(bitset_data, kEmbDocs, filtered_ids);
+
+                auto search = knowhere::BruteForce::Search<knowhere::fp32>(base_ds, query_ds, json, bitset);
+                RequireExpectedVectorResult(search, allowed_ids, filtered_ids, expect_empty);
+                if (search.has_value() && !expect_empty) {
+                    RequireExactFirstHits(*search.value(), query_ids, allowed_ids);
+                }
+
+                std::vector<int64_t> ids(query_ids.size() * kEmbTopK, -1);
+                std::vector<float> dists(query_ids.size() * kEmbTopK, 0.0f);
+                auto status = knowhere::BruteForce::SearchWithBuf<knowhere::fp32>(
+                    base_ds, query_ds, ids.data(), dists.data(), json, bitset);
+                RequireBufferedStatus(status, ids, allowed_ids, filtered_ids, expect_empty);
+                if (status == knowhere::Status::success && !expect_empty) {
+                    RequireBufferedExactFirstHits(ids, kEmbTopK, query_ids, allowed_ids);
+                }
+
+                auto chunk_search =
+                    knowhere::BruteForce::Search<knowhere::fp32>(chunk_base_ds, query_ds, json, bitset);
+                RequireExpectedVectorResult(chunk_search, allowed_ids, filtered_ids, expect_empty);
+                if (chunk_search.has_value() && !expect_empty) {
+                    RequireExactFirstHits(*chunk_search.value(), query_ids, allowed_ids);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("Nullable matrix has 53 index rows and 180 scenarios per row", "[nullable][matrix][count]") {
+    const auto rows = IndexRows();
+    const auto scenarios = BuildScenarios();
+    REQUIRE(rows.size() == 53);
+    REQUIRE(scenarios.size() == 180);
+    REQUIRE(rows.size() * scenarios.size() == 9540);
+
+    const std::vector<RequiredIndexRow> required_rows = {
+        {"FLAT", knowhere::IndexEnum::INDEX_FAISS_IDMAP, DataKind::DenseFp32},
+        {"BIN_FLAT / BINFLAT", knowhere::IndexEnum::INDEX_FAISS_BIN_IDMAP, DataKind::DenseBin},
+        {"FAISS (fp32)", knowhere::IndexEnum::INDEX_FAISS, DataKind::DenseFp32},
+        {"FAISS (bin1)", knowhere::IndexEnum::INDEX_FAISS, DataKind::DenseBin},
+        {"BIN_IVF_FLAT / IVFBIN", knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT, DataKind::DenseBin},
+        {"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32},
+        {"IVF_FLAT_CC / IVFFLATCC", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, DataKind::DenseFp32},
+        {"IVF_PQ / IVFPQ", knowhere::IndexEnum::INDEX_FAISS_IVFPQ, DataKind::DenseFp32},
+        {"IVF_SQ8", knowhere::IndexEnum::INDEX_FAISS_IVFSQ8, DataKind::DenseFp32},
+        {"IVF_SQ / IVFSQ", "IVF_SQ", DataKind::DenseFp32},
+        {"IVF_SQ_CC", knowhere::IndexEnum::INDEX_FAISS_IVFSQ_CC, DataKind::DenseFp32},
+        {"IVF_RABITQ / IVFRABITQ", knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ, DataKind::DenseFp32},
+        {"IVF_RABITQ_FASTSCAN", knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ_FASTSCAN, DataKind::DenseFp32},
+        {"SCANN", knowhere::IndexEnum::INDEX_FAISS_SCANN, DataKind::DenseFp32},
+        {"SCANN_DVR", knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, DataKind::DenseFp32},
+        {"HNSW (Knowhere/Faiss)", knowhere::IndexEnum::INDEX_HNSW, DataKind::DenseFp32},
+        {"HNSW_SQ", knowhere::IndexEnum::INDEX_HNSW_SQ, DataKind::DenseFp32},
+        {"HNSW_PQ", knowhere::IndexEnum::INDEX_HNSW_PQ, DataKind::DenseFp32},
+        {"HNSW_PRQ", knowhere::IndexEnum::INDEX_HNSW_PRQ, DataKind::DenseFp32},
+        {"HNSW_DEPRECATED", "HNSW_DEPRECATED", DataKind::DenseFp32},
+        {"HNSWLIB_DEPRECATED", "HNSWLIB_DEPRECATED", DataKind::DenseFp32},
+        {"HNSW_V1 sparse (Cardinal v1)", "HNSW_V1", DataKind::Sparse},
+        {"DISKANN (Knowhere native)", knowhere::IndexEnum::INDEX_DISKANN, DataKind::DiskAnn},
+        {"AISAQ", knowhere::IndexEnum::INDEX_AISAQ, DataKind::Aisaq},
+        {"DISKANN_DEPRECATED", "DISKANN_DEPRECATED", DataKind::DiskAnn},
+        {"SPARSE_INVERTED_INDEX (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX,
+         DataKind::Sparse},
+        {"SPARSE_WAND (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_WAND, DataKind::Sparse},
+        {"SPARSE_INVERTED_INDEX_CC (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC,
+         DataKind::Sparse},
+        {"SPARSE_WAND_CC (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_WAND_CC, DataKind::Sparse},
+        {"SPARSE_INVERTED_INDEX (Cardinal v1)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX,
+         DataKind::Sparse},
+        {"SPARSE_WAND (Cardinal v1)", knowhere::IndexEnum::INDEX_SPARSE_WAND, DataKind::Sparse},
+        {"SPARSE_INVERTED_INDEX_CC (Cardinal v1)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC,
+         DataKind::Sparse},
+        {"SPARSE_WAND_CC (Cardinal v1)", knowhere::IndexEnum::INDEX_SPARSE_WAND_CC, DataKind::Sparse},
+        {"MINHASH_LSH", knowhere::IndexEnum::INDEX_MINHASH_LSH, DataKind::MinHash},
+        {"GPU_CUVS_BRUTE_FORCE", knowhere::IndexEnum::INDEX_CUVS_BRUTEFORCE, DataKind::GpuFp32},
+        {"GPU_BRUTE_FORCE", knowhere::IndexEnum::INDEX_GPU_BRUTEFORCE, DataKind::GpuFp32},
+        {"GPU_CUVS_IVF_FLAT", knowhere::IndexEnum::INDEX_CUVS_IVFFLAT, DataKind::GpuFp32},
+        {"GPU_IVF_FLAT", knowhere::IndexEnum::INDEX_GPU_IVFFLAT, DataKind::GpuFp32},
+        {"GPU_CUVS_IVF_PQ", knowhere::IndexEnum::INDEX_CUVS_IVFPQ, DataKind::GpuFp32},
+        {"GPU_IVF_PQ", knowhere::IndexEnum::INDEX_GPU_IVFPQ, DataKind::GpuFp32},
+        {"GPU_CUVS_CAGRA", knowhere::IndexEnum::INDEX_CUVS_CAGRA, DataKind::GpuFp32},
+        {"GPU_CAGRA", knowhere::IndexEnum::INDEX_GPU_CAGRA, DataKind::GpuFp32},
+        {"GPU_FAISS_FLAT", knowhere::IndexEnum::INDEX_FAISS_GPU_IDMAP, DataKind::GpuFp32},
+        {"GPU_FAISS_IVF_FLAT", knowhere::IndexEnum::INDEX_FAISS_GPU_IVFFLAT, DataKind::GpuFp32},
+        {"GPU_FAISS_IVF_PQ", knowhere::IndexEnum::INDEX_FAISS_GPU_IVFPQ, DataKind::GpuFp32},
+        {"GPU_FAISS_IVF_SQ8", knowhere::IndexEnum::INDEX_FAISS_GPU_IVFSQ8, DataKind::GpuFp32},
+        {"SVS_FLAT", knowhere::IndexEnum::INDEX_SVS_FLAT, DataKind::DenseFp32},
+        {"SVS_VAMANA", knowhere::IndexEnum::INDEX_SVS_VAMANA, DataKind::DenseFp32},
+        {"SVS_VAMANA_LVQ", knowhere::IndexEnum::INDEX_SVS_VAMANA_LVQ, DataKind::DenseFp32},
+        {"SVS_VAMANA_LEANVEC", knowhere::IndexEnum::INDEX_SVS_VAMANA_LEANVEC, DataKind::DenseFp32},
+        {"HNSW (Cardinal v2)", knowhere::IndexEnum::INDEX_HNSW, DataKind::DenseFp32},
+        {"DISKANN (Cardinal v2)", knowhere::IndexEnum::INDEX_DISKANN, DataKind::DiskAnn},
+        {"CARDINAL_TIERED", knowhere::IndexEnum::INDEX_CARDINAL_TIERED, DataKind::DenseFp32},
+    };
+    REQUIRE(required_rows.size() == rows.size());
+    for (const auto& required : required_rows) {
+        CAPTURE(required.label, required.index_type);
+        REQUIRE(HasIndexRow(rows, required));
+    }
+}
+
+TEST_CASE("Nullable matrix covers every IndexNode operation", "[nullable][matrix]") {
+#ifdef KNOWHERE_WITH_CARDINAL
+    ConfigureTieredStorageForNullableMatrix();
+#endif
+    const auto rows = IndexRows();
+    const auto scenarios = BuildScenarios();
+
+    for (const auto& row : rows) {
+        SECTION(row.label) {
+            for (const auto& scenario : scenarios) {
+                SECTION(scenario.name) {
+                    ExecuteScenario(row, scenario);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add ExternalIdMap to centralize nullable and relayout id mapping.
- Wire mapped filtering and one-pass result id mapping across Knowhere index nodes, brute force, iterators, and vector retrieval paths.
- Add nullable external id map unit coverage.

## Test plan
- [x] `git diff --check HEAD~1..HEAD`
- [ ] Full compile/tests not rerun in this PR creation step.