### PR TITLE
enhance: support nullable external id mapping

### DIFF
--- a/docs/design_docs/20260731-nullable-id-mapping.md
+++ b/docs/design_docs/20260731-nullable-id-mapping.md
@@ -186,7 +186,7 @@ Negative result ids remain negative. They represent empty result slots and are n
 
 ### 7.2 Selected-ID APIs
 
-Selected-id APIs accept public ids. `MapOutToIn()` converts them to backend ids before raw-vector retrieval, distance calculation, or backend selected-id search.
+Selected-id APIs accept public ids. `CompactOutToIn()` validates them and converts them to backend ids before raw-vector retrieval, distance calculation, or backend selected-id search.
 
 `GetVectorByStorageIds()` is the internal boundary for ids that are already backend storage ids. Code that reaches this boundary must not map the ids again.
 

--- a/docs/design_docs/20260731-nullable-id-mapping.md
+++ b/docs/design_docs/20260731-nullable-id-mapping.md
@@ -1,0 +1,262 @@
+# Nullable ID Mapping Design
+
+- **Created:** 2026-07-31
+- **Component:** `DataSet`, `IdMap`, `BitsetView`, `IndexNode`, EmbList strategies, backend adapters
+- **Status:** Draft
+
+## 1. Summary
+
+Nullable vector fields can contain public rows or lists that do not have searchable vector payload. Knowhere handles this by allowing backends to build compact storage over only searchable payload while keeping public APIs, filters, and returned labels in the caller-visible id domain.
+
+`IdMap` is the index-owned boundary between those domains. `DataSet` carries nullable input as non-owning views, `IdMap` derives and owns the forward and reverse maps, `BitsetView` projects public filters to the backend id domain, and `IndexNode` maps results back once before returning.
+
+The design keeps three properties together:
+
+- the backend may store a compact dense layout;
+- callers continue to use public ids everywhere outside Knowhere backend internals;
+- query paths borrow stable index-owned mapping buffers instead of rebuilding or copying them per query.
+
+## 2. Goals
+
+| Goal | Requirement |
+|------|-------------|
+| Preserve public API labels | Search results, range results, selected-id APIs, and raw-vector APIs use public row/list ids at the API boundary. |
+| Allow compact backend storage | Backends may remove null rows or empty lists from their searchable payload and use dense backend ids internally. |
+| Keep filter semantics stable | Input bitsets are always addressed by public ids, even when the backend searches compact ids. |
+| Centralize nullable mapping | Mapping ownership and conversion rules live in `IdMap` and `IndexNode`, not in each caller. |
+| Avoid query-local map copies | Search and iterator paths borrow index-owned map arrays. |
+| Support sealed and growing indexes | Sealed maps publish immutable arrays; growing maps append new ranges while preserving previously published ids. |
+| Support reload and mmap | Derived map arrays can be reconstructed after load, and sealed dense maps can use mmap-backed allocations. |
+| Keep backend-local ids private | Relayout, partition, and sub-index ids are converted inside the backend wrapper before crossing shared boundaries. |
+
+## 3. Concepts And Domains
+
+### 3.1 ID Domains
+
+Knowhere code that handles nullable data must keep these domains separate.
+
+| Domain | Meaning | Examples |
+|--------|---------|----------|
+| Public id | Caller-visible row id for vector indexes, or caller-visible list/document id for EmbList indexes. | Input bitsets, selected ids, returned result labels. |
+| Backend id | Dense id used by the backend after non-searchable public ids are compacted away. | ANN storage ids, raw-vector storage ids, rerank inputs. |
+| Backend-local id | Private id introduced by backend relayout or partitioning. | HNSW sub-index local ids, chunk-local brute-force ids. |
+
+For a vector index:
+
+```text
+public rows:        0  1  2  3  4  5
+valid rows:         0     2        5
+backend ids:        0     1        2
+in_to_out_ids_:     [0, 2, 5]
+out_to_in_ids_:     0->0, 2->1, 5->2, others->-1
+```
+
+The caller still filters and receives labels `0`, `2`, and `5`. The backend searches ids `0`, `1`, and `2`.
+
+If the caller filters public id `5`, `BitsetView::test(2)` must return true because backend id `2` maps to public id `5`. If the backend returns id `1`, the result label returned by Knowhere is public id `2`.
+
+### 3.2 EmbList Domains
+
+EmbList adds a second public domain. A public EmbList id identifies a list/document; a backend base-vector id identifies one vector inside a compacted list range.
+
+`emb_list_offset_` stores compact list offsets in backend base-vector space:
+
+```text
+compact list id:       0      1      2
+base-vector range:   [0,2)  [2,2)  [2,5)
+```
+
+Nullable list compaction can make compact list ids different from public list ids. Strategies that search base vectors and evaluate list-level filters need a base-vector id -> public list id map. Strategies that search one encoded vector per list need only compact list id -> public list id at the normal result boundary.
+
+## 4. Mapping State
+
+### 4.1 Input View
+
+`IdMapData` is a non-owning input view attached to `DataSet`.
+
+| Format | Carries | Consumed as |
+|--------|---------|-------------|
+| `PACKED_BITMAP` | packed public-id validity bitmap | public id -> valid bit |
+| `BOOL_ARRAY` | bool validity array | public id -> valid bit |
+| `IDS` | compact backend id -> batch-local public id array plus public-domain count | direct forward map input |
+
+`DataSet` does not own these buffers. The buffers must remain valid until the build/add wrapper consumes them into the index-owned `IdMap`.
+
+### 4.2 Owned State
+
+`IdMap` owns the derived nullable mapping state.
+
+| Member | Domain | Purpose |
+|--------|--------|---------|
+| `valid_bitmap_` | public id -> valid bit | Records which public ids have searchable payload. Empty means identity/non-nullable. |
+| `in_to_out_ids_` | backend id -> public row/list id | Maps backend result ids to public labels. |
+| `out_to_in_ids_` | public row/list id -> backend id | Maps selected-id API inputs to backend ids. |
+| `in_to_out_ebl_ids_` | backend base-vector id -> public EmbList id | Lets base-vector EmbList backends evaluate public list bitsets. |
+| `out_count_` | public id domain size | Bounds public bitsets and selected ids. |
+| `valid_count_` | compact backend id count | Counts searchable payload represented by the map. |
+
+The forward and reverse maps must describe the same compacted layout. Updating one without the others changes the meaning of filters, results, or selected-id calls.
+
+### 4.3 Storage Forms
+
+`IdMap` selects its storage model before nullable data is consumed.
+
+| Type | Used by | Storage rule |
+|------|---------|--------------|
+| `SEALED` | immutable build/load indexes | `ArrayStore` publishes complete contiguous arrays, optionally backed by mmap. |
+| `GROWING` | appendable indexes | `ArrayStore` uses appendable storage so existing ids remain stable when a new public-id range is added. |
+
+`AdaptiveStore` stores public id -> backend id lookup. It can use sparse storage for sealed heap maps when the public domain is much larger than the valid id count. Mmap-backed sealed maps and growing maps use dense storage so lookup memory has a predictable addressable range.
+
+## 5. Lifecycle
+
+### 5.1 Build
+
+Build consumes nullable input before the backend build:
+
+1. The caller attaches `IdMapData` to the build `DataSet`.
+2. `Index<T>::Build()` consumes it into `IndexNode::GetIdMap()`.
+3. The backend builds compact searchable payload.
+4. `IndexNode::FinalizeIdMap()` derives missing maps after backend layout is available.
+
+Validity input does not fully define every map. For example, a validity bitmap says which public ids are valid, but the backend or EmbList strategy may still need to finish offsets, relayout, or strategy state before all backend id -> public id maps can be derived.
+
+An all-null build has no backend vector payload, but it still has public-domain nullable metadata. The build path finalizes the id map so search, selected-id validation, and load/reconstruct paths see the same public id domain as non-empty nullable indexes.
+
+### 5.2 Add
+
+Growing add consumes nullable input for the appended public range before the backend add:
+
+1. The caller sets `IdMap::Type::GROWING` before append data is consumed.
+2. `IdMapData` describes only the appended range.
+3. `IdMap` rebases batch-local public ids by the current `out_count_`.
+4. The backend receives compact payload for the valid rows in that appended range.
+
+Tail append is the important concurrency property. Existing backend ids and their public labels stay stable while new ids are added after the current range.
+
+Search visibility is still controlled by the caller's published public-id prefix. A search enters Knowhere with a public bitset for that prefix, and `PrepareBitset()` captures the mapped id count used by the backend for that request. Appends beyond that captured count are not part of the request.
+
+`Index::Add()` returns backend add failures to the caller. The id map is consumed before backend add because backend layout and EmbList relayout may need the map while ingesting the payload, but Knowhere does not treat a failed backend add as recovered by rolling back only the id map. A caller that owns a growing or interim index must publish the new searchable prefix only after `Add()` succeeds.
+
+### 5.3 Deserialize And File Load
+
+`IdMap` is not serialized as a standalone index payload. The owner of the index restores nullable validity or compact id data around load, and `FinalizeIdMap()` reconstructs the derived maps after backend data and EmbList offsets are available.
+
+This keeps the persisted backend index format focused on backend data. Nullable mapping is derived from the same public validity metadata used for build/add, so binary-set load and file load share the same mapping model.
+
+### 5.4 Finalization
+
+`FinalizeIdMap()` is the point where input metadata becomes backend-ready mapping state.
+
+For vector indexes, finalization derives:
+
+- `in_to_out_ids_` from public validity when no direct id array was supplied;
+- `out_to_in_ids_` from the final forward map.
+
+For EmbList indexes, finalization may also derive `in_to_out_ebl_ids_` after `emb_list_offset_` is available. That map is needed only when a base-vector backend evaluates filters in list/document space.
+
+Backend overrides may add one more derived map for backend-local ids. That map must remain inside the backend wrapper.
+
+## 6. Filtering
+
+Input filters never change domain. A `BitsetView` always points to a public-id bitset supplied by the caller.
+
+Backends call `BitsetView::test()` with the id they are about to accept or reject. `PrepareBitset()` configures how that backend id reaches the public bit:
+
+| Projection | Used when | Meaning |
+|------------|-----------|---------|
+| `id_offset_` | backend ids form a contiguous public-id window | `public_id = backend_id + id_offset_` |
+| `out_ids_` | backend ids need an explicit map | `public_id = out_ids_[backend_id]` |
+
+`BitsetView::size()` and `BitsetView::count()` are in the backend id domain seen by the selector. `num_bits()` remains the public bitset size.
+
+`filtered_count_` is optional because not every caller supplies an exact count. `std::nullopt` means unknown, while `0` means the projected filter is known to filter no backend ids. These states must not be collapsed together.
+
+Backends that use filter ratio or empty-filter shortcuts opt in through `NeedBitsetExactCount()`. Exact counting intersects public filters with nullable validity and then reports the result in the backend vector/list domain.
+
+Backends that accept only a contiguous filter bitmap materialize a backend-domain bitmap from `BitsetView::test()`. The source bitset still remains public-id addressed.
+
+## 7. API And Result Boundaries
+
+### 7.1 Search And Range Search
+
+Backend search returns backend ids after any backend-local ids have already been handled inside the backend wrapper. `IndexNode::MapSearchResultIdsToOutIds()` maps those ids to public labels once before returning the result `DataSet`.
+
+Negative result ids remain negative. They represent empty result slots and are not mapped.
+
+### 7.2 Selected-ID APIs
+
+Selected-id APIs accept public ids. `MapOutToIn()` converts them to backend ids before raw-vector retrieval, distance calculation, or backend selected-id search.
+
+`GetVectorByStorageIds()` is the internal boundary for ids that are already backend storage ids. Code that reaches this boundary must not map the ids again.
+
+### 7.3 Brute Force
+
+Brute-force kernels search contiguous buffers or chunk windows. The prepared `BitsetView` carries either a contiguous offset or an index-owned id map, so brute-force filtering and final result labels use the same public-id semantics as indexed search.
+
+Chunked brute force adjusts only the backend id window. It must not rewrite the caller's public bitset.
+
+### 7.4 Iterators
+
+Iterators may evaluate a prepared `BitsetView` after the facade call that created them returns. When a prepared bitset borrows an index-owned id array, the wrapper keeps the prepared state alive for the iterator. The id array itself remains owned by the index.
+
+## 8. EmbList Rules
+
+EmbList strategies differ by the id domain used in their first ANN stage.
+
+| Strategy shape | First ANN stage | Filter/result rule |
+|----------------|-----------------|--------------------|
+| Base-vector search | searches compact base-vector ids | Keep base-vector ids inside the strategy, use `in_to_out_ebl_ids_` for list filters, map final compact list ids to public list ids. |
+| Encoded-list search | searches one compact vector per list | Use the normal search result mapping to public list ids, and map back to compact list ids only when rerank state needs compact offsets. |
+
+The final `SearchEmbList()` boundary always returns public list ids.
+
+`in_to_out_ebl_ids_` is intentionally separate from `in_to_out_ids_` because it maps a different backend id space. `in_to_out_ids_` maps compact lists or vectors; `in_to_out_ebl_ids_` maps each compact base vector to the public list that owns it.
+
+Empty list metadata is still meaningful. A list can be public and valid while containing zero base vectors, or a nullable list can be absent from compact payload. Search code must keep list-domain validity and vector-domain payload counts separate.
+
+## 9. Backend-Local Boundaries
+
+Some backends introduce ids that are neither public ids nor the shared compact backend ids.
+
+Examples:
+
+- a multi-index backend can split one compact id range into sub-index local ids;
+- a backend can relayout storage for its own search structure;
+- a chunked brute-force path can search local chunk ids.
+
+These ids must be translated before crossing back into common `IndexNode` behavior. Backend wrappers may install backend-local id -> public id arrays into `BitsetView`, or map local results to compact backend ids before using the common result mapper.
+
+Composite nodes must apply the selected id-map type to every child that may consume nullable input. The outer node is still the public mapping boundary; child-specific maps are implementation details of that composite node.
+
+## 10. Mmap
+
+Nullable id-map mmap is a backing allocation for derived sealed arrays. It is not an additional serialized index format.
+
+Rules:
+
+- mmap is supported only for sealed id maps;
+- mmap options must be configured before nullable data is written;
+- forward maps and reverse lookup arrays may use mmap-backed allocation;
+- the validity bitmap remains caller-derived metadata and is not stored as a separate mmap id-map file;
+- backing files are owned by the map allocation and removed with the mmap region.
+
+On load, the owner configures mmap options before restoring nullable input. Finalization then allocates the derived dense arrays with the configured backing files.
+
+## 11. Invariants
+
+- Public APIs, selected ids, input bitsets, and returned labels use public ids.
+- Backend storage, raw-vector retrieval, and rerank internals use backend ids.
+- Backend-local ids do not escape backend wrappers.
+- Empty `valid_bitmap_` means identity/non-nullable mapping.
+- Non-empty `valid_bitmap_` is addressed over `[0, out_count_)`.
+- `valid_count_` is the compact backend count represented by the map.
+- `in_to_out_ids_` and `out_to_in_ids_` must describe the same compact layout.
+- `in_to_out_ebl_ids_` maps base-vector ids to public list ids and must not be used as a vector result map.
+- `BitsetView::num_bits()` is public-domain size; `size()` and `count()` are backend-domain counts.
+- Unknown filtered count is `std::nullopt`; known zero filtered count is `0`.
+- `id_offset_` is for contiguous windows; `out_ids_` is for explicit projection.
+- Search paths borrow index-owned map arrays and do not create per-query map copies.
+- Growing maps append at the tail and preserve existing backend id labels.
+- Sealed maps publish complete arrays after build/load finalization.
+- Mmap applies only to sealed derived id arrays and must be configured before data is written.

--- a/include/knowhere/adaptive_store.h
+++ b/include/knowhere/adaptive_store.h
@@ -1,0 +1,148 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef ADAPTIVE_STORE_H
+#define ADAPTIVE_STORE_H
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "knowhere/array_store.h"
+#include "knowhere/mmap.h"
+
+namespace knowhere {
+
+template <typename T>
+class AdaptiveStore {
+ public:
+    static_assert(std::is_integral_v<T>, "AdaptiveStore requires an integral value type");
+    static_assert(std::is_signed_v<T>, "AdaptiveStore uses -1 as the invalid value");
+
+    using ArrayType = typename ArrayStore<T>::Type;
+
+    AdaptiveStore() = default;
+
+    // Lookup table with dense-array or sparse-map storage. Sealed heap storage
+    // may use sparse mode; mmap and growing storage use dense arrays.
+    void
+    SetType(ArrayType type) {
+        type_ = type;
+        dense_values_.SetType(type_);
+    }
+
+    void
+    SetMmapFilePathGenerator(MmapFilePathGenerator mmap_file_paths) {
+        mmap_file_paths_ = std::move(mmap_file_paths);
+    }
+
+    void
+    Set(const T* keys, size_t value_count, size_t key_count) {
+        Clear();
+        // keys[value] is the lookup key for dense value "value".
+        use_sparse_ = type_ == ArrayType::ARRAY && mmap_file_paths_.empty() && value_count != 0 && key_count != 0 &&
+                      static_cast<double>(value_count) / static_cast<double>(key_count) <= kSparseMaxFillRatio;
+
+        if (use_sparse_) {
+            sparse_values_.reserve(value_count);
+            for (size_t value = 0; value < value_count; ++value) {
+                const auto key = keys[value];
+                const auto mapped_value = static_cast<T>(value);
+                auto insert_result = sparse_values_.emplace(key, mapped_value);
+                if (!insert_result.second) {
+                    throw std::runtime_error("adaptive store contains duplicate key");
+                }
+            }
+            return;
+        }
+
+        std::vector<T> values(key_count, kInvalidValue);
+        FillValues(keys, value_count, 0, key_count, 0, values);
+        if (type_ == ArrayType::ARRAY) {
+            dense_values_.Set(values.data(), values.size(), NextArrayMmapFilePath());
+            return;
+        }
+        dense_values_.Append(values.data(), values.size());
+    }
+
+    T
+    Get(T key) const {
+        if (key < 0) {
+            return kInvalidValue;
+        }
+        if (use_sparse_) {
+            auto iter = sparse_values_.find(key);
+            return iter == sparse_values_.end() ? kInvalidValue : iter->second;
+        }
+        const auto offset = static_cast<size_t>(key);
+        return offset < dense_values_.size() ? dense_values_[offset] : kInvalidValue;
+    }
+
+    void
+    Append(const T* keys, size_t value_count, size_t key_begin, size_t key_count, size_t value_begin) {
+        if (type_ != ArrayType::APPEND_ARRAY || use_sparse_) {
+            throw std::runtime_error("adaptive store append is only supported by append dense storage");
+        }
+        // Append extends one contiguous key range.
+        const auto key_end = key_begin + key_count;
+        if (dense_values_.size() != key_begin) {
+            throw std::runtime_error("adaptive store append key range is not contiguous");
+        }
+
+        std::vector<T> values(key_count, kInvalidValue);
+        FillValues(keys, value_count, key_begin, key_end, value_begin, values);
+        dense_values_.Append(values.data(), values.size());
+    }
+
+    void
+    Clear() {
+        dense_values_.Clear();
+        sparse_values_ = {};
+        use_sparse_ = false;
+    }
+
+ private:
+    static constexpr T kInvalidValue = static_cast<T>(-1);
+    static constexpr double kSparseMaxFillRatio = 0.10;
+
+    static void
+    FillValues(const T* keys, size_t value_count, size_t key_begin, size_t key_end, size_t value_begin,
+               std::vector<T>& values) {
+        for (size_t value = 0; value < value_count; ++value) {
+            const auto key = keys[value];
+            const auto key_offset = static_cast<size_t>(key);
+            const auto local_offset = key_offset - key_begin;
+            if (values[local_offset] != kInvalidValue) {
+                throw std::runtime_error("adaptive store contains duplicate key");
+            }
+            values[local_offset] = static_cast<T>(value_begin + value);
+        }
+    }
+
+    std::string
+    NextArrayMmapFilePath() {
+        return mmap_file_paths_.Next(this);
+    }
+
+    ArrayStore<T> dense_values_;
+    std::unordered_map<T, T> sparse_values_;
+    bool use_sparse_ = false;
+    ArrayType type_ = ArrayType::ARRAY;
+    MmapFilePathGenerator mmap_file_paths_;
+};
+
+}  // namespace knowhere
+
+#endif /* ADAPTIVE_STORE_H */

--- a/include/knowhere/adaptive_store.h
+++ b/include/knowhere/adaptive_store.h
@@ -13,6 +13,7 @@
 #define ADAPTIVE_STORE_H
 
 #include <cstddef>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -50,7 +51,11 @@ class AdaptiveStore {
 
     void
     Set(const T* keys, size_t value_count, size_t key_count) {
+        if (value_count != 0 && keys == nullptr) {
+            throw std::runtime_error("adaptive store keys are null");
+        }
         Clear();
+        dense_values_.SetType(type_);
         // keys[value] is the lookup key for dense value "value".
         use_sparse_ = type_ == ArrayType::ARRAY && mmap_file_paths_.empty() && value_count != 0 && key_count != 0 &&
                       static_cast<double>(value_count) / static_cast<double>(key_count) <= kSparseMaxFillRatio;
@@ -59,6 +64,8 @@ class AdaptiveStore {
             sparse_values_.reserve(value_count);
             for (size_t value = 0; value < value_count; ++value) {
                 const auto key = keys[value];
+                CheckKey(key, 0, key_count);
+                CheckValue(value);
                 const auto mapped_value = static_cast<T>(value);
                 auto insert_result = sparse_values_.emplace(key, mapped_value);
                 if (!insert_result.second) {
@@ -92,6 +99,9 @@ class AdaptiveStore {
 
     void
     Append(const T* keys, size_t value_count, size_t key_begin, size_t key_count, size_t value_begin) {
+        if (value_count != 0 && keys == nullptr) {
+            throw std::runtime_error("adaptive store keys are null");
+        }
         if (type_ != ArrayType::APPEND_ARRAY || use_sparse_) {
             throw std::runtime_error("adaptive store append is only supported by append dense storage");
         }
@@ -118,10 +128,30 @@ class AdaptiveStore {
     static constexpr double kSparseMaxFillRatio = 0.10;
 
     static void
+    CheckKey(T key, size_t key_begin, size_t key_end) {
+        if (key < 0) {
+            throw std::runtime_error("adaptive store key is negative");
+        }
+        const auto key_offset = static_cast<size_t>(key);
+        if (key_offset < key_begin || key_offset >= key_end) {
+            throw std::runtime_error("adaptive store key is out of range");
+        }
+    }
+
+    static void
+    CheckValue(size_t value) {
+        if (value > static_cast<size_t>(std::numeric_limits<T>::max())) {
+            throw std::runtime_error("adaptive store value overflows");
+        }
+    }
+
+    static void
     FillValues(const T* keys, size_t value_count, size_t key_begin, size_t key_end, size_t value_begin,
                std::vector<T>& values) {
         for (size_t value = 0; value < value_count; ++value) {
             const auto key = keys[value];
+            CheckKey(key, key_begin, key_end);
+            CheckValue(value_begin + value);
             const auto key_offset = static_cast<size_t>(key);
             const auto local_offset = key_offset - key_begin;
             if (values[local_offset] != kInvalidValue) {

--- a/include/knowhere/array_store.h
+++ b/include/knowhere/array_store.h
@@ -1,0 +1,565 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef ARRAY_STORE_H
+#define ARRAY_STORE_H
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "knowhere/mmap.h"
+
+namespace knowhere {
+
+// Contiguous sealed array allocation, heap-backed or mmap-backed.
+template <typename T>
+struct ArrayData {
+    explicit ArrayData(size_t size) : size(size), data(std::make_unique<T[]>(size)) {
+    }
+
+    ArrayData(const T* view_data, size_t size) : size(size), view_data(view_data) {
+    }
+
+    ArrayData(size_t size, const std::string& filepath)
+        : size(size), mmap_region(MmapRegion::Create(filepath, size * sizeof(T))) {
+    }
+
+    T*
+    mutable_data() {
+        if (view_data != nullptr) {
+            throw std::runtime_error("array data view is read only");
+        }
+        return mmap_region == nullptr ? data.get() : static_cast<T*>(mmap_region->data());
+    }
+
+    const T*
+    data_ptr() const {
+        if (view_data != nullptr) {
+            return view_data;
+        }
+        return mmap_region == nullptr ? data.get() : static_cast<const T*>(mmap_region->data());
+    }
+
+    size_t size;
+    const T* view_data = nullptr;
+    std::unique_ptr<T[]> data;
+    std::shared_ptr<MmapRegion> mmap_region;
+};
+
+template <typename T>
+class AppendArrayData {
+ public:
+    AppendArrayData() {
+        for (auto& chunk : chunk_ptrs_) {
+            chunk.store(nullptr, std::memory_order_relaxed);
+        }
+    }
+
+    AppendArrayData(const AppendArrayData&) = delete;
+    AppendArrayData&
+    operator=(const AppendArrayData&) = delete;
+
+    void
+    Append(const T* data, size_t count) {
+        const auto begin = committed_count_.load(std::memory_order_acquire);
+        if (count > std::numeric_limits<size_t>::max() - begin) {
+            throw std::runtime_error("append array size overflows");
+        }
+        const auto end = begin + count;
+        EnsureCapacity(end);
+
+        auto remaining = count;
+        auto offset = begin;
+        auto* source = data;
+        while (remaining != 0) {
+            const auto chunk_id = ChunkIndex(offset);
+            const auto chunk_offset = offset - ChunkBegin(chunk_id);
+            const auto write_count = std::min(remaining, ChunkSize(chunk_id) - chunk_offset);
+            auto* chunk = chunk_ptrs_[chunk_id].load(std::memory_order_acquire);
+            std::copy(source, source + write_count, chunk + chunk_offset);
+            source += write_count;
+            offset += write_count;
+            remaining -= write_count;
+        }
+
+        committed_count_.store(end, std::memory_order_release);
+    }
+
+    size_t
+    size() const {
+        return committed_count_.load(std::memory_order_acquire);
+    }
+
+    T
+    Get(size_t offset) const {
+        const auto chunk_id = ChunkIndex(offset);
+        const auto* chunk = chunk_ptrs_[chunk_id].load(std::memory_order_acquire);
+        return chunk[offset - ChunkBegin(chunk_id)];
+    }
+
+ private:
+    static constexpr size_t kFirstChunkBits = 10;
+    static constexpr size_t kFirstChunkSize = size_t{1} << kFirstChunkBits;
+    static constexpr size_t kMaxChunks = std::numeric_limits<size_t>::digits - kFirstChunkBits;
+
+    static size_t
+    ChunkIndex(size_t offset) {
+        const auto block = (offset >> kFirstChunkBits) + 1;
+        const auto chunk_id = static_cast<size_t>(std::numeric_limits<unsigned long long>::digits - 1 -
+                                                  __builtin_clzll(static_cast<unsigned long long>(block)));
+        if (chunk_id >= kMaxChunks) {
+            throw std::runtime_error("append array capacity is exhausted");
+        }
+        return chunk_id;
+    }
+
+    static size_t
+    ChunkBegin(size_t chunk_id) {
+        return (kFirstChunkSize << chunk_id) - kFirstChunkSize;
+    }
+
+    static size_t
+    ChunkSize(size_t chunk_id) {
+        return kFirstChunkSize << chunk_id;
+    }
+
+    void
+    EnsureCapacity(size_t count) {
+        if (count == 0) {
+            return;
+        }
+        const auto last_chunk_id = ChunkIndex(count - 1);
+        for (size_t chunk_id = 0; chunk_id <= last_chunk_id; ++chunk_id) {
+            if (chunks_[chunk_id] != nullptr) {
+                continue;
+            }
+            chunks_[chunk_id] = std::make_unique<T[]>(ChunkSize(chunk_id));
+            chunk_ptrs_[chunk_id].store(chunks_[chunk_id].get(), std::memory_order_release);
+        }
+    }
+
+    std::array<std::unique_ptr<T[]>, kMaxChunks> chunks_;
+    std::array<std::atomic<T*>, kMaxChunks> chunk_ptrs_;
+    std::atomic<size_t> committed_count_{0};
+};
+
+template <typename T>
+class ArrayStore {
+ public:
+    enum class Type {
+        ARRAY,
+        APPEND_ARRAY,
+    };
+
+    // ARRAY stores a complete sealed array through Set(). APPEND_ARRAY stores
+    // growing data through append-only chunks.
+    ArrayStore() = default;
+    ArrayStore(const T* data, size_t count) {
+        SetView(data, count);
+    }
+    ArrayStore(const ArrayStore& other) {
+        CopyFrom(other);
+    }
+    ArrayStore(ArrayStore&&) noexcept = default;
+    ArrayStore&
+    operator=(const ArrayStore& other) {
+        if (this != &other) {
+            CopyFrom(other);
+        }
+        return *this;
+    }
+    ArrayStore&
+    operator=(ArrayStore&&) noexcept = default;
+
+    void
+    SetType(Type type) {
+        type_ = type;
+        if (type_ == Type::APPEND_ARRAY && append_array_ == nullptr) {
+            append_array_ = std::make_shared<AppendArrayData<T>>();
+        }
+        visible_count_ = kDynamicCount;
+    }
+
+    void
+    SetView(const T* data, size_t count) {
+        if (count != 0 && data == nullptr) {
+            throw std::runtime_error("array store view data is null");
+        }
+        Clear();
+        type_ = Type::ARRAY;
+        if (count == 0) {
+            return;
+        }
+        array_ = std::make_shared<ArrayData<T>>(data, count);
+    }
+
+    void
+    Set(const T* data, size_t count, const std::string& filepath = std::string{}) {
+        if (count != 0 && data == nullptr) {
+            throw std::runtime_error("array store data is null");
+        }
+        Clear();
+        type_ = Type::ARRAY;
+        if (count == 0) {
+            return;
+        }
+        array_ = NewArray(count, filepath);
+        for (size_t i = 0; i < count; ++i) {
+            array_->mutable_data()[i] = data[i];
+        }
+    }
+
+    void
+    Append(const T* data, size_t count) {
+        if (count != 0 && data == nullptr) {
+            throw std::runtime_error("array store data is null");
+        }
+        if (count == 0) {
+            return;
+        }
+        type_ = Type::APPEND_ARRAY;
+        if (append_array_ == nullptr) {
+            append_array_ = std::make_shared<AppendArrayData<T>>();
+        }
+        visible_count_ = kDynamicCount;
+        append_array_->Append(data, count);
+    }
+
+    bool
+    empty() const {
+        return size() == 0;
+    }
+
+    size_t
+    size() const {
+        const auto storage_count = StorageSize();
+        return visible_count_ == kDynamicCount ? storage_count : std::min(visible_count_, storage_count);
+    }
+
+    bool
+    is_array() const {
+        return type_ == Type::ARRAY;
+    }
+
+    bool
+    is_append_array() const {
+        return type_ == Type::APPEND_ARRAY;
+    }
+
+    const T*
+    data() const {
+        return type_ == Type::ARRAY && array_ != nullptr ? array_->data_ptr() : nullptr;
+    }
+
+    T
+    operator[](size_t offset) const {
+        if (type_ == Type::ARRAY) {
+            return array_->data_ptr()[offset];
+        }
+        return append_array_->Get(offset);
+    }
+
+    T&
+    operator[](size_t offset) {
+        if (type_ == Type::ARRAY) {
+            return array_->mutable_data()[offset];
+        }
+        throw std::runtime_error("append array storage is read only");
+    }
+
+    void
+    Clear() {
+        array_.reset();
+        append_array_.reset();
+        visible_count_ = kDynamicCount;
+    }
+
+    ArrayStore
+    Prefix(size_t count) const {
+        ArrayStore copy(*this);
+        copy.visible_count_ = std::min(count, copy.size());
+        return copy;
+    }
+
+ private:
+    static constexpr size_t kDynamicCount = std::numeric_limits<size_t>::max();
+
+    void
+    CopyFrom(const ArrayStore& other) {
+        type_ = other.type_;
+        array_ = other.array_;
+        append_array_ = other.append_array_;
+        visible_count_ = other.size();
+    }
+
+    static std::shared_ptr<ArrayData<T>>
+    NewArray(size_t capacity, const std::string& filepath) {
+        if (filepath.empty()) {
+            return std::make_shared<ArrayData<T>>(capacity);
+        }
+        return std::make_shared<ArrayData<T>>(capacity, filepath);
+    }
+
+    size_t
+    StorageSize() const {
+        if (type_ == Type::ARRAY) {
+            return array_ == nullptr ? 0 : array_->size;
+        }
+        return append_array_ == nullptr ? 0 : append_array_->size();
+    }
+
+    Type type_ = Type::ARRAY;
+    std::shared_ptr<ArrayData<T>> array_;
+    std::shared_ptr<AppendArrayData<T>> append_array_;
+    size_t visible_count_ = kDynamicCount;
+};
+
+using IdArray = ArrayStore<int32_t>;
+
+struct BitmapRecord {
+    size_t bit_begin = 0;
+    size_t bit_count = 0;
+    std::shared_ptr<const std::vector<uint8_t>> bytes;
+
+    bool
+    Contains(size_t bit) const {
+        return bit >= bit_begin && bit < bit_begin + bit_count;
+    }
+
+    bool
+    Test(size_t bit) const {
+        const auto local_bit = bit - bit_begin;
+        return ((*bytes)[local_bit >> 3] & (1U << (local_bit & 7))) != 0;
+    }
+};
+
+class AppendBitmapData {
+ public:
+    AppendBitmapData() {
+        records_.SetType(ArrayStore<BitmapRecord>::Type::APPEND_ARRAY);
+    }
+
+    void
+    Append(const uint8_t* data, size_t bit_count) {
+        const auto bit_begin = bit_count_.load(std::memory_order_acquire);
+        const auto bytes = std::make_shared<const std::vector<uint8_t>>(data, data + ByteSize(bit_count));
+        const BitmapRecord record{bit_begin, bit_count, bytes};
+        records_.Append(&record, 1);
+        bit_count_.store(bit_begin + bit_count, std::memory_order_release);
+    }
+
+    size_t
+    size() const {
+        return bit_count_.load(std::memory_order_acquire);
+    }
+
+    uint8_t
+    GetByte(size_t byte_offset) const {
+        const auto bit_begin = byte_offset << 3;
+        const auto bit_end = size();
+        uint8_t value = 0;
+        for (size_t bit = 0; bit < 8; ++bit) {
+            const auto absolute_bit = bit_begin + bit;
+            if (absolute_bit >= bit_end) {
+                break;
+            }
+            if (Test(absolute_bit)) {
+                value |= static_cast<uint8_t>(1U << bit);
+            }
+        }
+        return value;
+    }
+
+ private:
+    static size_t
+    ByteSize(size_t bit_count) {
+        return (bit_count + 7) / 8;
+    }
+
+    bool
+    Test(size_t bit) const {
+        auto left = static_cast<size_t>(0);
+        auto right = records_.size();
+        while (left < right) {
+            const auto middle = left + (right - left) / 2;
+            if (records_[middle].bit_begin <= bit) {
+                left = middle + 1;
+            } else {
+                right = middle;
+            }
+        }
+        if (left == 0) {
+            return false;
+        }
+
+        const auto record = records_[left - 1];
+        return record.Contains(bit) && record.Test(bit);
+    }
+
+    ArrayStore<BitmapRecord> records_;
+    std::atomic<size_t> bit_count_{0};
+};
+
+// Packed public-id validity bitmap. size() returns the logical bit count.
+class BitmapArray {
+ public:
+    using Type = ArrayStore<uint8_t>::Type;
+
+    BitmapArray() {
+        bytes_.SetType(Type::ARRAY);
+    }
+
+    BitmapArray(const BitmapArray& other) {
+        CopyFrom(other);
+    }
+
+    BitmapArray(BitmapArray&&) noexcept = default;
+
+    BitmapArray&
+    operator=(const BitmapArray& other) {
+        if (this != &other) {
+            CopyFrom(other);
+        }
+        return *this;
+    }
+
+    BitmapArray&
+    operator=(BitmapArray&&) noexcept = default;
+
+    void
+    SetType(Type type) {
+        type_ = type;
+        if (type_ == Type::ARRAY) {
+            bytes_.SetType(Type::ARRAY);
+            bit_count_ = 0;
+            return;
+        }
+        if (append_data_ == nullptr) {
+            append_data_ = std::make_shared<AppendBitmapData>();
+        }
+        bit_count_ = kDynamicBitCount;
+    }
+
+    const uint8_t*
+    data() const {
+        return type_ == Type::ARRAY && bit_count_ != 0 ? bytes_.data() : nullptr;
+    }
+
+    size_t
+    size() const {
+        if (type_ == Type::ARRAY) {
+            return bit_count_;
+        }
+        if (append_data_ == nullptr) {
+            return 0;
+        }
+        return bit_count_ == kDynamicBitCount ? append_data_->size() : bit_count_;
+    }
+
+    bool
+    empty() const {
+        return size() == 0;
+    }
+
+    uint8_t
+    operator[](size_t offset) const {
+        return type_ == Type::ARRAY ? bytes_[offset] : append_data_->GetByte(offset);
+    }
+
+    void
+    Set(const uint8_t* data, size_t bit_count) {
+        Clear();
+        if (bit_count == 0) {
+            return;
+        }
+        if (data == nullptr) {
+            throw std::runtime_error("bitmap array data is null");
+        }
+        type_ = Type::ARRAY;
+        bytes_.Set(data, ByteSize(bit_count));
+        bit_count_ = bit_count;
+        MaskTail();
+    }
+
+    void
+    Append(const uint8_t* data, size_t bit_count) {
+        // Append is bit-oriented; batches may end in the middle of a byte.
+        if (bit_count == 0) {
+            return;
+        }
+        if (data == nullptr) {
+            throw std::runtime_error("bitmap array data is null");
+        }
+        type_ = Type::APPEND_ARRAY;
+        if (append_data_ == nullptr) {
+            append_data_ = std::make_shared<AppendBitmapData>();
+        }
+        bit_count_ = kDynamicBitCount;
+        append_data_->Append(data, bit_count);
+    }
+
+    void
+    Clear() {
+        bytes_.Clear();
+        bit_count_ = 0;
+        append_data_.reset();
+    }
+
+    BitmapArray
+    Prefix(size_t bit_count) const {
+        BitmapArray copy(*this);
+        copy.bit_count_ = std::min(bit_count, copy.size());
+        return copy;
+    }
+
+ private:
+    static constexpr size_t kDynamicBitCount = std::numeric_limits<size_t>::max();
+
+    static size_t
+    ByteSize(size_t bit_count) {
+        return (bit_count + 7) / 8;
+    }
+
+    void
+    CopyFrom(const BitmapArray& other) {
+        bytes_ = other.bytes_;
+        type_ = other.type_;
+        bit_count_ = type_ == Type::APPEND_ARRAY ? other.size() : other.bit_count_;
+        append_data_ = other.append_data_;
+    }
+
+    void
+    MaskTail() {
+        const auto used_bits = bit_count_ & 7U;
+        if (used_bits == 0 || bit_count_ == 0) {
+            return;
+        }
+        const auto byte = ByteSize(bit_count_) - 1;
+        bytes_[byte] = static_cast<uint8_t>(bytes_[byte] & static_cast<uint8_t>((1U << used_bits) - 1U));
+    }
+
+    ArrayStore<uint8_t> bytes_;
+    Type type_ = Type::ARRAY;
+    size_t bit_count_ = 0;
+    std::shared_ptr<AppendBitmapData> append_data_;
+};
+
+}  // namespace knowhere
+
+#endif /* ARRAY_STORE_H */

--- a/include/knowhere/array_store.h
+++ b/include/knowhere/array_store.h
@@ -233,11 +233,9 @@ class ArrayStore {
         if (count == 0) {
             return;
         }
-        type_ = Type::APPEND_ARRAY;
-        if (append_array_ == nullptr) {
-            append_array_ = std::make_shared<AppendArrayData<T>>();
+        if (type_ != Type::APPEND_ARRAY || append_array_ == nullptr || visible_count_ != kDynamicCount) {
+            throw std::runtime_error("array store append requires append storage");
         }
-        visible_count_ = kDynamicCount;
         append_array_->Append(data, count);
     }
 
@@ -506,11 +504,9 @@ class BitmapArray {
         if (data == nullptr) {
             throw std::runtime_error("bitmap array data is null");
         }
-        type_ = Type::APPEND_ARRAY;
-        if (append_data_ == nullptr) {
-            append_data_ = std::make_shared<AppendBitmapData>();
+        if (type_ != Type::APPEND_ARRAY || append_data_ == nullptr || bit_count_ != kDynamicBitCount) {
+            throw std::runtime_error("bitmap array append requires append storage");
         }
-        bit_count_ = kDynamicBitCount;
         append_data_->Append(data, bit_count);
     }
 

--- a/include/knowhere/bitsetview.h
+++ b/include/knowhere/bitsetview.h
@@ -15,19 +15,33 @@
 #include <algorithm>
 #include <bit>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <limits>
 #include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
+#include <utility>
+
+#include "knowhere/array_store.h"
 
 namespace knowhere {
+
+// Non-owning filter view.
+//
+// bits_ is always addressed by public ids. Backend selectors pass dense
+// internal/local ids to test(); id_offset_ handles contiguous windows and
+// out_ids_ handles compaction or backend relayout. Count fields are expressed
+// in the backend vector domain used by the selector.
 class BitsetView {
  public:
     BitsetView() = default;
     ~BitsetView() = default;
 
-    BitsetView(const uint8_t* data, size_t num_bits, size_t num_filtered_out_bits = 0, size_t id_offset = 0)
-        : bits_(data), num_bits_(num_bits), num_filtered_out_bits_(num_filtered_out_bits), id_offset_(id_offset) {
+    BitsetView(const uint8_t* data, size_t num_bits, std::optional<size_t> filtered_count = std::nullopt)
+        : bits_(data), num_bits_(num_bits), vector_count_(num_bits), filtered_count_(filtered_count) {
     }
 
     BitsetView(const std::nullptr_t) : BitsetView() {
@@ -35,25 +49,34 @@ class BitsetView {
 
     bool
     empty() const {
-        return num_bits_ == 0;
+        if (num_bits_ == 0) {
+            return true;
+        }
+        if (!filtered_count_.has_value() || filtered_count_.value() != 0) {
+            return false;
+        }
+        return !has_id_boundary_filter_();
     }
 
-    // return the number of the bits. if with id mapping, return the number of the internal ids.
     size_t
     size() const {
-        if (out_ids_ != nullptr) {
-            return num_internal_ids_;
-        }
-        return num_bits_;
+        return vector_count_;
     }
 
-    // return the number of filtered out bits. if with id mapping, return the number of filtered out ids.
+    bool
+    has_known_count() const {
+        return num_bits_ == 0 || filtered_count_.has_value();
+    }
+
     size_t
     count() const {
-        if (out_ids_ != nullptr) {
-            return num_filtered_out_ids_;
+        if (num_bits_ == 0) {
+            return 0;
         }
-        return num_filtered_out_bits_;
+        if (!filtered_count_.has_value()) {
+            throw std::logic_error("BitsetView filtered count is unknown");
+        }
+        return filtered_count_.value();
     }
 
     size_t
@@ -61,35 +84,71 @@ class BitsetView {
         return (num_bits_ + 8 - 1) >> 3;
     }
 
+    size_t
+    num_bits() const {
+        return num_bits_;
+    }
+
     const uint8_t*
     data() const {
         return bits_;
     }
 
-    bool
-    has_out_ids() const {
-        return out_ids_ != nullptr;
+    // Recomputes filter counters for a backend id range.
+    void
+    count_filtered_bits(size_t bit_offset, size_t bit_count, const uint8_t* valid_bitmap = nullptr) {
+        count_filtered_bits_impl_(
+            bit_offset, bit_count, valid_bitmap != nullptr,
+            [valid_bitmap](size_t byte_idx) { return valid_bitmap[byte_idx]; },
+            [valid_bitmap](size_t byte_idx) { return load_u64_unaligned_(valid_bitmap + byte_idx); });
     }
 
     void
-    set_out_ids(const uint32_t* out_ids, size_t num_internal_ids,
-                std::optional<size_t> num_filtered_out_ids = std::nullopt) {
-        out_ids_ = out_ids;
-        num_internal_ids_ = num_internal_ids;
-        if (num_filtered_out_ids.has_value()) {
-            num_filtered_out_ids_ = num_filtered_out_ids.value();
-        } else {
-            // auto calculate num_filtered_out_ids if not provided
-            num_filtered_out_ids_ = get_filtered_out_num_();
-        }
+    count_filtered_bits(size_t bit_offset, size_t bit_count, const BitmapArray& valid_bitmap) {
+        count_filtered_bits_impl_(
+            bit_offset, bit_count, !valid_bitmap.empty(),
+            [&valid_bitmap](size_t byte_idx) { return valid_bitmap[byte_idx]; },
+            [&valid_bitmap](size_t byte_idx) {
+                uint64_t value = 0;
+                for (size_t i = 0; i < sizeof(uint64_t); ++i) {
+                    value |= static_cast<uint64_t>(valid_bitmap[byte_idx + i]) << (i * 8);
+                }
+                return value;
+            });
     }
 
-    const uint32_t*
-    out_ids_data() const {
-        if (out_ids_ == nullptr) {
-            return nullptr;
+    void
+    set_vector_count(size_t vector_count) {
+        vector_count_ = vector_count;
+    }
+
+    void
+    set_filter_count(size_t filter_count) {
+        filtered_count_ = filter_count;
+    }
+
+    bool
+    has_out_ids() const {
+        return out_ids_count_ != 0;
+    }
+
+    void
+    set_out_ids(const IdArray& out_ids, size_t out_ids_count) {
+        if (out_ids_count > out_ids.size()) {
+            throw std::invalid_argument("out ids count exceeds out ids size");
         }
+        out_ids_ = out_ids;
+        out_ids_count_ = out_ids_count;
+    }
+
+    const IdArray&
+    get_out_ids() const {
         return out_ids_;
+    }
+
+    size_t
+    out_ids_count() const {
+        return out_ids_count_;
     }
 
     void
@@ -97,23 +156,39 @@ class BitsetView {
         id_offset_ = id_offset;
     }
 
-    // if the test succeeds, then the index should be skipped during search; otherwise, it should be included.
-    bool
-    test(int64_t index) const {
-        int64_t out_id = index + id_offset_;
-        if (out_ids_ != nullptr) {
-            out_id = out_ids_[out_id];
-        }
-        // when index is larger than the max_offset, ignore it
-        return (out_id >= static_cast<int64_t>(num_bits_)) || (bits_[out_id >> 3] & (0x1 << (out_id & 0x7)));
-    }
-    // return the filtered ratio. if with id mapping, calculated by internal_ids rather than bits.
-    float
-    filter_ratio() const {
-        return empty() ? 0.0f : ((float)count() / size());
+    size_t
+    id_offset() const {
+        return id_offset_;
     }
 
-    // Return whether every ID in the half-open range [begin, end) is filtered.
+    // Returns true when a backend id should be skipped.
+    bool
+    test(int64_t index) const {
+        if (index < 0) {
+            return true;
+        }
+        const auto internal_id = static_cast<size_t>(index);
+        auto out_id = internal_id + id_offset_;
+        if (has_out_ids()) {
+            if (out_id >= out_ids_count_) {
+                return true;
+            }
+            const auto mapped_id = out_ids_[out_id];
+            if (mapped_id < 0) {
+                return true;
+            }
+            out_id = static_cast<size_t>(mapped_id);
+        }
+        return out_id >= num_bits_ || (bits_[out_id >> 3] & (0x1 << (out_id & 0x7)));
+    }
+
+    float
+    filter_ratio() const {
+        auto current_size = size();
+        return current_size == 0 ? 0.0f : ((float)count() / current_size);
+    }
+
+    // Return whether every backend id in [begin, end) is filtered.
     bool
     range_all_filtered(size_t begin, size_t end) const {
         assert(begin <= end);
@@ -122,8 +197,8 @@ class BitsetView {
             return true;
         }
 
-        // With id mapping the bit lookup requires per-index indirection, so a word-level scan is not possible.
-        if (out_ids_ != nullptr) {
+        // Mapped ids require per-id tests.
+        if (has_out_ids()) {
             for (size_t index = begin; index < end; ++index) {
                 if (!test(index)) {
                     return false;
@@ -132,17 +207,17 @@ class BitsetView {
             return true;
         }
 
-        // Without id mapping, internal index i maps to bit (i + id_offset_). Mapped ids >= num_bits_ are
-        // treated as filtered by test(), so only the clamped range [lo, hi) needs an explicit bit check.
-        const size_t lo = begin + id_offset_;
-        const size_t hi = std::min(end + id_offset_, num_bits_);
+        // Contiguous ids can scan the translated public-bit range.
+        const auto offset = static_cast<size_t>(id_offset_);
+        const size_t lo = begin + offset;
+        const size_t hi = std::min(end + offset, num_bits_);
         if (hi <= lo) {
             return true;
         }
         return all_bits_set(lo, hi);
     }
 
-    // Return the last valid ID below upper_bound.
+    // Return the last unfiltered backend id below upper_bound.
     std::optional<size_t>
     previous_valid_index(size_t upper_bound) const {
         if (upper_bound == 0) {
@@ -152,9 +227,9 @@ class BitsetView {
             return upper_bound - 1;
         }
 
-        // With id mapping the bit lookup requires per-index indirection, so a word-level scan is not possible.
-        if (out_ids_ != nullptr) {
-            size_t index = std::min(upper_bound, num_internal_ids_);
+        // Mapped ids require per-id tests.
+        if (has_out_ids()) {
+            size_t index = std::min(upper_bound, size());
             while (index > 0) {
                 --index;
                 if (!test(index)) {
@@ -164,10 +239,10 @@ class BitsetView {
             return std::nullopt;
         }
 
-        // Without id mapping, internal index i maps to bit (i + id_offset_). Scan the bit range
-        // [id_offset_, hi_bit) word by word, where bits >= num_bits_ are treated as filtered out.
-        const size_t low_bit = id_offset_;
-        const size_t hi_bit = std::min(id_offset_ + upper_bound, num_bits_);
+        // Contiguous ids can scan the translated public-bit range.
+        const auto offset = static_cast<size_t>(id_offset_);
+        const size_t low_bit = offset;
+        const size_t hi_bit = std::min(offset + upper_bound, num_bits_);
         if (hi_bit <= low_bit) {
             return std::nullopt;
         }
@@ -179,7 +254,7 @@ class BitsetView {
                 valid &= ~lower_bits_mask(low_bit & 63);
             }
             if (valid != 0) {
-                return (word_index << 6) + 63 - __builtin_clzll(valid) - id_offset_;
+                return (word_index << 6) + 63 - __builtin_clzll(valid) - offset;
             }
             if (word_index == low_word) {
                 return std::nullopt;
@@ -189,90 +264,40 @@ class BitsetView {
         }
     }
 
-    size_t
-    get_filtered_out_num_() const {
-        if (empty()) {
-            return 0;
-        }
-        if (out_ids_ != nullptr) {
-            // if with id mapping, there is no optimization for the traversal.
-            size_t count = 0;
-            for (size_t i = 0; i < num_internal_ids_; i++) {
-                if (test(i)) {
-                    count++;
-                }
-            }
-            return count;
-        }
-        // if without id mapping, use a better algorithm to calculate the number of filtered out bits.
-        size_t ret = 0;
-        auto len_uint8 = byte_size();
-        auto len_uint64 = len_uint8 >> 3;
-
-        auto popcount8 = [&](uint8_t x) -> int {
-            x = (x & 0x55) + ((x >> 1) & 0x55);
-            x = (x & 0x33) + ((x >> 2) & 0x33);
-            x = (x & 0x0F) + ((x >> 4) & 0x0F);
-            return x;
-        };
-
-        uint64_t* p_uint64 = (uint64_t*)bits_;
-        for (size_t i = 0; i < len_uint64; i++) {
-            ret += __builtin_popcountll(*p_uint64);
-            p_uint64++;
-        }
-
-        // calculate remainder
-        uint8_t* p_uint8 = (uint8_t*)bits_ + (len_uint64 << 3);
-        for (size_t i = (len_uint64 << 3); i < len_uint8; i++) {
-            ret += popcount8(*p_uint8);
-            p_uint8++;
-        }
-
-        return ret;
-    }
-
-    // return the first valid idx. if with id mapping, return the first valid internal_id.
+    // Return the first unfiltered backend id.
     size_t
     get_first_valid_index() const {
-        if (out_ids_ != nullptr) {
-            // if with id mapping, there is no optimization for the traversal.
-            for (size_t i = 0; i < num_internal_ids_; i++) {
+        if (has_out_ids()) {
+            for (size_t i = 0; i < size(); i++) {
                 if (!test(i)) {
                     return i;
                 }
             }
-            return num_internal_ids_;
+            return size();
         }
-        // if without id mapping, use a better algorithm to find the first valid index.
-        size_t ret = 0;
-        auto len_uint8 = byte_size();
-        auto len_uint64 = len_uint8 >> 3;
 
-        uint64_t* p_uint64 = (uint64_t*)bits_;
-        for (size_t i = 0; i < len_uint64; i++) {
-            uint64_t value = (~(*p_uint64));
-            if (value == 0) {
-                p_uint64++;
-                continue;
+        const size_t bit_begin = std::min(id_offset_, num_bits_);
+        const size_t bit_count = std::min(size(), num_bits_ - bit_begin);
+        if (bit_count == 0) {
+            return size();
+        }
+
+        const size_t bit_end = bit_begin + bit_count;
+        const size_t last_word = (bit_end - 1) >> 6;
+        for (size_t word_index = bit_begin >> 6; word_index <= last_word; ++word_index) {
+            uint64_t value = ~load_word(word_index);
+            if (word_index == (bit_begin >> 6)) {
+                value &= ~lower_bits_mask(bit_begin & 63);
             }
-            ret = __builtin_ctzll(value);
-            return i * 64 + ret;
-        }
-
-        // calculate remainder
-        uint8_t* p_uint8 = (uint8_t*)bits_ + (len_uint64 << 3);
-        for (size_t i = 0; i < len_uint8 - (len_uint64 << 3); i++) {
-            uint8_t value = (~(*p_uint8));
-            if (value == 0) {
-                p_uint8++;
-                continue;
+            if (word_index == last_word) {
+                value &= lower_bits_mask(((bit_end - 1) & 63) + 1);
             }
-            ret = __builtin_ctz(value);
-            return len_uint64 * 64 + i * 8 + ret;
+            if (value != 0) {
+                return (word_index << 6) + __builtin_ctzll(value) - id_offset_;
+            }
         }
 
-        return num_bits_;
+        return size();
     }
 
     std::string
@@ -289,6 +314,90 @@ class BitsetView {
     }
 
  private:
+    template <typename ValidByteAt, typename ValidWordAt>
+    void
+    count_filtered_bits_impl_(size_t bit_offset, size_t bit_count, bool has_valid_bitmap, ValidByteAt valid_byte_at,
+                              ValidWordAt valid_word_at) {
+        if (bits_ == nullptr || num_bits_ == 0 || bit_count == 0 || bit_offset >= num_bits_) {
+            set_vector_count(0);
+            set_filter_count(0);
+            return;
+        }
+
+        const auto count_bits = std::min(bit_count, num_bits_ - bit_offset);
+        const auto end_bit = bit_offset + count_bits;
+        size_t bit_pos = bit_offset;
+        size_t filtered_count = 0;
+        size_t vector_count = 0;
+
+        if ((bit_pos & 0x7) != 0) {
+            const auto byte_idx = bit_pos >> 3;
+            const auto bits_in_byte = std::min<size_t>(8 - (bit_pos & 0x7), end_bit - bit_pos);
+            const auto mask = static_cast<uint8_t>(((1U << bits_in_byte) - 1) << (bit_pos & 0x7));
+            auto bits = bits_[byte_idx];
+            auto valid_bits = mask;
+            if (has_valid_bitmap) {
+                valid_bits &= valid_byte_at(byte_idx);
+                bits &= valid_bits;
+            } else {
+                bits &= valid_bits;
+            }
+            vector_count += __builtin_popcount(static_cast<unsigned>(valid_bits));
+            filtered_count += __builtin_popcount(static_cast<unsigned>(bits));
+            bit_pos += bits_in_byte;
+        }
+
+        const auto full_bytes = (end_bit - bit_pos) >> 3;
+        const auto byte_begin = bit_pos >> 3;
+        const auto len_uint64 = full_bytes >> 3;
+        for (size_t i = 0; i < len_uint64; ++i) {
+            auto bits = load_u64_unaligned_(bits_ + byte_begin + i * sizeof(uint64_t));
+            if (has_valid_bitmap) {
+                auto valid_bits = valid_word_at(byte_begin + i * sizeof(uint64_t));
+                vector_count += __builtin_popcountll(valid_bits);
+                bits &= valid_bits;
+            } else {
+                vector_count += sizeof(uint64_t) * 8;
+            }
+            filtered_count += __builtin_popcountll(bits);
+        }
+
+        auto byte_pos = byte_begin + (len_uint64 << 3);
+        const auto byte_end = byte_begin + full_bytes;
+        while (byte_pos < byte_end) {
+            auto bits = bits_[byte_pos];
+            if (has_valid_bitmap) {
+                auto valid_bits = valid_byte_at(byte_pos);
+                vector_count += __builtin_popcount(static_cast<unsigned>(valid_bits));
+                bits &= valid_bits;
+            } else {
+                vector_count += 8;
+            }
+            filtered_count += __builtin_popcount(static_cast<unsigned>(bits));
+            ++byte_pos;
+        }
+        bit_pos += full_bytes << 3;
+
+        if (bit_pos < end_bit) {
+            const auto byte_idx = bit_pos >> 3;
+            const auto tail_bits = end_bit - bit_pos;
+            const auto mask = static_cast<uint8_t>((1U << tail_bits) - 1);
+            auto bits = bits_[byte_idx];
+            auto valid_bits = mask;
+            if (has_valid_bitmap) {
+                valid_bits &= valid_byte_at(byte_idx);
+                bits &= valid_bits;
+            } else {
+                bits &= valid_bits;
+            }
+            vector_count += __builtin_popcount(static_cast<unsigned>(valid_bits));
+            filtered_count += __builtin_popcount(static_cast<unsigned>(bits));
+        }
+
+        set_vector_count(vector_count);
+        set_filter_count(filtered_count);
+    }
+
     static uint64_t
     lower_bits_mask(size_t bits) {
         assert(bits <= 64);
@@ -296,11 +405,10 @@ class BitsetView {
     }
 
     static uint64_t
-    load_full_word(const uint8_t* data) {
-        return static_cast<uint64_t>(data[0]) | (static_cast<uint64_t>(data[1]) << 8) |
-               (static_cast<uint64_t>(data[2]) << 16) | (static_cast<uint64_t>(data[3]) << 24) |
-               (static_cast<uint64_t>(data[4]) << 32) | (static_cast<uint64_t>(data[5]) << 40) |
-               (static_cast<uint64_t>(data[6]) << 48) | (static_cast<uint64_t>(data[7]) << 56);
+    load_u64_unaligned_(const uint8_t* data) {
+        uint64_t value = 0;
+        std::memcpy(&value, data, sizeof(value));
+        return value;
     }
 
     uint64_t
@@ -314,7 +422,7 @@ class BitsetView {
         const auto* data = bits_ + byte_offset;
         const size_t remaining_bytes = bytes - byte_offset;
         if (remaining_bytes >= sizeof(uint64_t)) {
-            return load_full_word(data);
+            return load_u64_unaligned_(data);
         }
 
         uint64_t word = 0;
@@ -324,12 +432,8 @@ class BitsetView {
         return word;
     }
 
-    // Return whether every bit in the half-open bit range [bit_begin, bit_end) is set.
-    // Requires bit_begin < bit_end <= num_bits_.
     bool
     all_bits_set(size_t bit_begin, size_t bit_end) const {
-        // Only the first word carries a low boundary and only the last word carries a high boundary; the
-        // interior words must be fully set, so they reduce to a plain "all bits set" check.
         const size_t first_word = bit_begin >> 6;
         const size_t last_word = (bit_end - 1) >> 6;
         const uint64_t first_mask = ~lower_bits_mask(bit_begin & 63);
@@ -343,28 +447,40 @@ class BitsetView {
         if ((load_word(first_word) & first_mask) != first_mask) {
             return false;
         }
-        // Interior words are fully in-bounds (highest bit < bit_end <= num_bits_), so read them directly.
         for (size_t word_index = first_word + 1; word_index < last_word; ++word_index) {
-            if (load_full_word(bits_ + (word_index << 3)) != ~uint64_t{0}) {
+            if (load_u64_unaligned_(bits_ + (word_index << 3)) != ~uint64_t{0}) {
                 return false;
             }
         }
         return (load_word(last_word) & last_mask) == last_mask;
     }
 
+    bool
+    has_id_boundary_filter_() const {
+        if (vector_count_ == 0) {
+            return false;
+        }
+        if (has_out_ids()) {
+            return out_ids_count_ < vector_count_;
+        }
+        return id_offset_ >= num_bits_ || vector_count_ > num_bits_ - id_offset_;
+    }
+
     const uint8_t* bits_ = nullptr;
     size_t num_bits_ = 0;
-    size_t num_filtered_out_bits_ = 0;
+    // Backend-vector count used as the filter-ratio denominator.
+    size_t vector_count_ = 0;
+    // Backend-vector count filtered out by bits_.
+    // std::nullopt means unknown; 0 means known empty filtering.
+    std::optional<size_t> filtered_count_ = std::nullopt;
 
-    // optional. many indexes will share one bitset, requiring offset to distinguish between them.
-    //  like multi-chunk brute-force in /src/common/comp/brute_force.cc, or mv-only in /src/index/hnsw/faiss_hnsw.cc
-    size_t id_offset_ = 0;  // offset of the internal ids
+    // Contiguous backend id window into the public bitset.
+    size_t id_offset_ = 0;
 
-    // optional. bitset supports id mapping.
-    // Even allows multiple ids to map to the same bit, so the number of internal ids and bits may be not equal.
-    const uint32_t* out_ids_ = nullptr;
-    size_t num_internal_ids_ = 0;
-    size_t num_filtered_out_ids_ = 0;
+    // Backend/local id -> public id map. Owning index maps and BF-local
+    // pointer windows are both represented by IdArray without copying data.
+    IdArray out_ids_;
+    size_t out_ids_count_ = 0;
 };
 
 }  // namespace knowhere

--- a/include/knowhere/dataset.h
+++ b/include/knowhere/dataset.h
@@ -13,6 +13,8 @@
 #define DATASET_H
 
 #include <any>
+#include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -25,6 +27,49 @@
 #include "knowhere/sparse_utils.h"
 
 namespace knowhere {
+
+// Non-owning input view for nullable id-map build/add data.
+class IdMapData {
+ public:
+    // PACKED_BITMAP and BOOL_ARRAY carry public-id validity. IDS carries an
+    // already compact internal-id -> public-id array plus its public-id domain
+    // size.
+    enum class Format {
+        NONE,
+        PACKED_BITMAP,
+        BOOL_ARRAY,
+        IDS,
+    };
+
+    static IdMapData
+    FromValidBitmap(const uint8_t* valid_bitmap, size_t out_count) {
+        return {Format::PACKED_BITMAP, valid_bitmap, nullptr, nullptr, 0, out_count};
+    }
+
+    static IdMapData
+    FromValidData(const bool* valid_data, size_t out_count) {
+        return {Format::BOOL_ARRAY, nullptr, valid_data, nullptr, 0, out_count};
+    }
+
+    static IdMapData
+    FromIds(const int32_t* out_ids, size_t in_count, size_t out_count) {
+        return {Format::IDS, nullptr, nullptr, out_ids, in_count, out_count};
+    }
+
+    bool
+    HasValue() const {
+        return format != Format::NONE;
+    }
+
+    static constexpr const char* DATASET_KEY = "__knowhere_id_map_data";
+
+    Format format = Format::NONE;
+    const uint8_t* valid_bitmap = nullptr;
+    const bool* valid_data = nullptr;
+    const int32_t* out_ids = nullptr;
+    size_t in_count = 0;
+    size_t out_count = 0;
+};
 
 class DataSet : public std::enable_shared_from_this<const DataSet> {
  public:
@@ -184,6 +229,53 @@ class DataSet : public std::enable_shared_from_this<const DataSet> {
     SetJsonIdSet(const std::string& idset) {
         std::unique_lock lock(mutex_);
         this->data_[meta::JSON_ID_SET] = Var(std::in_place_index<5>, idset);
+    }
+
+    void
+    SetIdMapData(const IdMapData& id_map_data) {
+        // The pointed-to buffers must outlive the Build/Add call.
+        std::unique_lock lock(mutex_);
+        this->data_[IdMapData::DATASET_KEY] = Var(std::in_place_type<std::any>, id_map_data);
+    }
+
+    IdMapData
+    GetIdMapData() const {
+        std::shared_lock lock(mutex_);
+        auto it = this->data_.find(IdMapData::DATASET_KEY);
+        if (it == this->data_.end()) {
+            return {};
+        }
+
+        auto any_ptr = std::get_if<std::any>(&it->second);
+        if (any_ptr == nullptr) {
+            return {};
+        }
+
+        auto id_map_data = std::any_cast<IdMapData>(any_ptr);
+        return id_map_data == nullptr ? IdMapData{} : *id_map_data;
+    }
+
+    bool
+    HasIdMapData() const {
+        std::shared_lock lock(mutex_);
+        auto it = this->data_.find(IdMapData::DATASET_KEY);
+        if (it == this->data_.end()) {
+            return false;
+        }
+
+        auto any_ptr = std::get_if<std::any>(&it->second);
+        if (any_ptr == nullptr) {
+            return false;
+        }
+
+        auto id_map_data = std::any_cast<IdMapData>(any_ptr);
+        return id_map_data != nullptr && id_map_data->HasValue();
+    }
+
+    void
+    ClearIdMapData() {
+        std::unique_lock lock(mutex_);
+        this->data_.erase(IdMapData::DATASET_KEY);
     }
 
     const float*

--- a/include/knowhere/emb_list_utils.h
+++ b/include/knowhere/emb_list_utils.h
@@ -40,6 +40,17 @@ class EmbListOffset {
         offset.push_back(lims[idx]);
     }
 
+    EmbListOffset(const size_t* lims, size_t rows, size_t num_el) {
+        assert(lims != nullptr);
+        assert(num_el > 0);
+        assert(lims[0] == 0);
+        offset.assign(lims, lims + num_el + 1);
+        assert(offset.back() == rows);
+        for (size_t i = 1; i < offset.size(); ++i) {
+            assert(offset[i] >= offset[i - 1]);
+        }
+    }
+
     EmbListOffset(std::vector<size_t>& offset_) {
         assert(offset_.size() > 0);
         assert(offset_[0] == 0);

--- a/include/knowhere/id_map.h
+++ b/include/knowhere/id_map.h
@@ -27,6 +27,7 @@
 #include "knowhere/adaptive_store.h"
 #include "knowhere/array_store.h"
 #include "knowhere/dataset.h"
+#include "knowhere/expected.h"
 #include "knowhere/mmap.h"
 
 namespace knowhere {
@@ -50,6 +51,7 @@ struct IdMapMmapOptions {
 class IdMap {
  public:
     enum class Type {
+        DISABLED,
         SEALED,
         GROWING,
     };
@@ -61,16 +63,37 @@ class IdMap {
     };
 
     IdMap() {
-        SetType(Type::SEALED);
+        SetType(Type::DISABLED);
     }
 
     void
     SetType(Type type) {
+        if (type_ == type) {
+            return;
+        }
+        if (HasData()) {
+            throw std::runtime_error("id map type cannot change after data is written");
+        }
         type_ = type;
         in_to_out_ids_.SetType(IdArrayTypeFor(type_));
         in_to_out_ebl_ids_.SetType(IdArrayTypeFor(type_));
         out_to_in_ids_.SetType(IdArrayTypeFor(type_));
         valid_bitmap_.SetType(BitmapTypeFor(type_));
+    }
+
+    Type
+    type() const {
+        return type_;
+    }
+
+    bool
+    IsEnabled() const {
+        return type_ != Type::DISABLED;
+    }
+
+    bool
+    HasVectorMap() const {
+        return OutCount() != 0 || InCount() != 0 || !in_to_out_ids_.empty() || !valid_bitmap_.empty();
     }
 
     IdMap(const IdMap&) = delete;
@@ -121,20 +144,39 @@ class IdMap {
 
     void
     AddFromData(const IdMapData& data) {
+        if (!IsEnabled()) {
+            throw std::runtime_error("id map data requires enabled id map storage");
+        }
         switch (data.format) {
             case IdMapData::Format::IDS: {
                 if (data.out_count == 0) {
+                    if (data.in_count != 0) {
+                        throw std::runtime_error("id map ids have empty public domain");
+                    }
                     return;
+                }
+                if (data.in_count != 0 && data.out_ids == nullptr) {
+                    throw std::runtime_error("id map ids are null");
                 }
 
                 const auto old_out_count = type_ == Type::GROWING ? OutCount() : 0;
                 const auto old_valid_count = type_ == Type::GROWING ? InCount() : 0;
                 const auto in_id_begin = type_ == Type::GROWING ? old_valid_count : 0;
+                CheckPublicDomain(old_out_count, data.out_count);
 
                 std::vector<int32_t> ids(data.in_count);
                 std::vector<uint8_t> bitmap(BitmapByteSize(data.out_count), 0);
                 for (size_t i = 0; i < data.in_count; ++i) {
+                    if (data.out_ids[i] < 0) {
+                        throw std::runtime_error("id map id is negative");
+                    }
                     const auto local_out_id = static_cast<size_t>(data.out_ids[i]);
+                    if (local_out_id >= data.out_count) {
+                        throw std::runtime_error("id map id is out of range");
+                    }
+                    if (PackedBit(bitmap.data(), local_out_id)) {
+                        throw std::runtime_error("id map ids contain duplicate public id");
+                    }
                     ids[i] = static_cast<int32_t>(old_out_count + local_out_id);
                     SetPackedBit(bitmap, local_out_id);
                 }
@@ -159,8 +201,12 @@ class IdMap {
                 if (data.out_count == 0) {
                     return;
                 }
+                if (data.valid_bitmap == nullptr) {
+                    throw std::runtime_error("id map bitmap is null");
+                }
 
                 if (type_ == Type::SEALED) {
+                    CheckPublicDomain(0, data.out_count);
                     valid_bitmap_.Set(data.valid_bitmap, data.out_count);
                     PublishCounts(data.out_count, CountPackedBitmap(data.valid_bitmap, data.out_count));
                     return;
@@ -169,6 +215,7 @@ class IdMap {
                 const auto old_out_count = OutCount();
                 const auto old_valid_count = InCount();
                 const auto in_id_begin = old_valid_count;
+                CheckPublicDomain(old_out_count, data.out_count);
 
                 std::vector<int32_t> ids;
                 ids.reserve(data.out_count);
@@ -188,9 +235,13 @@ class IdMap {
                 if (data.out_count == 0) {
                     return;
                 }
+                if (data.valid_data == nullptr) {
+                    throw std::runtime_error("id map valid data is null");
+                }
 
                 auto bitmap = PackBoolArray(data.valid_data, data.out_count);
                 if (type_ == Type::SEALED) {
+                    CheckPublicDomain(0, data.out_count);
                     valid_bitmap_.Set(bitmap.data(), data.out_count);
                     PublishCounts(data.out_count, CountPackedBitmap(bitmap.data(), data.out_count));
                     return;
@@ -199,6 +250,7 @@ class IdMap {
                 const auto old_out_count = OutCount();
                 const auto old_valid_count = InCount();
                 const auto in_id_begin = old_valid_count;
+                CheckPublicDomain(old_out_count, data.out_count);
 
                 std::vector<int32_t> ids;
                 ids.reserve(data.out_count);
@@ -222,6 +274,9 @@ class IdMap {
     void
     FinalizeVectorIds() {
         // Derives vector maps from public-id validity input.
+        if (!IsEnabled()) {
+            return;
+        }
         const auto out_count = OutCount();
         if (out_count == 0 || valid_bitmap_.empty()) {
             valid_count_.store(0, std::memory_order_release);
@@ -233,6 +288,7 @@ class IdMap {
 
         std::vector<int32_t> ids;
         ids.reserve(InCount());
+        CheckPublicDomain(0, out_count);
         for (size_t out_id = 0; out_id < out_count; ++out_id) {
             if (PackedBit(valid_bitmap_, out_id)) {
                 ids.push_back(static_cast<int32_t>(out_id));
@@ -256,12 +312,18 @@ class IdMap {
         if (ebl_count == 0) {
             return;
         }
+        if (ebl_offsets == nullptr) {
+            throw std::runtime_error("emb_list offsets are null");
+        }
 
         const auto in_count = ebl_offsets[ebl_count];
 
         std::vector<int32_t> ids(in_count, kInvalidId);
         for (size_t ebl_id = 0; ebl_id < ebl_count; ++ebl_id) {
-            const auto out_id = in_to_out_ids_.empty() ? static_cast<int32_t>(ebl_id) : in_to_out_ids_[ebl_id];
+            if (ebl_offsets[ebl_id + 1] < ebl_offsets[ebl_id] || ebl_offsets[ebl_id + 1] > in_count) {
+                throw std::runtime_error("emb_list offsets are inconsistent");
+            }
+            const auto out_id = ListOutId(ebl_id);
             std::fill(ids.begin() + ebl_offsets[ebl_id], ids.begin() + ebl_offsets[ebl_id + 1], out_id);
         }
         if (type_ == Type::GROWING) {
@@ -278,12 +340,22 @@ class IdMap {
         if (list_count == 0) {
             return;
         }
+        if (ebl_id_begin < 0) {
+            throw std::runtime_error("emb_list id begin is negative");
+        }
+        if (ebl_offsets == nullptr) {
+            throw std::runtime_error("emb_list offsets are null");
+        }
 
         const auto append_count = ebl_offsets[list_count];
 
         std::vector<int32_t> ids(append_count, kInvalidId);
+        const auto list_id_begin = static_cast<size_t>(ebl_id_begin);
         for (size_t ebl_id = 0; ebl_id < list_count; ++ebl_id) {
-            const auto out_id = static_cast<int32_t>(ebl_id_begin + static_cast<int64_t>(ebl_id));
+            if (ebl_offsets[ebl_id + 1] < ebl_offsets[ebl_id] || ebl_offsets[ebl_id + 1] > append_count) {
+                throw std::runtime_error("emb_list append offsets are inconsistent");
+            }
+            const auto out_id = ListOutId(list_id_begin + ebl_id);
             std::fill(ids.begin() + ebl_offsets[ebl_id], ids.begin() + ebl_offsets[ebl_id + 1], out_id);
         }
         in_to_out_ebl_ids_.Append(ids.data(), ids.size());
@@ -353,21 +425,41 @@ class IdMap {
         }
     }
 
-    int64_t
-    MapOutToIn(int64_t out_id) const {
-        return OutCount() == 0 ? out_id : static_cast<int64_t>(GetOutToInId(out_id));
+    expected<int64_t>
+    CompactOutToIn(int64_t out_id, size_t compact_count) const {
+        const auto compact_id = OutCount() == 0 ? out_id : static_cast<int64_t>(GetOutToInId(out_id));
+        if (compact_id < 0 || static_cast<size_t>(compact_id) >= compact_count) {
+            return expected<int64_t>::Err(Status::invalid_args,
+                                          "selected id maps outside compact storage: " + std::to_string(out_id));
+        }
+        return compact_id;
     }
 
-    const int64_t*
-    MapOutToIn(const int64_t* ids, size_t count, std::vector<int64_t>& in_ids) const {
+    expected<const int64_t*>
+    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids,
+                   size_t compact_count) const {
+        if (count != 0 && out_ids == nullptr) {
+            return expected<const int64_t*>::Err(Status::invalid_args, "selected ids are null");
+        }
         if (OutCount() == 0) {
-            return ids;
+            for (size_t i = 0; i < count; ++i) {
+                auto compact_id = CompactOutToIn(out_ids[i], compact_count);
+                if (!compact_id.has_value()) {
+                    return expected<const int64_t*>::Err(compact_id.error(), compact_id.what());
+                }
+            }
+            return out_ids;
         }
-        in_ids.resize(count);
+
+        compact_ids.resize(count);
         for (size_t i = 0; i < count; ++i) {
-            in_ids[i] = GetOutToInId(ids[i]);
+            auto compact_id = CompactOutToIn(out_ids[i], compact_count);
+            if (!compact_id.has_value()) {
+                return expected<const int64_t*>::Err(compact_id.error(), compact_id.what());
+            }
+            compact_ids[i] = compact_id.value();
         }
-        return in_ids.data();
+        return compact_ids.data();
     }
 
  private:
@@ -393,12 +485,26 @@ class IdMap {
         bitmap[bit >> 3] |= static_cast<uint8_t>(1U << (bit & 7));
     }
 
+    static void
+    CheckPublicDomain(size_t old_out_count, size_t append_out_count) {
+        if (append_out_count == 0) {
+            return;
+        }
+        constexpr auto max_id = static_cast<size_t>(std::numeric_limits<int32_t>::max());
+        if (old_out_count > max_id || append_out_count - 1 > max_id - old_out_count) {
+            throw std::runtime_error("id map public id overflows int32");
+        }
+    }
+
     static size_t
     CountPackedBitmap(const uint8_t* valid_bitmap, size_t out_count) {
         // Count only the logical public-id range. Padding bits in the final
         // byte/word are ignored even if the caller's buffer contains garbage.
         if (out_count == 0) {
             return 0;
+        }
+        if (valid_bitmap == nullptr) {
+            throw std::runtime_error("id map bitmap is null");
         }
         size_t count = 0;
         const auto full_words = out_count / 64;
@@ -420,6 +526,9 @@ class IdMap {
 
     static std::vector<uint8_t>
     PackBoolArray(const bool* valid_data, size_t out_count) {
+        if (out_count != 0 && valid_data == nullptr) {
+            throw std::runtime_error("id map valid data is null");
+        }
         std::vector<uint8_t> bitmap(BitmapByteSize(out_count), 0);
         for (size_t out_id = 0; out_id < out_count; ++out_id) {
             if (valid_data[out_id]) {
@@ -439,6 +548,20 @@ class IdMap {
             return kInvalidId;
         }
         return out_to_in_ids_.Get(static_cast<int32_t>(out_id));
+    }
+
+    int32_t
+    ListOutId(size_t list_id) const {
+        if (in_to_out_ids_.empty()) {
+            if (list_id > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+                throw std::runtime_error("emb_list public id overflows int32");
+            }
+            return static_cast<int32_t>(list_id);
+        }
+        if (list_id >= InCount()) {
+            throw std::runtime_error("emb_list id exceeds list id map size");
+        }
+        return in_to_out_ids_[list_id];
     }
 
     static ArrayStore<int32_t>::Type
@@ -482,7 +605,7 @@ class IdMap {
         mmap_configured_ = other.mmap_configured_;
     }
 
-    Type type_ = Type::SEALED;
+    Type type_ = Type::DISABLED;
     // Compact vector internal id -> public row id.
     IdArray in_to_out_ids_;
     // Compact base-vector internal id -> public embedding-list id. Only

--- a/include/knowhere/id_map.h
+++ b/include/knowhere/id_map.h
@@ -1,0 +1,506 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#ifndef ID_MAP_H
+#define ID_MAP_H
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "knowhere/adaptive_store.h"
+#include "knowhere/array_store.h"
+#include "knowhere/dataset.h"
+#include "knowhere/mmap.h"
+
+namespace knowhere {
+
+struct IdMapMmapOptions {
+    // Mmap-backed arrays are used by sealed id maps.
+    bool enable_in_to_out_ids = false;
+    bool enable_out_to_in_ids = false;
+    std::string mmap_dir_path;
+};
+
+// Owns the nullable ID-domain boundary.
+//
+// Public ids are row/list ids used by APIs and filter bitsets. Backend ids are
+// dense storage ids after null rows or empty lists are compacted away. IdMap
+// provides both directions for result mapping, selected-id lookup, and EmbList
+// vector-level filtering.
+//
+// SEALED maps publish immutable arrays, optionally mmap-backed. GROWING maps
+// append new public-id ranges while keeping existing backend ids stable.
+class IdMap {
+ public:
+    enum class Type {
+        SEALED,
+        GROWING,
+    };
+
+    // VECTOR maps vector storage ids. EMB_LIST maps base-vector ids to list ids.
+    enum class Domain {
+        VECTOR,
+        EMB_LIST,
+    };
+
+    IdMap() {
+        SetType(Type::SEALED);
+    }
+
+    void
+    SetType(Type type) {
+        type_ = type;
+        in_to_out_ids_.SetType(IdArrayTypeFor(type_));
+        in_to_out_ebl_ids_.SetType(IdArrayTypeFor(type_));
+        out_to_in_ids_.SetType(IdArrayTypeFor(type_));
+        valid_bitmap_.SetType(BitmapTypeFor(type_));
+    }
+
+    IdMap(const IdMap&) = delete;
+    IdMap(IdMap&& other) noexcept {
+        MoveFrom(std::move(other));
+    }
+
+    IdMap&
+    operator=(const IdMap&) = delete;
+    IdMap&
+    operator=(IdMap&& other) noexcept {
+        if (this != &other) {
+            MoveFrom(std::move(other));
+        }
+        return *this;
+    }
+
+    void
+    ConfigureMmap(IdMapMmapOptions options) {
+        const auto enable_mmap = options.enable_in_to_out_ids || options.enable_out_to_in_ids;
+        if (!enable_mmap) {
+            return;
+        }
+        if (type_ != Type::SEALED) {
+            throw std::runtime_error("id map mmap is only supported by sealed storage");
+        }
+        if (mmap_configured_) {
+            throw std::runtime_error("id map mmap has already been configured");
+        }
+        if (HasData()) {
+            throw std::runtime_error("id map mmap must be configured before data is written");
+        }
+        if (enable_mmap && options.mmap_dir_path.empty()) {
+            throw std::runtime_error("id map mmap directory is empty");
+        }
+        std::filesystem::create_directories(options.mmap_dir_path);
+
+        // These files are local backing allocations.
+        const auto dir = std::filesystem::path(options.mmap_dir_path);
+        in_to_out_ids_mmap_file_paths_ =
+            MmapFilePathGenerator(options.enable_in_to_out_ids ? (dir / "in_to_out_ids").string() : std::string{});
+        in_to_out_ebl_ids_mmap_file_paths_ =
+            MmapFilePathGenerator(options.enable_in_to_out_ids ? (dir / "in_to_out_ebl_ids").string() : std::string{});
+        out_to_in_ids_.SetMmapFilePathGenerator(
+            MmapFilePathGenerator(options.enable_out_to_in_ids ? (dir / "out_to_in_ids").string() : std::string{}));
+        mmap_configured_ = true;
+    }
+
+    void
+    AddFromData(const IdMapData& data) {
+        switch (data.format) {
+            case IdMapData::Format::IDS: {
+                if (data.out_count == 0) {
+                    return;
+                }
+
+                const auto old_out_count = type_ == Type::GROWING ? OutCount() : 0;
+                const auto old_valid_count = type_ == Type::GROWING ? InCount() : 0;
+                const auto in_id_begin = type_ == Type::GROWING ? old_valid_count : 0;
+
+                std::vector<int32_t> ids(data.in_count);
+                std::vector<uint8_t> bitmap(BitmapByteSize(data.out_count), 0);
+                for (size_t i = 0; i < data.in_count; ++i) {
+                    const auto local_out_id = static_cast<size_t>(data.out_ids[i]);
+                    ids[i] = static_cast<int32_t>(old_out_count + local_out_id);
+                    SetPackedBit(bitmap, local_out_id);
+                }
+
+                if (type_ == Type::GROWING) {
+                    valid_bitmap_.Append(bitmap.data(), data.out_count);
+                    in_to_out_ids_.Append(ids.data(), ids.size());
+                    out_to_in_ids_.Append(ids.data(), ids.size(), old_out_count, data.out_count, in_id_begin);
+                    PublishCounts(old_out_count + data.out_count, old_valid_count + ids.size());
+                } else {
+                    valid_bitmap_.Set(bitmap.data(), data.out_count);
+                    in_to_out_ids_.Set(ids.data(), ids.size(), in_to_out_ids_mmap_file_paths_.Next(this));
+                    PublishCounts(data.out_count, data.in_count);
+                    if (ids.empty()) {
+                        return;
+                    }
+                    out_to_in_ids_.Set(ids.data(), ids.size(), data.out_count);
+                }
+                return;
+            }
+            case IdMapData::Format::PACKED_BITMAP: {
+                if (data.out_count == 0) {
+                    return;
+                }
+
+                if (type_ == Type::SEALED) {
+                    valid_bitmap_.Set(data.valid_bitmap, data.out_count);
+                    PublishCounts(data.out_count, CountPackedBitmap(data.valid_bitmap, data.out_count));
+                    return;
+                }
+
+                const auto old_out_count = OutCount();
+                const auto old_valid_count = InCount();
+                const auto in_id_begin = old_valid_count;
+
+                std::vector<int32_t> ids;
+                ids.reserve(data.out_count);
+                for (size_t out_id = 0; out_id < data.out_count; ++out_id) {
+                    if (PackedBit(data.valid_bitmap, out_id)) {
+                        ids.push_back(static_cast<int32_t>(old_out_count + out_id));
+                    }
+                }
+
+                valid_bitmap_.Append(data.valid_bitmap, data.out_count);
+                in_to_out_ids_.Append(ids.data(), ids.size());
+                out_to_in_ids_.Append(ids.data(), ids.size(), old_out_count, data.out_count, in_id_begin);
+                PublishCounts(old_out_count + data.out_count, old_valid_count + ids.size());
+                return;
+            }
+            case IdMapData::Format::BOOL_ARRAY: {
+                if (data.out_count == 0) {
+                    return;
+                }
+
+                auto bitmap = PackBoolArray(data.valid_data, data.out_count);
+                if (type_ == Type::SEALED) {
+                    valid_bitmap_.Set(bitmap.data(), data.out_count);
+                    PublishCounts(data.out_count, CountPackedBitmap(bitmap.data(), data.out_count));
+                    return;
+                }
+
+                const auto old_out_count = OutCount();
+                const auto old_valid_count = InCount();
+                const auto in_id_begin = old_valid_count;
+
+                std::vector<int32_t> ids;
+                ids.reserve(data.out_count);
+                for (size_t out_id = 0; out_id < data.out_count; ++out_id) {
+                    if (data.valid_data[out_id]) {
+                        ids.push_back(static_cast<int32_t>(old_out_count + out_id));
+                    }
+                }
+
+                valid_bitmap_.Append(bitmap.data(), data.out_count);
+                in_to_out_ids_.Append(ids.data(), ids.size());
+                out_to_in_ids_.Append(ids.data(), ids.size(), old_out_count, data.out_count, in_id_begin);
+                PublishCounts(old_out_count + data.out_count, old_valid_count + ids.size());
+                return;
+            }
+            default:
+                throw std::runtime_error("unsupported id map data format");
+        }
+    }
+
+    void
+    FinalizeVectorIds() {
+        // Derives vector maps from public-id validity input.
+        const auto out_count = OutCount();
+        if (out_count == 0 || valid_bitmap_.empty()) {
+            valid_count_.store(0, std::memory_order_release);
+            return;
+        }
+        if (!in_to_out_ids_.empty()) {
+            return;
+        }
+
+        std::vector<int32_t> ids;
+        ids.reserve(InCount());
+        for (size_t out_id = 0; out_id < out_count; ++out_id) {
+            if (PackedBit(valid_bitmap_, out_id)) {
+                ids.push_back(static_cast<int32_t>(out_id));
+            }
+        }
+        valid_count_.store(ids.size(), std::memory_order_release);
+        if (ids.empty()) {
+            return;
+        }
+        if (type_ == Type::GROWING) {
+            in_to_out_ids_.Append(ids.data(), ids.size());
+        } else {
+            in_to_out_ids_.Set(ids.data(), ids.size(), in_to_out_ids_mmap_file_paths_.Next(this));
+        }
+        out_to_in_ids_.Set(ids.data(), ids.size(), out_count);
+    }
+
+    void
+    FinalizeEmbListIds(const size_t* ebl_offsets, size_t ebl_count) {
+        // Base-vector id -> public-list id map for list-domain filters.
+        if (ebl_count == 0) {
+            return;
+        }
+
+        const auto in_count = ebl_offsets[ebl_count];
+
+        std::vector<int32_t> ids(in_count, kInvalidId);
+        for (size_t ebl_id = 0; ebl_id < ebl_count; ++ebl_id) {
+            const auto out_id = in_to_out_ids_.empty() ? static_cast<int32_t>(ebl_id) : in_to_out_ids_[ebl_id];
+            std::fill(ids.begin() + ebl_offsets[ebl_id], ids.begin() + ebl_offsets[ebl_id + 1], out_id);
+        }
+        if (type_ == Type::GROWING) {
+            in_to_out_ebl_ids_.Append(ids.data(), ids.size());
+        } else {
+            in_to_out_ebl_ids_.Set(ids.data(), ids.size(), in_to_out_ebl_ids_mmap_file_paths_.Next(this));
+        }
+    }
+
+    void
+    AppendEmbListIds(int64_t ebl_id_begin, const size_t* ebl_offsets, int64_t ebl_count) {
+        // Appends base-vector ids for a growing EmbList batch.
+        const auto list_count = static_cast<size_t>(ebl_count);
+        if (list_count == 0) {
+            return;
+        }
+
+        const auto append_count = ebl_offsets[list_count];
+
+        std::vector<int32_t> ids(append_count, kInvalidId);
+        for (size_t ebl_id = 0; ebl_id < list_count; ++ebl_id) {
+            const auto out_id = static_cast<int32_t>(ebl_id_begin + static_cast<int64_t>(ebl_id));
+            std::fill(ids.begin() + ebl_offsets[ebl_id], ids.begin() + ebl_offsets[ebl_id + 1], out_id);
+        }
+        in_to_out_ebl_ids_.Append(ids.data(), ids.size());
+    }
+
+    size_t
+    OutCount() const {
+        return out_count_.load(std::memory_order_acquire);
+    }
+
+    size_t
+    InCount() const {
+        return valid_count_.load(std::memory_order_acquire);
+    }
+
+    bool
+    IsValidOutId(int64_t out_id) const {
+        if (out_id < 0) {
+            return false;
+        }
+        const auto offset = static_cast<size_t>(out_id);
+        const auto out_count = OutCount();
+        if (out_count != 0 && offset >= out_count) {
+            return false;
+        }
+        return valid_bitmap_.empty() || PackedBit(valid_bitmap_, offset);
+    }
+
+    BitmapArray
+    ValidBitmap() const {
+        return valid_bitmap_.Prefix(OutCount());
+    }
+
+    IdArray
+    InToOutIds(Domain domain = Domain::VECTOR) const {
+        if (domain == Domain::EMB_LIST) {
+            return in_to_out_ebl_ids_;
+        }
+        return in_to_out_ids_.Prefix(InCount());
+    }
+
+    int64_t
+    MapInToOut(int64_t in_id, Domain domain = Domain::VECTOR) const {
+        const auto& ids = domain == Domain::EMB_LIST ? in_to_out_ebl_ids_ : in_to_out_ids_;
+        if (in_id < 0 || ids.empty()) {
+            return in_id;
+        }
+        const auto offset = static_cast<size_t>(in_id);
+        const auto count = InToOutCount(domain);
+        return offset < count ? ids[offset] : kInvalidId;
+    }
+
+    template <typename IdType>
+    void
+    MapInToOut(IdType* ids, size_t count, Domain domain = Domain::VECTOR) const {
+        const auto& id_map = domain == Domain::EMB_LIST ? in_to_out_ebl_ids_ : in_to_out_ids_;
+        if (ids == nullptr || id_map.empty()) {
+            return;
+        }
+        const auto id_map_count = InToOutCount(domain);
+        for (size_t i = 0; i < count; ++i) {
+            if (ids[i] < 0) {
+                continue;
+            }
+            const auto offset = static_cast<size_t>(ids[i]);
+            ids[i] = static_cast<IdType>(offset < id_map_count ? id_map[offset] : kInvalidId);
+        }
+    }
+
+    int64_t
+    MapOutToIn(int64_t out_id) const {
+        return OutCount() == 0 ? out_id : static_cast<int64_t>(GetOutToInId(out_id));
+    }
+
+    const int64_t*
+    MapOutToIn(const int64_t* ids, size_t count, std::vector<int64_t>& in_ids) const {
+        if (OutCount() == 0) {
+            return ids;
+        }
+        in_ids.resize(count);
+        for (size_t i = 0; i < count; ++i) {
+            in_ids[i] = GetOutToInId(ids[i]);
+        }
+        return in_ids.data();
+    }
+
+ private:
+    static constexpr int32_t kInvalidId = -1;
+
+    static size_t
+    BitmapByteSize(size_t bit_count) {
+        return (bit_count + 7) / 8;
+    }
+
+    static bool
+    PackedBit(const uint8_t* bitmap, size_t bit) {
+        return (bitmap[bit >> 3] & (1U << (bit & 7))) != 0;
+    }
+
+    static bool
+    PackedBit(const BitmapArray& bitmap, size_t bit) {
+        return bit < bitmap.size() && (bitmap[bit >> 3] & (1U << (bit & 7))) != 0;
+    }
+
+    static void
+    SetPackedBit(std::vector<uint8_t>& bitmap, size_t bit) {
+        bitmap[bit >> 3] |= static_cast<uint8_t>(1U << (bit & 7));
+    }
+
+    static size_t
+    CountPackedBitmap(const uint8_t* valid_bitmap, size_t out_count) {
+        // Count only the logical public-id range. Padding bits in the final
+        // byte/word are ignored even if the caller's buffer contains garbage.
+        if (out_count == 0) {
+            return 0;
+        }
+        size_t count = 0;
+        const auto full_words = out_count / 64;
+        for (size_t i = 0; i < full_words; ++i) {
+            uint64_t word = 0;
+            std::memcpy(&word, valid_bitmap + i * sizeof(uint64_t), sizeof(uint64_t));
+            count += static_cast<size_t>(__builtin_popcountll(static_cast<unsigned long long>(word)));
+        }
+
+        const auto tail_bits = out_count % 64;
+        if (tail_bits != 0) {
+            uint64_t word = 0;
+            std::memcpy(&word, valid_bitmap + full_words * sizeof(uint64_t), BitmapByteSize(tail_bits));
+            word &= (uint64_t{1} << tail_bits) - 1;
+            count += static_cast<size_t>(__builtin_popcountll(static_cast<unsigned long long>(word)));
+        }
+        return count;
+    }
+
+    static std::vector<uint8_t>
+    PackBoolArray(const bool* valid_data, size_t out_count) {
+        std::vector<uint8_t> bitmap(BitmapByteSize(out_count), 0);
+        for (size_t out_id = 0; out_id < out_count; ++out_id) {
+            if (valid_data[out_id]) {
+                SetPackedBit(bitmap, out_id);
+            }
+        }
+        return bitmap;
+    }
+
+    int32_t
+    GetOutToInId(int64_t out_id) const {
+        if (out_id < 0 || out_id > std::numeric_limits<int32_t>::max()) {
+            return kInvalidId;
+        }
+        const auto out_count = OutCount();
+        if (out_count != 0 && static_cast<size_t>(out_id) >= out_count) {
+            return kInvalidId;
+        }
+        return out_to_in_ids_.Get(static_cast<int32_t>(out_id));
+    }
+
+    static ArrayStore<int32_t>::Type
+    IdArrayTypeFor(Type type) {
+        return type == Type::GROWING ? ArrayStore<int32_t>::Type::APPEND_ARRAY : ArrayStore<int32_t>::Type::ARRAY;
+    }
+
+    static BitmapArray::Type
+    BitmapTypeFor(Type type) {
+        return type == Type::GROWING ? BitmapArray::Type::APPEND_ARRAY : BitmapArray::Type::ARRAY;
+    }
+
+    bool
+    HasData() const {
+        return OutCount() != 0 || InCount() != 0 || !in_to_out_ids_.empty() || !in_to_out_ebl_ids_.empty() ||
+               !valid_bitmap_.empty();
+    }
+
+    void
+    PublishCounts(size_t out_count, size_t valid_count) {
+        valid_count_.store(valid_count, std::memory_order_release);
+        out_count_.store(out_count, std::memory_order_release);
+    }
+
+    size_t
+    InToOutCount(Domain domain) const {
+        return domain == Domain::EMB_LIST ? in_to_out_ebl_ids_.size() : InCount();
+    }
+
+    void
+    MoveFrom(IdMap&& other) noexcept {
+        type_ = other.type_;
+        in_to_out_ids_ = std::move(other.in_to_out_ids_);
+        in_to_out_ebl_ids_ = std::move(other.in_to_out_ebl_ids_);
+        out_to_in_ids_ = std::move(other.out_to_in_ids_);
+        valid_bitmap_ = std::move(other.valid_bitmap_);
+        out_count_.store(other.OutCount(), std::memory_order_release);
+        valid_count_.store(other.InCount(), std::memory_order_release);
+        in_to_out_ids_mmap_file_paths_ = std::move(other.in_to_out_ids_mmap_file_paths_);
+        in_to_out_ebl_ids_mmap_file_paths_ = std::move(other.in_to_out_ebl_ids_mmap_file_paths_);
+        mmap_configured_ = other.mmap_configured_;
+    }
+
+    Type type_ = Type::SEALED;
+    // Compact vector internal id -> public row id.
+    IdArray in_to_out_ids_;
+    // Compact base-vector internal id -> public embedding-list id. Only
+    // populated for EmbList strategies whose base index filters at vector level.
+    IdArray in_to_out_ebl_ids_;
+    // Public row/list id -> compact vector/list id for selected-id APIs.
+    AdaptiveStore<int32_t> out_to_in_ids_;
+    // Public-id validity over [0, out_count_). Empty means identity/non-nullable.
+    BitmapArray valid_bitmap_;
+    // Size of the public id domain.
+    std::atomic<size_t> out_count_{0};
+    // Number of compact vector/list ids represented by this map.
+    std::atomic<size_t> valid_count_{0};
+    MmapFilePathGenerator in_to_out_ids_mmap_file_paths_;
+    MmapFilePathGenerator in_to_out_ebl_ids_mmap_file_paths_;
+    bool mmap_configured_ = false;
+};
+
+}  // namespace knowhere
+
+#endif /* ID_MAP_H */

--- a/include/knowhere/index/index.h
+++ b/include/knowhere/index/index.h
@@ -139,6 +139,24 @@ class Index {
         return Index(dynamic_cast<T2>(node));
     }
 
+    IdMap&
+    GetIdMap() {
+        assert(node != nullptr);
+        return this->node->GetIdMap();
+    }
+
+    const IdMap&
+    GetIdMap() const {
+        assert(node != nullptr);
+        return this->node->GetIdMap();
+    }
+
+    void
+    SetIdMapType(IdMap::Type type) {
+        assert(node != nullptr);
+        this->node->SetIdMapType(type);
+    }
+
     Status
     Build(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool = true) noexcept;
 

--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -12,9 +12,20 @@
 #ifndef INDEX_NODE_H
 #define INDEX_NODE_H
 
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <exception>
 #include <functional>
+#include <iterator>
+#include <limits>
+#include <memory>
 #include <mutex>
+#include <numeric>
+#include <optional>
 #include <queue>
+#include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -24,6 +35,7 @@
 #include "knowhere/dataset.h"
 #include "knowhere/emb_list_utils.h"
 #include "knowhere/expected.h"
+#include "knowhere/id_map.h"
 #include "knowhere/index/emb_list_strategy.h"
 #include "knowhere/object.h"
 #include "knowhere/operands.h"
@@ -187,6 +199,16 @@ class IndexNode : public Object {
     };
     using IteratorPtr = std::shared_ptr<iterator>;
 
+    struct PreparedBitset {
+        // BitsetView after id-domain projection.
+        BitsetView bitset;
+
+        PreparedBitset() = default;
+
+        explicit PreparedBitset(BitsetView bitset) : bitset(bitset) {
+        }
+    };
+
     virtual expected<std::vector<IteratorPtr>>
     AnnIterator(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset,
                 bool use_knowhere_search_pool = true, milvus::OpContext* op_context = nullptr) const {
@@ -237,6 +259,40 @@ class IndexNode : public Object {
     HasRawData(const std::string& metric_type) const = 0;
 
     virtual bool
+    NeedBitsetExactCount() const {
+        // Backends with filter-ratio shortcuts need exact projected counts.
+        return false;
+    }
+
+    // Projects a public-id bitset to the backend id domain.
+    virtual expected<PreparedBitset>
+    PrepareBitset(BitsetView bitset) const {
+        PreparedBitset prepared(bitset);
+        const auto& id_map = GetIdMap();
+        const auto count = id_map.OutCount();
+        if (count != 0 && bitset.num_bits() > static_cast<size_t>(count)) {
+            const auto msg = std::string("bitset size should be <= external count, but we get bitset size: ") +
+                             std::to_string(bitset.num_bits()) + ", external count: " + std::to_string(count);
+            LOG_KNOWHERE_ERROR_ << msg;
+            return expected<PreparedBitset>::Err(Status::invalid_args, msg);
+        }
+        if (bitset.num_bits() == 0) {
+            return prepared;
+        }
+        if (bitset.data() == nullptr) {
+            const auto msg = std::string("bitset data is null while bitset size is non-zero");
+            LOG_KNOWHERE_ERROR_ << msg;
+            return expected<PreparedBitset>::Err(Status::invalid_args, msg);
+        }
+
+        PrepareBitsetMap(prepared, id_map);
+        if (NeedBitsetExactCount()) {
+            CalcBitsetCount(prepared.bitset, id_map, 0, std::numeric_limits<size_t>::max());
+        }
+        return prepared;
+    }
+
+    virtual bool
     IsAdditionalScalarSupported(bool is_mv_only) const {
         return false;
     }
@@ -247,9 +303,7 @@ class IndexNode : public Object {
     }
 
     /**
-     * @unused Milvus is not using this method, so it cannot guarantee all indexes implement this method.
-     *
-     * This is for Feder, and we can ignore it for now.
+     * @unused Not every index implementation supports this optional metadata path.
      */
     virtual expected<DataSetPtr>
     GetIndexMeta(std::unique_ptr<Config> cfg) const = 0;
@@ -304,8 +358,6 @@ class IndexNode : public Object {
     Dim() const = 0;
 
     /**
-     * @unused Milvus is not using this method, so it cannot guarantee all indexes implement this method.
-     *
      * @brief Gets the memory usage of the index in bytes.
      *
      * @return The size of the index as an int64_t.
@@ -322,6 +374,391 @@ class IndexNode : public Object {
     virtual int64_t
     Count() const = 0;
 
+    virtual IdMap&
+    GetIdMap() {
+        return id_map_;
+    }
+
+    virtual const IdMap&
+    GetIdMap() const {
+        return id_map_;
+    }
+
+    virtual void
+    SetIdMapType(IdMap::Type type) {
+        // Selects sealed/growing id-map storage for this node and wrappers.
+        GetIdMap().SetType(type);
+    }
+
+    virtual int64_t
+    MapOutToIn(int64_t out_id) const {
+        return GetIdMap().MapOutToIn(out_id);
+    }
+
+    virtual const int64_t*
+    MapOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& in_ids) const {
+        return GetIdMap().MapOutToIn(out_ids, count, in_ids);
+    }
+
+    /**
+     * Finalizes derived id maps after backend layout is available.
+     *
+     * Bitmap input carries public validity only. This step builds the
+     * internal-to-public and public-to-internal maps used by result mapping and
+     * selected-id APIs. EmbList strategies may also derive a base-vector ->
+     * public-list map for vector-level filtering.
+     */
+    virtual Status
+    FinalizeIdMap() {
+        if (id_map_.InToOutIds().empty()) {
+            id_map_.FinalizeVectorIds();
+        }
+        if (emb_list_offset_ != nullptr && emb_list_strategy_ != nullptr && emb_list_strategy_->NeedsBaseIndexIDMap()) {
+            id_map_.FinalizeEmbListIds(emb_list_offset_->offset.data(), emb_list_offset_->num_el());
+        }
+        return Status::success;
+    }
+
+ protected:
+    // Retrieve vectors by ids already in this node's base-vector storage domain.
+    virtual expected<DataSetPtr>
+    GetVectorByStorageIds(const DataSetPtr dataset, milvus::OpContext* op_context = nullptr) const {
+        return expected<DataSetPtr>::Err(Status::not_implemented, "GetVectorByStorageIds not implemented");
+    }
+
+    Status
+    AppendEmbListOffsetAndIdMap(const size_t* lims, size_t append_row_count) {
+        // lims is absolute in the whole index; AppendEmbListIds consumes the
+        // appended local offset window.
+        const auto old_el_count = emb_list_offset_->num_el();
+        const auto old_vector_count = emb_list_offset_->offset.back();
+        const auto new_vector_count = old_vector_count + append_row_count;
+        if (lims[0] != old_vector_count) {
+            LOG_KNOWHERE_WARNING_ << "emb list offset is not continuous";
+            return Status::emb_list_inner_error;
+        }
+
+        size_t append_el_count = 1;
+        while (lims[append_el_count] < new_vector_count) {
+            if (lims[append_el_count] < lims[append_el_count - 1]) {
+                LOG_KNOWHERE_WARNING_ << "emb list offset is not increasing";
+                return Status::emb_list_inner_error;
+            }
+            ++append_el_count;
+        }
+        if (lims[append_el_count] != new_vector_count) {
+            LOG_KNOWHERE_WARNING_ << "emb list offset should end with the total_cnt of the whole index";
+            return Status::emb_list_inner_error;
+        }
+
+        std::vector<size_t> append_lims;
+        append_lims.reserve(append_el_count + 1);
+        append_lims.push_back(0);
+        for (size_t i = 1; i <= append_el_count; ++i) {
+            append_lims.push_back(lims[i] - old_vector_count);
+        }
+        emb_list_offset_->offset.reserve(emb_list_offset_->offset.size() + append_el_count);
+
+        if (emb_list_strategy_ != nullptr && emb_list_strategy_->NeedsBaseIndexIDMap()) {
+            const auto& ebl_ids = id_map_.InToOutIds(IdMap::Domain::EMB_LIST);
+            if (ebl_ids.size() != old_vector_count && ebl_ids.size() != new_vector_count) {
+                LOG_KNOWHERE_WARNING_ << "invalid emb_list external id map size: " << ebl_ids.size()
+                                      << ", expected: " << old_vector_count << " or " << new_vector_count;
+                return Status::invalid_args;
+            }
+            try {
+                if (ebl_ids.size() == old_vector_count) {
+                    // Extend the vector -> public-list map for this append batch.
+                    id_map_.AppendEmbListIds(static_cast<int64_t>(old_el_count), append_lims.data(),
+                                             static_cast<int64_t>(append_el_count));
+                }
+            } catch (const std::exception& e) {
+                LOG_KNOWHERE_WARNING_ << "invalid emb_list external id map: " << e.what();
+                return Status::invalid_args;
+            }
+        }
+        for (size_t i = 1; i <= append_el_count; ++i) {
+            emb_list_offset_->offset.push_back(lims[i]);
+        }
+        return Status::success;
+    }
+
+    void
+    PrepareBitsetMap(PreparedBitset& prepared, const IdMap& id_map) const {
+        // Backend selectors test internal ids; bitsets use public ids.
+        const auto& ebl_out_ids = id_map.InToOutIds(IdMap::Domain::EMB_LIST);
+        const auto& out_ids = ebl_out_ids.empty() ? id_map.InToOutIds() : ebl_out_ids;
+        if (!out_ids.empty()) {
+            prepared.bitset.set_id_offset(0);
+            prepared.bitset.set_out_ids(out_ids, out_ids.size());
+        }
+    }
+
+    static size_t
+    CountBitmapBits(const uint8_t* data, size_t bit_offset, size_t bit_count) {
+        // Counts a logical bit range in a packed public-id bitmap.
+        if (data == nullptr || bit_count == 0) {
+            return 0;
+        }
+
+        const auto end_bit = bit_offset + bit_count;
+        auto bit_pos = bit_offset;
+        size_t count = 0;
+
+        if ((bit_pos & 7) != 0) {
+            const auto byte_idx = bit_pos >> 3;
+            const auto bits_in_byte = std::min<size_t>(8 - (bit_pos & 7), end_bit - bit_pos);
+            const auto mask = static_cast<uint8_t>(((1U << bits_in_byte) - 1) << (bit_pos & 7));
+            count += __builtin_popcount(static_cast<unsigned>(data[byte_idx] & mask));
+            bit_pos += bits_in_byte;
+        }
+
+        const auto full_bytes = (end_bit - bit_pos) >> 3;
+        const auto byte_begin = bit_pos >> 3;
+        const auto len_u64 = full_bytes >> 3;
+        for (size_t i = 0; i < len_u64; ++i) {
+            uint64_t bits;
+            std::memcpy(&bits, data + byte_begin + i * sizeof(uint64_t), sizeof(bits));
+            count += __builtin_popcountll(bits);
+        }
+
+        auto byte_pos = byte_begin + len_u64 * sizeof(uint64_t);
+        const auto byte_end = byte_begin + full_bytes;
+        while (byte_pos < byte_end) {
+            count += __builtin_popcount(static_cast<unsigned>(data[byte_pos]));
+            ++byte_pos;
+        }
+        bit_pos += full_bytes << 3;
+
+        if (bit_pos < end_bit) {
+            const auto byte_idx = bit_pos >> 3;
+            const auto tail_bits = end_bit - bit_pos;
+            const auto mask = static_cast<uint8_t>((1U << tail_bits) - 1);
+            count += __builtin_popcount(static_cast<unsigned>(data[byte_idx] & mask));
+        }
+
+        return count;
+    }
+
+    static size_t
+    CountBitmapBits(const BitmapArray& data, size_t bit_offset, size_t bit_count) {
+        // BitmapArray may be backed by append records, where data() is not a
+        // contiguous pointer.
+        if (data.empty() || bit_count == 0 || bit_offset >= data.size()) {
+            return 0;
+        }
+
+        const auto end_bit = bit_offset + std::min(bit_count, data.size() - bit_offset);
+        auto bit_pos = bit_offset;
+        size_t count = 0;
+
+        if ((bit_pos & 7) != 0) {
+            const auto byte_idx = bit_pos >> 3;
+            const auto bits_in_byte = std::min<size_t>(8 - (bit_pos & 7), end_bit - bit_pos);
+            const auto mask = static_cast<uint8_t>(((1U << bits_in_byte) - 1) << (bit_pos & 7));
+            count += __builtin_popcount(static_cast<unsigned>(data[byte_idx] & mask));
+            bit_pos += bits_in_byte;
+        }
+
+        const auto full_bytes = (end_bit - bit_pos) >> 3;
+        const auto byte_begin = bit_pos >> 3;
+        const auto len_u64 = full_bytes >> 3;
+        for (size_t i = 0; i < len_u64; ++i) {
+            uint64_t bits = 0;
+            const auto byte_offset = byte_begin + i * sizeof(uint64_t);
+            for (size_t byte = 0; byte < sizeof(uint64_t); ++byte) {
+                bits |= static_cast<uint64_t>(data[byte_offset + byte]) << (byte * 8);
+            }
+            count += __builtin_popcountll(bits);
+        }
+
+        auto byte_pos = byte_begin + len_u64 * sizeof(uint64_t);
+        const auto byte_end = byte_begin + full_bytes;
+        while (byte_pos < byte_end) {
+            count += __builtin_popcount(static_cast<unsigned>(data[byte_pos]));
+            ++byte_pos;
+        }
+        bit_pos += full_bytes << 3;
+
+        if (bit_pos < end_bit) {
+            const auto byte_idx = bit_pos >> 3;
+            const auto tail_bits = end_bit - bit_pos;
+            const auto mask = static_cast<uint8_t>((1U << tail_bits) - 1);
+            count += __builtin_popcount(static_cast<unsigned>(data[byte_idx] & mask));
+        }
+
+        return count;
+    }
+
+    void
+    CalcBitsetCount(BitsetView& bitset, const IdMap& id_map, size_t offset = 0,
+                    size_t bitset_count = std::numeric_limits<size_t>::max()) const {
+        // Exact filter counts are reported in the backend vector domain.
+        if (bitset.num_bits() == 0 || bitset.data() == nullptr) {
+            return;
+        }
+
+        auto count_to_check = [](size_t total, size_t offset, size_t bitset_count) {
+            if (offset >= total) {
+                return static_cast<size_t>(0);
+            }
+            const auto remain = total - offset;
+            return bitset_count == std::numeric_limits<size_t>::max() ? remain : std::min(bitset_count, remain);
+        };
+
+        const auto& valid_bitmap = id_map.ValidBitmap();
+        if (emb_list_offset_ != nullptr) {
+            auto bit_is_set = [](const uint8_t* data, size_t bit) { return (data[bit >> 3] & (1U << (bit & 7))) != 0; };
+
+            auto is_valid_out_id = [&](int64_t out_id) { return id_map.IsValidOutId(out_id); };
+
+            auto is_filtered_out_id = [&](int64_t out_id) {
+                if (out_id < 0) {
+                    return true;
+                }
+                const auto bit = static_cast<size_t>(out_id);
+                return bit >= bitset.num_bits() || bit_is_set(bitset.data(), bit);
+            };
+
+            const auto& in_to_out_ids = id_map.InToOutIds();
+            auto get_out_el_id = [&](size_t in_el_id) {
+                if (in_to_out_ids.empty()) {
+                    return static_cast<int64_t>(in_el_id);
+                }
+                return static_cast<int64_t>(in_to_out_ids[in_el_id]);
+            };
+
+            const auto& in_to_out_ebl_ids = id_map.InToOutIds(IdMap::Domain::EMB_LIST);
+            const auto in_el_count = emb_list_offset_->num_el();
+            if (!in_to_out_ebl_ids.empty()) {
+                // Base-vector EmbList backends search vector ids while filters
+                // are list-id addressed.
+                const auto total_vector_count = emb_list_offset_->offset.back();
+                const auto scoped_count = count_to_check(total_vector_count, offset, bitset_count);
+                const auto scope_end = offset + scoped_count;
+                size_t vector_count = 0;
+                size_t filtered_count = 0;
+                auto iter = std::upper_bound(emb_list_offset_->offset.begin(), emb_list_offset_->offset.end(), offset);
+                size_t in_el_id = iter == emb_list_offset_->offset.begin()
+                                      ? 0
+                                      : static_cast<size_t>(std::distance(emb_list_offset_->offset.begin(), iter) - 1);
+                for (; in_el_id < in_el_count && emb_list_offset_->offset[in_el_id] < scope_end; ++in_el_id) {
+                    const auto vector_begin = std::max(emb_list_offset_->offset[in_el_id], offset);
+                    const auto vector_end = std::min(emb_list_offset_->offset[in_el_id + 1], scope_end);
+                    if (vector_begin >= vector_end) {
+                        continue;
+                    }
+                    const auto out_el_id = static_cast<int64_t>(in_to_out_ebl_ids[vector_begin]);
+                    if (!is_valid_out_id(out_el_id)) {
+                        continue;
+                    }
+                    vector_count += vector_end - vector_begin;
+                    if (is_filtered_out_id(out_el_id)) {
+                        filtered_count += vector_end - vector_begin;
+                    }
+                }
+                bitset.set_vector_count(vector_count);
+                bitset.set_filter_count(filtered_count);
+                return;
+            }
+
+            // Compact-list strategies count by list ranges.
+            const auto total_vector_count = emb_list_offset_->offset.back();
+            const auto scoped_count = count_to_check(total_vector_count, offset, bitset_count);
+            const auto scope_end = offset + scoped_count;
+            size_t vector_count = 0;
+            size_t filtered_count = 0;
+            auto iter = std::upper_bound(emb_list_offset_->offset.begin(), emb_list_offset_->offset.end(), offset);
+            size_t in_el_id = iter == emb_list_offset_->offset.begin()
+                                  ? 0
+                                  : static_cast<size_t>(std::distance(emb_list_offset_->offset.begin(), iter) - 1);
+            for (; in_el_id < in_el_count && emb_list_offset_->offset[in_el_id] < scope_end; ++in_el_id) {
+                const auto vector_begin = std::max(emb_list_offset_->offset[in_el_id], offset);
+                const auto vector_end = std::min(emb_list_offset_->offset[in_el_id + 1], scope_end);
+                if (vector_begin >= vector_end) {
+                    continue;
+                }
+                const auto out_el_id = get_out_el_id(in_el_id);
+                if (!is_valid_out_id(out_el_id)) {
+                    continue;
+                }
+                vector_count += vector_end - vector_begin;
+                if (is_filtered_out_id(out_el_id)) {
+                    filtered_count += vector_end - vector_begin;
+                }
+            }
+            bitset.set_vector_count(vector_count);
+            bitset.set_filter_count(filtered_count);
+            return;
+        }
+
+        const auto count = Count();
+        const auto total = valid_bitmap.empty() && count > 0 ? static_cast<size_t>(count) : bitset.num_bits();
+        const auto scoped_count = count_to_check(total, offset, bitset_count);
+        // Vector indexes intersect the public filter with public validity.
+        if (valid_bitmap.empty()) {
+            bitset.count_filtered_bits(offset, scoped_count);
+        } else {
+            bitset.count_filtered_bits(offset, scoped_count, valid_bitmap);
+        }
+        if (offset != 0 || bitset_count != std::numeric_limits<size_t>::max()) {
+            return;
+        }
+        if (!valid_bitmap.empty()) {
+            if (valid_bitmap.size() <= bitset.num_bits()) {
+                return;
+            }
+            auto filter_count = bitset.count();
+            filter_count += CountBitmapBits(valid_bitmap, bitset.num_bits(), valid_bitmap.size() - bitset.num_bits());
+            bitset.set_vector_count(count > 0 ? static_cast<size_t>(count) : bitset.size());
+            bitset.set_filter_count(std::min(filter_count, bitset.size()));
+            return;
+        }
+        if (count > 0 && static_cast<size_t>(count) > bitset.num_bits()) {
+            auto filter_count = bitset.count();
+            bitset.set_vector_count(static_cast<size_t>(count));
+            bitset.set_filter_count(
+                std::min(filter_count + static_cast<size_t>(count) - bitset.num_bits(), bitset.size()));
+        }
+    }
+
+    // Base ANN result id map. Base-vector EmbList stages keep compact ids until
+    // final list mapping.
+    const IdMap*
+    SearchResultIdMap(const IdMap& id_map) const {
+        if (emb_list_offset_ != nullptr && emb_list_strategy_ != nullptr && emb_list_strategy_->NeedsBaseIndexIDMap()) {
+            return nullptr;
+        }
+        return &id_map;
+    }
+
+    void
+    MapResultIdsToOutIds(const DataSetPtr& result, const IdMap* id_map) const {
+        // Backend storage ids -> public result ids.
+        if (id_map == nullptr || result == nullptr || result->GetIds() == nullptr) {
+            return;
+        }
+        auto* ids = const_cast<int64_t*>(result->GetIds());
+        const auto* lims = result->GetLims();
+        const auto rows = result->GetRows();
+        const auto count = lims != nullptr ? lims[rows] : static_cast<size_t>(rows * result->GetDim());
+        id_map->MapInToOut(ids, count);
+    }
+
+    void
+    MapSearchResultIdsToOutIds(const DataSetPtr& result) const {
+        const auto& id_map = GetIdMap();
+        MapResultIdsToOutIds(result, SearchResultIdMap(id_map));
+    }
+
+    void
+    MapEmbListResultIdsToOutIds(const DataSetPtr& result) const {
+        // Compact list ids -> public list ids.
+        const auto& id_map = GetIdMap();
+        MapResultIdsToOutIds(result, &id_map);
+    }
+
+ public:
     virtual std::string
     Type() const = 0;
 
@@ -358,32 +795,6 @@ class IndexNode : public Object {
         return GetLatencyMetric(prometheus_metrics_.range_search, range_search_latency_family);
     }
 #endif
-
-    /**
-     * @brief Gets the mapping from internal IDs to external IDs.
-     *
-     * @return A reference to the mapping vector.
-     * @note If not implemented, the default implementation is to return a mapping, from 0 to Count()-1.
-     */
-    virtual std::shared_ptr<std::vector<uint32_t>>
-    GetInternalIdToExternalIdMap() const {
-        auto n_rows = Count();
-        auto internal_id_to_external_id_map = std::make_shared<std::vector<uint32_t>>(n_rows);
-        std::iota(internal_id_to_external_id_map->begin(), internal_id_to_external_id_map->end(), 0);
-        return internal_id_to_external_id_map;
-    }
-
-    /**
-     * @brief Sets the mapping from internal IDs to "most external" IDs for 1-hop bitset check!
-     * Only used for hierarchical indexnode, such as emb_list + hnsw, each index node has its own relayout mapping.
-     *
-     * @param map The mapping vector to set.
-     * @return Status indicating success or failure of the mapping.
-     */
-    virtual Status
-    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) {
-        return Status::not_implemented;
-    }
 
     virtual Status
     BuildEmbListIfNeed(const DataSetPtr dataset, std::shared_ptr<Config> cfg, bool use_knowhere_build_pool = true) {
@@ -523,18 +934,9 @@ class IndexNode : public Object {
                              bool use_knowhere_search_pool = true, milvus::OpContext* op_context = nullptr) const;
 
     /**
-     * @brief Retrieve raw vectors for embedding list rows by their row-level IDs (el_ids).
+     * @brief Retrieve raw vectors for public embedding-list ids.
      *
-     * @param dataset Input dataset containing row-level IDs (el_ids) via GetIds(), and GetRows() for the count.
-     * @param metric_type The original metric type (e.g., MAX_SIM_COSINE) used to check raw data availability.
-     * @param op_context Optional operation context.
-     * @return DataSetPtr containing:
-     *   - Tensor: flattened raw vector data for all vectors across requested rows
-     *   - Rows: number of requested el_ids (i.e., num_el_ids)
-     *   - Dim: vector dimension
-     *   - EMB_LIST_OFFSET: size_t array of length (num_el_ids + 1), marking per-row vector boundaries
-     *
-     * Returns error if emb_list_offset_ is not available (i.e., not an embedding list index).
+     * The result tensor is flattened and accompanied by EMB_LIST_OFFSET.
      */
     virtual expected<DataSetPtr>
     GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_type,
@@ -554,28 +956,6 @@ class IndexNode : public Object {
         int64_t strategy_blob_size;
     };
 
-    /**
-     * @brief Establishes the mapping from internal base-index IDs to emb_list IDs.
-     *
-     * This mapping is essential for base indexes to correctly apply bitset filtering using only a 1-hop mapping during
-     * search. In some cases, such as with mv-only *relayout*, a base-index may have its own
-     * (base)internal-to-external ID mapping.
-     * However, the emb_list search bitset operates on emb_list IDs, which we refer to as the "most external" IDs.
-     * Therefore, we need to create a mapping from the base_internal_id (used by the base-index) to the most external
-     * emb_list_id, ensuring that bitset checks and search results are consistent at the emb_list level.
-     */
-    Status
-    SetBaseIndexIDMap() {
-        auto internal_id_to_external_id_map = GetInternalIdToExternalIdMap();
-        size_t id_map_size = internal_id_to_external_id_map->size();
-        assert(id_map_size == static_cast<size_t>(Count()));
-        std::vector<uint32_t> internal_id_to_most_external_id_map(id_map_size);
-        for (size_t i = 0; i < id_map_size; i++) {
-            internal_id_to_most_external_id_map[i] = emb_list_offset_->get_el_id(internal_id_to_external_id_map->at(i));
-        }
-        return SetInternalIdToMostExternalIdMap(std::move(internal_id_to_most_external_id_map));
-    }
-
     virtual Status
     BuildEmbList(const DataSetPtr dataset, std::shared_ptr<Config> cfg, const size_t* lims, size_t num_rows,
                  bool use_knowhere_build_pool);
@@ -587,32 +967,22 @@ class IndexNode : public Object {
     SerializeEmbList(BinarySet& binset) const;
 
     /**
-     * @brief Deserialize emb_list: base index, strategy, raw index, and ID mapping from BinarySet.
+     * @brief Deserialize emb_list: base index, strategy, and optional raw index from BinarySet.
      */
     Status
     DeserializeEmbListFromBinarySet(const BinarySet& binset, std::shared_ptr<Config> config);
 
     /**
-     * @brief Deserialize emb_list: base index, strategy, raw index, and ID mapping from files.
+     * @brief Deserialize emb_list: base index, strategy, and optional raw index from files.
      */
     Status
     DeserializeEmbListFromFile(const std::string& filename, std::shared_ptr<Config> config);
 
     /**
-     * @brief Search interface supporting two-stage emb_list search.
-     * @param dataset Query dataset
-     * @param cfg     Search configuration
-     * @param bitset  Mask for filtering vectors
+     * @brief Search embedding-list queries through the selected strategy.
      *
-     * Search process:
-     * 1. Check emb_list offset information and build the query group structure.
-     * 2. Stage 1: Call (vector-based) Search method to retrieve candidate vector IDs for each query emb_list.
-     * 3. Stage 2: For each query emb_list, collect candidate emb_list IDs and its vectors, and perform brute-force
-     *    distance calculation to aggregate scores at the emb_list level.
-     * 4. Return top-k emb_list results.
-     *
-     * Note: The emb_list index node does not need to split tasks by nq and dispatch them to the search thread pool for
-     * parallel processing, because the (vector-based) Search method already handles this.
+     * Input filters are public list-id addressed. Strategy results are compact
+     * list ids until this boundary maps them back to public ids.
      */
     virtual expected<DataSetPtr>
     SearchEmbList(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset,
@@ -638,16 +1008,11 @@ class IndexNode : public Object {
 
     Version version_;
     std::shared_ptr<EmbListOffset> emb_list_offset_;  // emb_list group offset structure (shared with strategy)
+    IdMap id_map_;
     std::string el_metric_type_;
     EmbListStrategyPtr emb_list_strategy_;  // emb_list encoding strategy (tokenann/muvera)
-    // Raw vector storage for EmbList strategies (MUVERA/LEMUR) that encode documents
-    // into different representations for ANN search. Since the base index holds encoded
-    // vectors (not raw), this IndexFlat stores original vectors for exact distance
-    // computation during MaxSim reranking.
-    // Baseline type so that the same shared_ptr can hold either the knowhere
-    // Jaccard-aware IndexFlat subclass (fresh build path, if ever needed) or
-    // a plain ::faiss::IndexFlat{,IP,L2} restored by the deserialization
-    // factory in cppcontrib/knowhere/impl/index_read.cpp.
+    // Raw vector storage for EmbList strategies whose ANN payload is encoded.
+    // Distance rerank uses original vectors by compact base-vector id.
     std::shared_ptr<::faiss::IndexFlat> emb_list_raw_index_;
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
@@ -678,6 +1043,12 @@ class IndexIterator : public IndexNode::iterator {
           retain_iterator_order_(retain_iterator_order),
           sign_(larger_is_closer ? -1 : 1),
           use_knowhere_search_pool_(use_knowhere_search_pool) {
+    }
+
+    void
+    SetResultIdMap(const IdMap* id_map) {
+        // Index-owned backend id -> public id map.
+        result_id_map_ = id_map;
     }
 
     expected<std::pair<int64_t, float>>
@@ -746,7 +1117,7 @@ class IndexIterator : public IndexNode::iterator {
             update_next_func();
         }
 
-        return std::make_pair(ret.id, ret.val * sign_);
+        return std::make_pair(MapResultId(ret.id), ret.val * sign_);
     }
 
     virtual expected<bool>
@@ -774,6 +1145,11 @@ class IndexIterator : public IndexNode::iterator {
             throw std::runtime_error("raw_distance should not be called for indexes without quantization");
         }
         throw std::runtime_error("raw_distance not implemented");
+    }
+
+    int64_t
+    MapResultId(int64_t id) const {
+        return result_id_map_ == nullptr ? id : result_id_map_->MapInToOut(id);
     }
 
     const float refine_ratio_;
@@ -805,6 +1181,7 @@ class IndexIterator : public IndexNode::iterator {
     }
 
     bool use_knowhere_search_pool_ = true;
+    const IdMap* result_id_map_ = nullptr;
 };
 
 // An iterator implementation that accepts a function to get distances and ids list and returns them in order.
@@ -819,6 +1196,12 @@ class PrecomputedDistanceIterator : public IndexNode::iterator {
         : compute_dist_func_(compute_dist_func),
           larger_is_closer_(larger_is_closer),
           use_knowhere_search_pool_(use_knowhere_search_pool) {
+    }
+
+    void
+    SetResultIdMap(const IdMap* id_map) {
+        // Index-owned backend id -> public id map.
+        result_id_map_ = id_map;
     }
 
     expected<std::pair<int64_t, float>>
@@ -845,7 +1228,7 @@ class PrecomputedDistanceIterator : public IndexNode::iterator {
                 sort_next();
             }
             auto& result = results_[next_++];
-            return std::make_pair(result.id, result.val);
+            return std::make_pair(MapResultId(result.id), result.val);
         });
     }
 
@@ -912,6 +1295,11 @@ class PrecomputedDistanceIterator : public IndexNode::iterator {
         sorted_ = current_end;
     }
 
+    int64_t
+    MapResultId(int64_t id) const {
+        return result_id_map_ == nullptr ? id : result_id_map_->MapInToOut(id);
+    }
+
     std::function<std::vector<DistId>()> compute_dist_func_;
     const bool larger_is_closer_;
     bool use_knowhere_search_pool_ = true;
@@ -920,6 +1308,7 @@ class PrecomputedDistanceIterator : public IndexNode::iterator {
     size_t next_ = 0;
     size_t sorted_ = 0;
     size_t sort_size_ = 0;
+    const IdMap* result_id_map_ = nullptr;
 };
 
 }  // namespace knowhere

--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -390,14 +390,15 @@ class IndexNode : public Object {
         GetIdMap().SetType(type);
     }
 
-    virtual int64_t
-    MapOutToIn(int64_t out_id) const {
-        return GetIdMap().MapOutToIn(out_id);
+    virtual expected<int64_t>
+    CompactOutToIn(int64_t out_id, size_t compact_count) const {
+        return GetIdMap().CompactOutToIn(out_id, compact_count);
     }
 
-    virtual const int64_t*
-    MapOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& in_ids) const {
-        return GetIdMap().MapOutToIn(out_ids, count, in_ids);
+    virtual expected<const int64_t*>
+    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids,
+                   size_t compact_count) const {
+        return GetIdMap().CompactOutToIn(out_ids, count, compact_ids, compact_count);
     }
 
     /**
@@ -427,7 +428,7 @@ class IndexNode : public Object {
     }
 
     Status
-    AppendEmbListOffsetAndIdMap(const size_t* lims, size_t append_row_count) {
+    AppendEmbListOffsetAndIdMap(const size_t* lims, size_t append_row_count, size_t append_el_count_hint = 0) {
         // lims is absolute in the whole index; AppendEmbListIds consumes the
         // appended local offset window.
         const auto old_el_count = emb_list_offset_->num_el();
@@ -439,12 +440,22 @@ class IndexNode : public Object {
         }
 
         size_t append_el_count = 1;
-        while (lims[append_el_count] < new_vector_count) {
-            if (lims[append_el_count] < lims[append_el_count - 1]) {
-                LOG_KNOWHERE_WARNING_ << "emb list offset is not increasing";
-                return Status::emb_list_inner_error;
+        if (append_el_count_hint != 0) {
+            append_el_count = append_el_count_hint;
+            for (size_t i = 1; i <= append_el_count; ++i) {
+                if (lims[i] < lims[i - 1]) {
+                    LOG_KNOWHERE_WARNING_ << "emb list offset is not increasing";
+                    return Status::emb_list_inner_error;
+                }
             }
-            ++append_el_count;
+        } else {
+            while (lims[append_el_count] < new_vector_count) {
+                if (lims[append_el_count] < lims[append_el_count - 1]) {
+                    LOG_KNOWHERE_WARNING_ << "emb list offset is not increasing";
+                    return Status::emb_list_inner_error;
+                }
+                ++append_el_count;
+            }
         }
         if (lims[append_el_count] != new_vector_count) {
             LOG_KNOWHERE_WARNING_ << "emb list offset should end with the total_cnt of the whole index";
@@ -815,7 +826,9 @@ class IndexNode : public Object {
             return Status::emb_list_inner_error;
         }
 
-        return BuildEmbList(dataset, std::move(cfg), lims, dataset->GetRows(), use_knowhere_build_pool);
+        return BuildEmbList(dataset, std::move(cfg), lims, dataset->GetRows(),
+                            EmbListCount(dataset, lims, static_cast<size_t>(dataset->GetRows())),
+                            use_knowhere_build_pool);
     }
 
     virtual Status
@@ -958,7 +971,7 @@ class IndexNode : public Object {
 
     virtual Status
     BuildEmbList(const DataSetPtr dataset, std::shared_ptr<Config> cfg, const size_t* lims, size_t num_rows,
-                 bool use_knowhere_build_pool);
+                 size_t num_el, bool use_knowhere_build_pool);
 
     /**
      * @brief Serialize emb_list: strategy meta, raw index, and base index to BinarySet.
@@ -1005,6 +1018,21 @@ class IndexNode : public Object {
     expected<DataSetPtr>
     CalcDistByRawIndex(const DataSetPtr dataset, const int64_t* labels, size_t labels_len, bool is_cosine,
                        std::shared_ptr<ThreadPool> pool, milvus::OpContext* op_context = nullptr) const;
+
+    static size_t
+    EmbListCount(const DataSetPtr& dataset, const size_t* lims, size_t num_rows) {
+        if (dataset != nullptr) {
+            const auto nq = dataset->Get<int64_t>(meta::NQ);
+            if (nq > 0) {
+                return static_cast<size_t>(nq);
+            }
+        }
+        size_t count = 0;
+        while (lims[count] < num_rows) {
+            ++count;
+        }
+        return count;
+    }
 
     Version version_;
     std::shared_ptr<EmbListOffset> emb_list_offset_;  // emb_list group offset structure (shared with strategy)

--- a/include/knowhere/index/index_node_data_mock_wrapper.h
+++ b/include/knowhere/index/index_node_data_mock_wrapper.h
@@ -57,11 +57,6 @@ class IndexNodeDataMockWrapper : public IndexNode {
     expected<DataSetPtr>
     CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
                   const bool is_cosine, milvus::OpContext* op_context) const override;
-    Status
-    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) override {
-        return index_node_->SetInternalIdToMostExternalIdMap(std::move(map));
-    }
-
     std::optional<size_t>
     GetQueryCodeSize(const DataSetPtr dataset) const override {
         auto dim = dataset->GetDim();
@@ -119,6 +114,46 @@ class IndexNodeDataMockWrapper : public IndexNode {
     int64_t
     Count() const override {
         return index_node_->Count();
+    }
+
+    bool
+    NeedBitsetExactCount() const override {
+        return index_node_->NeedBitsetExactCount();
+    }
+
+    IdMap&
+    GetIdMap() override {
+        return index_node_->GetIdMap();
+    }
+
+    const IdMap&
+    GetIdMap() const override {
+        return index_node_->GetIdMap();
+    }
+
+    void
+    SetIdMapType(IdMap::Type type) override {
+        index_node_->SetIdMapType(type);
+    }
+
+    int64_t
+    MapOutToIn(int64_t out_id) const override {
+        return index_node_->MapOutToIn(out_id);
+    }
+
+    const int64_t*
+    MapOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& in_ids) const override {
+        return index_node_->MapOutToIn(out_ids, count, in_ids);
+    }
+
+    expected<PreparedBitset>
+    PrepareBitset(BitsetView bitset) const override {
+        return index_node_->PrepareBitset(bitset);
+    }
+
+    Status
+    FinalizeIdMap() override {
+        return index_node_->FinalizeIdMap();
     }
 
     std::string

--- a/include/knowhere/index/index_node_data_mock_wrapper.h
+++ b/include/knowhere/index/index_node_data_mock_wrapper.h
@@ -136,14 +136,15 @@ class IndexNodeDataMockWrapper : public IndexNode {
         index_node_->SetIdMapType(type);
     }
 
-    int64_t
-    MapOutToIn(int64_t out_id) const override {
-        return index_node_->MapOutToIn(out_id);
+    expected<int64_t>
+    CompactOutToIn(int64_t out_id, size_t compact_count) const override {
+        return index_node_->CompactOutToIn(out_id, compact_count);
     }
 
-    const int64_t*
-    MapOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& in_ids) const override {
-        return index_node_->MapOutToIn(out_ids, count, in_ids);
+    expected<const int64_t*>
+    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids,
+                   size_t compact_count) const override {
+        return index_node_->CompactOutToIn(out_ids, count, compact_ids, compact_count);
     }
 
     expected<PreparedBitset>

--- a/include/knowhere/index/index_node_thread_pool_wrapper.h
+++ b/include/knowhere/index/index_node_thread_pool_wrapper.h
@@ -46,6 +46,12 @@ class IndexNodeThreadPoolWrapper : public IndexNode {
         return index_node_->GetVectorByIds(dataset, op_context);
     }
 
+    expected<DataSetPtr>
+    GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_type,
+                    milvus::OpContext* op_context) const override {
+        return index_node_->GetEmbListByIds(dataset, metric_type, op_context);
+    }
+
     bool
     HasRawData(const std::string& metric_type) const override {
         return index_node_->HasRawData(metric_type);
@@ -89,6 +95,46 @@ class IndexNodeThreadPoolWrapper : public IndexNode {
     int64_t
     Count() const override {
         return index_node_->Count();
+    }
+
+    bool
+    NeedBitsetExactCount() const override {
+        return index_node_->NeedBitsetExactCount();
+    }
+
+    IdMap&
+    GetIdMap() override {
+        return index_node_->GetIdMap();
+    }
+
+    const IdMap&
+    GetIdMap() const override {
+        return index_node_->GetIdMap();
+    }
+
+    void
+    SetIdMapType(IdMap::Type type) override {
+        index_node_->SetIdMapType(type);
+    }
+
+    int64_t
+    MapOutToIn(int64_t out_id) const override {
+        return index_node_->MapOutToIn(out_id);
+    }
+
+    const int64_t*
+    MapOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& in_ids) const override {
+        return index_node_->MapOutToIn(out_ids, count, in_ids);
+    }
+
+    expected<PreparedBitset>
+    PrepareBitset(BitsetView bitset) const override {
+        return index_node_->PrepareBitset(bitset);
+    }
+
+    Status
+    FinalizeIdMap() override {
+        return index_node_->FinalizeIdMap();
     }
 
     std::string

--- a/include/knowhere/index/index_node_thread_pool_wrapper.h
+++ b/include/knowhere/index/index_node_thread_pool_wrapper.h
@@ -117,14 +117,15 @@ class IndexNodeThreadPoolWrapper : public IndexNode {
         index_node_->SetIdMapType(type);
     }
 
-    int64_t
-    MapOutToIn(int64_t out_id) const override {
-        return index_node_->MapOutToIn(out_id);
+    expected<int64_t>
+    CompactOutToIn(int64_t out_id, size_t compact_count) const override {
+        return index_node_->CompactOutToIn(out_id, compact_count);
     }
 
-    const int64_t*
-    MapOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& in_ids) const override {
-        return index_node_->MapOutToIn(out_ids, count, in_ids);
+    expected<const int64_t*>
+    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids,
+                   size_t compact_count) const override {
+        return index_node_->CompactOutToIn(out_ids, count, compact_ids, compact_count);
     }
 
     expected<PreparedBitset>

--- a/include/knowhere/mmap.h
+++ b/include/knowhere/mmap.h
@@ -1,0 +1,129 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef MMAP_H
+#define MMAP_H
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <utility>
+
+namespace knowhere {
+
+// File-backed writable memory used as transient backing storage for derived
+// arrays. The file is removed with the region; durability still belongs to the
+// caller's normal index/metadata serialization.
+class MmapRegion {
+ public:
+    static std::shared_ptr<MmapRegion>
+    Create(const std::string& filepath, size_t byte_size) {
+        if (filepath.empty()) {
+            throw std::runtime_error("mmap region filepath is empty");
+        }
+        if (byte_size == 0) {
+            throw std::runtime_error("mmap region size is zero");
+        }
+        const auto parent_path = std::filesystem::path(filepath).parent_path();
+        if (!parent_path.empty()) {
+            std::filesystem::create_directories(parent_path);
+        }
+
+        const int fd = ::open(filepath.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0600);
+        if (fd < 0) {
+            throw std::runtime_error(std::string("failed to create mmap region file: ") + std::strerror(errno));
+        }
+
+        const auto close_fd = [&] { ::close(fd); };
+        if (::ftruncate(fd, static_cast<off_t>(byte_size)) != 0) {
+            const auto err = errno;
+            close_fd();
+            std::error_code ec;
+            std::filesystem::remove(filepath, ec);
+            throw std::runtime_error(std::string("failed to resize mmap region file: ") + std::strerror(err));
+        }
+
+        void* data = ::mmap(nullptr, byte_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        const auto mmap_errno = errno;
+        close_fd();
+        if (data == MAP_FAILED) {
+            std::error_code ec;
+            std::filesystem::remove(filepath, ec);
+            throw std::runtime_error(std::string("failed to mmap region file: ") + std::strerror(mmap_errno));
+        }
+        return std::shared_ptr<MmapRegion>(new MmapRegion(filepath, byte_size, data));
+    }
+
+    ~MmapRegion() {
+        if (data_ != nullptr) {
+            ::munmap(data_, byte_size_);
+        }
+        if (!filepath_.empty()) {
+            std::error_code ec;
+            std::filesystem::remove(filepath_, ec);
+        }
+    }
+
+    void*
+    data() const {
+        return data_;
+    }
+
+ private:
+    MmapRegion(std::string filepath, size_t byte_size, void* data)
+        : filepath_(std::move(filepath)), byte_size_(byte_size), data_(data) {
+    }
+
+    std::string filepath_;
+    size_t byte_size_;
+    void* data_;
+};
+
+// Generates distinct backing file names for repeated derived-array builds under
+// the same IdMap object.
+class MmapFilePathGenerator {
+ public:
+    MmapFilePathGenerator() = default;
+
+    explicit MmapFilePathGenerator(std::string prefix) : prefix_(std::move(prefix)) {
+    }
+
+    bool
+    empty() const {
+        return prefix_.empty();
+    }
+
+    std::string
+    Next(const void* owner) {
+        if (empty()) {
+            return {};
+        }
+        return prefix_ + "." + std::to_string(reinterpret_cast<uintptr_t>(owner)) + "." + std::to_string(++generation_);
+    }
+
+ private:
+    std::string prefix_;
+    size_t generation_ = 0;
+};
+
+}  // namespace knowhere
+
+#endif /* MMAP_H */

--- a/include/knowhere/utils.h
+++ b/include/knowhere/utils.h
@@ -220,6 +220,7 @@ data_type_conversion(const DataSet& src, const std::optional<int64_t> start = st
         }
         const size_t* lims_data_const = lims_data.release();
         des->Set(knowhere::meta::EMB_LIST_OFFSET, lims_data_const);
+        des->Set(knowhere::meta::NQ, static_cast<int64_t>(lims_size));
     }
     return des;
 }

--- a/src/common/comp/brute_force.cc
+++ b/src/common/comp/brute_force.cc
@@ -141,6 +141,101 @@ GetInverseVecNorms(const DataSetPtr& base) {
         return inv_norms;
     }
 }
+
+void
+PrepareBitsetForInternalRange(BitsetView& bitset, size_t num_internal_ids, size_t internal_id_offset) {
+    if (bitset.has_out_ids()) {
+        return;
+    }
+    if (bitset.empty() || bitset.data() == nullptr) {
+        return;
+    }
+
+    // Local chunk ids use a contiguous public-id offset when no map is present.
+    bitset.set_id_offset(internal_id_offset);
+    bitset.count_filtered_bits(internal_id_offset, num_internal_ids);
+}
+
+Status
+UseOutIdsWindow(BitsetView& bitset, size_t internal_id_offset, size_t num_internal_ids) {
+    if (!bitset.has_out_ids()) {
+        return Status::success;
+    }
+    const auto total_out_ids = bitset.out_ids_count();
+    if (internal_id_offset > total_out_ids || num_internal_ids > total_out_ids - internal_id_offset) {
+        LOG_KNOWHERE_WARNING_ << "brute-force out id map is smaller than the internal id range";
+        return Status::invalid_args;
+    }
+    // Filtering and result mapping use the same local physical-id window.
+    bitset.set_id_offset(internal_id_offset);
+    bitset.set_vector_count(num_internal_ids);
+    return Status::success;
+}
+
+Status
+MapOneResultId(int64_t& id, const BitsetView& bitset, int64_t id_offset) {
+    if (id < 0) {
+        return Status::success;
+    }
+    if (bitset.has_out_ids()) {
+        const auto internal_id = static_cast<size_t>(id);
+        const auto& out_ids = bitset.get_out_ids();
+        id = out_ids[bitset.id_offset() + internal_id];
+        return Status::success;
+    }
+    id += id_offset;
+    return Status::success;
+}
+
+template <typename IdType>
+Status
+MapResultIds(IdType* ids, size_t count, const BitsetView& bitset, int64_t id_offset) {
+    for (size_t i = 0; i < count; ++i) {
+        int64_t id = static_cast<int64_t>(ids[i]);
+        RETURN_IF_ERROR(MapOneResultId(id, bitset, id_offset));
+        ids[i] = static_cast<IdType>(id);
+    }
+    return Status::success;
+}
+
+Status
+MapResultIdArray(std::vector<std::vector<int64_t>>& result_id_array, const BitsetView& bitset, int64_t id_offset) {
+    for (auto& ids : result_id_array) {
+        RETURN_IF_ERROR(MapResultIds(ids.data(), ids.size(), bitset, id_offset));
+    }
+    return Status::success;
+}
+
+void
+MapOneResultIdOrThrow(int64_t& id, const BitsetView& bitset, int64_t id_offset) {
+    auto status = MapOneResultId(id, bitset, id_offset);
+    if (status != Status::success) {
+        KNOWHERE_THROW_MSG("failed to map brute-force result id");
+    }
+}
+
+void
+MapDistIdsOrThrow(std::vector<DistId>& distances_ids, const BitsetView& bitset, int64_t id_offset) {
+    for (auto& distances_id : distances_ids) {
+        MapOneResultIdOrThrow(distances_id.id, bitset, id_offset);
+    }
+}
+
+void
+CopyMappedChunkDistIds(std::vector<DistId>& dst, size_t dst_begin, const std::vector<DistId>& src,
+                       const BitsetView& bitset, int64_t id_offset) {
+    for (size_t i = 0; i < src.size(); ++i) {
+        auto id = src[i].id;
+        MapOneResultIdOrThrow(id, bitset, id_offset);
+        dst[dst_begin + i] = {id, src[i].val};
+    }
+}
+
+struct PreparedBitsetState {
+    // Owns bitset windows used by lazy brute-force iterators.
+    BitsetView bitset;
+    std::vector<BitsetView> chunk_bitsets;
+};
 }  // namespace
 
 template <typename DataType>
@@ -326,10 +421,11 @@ brute_force_minhash_impl(const void* xq, const void* xb, int64_t* labels, float*
 
 template <typename DataType>
 Status
-brute_force_emb_list_impl(const void* xq, size_t query_el_idx, const void* xb, int64_t* ids, float* dis, size_t topk,
-                          size_t dim, const EmbListOffset& base_el_offset, const EmbListOffset& query_el_offset,
-                          const std::string& el_metric_type, const std::string& el_sub_metric_type,
-                          const BitsetView& bitset, const BaseConfig& cfg, size_t xb_id_offset) {
+brute_force_emb_list_impl(const void* xq, size_t query_el_idx, size_t result_el_idx, const void* xb, int64_t* ids,
+                          float* dis, size_t topk, size_t dim, const EmbListOffset& base_el_offset,
+                          const EmbListOffset& query_el_offset, const std::string& el_metric_type,
+                          const std::string& el_sub_metric_type, const BitsetView& bitset, const BaseConfig& cfg,
+                          size_t xb_id_offset) {
     auto num_base_el = base_el_offset.num_el();
 
     auto el_agg_func_or = get_emb_list_agg_func(el_metric_type);
@@ -434,51 +530,54 @@ brute_force_emb_list_impl(const void* xq, size_t query_el_idx, const void* xb, i
                 return Status::brute_force_inner_error;
             }
             auto score = score_or.value();
+            auto out_id = static_cast<int64_t>(base_el_idx);
+            RETURN_IF_ERROR(MapOneResultId(out_id, bitset, xb_id_offset));
             if (larger_is_closer) {
                 if (minheap.size() < topk) {
-                    minheap.emplace(static_cast<int64_t>(base_el_idx) + xb_id_offset, score);
+                    minheap.emplace(out_id, score);
                 } else {
                     if (score > minheap.top().val) {
                         minheap.pop();
-                        minheap.emplace(static_cast<int64_t>(base_el_idx) + xb_id_offset, score);
+                        minheap.emplace(out_id, score);
                     }
                 }
             } else {
                 if (maxheap.size() < topk) {
-                    maxheap.emplace(static_cast<int64_t>(base_el_idx) + xb_id_offset, score);
+                    maxheap.emplace(out_id, score);
                 } else {
                     if (score < maxheap.top().val) {
                         maxheap.pop();
-                        maxheap.emplace(static_cast<int64_t>(base_el_idx) + xb_id_offset, score);
+                        maxheap.emplace(out_id, score);
                     }
                 }
             }
         }
     }
     size_t real_el_k = 0;
+    const auto result_offset = result_el_idx * topk;
     if (larger_is_closer) {
         real_el_k = minheap.size();
         for (size_t j = 0; j < real_el_k; j++) {
             auto& a = minheap.top();
-            ids[query_el_idx * topk + real_el_k - j - 1] = a.id;
-            dis[query_el_idx * topk + real_el_k - j - 1] = a.val;
+            ids[result_offset + real_el_k - j - 1] = a.id;
+            dis[result_offset + real_el_k - j - 1] = a.val;
             minheap.pop();
         }
         for (size_t j = real_el_k; j < topk; j++) {
-            ids[query_el_idx * topk + j] = -1;
-            dis[query_el_idx * topk + j] = std::numeric_limits<float>::min();
+            ids[result_offset + j] = -1;
+            dis[result_offset + j] = std::numeric_limits<float>::min();
         }
     } else {
         real_el_k = maxheap.size();
         for (size_t j = 0; j < real_el_k; j++) {
             auto& a = maxheap.top();
-            ids[query_el_idx * topk + real_el_k - j - 1] = a.id;
-            dis[query_el_idx * topk + real_el_k - j - 1] = a.val;
+            ids[result_offset + real_el_k - j - 1] = a.id;
+            dis[result_offset + real_el_k - j - 1] = a.val;
             maxheap.pop();
         }
         for (size_t j = real_el_k; j < topk; j++) {
-            ids[query_el_idx * topk + j] = -1;
-            dis[query_el_idx * topk + j] = std::numeric_limits<float>::max();
+            ids[result_offset + j] = -1;
+            dis[result_offset + j] = std::numeric_limits<float>::max();
         }
     }
     return Status::success;
@@ -499,7 +598,6 @@ BruteForceSearchWithBufImpl(const DataSetPtr base_dataset, const DataSetPtr quer
     bool base_data_is_emb_list = base_dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET) != nullptr;
     auto xb_id_offset = base_dataset->GetTensorBeginId();
     BitsetView bitset = bitset_;
-    bitset.set_id_offset(xb_id_offset);
 
     auto xq = query_dataset->GetTensor();
     auto nq = query_dataset->GetRows();
@@ -543,6 +641,7 @@ BruteForceSearchWithBufImpl(const DataSetPtr base_dataset, const DataSetPtr quer
 
         auto base_el_offset = EmbListOffset(base_dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET), nb);
         auto query_el_offset = EmbListOffset(query_dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET), nq);
+        PrepareBitsetForInternalRange(bitset, base_el_offset.num_el(), static_cast<size_t>(xb_id_offset));
         auto num_query_el = query_el_offset.num_el();
 
         auto pool = ThreadPool::GetGlobalSearchThreadPool();
@@ -556,28 +655,26 @@ BruteForceSearchWithBufImpl(const DataSetPtr base_dataset, const DataSetPtr quer
             }
             futs.emplace_back(pool->push([&, query_el_idx = query_el_i] {
                 ThreadPool::ScopedSearchOmpSetter setter(1);
-                RETURN_IF_ERROR(brute_force_emb_list_impl<DataType>(xq, query_el_idx, xb, ids, dis, topk, dim,
-                                                                    base_el_offset, query_el_offset, el_metric_type,
-                                                                    el_sub_metric_type, bitset, cfg, xb_id_offset));
+                RETURN_IF_ERROR(brute_force_emb_list_impl<DataType>(
+                    xq, query_el_idx, query_el_idx, xb, ids, dis, topk, dim, base_el_offset, query_el_offset,
+                    el_metric_type, el_sub_metric_type, bitset, cfg, xb_id_offset));
                 return Status::success;
             }));
         }
 
         RETURN_IF_ERROR(WaitAllSuccess(futs));
     } else if (IsMetricType(metric_str, metric::MHJACCARD)) {
+        PrepareBitsetForInternalRange(bitset, nb, static_cast<size_t>(xb_id_offset));
         auto labels = ids;
         auto distances = dis;
         RETURN_IF_ERROR(brute_force_minhash_impl<DataType>(xq, xb, labels, distances, dim, nb, nq, topk, bitset, cfg));
-        if (xb_id_offset != 0) {
-            for (auto i = 0; i < nq * topk; i++) {
-                labels[i] = labels[i] == -1 ? -1 : labels[i] + xb_id_offset;
-            }
-        }
+        RETURN_IF_ERROR(MapResultIds(labels, nq * topk, bitset, xb_id_offset));
     } else {
         if (query_is_emb_list) {
             LOG_KNOWHERE_ERROR_ << "query dataset is emb_list, but metric is not for emb_list";
             return Status::invalid_metric_type;
         }
+        PrepareBitsetForInternalRange(bitset, nb, static_cast<size_t>(xb_id_offset));
         auto result = Str2FaissMetricType(cfg.metric_type.value());
         if (result.error() != Status::success) {
             return result.error();
@@ -606,11 +703,7 @@ BruteForceSearchWithBufImpl(const DataSetPtr base_dataset, const DataSetPtr quer
         }
         RETURN_IF_ERROR(WaitAllSuccess(futs));
 
-        if (xb_id_offset != 0) {
-            for (auto i = 0; i < nq * topk; i++) {
-                labels[i] = labels[i] == -1 ? -1 : labels[i] + xb_id_offset;
-            }
-        }
+        RETURN_IF_ERROR(MapResultIds(labels, nq * topk, bitset, xb_id_offset));
     }
 
     return Status::success;
@@ -636,7 +729,6 @@ BruteForceSearchOnChunkWithBufImpl(const DataSetPtr base_dataset, const DataSetP
 
     auto xb_id_offset = base_dataset->GetTensorBeginId();
     BitsetView bitset = bitset_;
-    bitset.set_id_offset(xb_id_offset);
 
     BruteForceConfig cfg;
     RETURN_IF_ERROR(Config::Load(cfg, config, knowhere::SEARCH));
@@ -693,6 +785,15 @@ BruteForceSearchOnChunkWithBufImpl(const DataSetPtr base_dataset, const DataSetP
             larger_is_closer = false;
         }
 
+        std::vector<BitsetView> chunk_bitsets(num_chunk);
+        for (int chunk_idx = 0; chunk_idx < num_chunk; ++chunk_idx) {
+            auto num_base_vectors = chunk_lims[chunk_idx + 1] - chunk_lims[chunk_idx];
+            chunk_bitsets[chunk_idx] = bitset;
+            RETURN_IF_ERROR(UseOutIdsWindow(chunk_bitsets[chunk_idx], chunk_lims[chunk_idx], num_base_vectors));
+            PrepareBitsetForInternalRange(chunk_bitsets[chunk_idx], num_base_vectors,
+                                          xb_id_offset + chunk_lims[chunk_idx]);
+        }
+
         auto pool = ThreadPool::GetGlobalSearchThreadPool();
         std::vector<folly::Future<Status>> futs;
         futs.reserve(nq);
@@ -712,9 +813,7 @@ BruteForceSearchOnChunkWithBufImpl(const DataSetPtr base_dataset, const DataSetP
                     std::fill(tmp_distances.begin(), tmp_distances.end(),
                               larger_is_closer ? std::numeric_limits<float>::min() : std::numeric_limits<float>::max());
 
-                    // adjust bitset offset for this chunk so selector indices map to global ids
-                    BitsetView chunk_bitset = bitset;
-                    chunk_bitset.set_id_offset(xb_id_offset + chunk_lims[chunk_idx]);
+                    const auto& chunk_bitset = chunk_bitsets[chunk_idx];
                     auto chunk_inv_norms = inv_norms == nullptr ? nullptr : inv_norms.get() + chunk_lims[chunk_idx];
 
                     RETURN_IF_ERROR(brute_force_dense_impl<DataType>(
@@ -727,7 +826,9 @@ BruteForceSearchOnChunkWithBufImpl(const DataSetPtr base_dataset, const DataSetP
                         if (id < 0) {
                             continue;
                         }
-                        auto global_id = static_cast<int64_t>(id) + static_cast<int64_t>(chunk_lims[chunk_idx]);
+                        auto global_id = id;
+                        RETURN_IF_ERROR(MapOneResultId(global_id, chunk_bitset,
+                                                       xb_id_offset + static_cast<int64_t>(chunk_lims[chunk_idx])));
                         auto distance = tmp_distances[j];
                         if (larger_is_closer) {
                             if (minheap.size() < static_cast<size_t>(k)) {
@@ -781,12 +882,6 @@ BruteForceSearchOnChunkWithBufImpl(const DataSetPtr base_dataset, const DataSetP
         }
         RETURN_IF_ERROR(WaitAllSuccess(futs));
 
-        if (xb_id_offset != 0) {
-            for (auto i = 0; i < nq * k; i++) {
-                ids[i] = ids[i] == -1 ? -1 : ids[i] + xb_id_offset;
-            }
-        }
-
     } else {
         if (!base_is_emb_list || !query_is_emb_list) {
             LOG_KNOWHERE_ERROR_ << "both base dataset and query dataset must be emb_list if metric is for emb_list";
@@ -813,6 +908,12 @@ BruteForceSearchOnChunkWithBufImpl(const DataSetPtr base_dataset, const DataSetP
         auto pool = ThreadPool::GetGlobalSearchThreadPool();
         std::vector<folly::Future<Status>> futs;
         futs.reserve(num_query_el);
+        std::vector<BitsetView> chunk_bitsets(num_chunk);
+        for (int chunk_idx = 0; chunk_idx < num_chunk; ++chunk_idx) {
+            chunk_bitsets[chunk_idx] = bitset;
+            RETURN_IF_ERROR(UseOutIdsWindow(chunk_bitsets[chunk_idx], chunk_idx, 1));
+            PrepareBitsetForInternalRange(chunk_bitsets[chunk_idx], 1, xb_id_offset + chunk_idx);
+        }
         for (auto query_el_i = 0; std::cmp_less(query_el_i, num_query_el); query_el_i++) {
             auto num_query_vectors = query_el_offset.get_el_len(query_el_i);
             if (num_query_vectors == 0) {
@@ -834,8 +935,7 @@ BruteForceSearchOnChunkWithBufImpl(const DataSetPtr base_dataset, const DataSetP
                     std::fill(tmp_distances.begin(), tmp_distances.end(),
                               larger_is_closer ? std::numeric_limits<float>::min() : std::numeric_limits<float>::max());
 
-                    BitsetView chunk_bitset = bitset;
-                    chunk_bitset.set_id_offset(xb_id_offset + chunk_idx);
+                    const auto& chunk_bitset = chunk_bitsets[chunk_idx];
 
                     std::vector<size_t> tmp_base_lims = {0, num_base_vectors};
                     auto tmp_base_el_offset = EmbListOffset(tmp_base_lims);
@@ -843,8 +943,8 @@ BruteForceSearchOnChunkWithBufImpl(const DataSetPtr base_dataset, const DataSetP
                     auto cur_base = (static_cast<const DataType* const*>(base_tensor))[chunk_idx];
 
                     RETURN_IF_ERROR(brute_force_emb_list_impl<DataType>(
-                        xq, query_el_idx, cur_base, tmp_labels.data(), tmp_distances.data(), k, dim, tmp_base_el_offset,
-                        query_el_offset, el_metric_type, el_sub_metric_type, chunk_bitset, cfg,
+                        xq, query_el_idx, 0, cur_base, tmp_labels.data(), tmp_distances.data(), k, dim,
+                        tmp_base_el_offset, query_el_offset, el_metric_type, el_sub_metric_type, chunk_bitset, cfg,
                         xb_id_offset + chunk_idx));
 
                     // merge chunk-topk results to heap
@@ -922,7 +1022,7 @@ BruteForceRangeSearchImpl(const DataSetPtr base_dataset, const DataSetPtr query_
     auto dim = base_dataset->GetDim();
     auto xb_id_offset = base_dataset->GetTensorBeginId();
     BitsetView bitset = bitset_;
-    bitset.set_id_offset(xb_id_offset);
+    PrepareBitsetForInternalRange(bitset, nb, static_cast<size_t>(xb_id_offset));
     auto xq = query_dataset->GetTensor();
     auto nq = query_dataset->GetRows();
 
@@ -996,8 +1096,7 @@ BruteForceRangeSearchImpl(const DataSetPtr base_dataset, const DataSetPtr query_
                 auto xb_sparse = static_cast<const sparse::SparseRow<float>*>(xb);
                 std::set<std::pair<float, int64_t>, std::greater<>> result;
                 for (int j = 0; j < nb; ++j) {
-                    auto xid = xb_id_offset + j;
-                    // bitset has already set the id_offset, so we need to use j instead of xid
+                    // j is the chunk-local backend id tested by BitsetView.
                     if (!bitset.empty() && bitset.test(j)) {
                         continue;
                     }
@@ -1010,7 +1109,7 @@ BruteForceRangeSearchImpl(const DataSetPtr base_dataset, const DataSetPtr query_
                     }
                     auto dist = cur_query->dot(xb_sparse[j], sparse_computer, row_sum);
                     if (dist > radius && dist <= range_filter) {
-                        result.insert({dist, xid});
+                        result.insert({dist, j});
                     }
                 }
                 result_id_array[index].reserve(result.size());
@@ -1097,7 +1196,7 @@ BruteForceRangeSearchImpl(const DataSetPtr base_dataset, const DataSetPtr query_
                 result_id_array[index].resize(elem_cnt);
                 for (size_t j = 0; j < elem_cnt; j++) {
                     result_dist_array[index][j] = res.distances[j];
-                    result_id_array[index][j] = res.labels[j] + xb_id_offset;
+                    result_id_array[index][j] = res.labels[j];
                 }
                 if (cfg.range_filter.value() != defaultRangeFilter) {
                     FilterRangeSearchResultForOneNq(result_dist_array[index], result_id_array[index],
@@ -1113,6 +1212,10 @@ BruteForceRangeSearchImpl(const DataSetPtr base_dataset, const DataSetPtr query_
         return expected<DataSetPtr>::Err(ret, "failed to brute force search");
     }
 
+    auto map_status = MapResultIdArray(result_id_array, bitset, xb_id_offset);
+    if (map_status != Status::success) {
+        return expected<DataSetPtr>::Err(map_status, "failed to map brute force range search result ids");
+    }
     auto range_search_result =
         GetRangeSearchResult(result_dist_array, result_id_array, the_larger_the_closer, nq, radius, range_filter);
     auto res = GenResultDataSet(nq, std::move(range_search_result));
@@ -1121,12 +1224,12 @@ BruteForceRangeSearchImpl(const DataSetPtr base_dataset, const DataSetPtr query_
 }
 
 Status
-BruteForceSearchSparseWithBufImpl(const DataSetPtr base_dataset, const DataSetPtr query_dataset,
-                                  sparse::label_t* labels, float* distances, const Json& config,
-                                  const BitsetView& bitset, milvus::OpContext* op_context) {
+SearchSparseWithBufImpl(const DataSetPtr base_dataset, const DataSetPtr query_dataset, sparse::label_t* labels,
+                        float* distances, const Json& config, BitsetView bitset, milvus::OpContext* op_context) {
     auto base = static_cast<const sparse::SparseRow<float>*>(base_dataset->GetTensor());
     auto rows = base_dataset->GetRows();
     auto xb_id_offset = base_dataset->GetTensorBeginId();
+    PrepareBitsetForInternalRange(bitset, rows, static_cast<size_t>(xb_id_offset));
 
     auto xq = static_cast<const sparse::SparseRow<float>*>(query_dataset->GetTensor());
     auto nq = query_dataset->GetRows();
@@ -1182,8 +1285,7 @@ BruteForceSearchSparseWithBufImpl(const DataSetPtr base_dataset, const DataSetPt
             }
             ResultMinHeap<float, int64_t> heap(topk);
             for (int64_t j = 0; j < rows; ++j) {
-                auto x_id = j + xb_id_offset;
-                if (!bitset.empty() && bitset.test(x_id)) {
+                if (!bitset.empty() && bitset.test(j)) {
                     continue;
                 }
                 float row_sum = 0;
@@ -1195,7 +1297,7 @@ BruteForceSearchSparseWithBufImpl(const DataSetPtr base_dataset, const DataSetPt
                 }
                 float dist = row.dot(base[j], computer, row_sum);
                 if (dist > 0) {
-                    heap.Push(dist, x_id);
+                    heap.Push(dist, j);
                 }
             }
             heap.Finalize();
@@ -1207,6 +1309,7 @@ BruteForceSearchSparseWithBufImpl(const DataSetPtr base_dataset, const DataSetPt
         }));
     }
     WaitAllSuccess(futs);
+    RETURN_IF_ERROR(MapResultIds(labels, nq * topk, bitset, xb_id_offset));
 
     return Status::success;
 }
@@ -1226,8 +1329,8 @@ BruteForceSearchSparseImpl(const DataSetPtr base_dataset, const DataSetPtr query
     auto labels = std::make_unique<sparse::label_t[]>(nq * topk);
     auto distances = std::make_unique<float[]>(nq * topk);
 
-    auto search_status = BruteForceSearchSparseWithBufImpl(base_dataset, query_dataset, labels.get(), distances.get(),
-                                                           config, bitset, op_context);
+    auto search_status =
+        SearchSparseWithBufImpl(base_dataset, query_dataset, labels.get(), distances.get(), config, bitset, op_context);
     if (search_status != Status::success) {
         return expected<DataSetPtr>::Err(search_status, "sparse search failed");
     }
@@ -1286,6 +1389,10 @@ BruteForceAnnIteratorImpl(const DataSetPtr base_dataset, const DataSetPtr query_
     }
     auto vec = std::vector<IndexNode::IteratorPtr>(nq, nullptr);
     std::shared_ptr<float[]> inv_norms = GetInverseVecNorms<DataType>(base_dataset);
+    auto bitset_state = std::make_shared<PreparedBitsetState>();
+    auto xb_id_offset = base_dataset->GetTensorBeginId();
+    bitset_state->bitset = bitset_;
+    PrepareBitsetForInternalRange(bitset_state->bitset, nb, static_cast<size_t>(xb_id_offset));
 
     try {
         for (int i = 0; i < nq; ++i) {
@@ -1293,11 +1400,9 @@ BruteForceAnnIteratorImpl(const DataSetPtr base_dataset, const DataSetPtr query_
             auto compute_dist_func = [=]() -> std::vector<DistId> {
                 auto xb = base_dataset->GetTensor();
                 auto xq = query_dataset->GetTensor();
-                auto xb_id_offset = base_dataset->GetTensorBeginId();
-                BitsetView bitset = bitset_;
-                bitset.set_id_offset(xb_id_offset);
-                BitsetViewIDSelector bw_idselector(bitset);
-                [[maybe_unused]] faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
+                BitsetViewIDSelector bw_idselector(bitset_state->bitset);
+                [[maybe_unused]] faiss::IDSelector* id_selector =
+                    !bitset_state->bitset.empty() ? &bw_idselector : nullptr;
                 auto max_dis =
                     larger_is_closer ? std::numeric_limits<float>::lowest() : std::numeric_limits<float>::max();
                 std::vector<DistId> distances_ids(nb, {-1, max_dis});
@@ -1401,11 +1506,7 @@ BruteForceAnnIteratorImpl(const DataSetPtr base_dataset, const DataSetPtr query_
                         KNOWHERE_THROW_MSG(err_msg);
                     }
                 }
-                if (xb_id_offset != 0) {
-                    for (auto& distances_id : distances_ids) {
-                        distances_id.id = distances_id.id == -1 ? -1 : distances_id.id + xb_id_offset;
-                    }
-                }
+                MapDistIdsOrThrow(distances_ids, bitset_state->bitset, xb_id_offset);
                 return distances_ids;
             };
             vec[i] = std::make_shared<PrecomputedDistanceIterator>(compute_dist_func, larger_is_closer,
@@ -1485,6 +1586,21 @@ BruteForceAnnIteratorOnChunkImpl(const DataSetPtr base_dataset, const DataSetPtr
     bool is_cosine = IsMetricType(metric_str, metric::COSINE);
     auto vec = std::vector<IndexNode::IteratorPtr>(nq, nullptr);
     std::shared_ptr<float[]> inv_norms = GetInverseVecNorms<DataType>(base_dataset);
+    auto bitset_state = std::make_shared<PreparedBitsetState>();
+    auto xb_id_offset = base_dataset->GetTensorBeginId();
+    bitset_state->chunk_bitsets.resize(num_chunk);
+    for (int chunk_idx = 0; chunk_idx < num_chunk; ++chunk_idx) {
+        const size_t num_base_vectors = chunk_lims[chunk_idx + 1] - chunk_lims[chunk_idx];
+        bitset_state->chunk_bitsets[chunk_idx] = bitset_;
+        auto window_status =
+            UseOutIdsWindow(bitset_state->chunk_bitsets[chunk_idx], chunk_lims[chunk_idx], num_base_vectors);
+        if (window_status != Status::success) {
+            return expected<std::vector<IndexNode::IteratorPtr>>::Err(window_status,
+                                                                      "failed to prepare brute-force out id map");
+        }
+        PrepareBitsetForInternalRange(bitset_state->chunk_bitsets[chunk_idx], num_base_vectors,
+                                      static_cast<size_t>(xb_id_offset) + chunk_lims[chunk_idx]);
+    }
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
     // LCOV_EXCL_START
@@ -1506,7 +1622,6 @@ BruteForceAnnIteratorOnChunkImpl(const DataSetPtr base_dataset, const DataSetPtr
             auto compute_dist_func = [=]() -> std::vector<DistId> {
                 auto chunk_tensor = static_cast<const DataType* const*>(base_dataset->GetTensor());
                 auto xq = query_dataset->GetTensor();
-                auto xb_id_offset = base_dataset->GetTensorBeginId();
 
                 auto max_dis =
                     larger_is_closer ? std::numeric_limits<float>::lowest() : std::numeric_limits<float>::max();
@@ -1521,10 +1636,9 @@ BruteForceAnnIteratorOnChunkImpl(const DataSetPtr base_dataset, const DataSetPtr
                     const size_t num_base_vectors = chunk_lims[chunk_idx + 1] - chunk_lims[chunk_idx];
                     auto xb = chunk_tensor[chunk_idx];
 
-                    BitsetView bitset = bitset_;
-                    bitset.set_id_offset(xb_id_offset + chunk_lims[chunk_idx]);
-                    BitsetViewIDSelector bw_idselector(bitset);
-                    [[maybe_unused]] faiss::IDSelector* id_selector = (bitset.empty()) ? nullptr : &bw_idselector;
+                    const auto& chunk_bitset = bitset_state->chunk_bitsets[chunk_idx];
+                    BitsetViewIDSelector bw_idselector(chunk_bitset);
+                    [[maybe_unused]] faiss::IDSelector* id_selector = !chunk_bitset.empty() ? &bw_idselector : nullptr;
                     std::vector<DistId> chunk_distances_ids(num_base_vectors, {-1, max_dis});
 
                     switch (faiss_metric_type) {
@@ -1542,14 +1656,9 @@ BruteForceAnnIteratorOnChunkImpl(const DataSetPtr base_dataset, const DataSetPtr
                                 LOG_KNOWHERE_ERROR_ << err_msg;
                                 KNOWHERE_THROW_MSG(err_msg);
                             }
-                            // copy chunk_distances_ids to distances_ids
-                            for (size_t j = 0; j < num_base_vectors; ++j) {
-                                distances_ids[chunk_lims[chunk_idx] + j].id =
-                                    chunk_distances_ids[j].id == -1
-                                        ? -1
-                                        : chunk_distances_ids[j].id + xb_id_offset + chunk_lims[chunk_idx];
-                                distances_ids[chunk_lims[chunk_idx] + j].val = chunk_distances_ids[j].val;
-                            }
+                            CopyMappedChunkDistIds(distances_ids, chunk_lims[chunk_idx], chunk_distances_ids,
+                                                   chunk_bitset,
+                                                   xb_id_offset + static_cast<int64_t>(chunk_lims[chunk_idx]));
                             break;
                         }
                         case faiss::METRIC_INNER_PRODUCT: {
@@ -1571,14 +1680,9 @@ BruteForceAnnIteratorOnChunkImpl(const DataSetPtr base_dataset, const DataSetPtr
                                     LOG_KNOWHERE_ERROR_ << err_msg;
                                     KNOWHERE_THROW_MSG(err_msg);
                                 }
-                                // copy chunk_distances_ids to distances_ids
-                                for (size_t j = 0; j < num_base_vectors; ++j) {
-                                    distances_ids[chunk_lims[chunk_idx] + j].id =
-                                        chunk_distances_ids[j].id == -1
-                                            ? -1
-                                            : chunk_distances_ids[j].id + xb_id_offset + chunk_lims[chunk_idx];
-                                    distances_ids[chunk_lims[chunk_idx] + j].val = chunk_distances_ids[j].val;
-                                }
+                                CopyMappedChunkDistIds(distances_ids, chunk_lims[chunk_idx], chunk_distances_ids,
+                                                       chunk_bitset,
+                                                       xb_id_offset + static_cast<int64_t>(chunk_lims[chunk_idx]));
                             } else {
                                 if constexpr (std::is_same_v<DataType, knowhere::fp32>) {
                                     faiss::cppcontrib::knowhere::all_inner_product(
@@ -1593,14 +1697,9 @@ BruteForceAnnIteratorOnChunkImpl(const DataSetPtr base_dataset, const DataSetPtr
                                     LOG_KNOWHERE_ERROR_ << err_msg;
                                     KNOWHERE_THROW_MSG(err_msg);
                                 }
-                                // copy chunk_distances_ids to distances_ids
-                                for (size_t j = 0; j < num_base_vectors; ++j) {
-                                    distances_ids[chunk_lims[chunk_idx] + j].id =
-                                        chunk_distances_ids[j].id == -1
-                                            ? -1
-                                            : chunk_distances_ids[j].id + xb_id_offset + chunk_lims[chunk_idx];
-                                    distances_ids[chunk_lims[chunk_idx] + j].val = chunk_distances_ids[j].val;
-                                }
+                                CopyMappedChunkDistIds(distances_ids, chunk_lims[chunk_idx], chunk_distances_ids,
+                                                       chunk_bitset,
+                                                       xb_id_offset + static_cast<int64_t>(chunk_lims[chunk_idx]));
                             }
                             break;
                         }
@@ -1615,8 +1714,11 @@ BruteForceAnnIteratorOnChunkImpl(const DataSetPtr base_dataset, const DataSetPtr
                                         distances_ids[chunk_lims[chunk_idx] + j].id = -1;
                                         distances_ids[chunk_lims[chunk_idx] + j].val = max_dis;
                                     } else {
-                                        distances_ids[chunk_lims[chunk_idx] + j].id =
-                                            xb_id_offset + chunk_lims[chunk_idx] + j;
+                                        auto global_id = static_cast<int64_t>(j);
+                                        MapOneResultIdOrThrow(
+                                            global_id, chunk_bitset,
+                                            xb_id_offset + static_cast<int64_t>(chunk_lims[chunk_idx]));
+                                        distances_ids[chunk_lims[chunk_idx] + j].id = global_id;
                                         distances_ids[chunk_lims[chunk_idx] + j].val = static_cast<float>(distances[j]);
                                     }
                                 }
@@ -1638,8 +1740,11 @@ BruteForceAnnIteratorOnChunkImpl(const DataSetPtr base_dataset, const DataSetPtr
                                         distances_ids[chunk_lims[chunk_idx] + j].id = -1;
                                         distances_ids[chunk_lims[chunk_idx] + j].val = max_dis;
                                     } else {
-                                        distances_ids[chunk_lims[chunk_idx] + j].id =
-                                            xb_id_offset + chunk_lims[chunk_idx] + j;
+                                        auto global_id = static_cast<int64_t>(j);
+                                        MapOneResultIdOrThrow(
+                                            global_id, chunk_bitset,
+                                            xb_id_offset + static_cast<int64_t>(chunk_lims[chunk_idx]));
+                                        distances_ids[chunk_lims[chunk_idx] + j].id = global_id;
                                         distances_ids[chunk_lims[chunk_idx] + j].val = distances[j];
                                     }
                                 }
@@ -1676,7 +1781,6 @@ BruteForceAnnIteratorImpl<knowhere::sparse::SparseRow<float>>(const DataSetPtr b
                                                               const BitsetView& bitset, bool use_knowhere_search_pool,
                                                               milvus::OpContext* op_context) {
     auto rows = base_dataset->GetRows();
-    auto xb_id_offset = base_dataset->GetTensorBeginId();
     auto nq = query_dataset->GetRows();
 
     BruteForceConfig cfg;
@@ -1713,6 +1817,10 @@ BruteForceAnnIteratorImpl<knowhere::sparse::SparseRow<float>>(const DataSetPtr b
     auto computer = computer_or.value();
 
     auto vec = std::vector<IndexNode::IteratorPtr>(nq, nullptr);
+    auto bitset_state = std::make_shared<PreparedBitsetState>();
+    auto xb_id_offset = base_dataset->GetTensorBeginId();
+    bitset_state->bitset = bitset;
+    PrepareBitsetForInternalRange(bitset_state->bitset, rows, static_cast<size_t>(xb_id_offset));
     try {
         for (int64_t i = 0; i < nq; ++i) {
             // Heavy computations with `compute_dist_func` will be deferred until the first call to 'Iterator->Next()'.
@@ -1723,8 +1831,7 @@ BruteForceAnnIteratorImpl<knowhere::sparse::SparseRow<float>>(const DataSetPtr b
                 std::vector<DistId> distances_ids;
                 if (row.size() > 0) {
                     for (int64_t j = 0; j < rows; ++j) {
-                        auto xb_id = j + xb_id_offset;
-                        if (!bitset.empty() && bitset.test(xb_id)) {
+                        if (!bitset_state->bitset.empty() && bitset_state->bitset.test(j)) {
                             continue;
                         }
                         float row_sum = 0;
@@ -1736,7 +1843,9 @@ BruteForceAnnIteratorImpl<knowhere::sparse::SparseRow<float>>(const DataSetPtr b
                         }
                         auto dist = row.dot(base[j], computer, row_sum);
                         if (dist > 0) {
-                            distances_ids.emplace_back(xb_id, dist);
+                            auto id = j;
+                            MapOneResultIdOrThrow(id, bitset_state->bitset, xb_id_offset);
+                            distances_ids.emplace_back(id, dist);
                         }
                     }
                 }
@@ -1795,8 +1904,7 @@ BruteForce::SearchSparseWithBuf(const DataSetPtr base_dataset, const DataSetPtr 
                                 float* distances, const Json& config, const BitsetView& bitset,
                                 milvus::OpContext* op_context) noexcept {
     return GuardedCall([&]() -> Status {
-        return BruteForceSearchSparseWithBufImpl(base_dataset, query_dataset, labels, distances, config, bitset,
-                                                 op_context);
+        return SearchSparseWithBufImpl(base_dataset, query_dataset, labels, distances, config, bitset, op_context);
     });
 }
 

--- a/src/index/data_view_dense_index/data_view_dense_index.h
+++ b/src/index/data_view_dense_index/data_view_dense_index.h
@@ -31,6 +31,7 @@
 #include "knowhere/comp/task.h"
 #include "knowhere/config.h"
 #include "knowhere/context.h"
+#include "knowhere/id_map.h"
 #include "knowhere/operands.h"
 #include "knowhere/range_util.h"
 
@@ -348,13 +349,14 @@ DataViewIndexFlat::Search(const idx_t n, const void* __restrict x, const idx_t k
                           const bool use_quant) const {
     // todo: need more test to check
     const auto& search_pool = ThreadPool::GetGlobalSearchThreadPool();
+    const auto ntotal = Count();
     std::vector<folly::Future<folly::Unit>> futs;
     futs.reserve(n);
     if (k < faiss::distance_compute_min_k_reservoir) {
         if (metric_type_ == metric::L2) {
             faiss::cppcontrib::knowhere::HeapBlockResultHandler<CMAX> res(n, distances, labels, k);
             for (auto i = 0; i < n; i++) {
-                futs.emplace_back(search_pool->push([&] {
+                futs.emplace_back(search_pool->push([&, i = i] {
                     knowhere::checkCancellation(op_context);
                     ThreadPool::ScopedSearchOmpSetter setter(1);
                     faiss::cppcontrib::knowhere::HeapBlockResultHandler<CMAX>::SingleResultHandler resi(res);
@@ -363,9 +365,9 @@ DataViewIndexFlat::Search(const idx_t n, const void* __restrict x, const idx_t k
                     computer->set_query((const float*)((const char*)x + code_size_ * i));
                     resi.begin(i);
                     if (bitset.empty()) {
-                        exhaustive_search_in_one_query_impl(computer, n, resi, faiss::IDSelectorAll());
+                        exhaustive_search_in_one_query_impl(computer, ntotal, resi, faiss::IDSelectorAll());
                     } else {
-                        exhaustive_search_in_one_query_impl(computer, n, resi, BitsetViewIDSelector(bitset));
+                        exhaustive_search_in_one_query_impl(computer, ntotal, resi, BitsetViewIDSelector(bitset));
                     }
                     resi.end();
                 }));
@@ -374,7 +376,7 @@ DataViewIndexFlat::Search(const idx_t n, const void* __restrict x, const idx_t k
         } else {
             faiss::cppcontrib::knowhere::HeapBlockResultHandler<CMIN> res(n, distances, labels, k);
             for (auto i = 0; i < n; i++) {
-                futs.emplace_back(search_pool->push([&] {
+                futs.emplace_back(search_pool->push([&, i = i] {
                     knowhere::checkCancellation(op_context);
                     ThreadPool::ScopedSearchOmpSetter setter(1);
                     faiss::cppcontrib::knowhere::HeapBlockResultHandler<CMIN>::SingleResultHandler resi(res);
@@ -383,9 +385,9 @@ DataViewIndexFlat::Search(const idx_t n, const void* __restrict x, const idx_t k
                     computer->set_query((const float*)((const char*)x + code_size_ * i));
                     resi.begin(i);
                     if (bitset.empty()) {
-                        exhaustive_search_in_one_query_impl(computer, n, resi, faiss::IDSelectorAll());
+                        exhaustive_search_in_one_query_impl(computer, ntotal, resi, faiss::IDSelectorAll());
                     } else {
-                        exhaustive_search_in_one_query_impl(computer, n, resi, BitsetViewIDSelector(bitset));
+                        exhaustive_search_in_one_query_impl(computer, ntotal, resi, BitsetViewIDSelector(bitset));
                     }
                     resi.end();
                 }));
@@ -397,7 +399,7 @@ DataViewIndexFlat::Search(const idx_t n, const void* __restrict x, const idx_t k
             faiss::cppcontrib::knowhere::ReservoirBlockResultHandler<CMAX> res(n, distances, labels, k);
 
             for (auto i = 0; i < n; i++) {
-                futs.emplace_back(search_pool->push([&] {
+                futs.emplace_back(search_pool->push([&, i = i] {
                     ThreadPool::ScopedSearchOmpSetter setter(1);
                     faiss::cppcontrib::knowhere::ReservoirBlockResultHandler<CMAX>::SingleResultHandler resi(res);
                     auto computer = SelectDataViewComputer(view_data_, data_type_, metric_type_, d_, is_cosine_,
@@ -405,9 +407,9 @@ DataViewIndexFlat::Search(const idx_t n, const void* __restrict x, const idx_t k
                     computer->set_query((const float*)((const char*)x + code_size_ * i));
                     resi.begin(i);
                     if (bitset.empty()) {
-                        exhaustive_search_in_one_query_impl(computer, n, resi, faiss::IDSelectorAll());
+                        exhaustive_search_in_one_query_impl(computer, ntotal, resi, faiss::IDSelectorAll());
                     } else {
-                        exhaustive_search_in_one_query_impl(computer, n, resi, BitsetViewIDSelector(bitset));
+                        exhaustive_search_in_one_query_impl(computer, ntotal, resi, BitsetViewIDSelector(bitset));
                     }
                     resi.end();
                 }));
@@ -416,7 +418,7 @@ DataViewIndexFlat::Search(const idx_t n, const void* __restrict x, const idx_t k
         } else {
             faiss::cppcontrib::knowhere::ReservoirBlockResultHandler<CMIN> res(n, distances, labels, k);
             for (auto i = 0; i < n; i++) {
-                futs.emplace_back(search_pool->push([&] {
+                futs.emplace_back(search_pool->push([&, i = i] {
                     ThreadPool::ScopedSearchOmpSetter setter(1);
                     faiss::cppcontrib::knowhere::ReservoirBlockResultHandler<CMIN>::SingleResultHandler resi(res);
                     auto computer = SelectDataViewComputer(view_data_, data_type_, metric_type_, d_, is_cosine_,
@@ -424,9 +426,9 @@ DataViewIndexFlat::Search(const idx_t n, const void* __restrict x, const idx_t k
                     computer->set_query((const float*)((const char*)x + code_size_ * i));
                     resi.begin(i);
                     if (bitset.empty()) {
-                        exhaustive_search_in_one_query_impl(computer, n, resi, faiss::IDSelectorAll());
+                        exhaustive_search_in_one_query_impl(computer, ntotal, resi, faiss::IDSelectorAll());
                     } else {
-                        exhaustive_search_in_one_query_impl(computer, n, resi, BitsetViewIDSelector(bitset));
+                        exhaustive_search_in_one_query_impl(computer, ntotal, resi, BitsetViewIDSelector(bitset));
                     }
                     resi.end();
                 }));
@@ -508,6 +510,7 @@ DataViewIndexFlat::RangeSearch(const idx_t n, const void* __restrict x, const fl
     // todo: need more test to check
     std::vector<std::vector<float>> result_dist_array(n);
     std::vector<std::vector<idx_t>> result_id_array(n);
+    const auto ntotal = Count();
 
     std::shared_ptr<float[]> base_norms = nullptr;
     if (is_cosine_) {
@@ -527,17 +530,19 @@ DataViewIndexFlat::RangeSearch(const idx_t n, const void* __restrict x, const fl
                 ThreadPool::ScopedSearchOmpSetter setter(1);
                 auto computer = SelectDataViewComputer(view_data_, data_type_, metric_type_, d_, is_cosine_,
                                                        use_quant ? quant_data_ : nullptr);
+                computer->set_query((const float*)((const char*)x + code_size_ * i));
                 faiss::RangeSearchResult res(1);
-                faiss::cppcontrib::knowhere::RangeSearchBlockResultHandler<CMAX> resh(&res, radius);
-                faiss::cppcontrib::knowhere::RangeSearchBlockResultHandler<CMAX>::SingleResultHandler reshi(resh);
-                computer->set_query(((const float*)x + code_size_ * i));
-                reshi.begin(i);
-                if (bitset.empty()) {
-                    exhaustive_search_in_one_query_impl(computer, n, reshi, faiss::IDSelectorAll());
-                } else {
-                    exhaustive_search_in_one_query_impl(computer, n, reshi, BitsetViewIDSelector(bitset));
+                {
+                    faiss::cppcontrib::knowhere::RangeSearchBlockResultHandler<CMAX> resh(&res, radius);
+                    faiss::cppcontrib::knowhere::RangeSearchBlockResultHandler<CMAX>::SingleResultHandler reshi(resh);
+                    reshi.begin(0);
+                    if (bitset.empty()) {
+                        exhaustive_search_in_one_query_impl(computer, ntotal, reshi, faiss::IDSelectorAll());
+                    } else {
+                        exhaustive_search_in_one_query_impl(computer, ntotal, reshi, BitsetViewIDSelector(bitset));
+                    }
+                    reshi.end();
                 }
-                reshi.end();
                 auto elem_cnt = res.lims[1];
                 result_dist_array[i].resize(elem_cnt);
                 result_id_array[i].resize(elem_cnt);
@@ -558,17 +563,19 @@ DataViewIndexFlat::RangeSearch(const idx_t n, const void* __restrict x, const fl
                 ThreadPool::ScopedSearchOmpSetter setter(1);
                 auto computer = SelectDataViewComputer(view_data_, data_type_, metric_type_, d_, is_cosine_,
                                                        use_quant ? quant_data_ : nullptr);
+                computer->set_query((const float*)((const char*)x + code_size_ * i));
                 faiss::RangeSearchResult res(1);
-                faiss::cppcontrib::knowhere::RangeSearchBlockResultHandler<CMIN> resh(&res, radius);
-                faiss::cppcontrib::knowhere::RangeSearchBlockResultHandler<CMIN>::SingleResultHandler reshi(resh);
-                computer->set_query(((const float*)x + code_size_ * i));
-                reshi.begin(i);
-                if (bitset.empty()) {
-                    exhaustive_search_in_one_query_impl(computer, n, reshi, faiss::IDSelectorAll());
-                } else {
-                    exhaustive_search_in_one_query_impl(computer, n, reshi, BitsetViewIDSelector(bitset));
+                {
+                    faiss::cppcontrib::knowhere::RangeSearchBlockResultHandler<CMIN> resh(&res, radius);
+                    faiss::cppcontrib::knowhere::RangeSearchBlockResultHandler<CMIN>::SingleResultHandler reshi(resh);
+                    reshi.begin(0);
+                    if (bitset.empty()) {
+                        exhaustive_search_in_one_query_impl(computer, ntotal, reshi, faiss::IDSelectorAll());
+                    } else {
+                        exhaustive_search_in_one_query_impl(computer, ntotal, reshi, BitsetViewIDSelector(bitset));
+                    }
+                    reshi.end();
                 }
-                reshi.end();
                 auto elem_cnt = res.lims[1];
                 result_dist_array[i].resize(elem_cnt);
                 result_id_array[i].resize(elem_cnt);

--- a/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
+++ b/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
@@ -464,9 +464,12 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::AddEmbList(const DataSetP
 
     {
         FairWriteLockGuard guard(*this->base_index_lock_);
-        RETURN_IF_ERROR(this->AppendEmbListOffsetAndIdMap(lims, num_rows));
+        RETURN_IF_ERROR(this->AppendEmbListOffsetAndIdMap(lims, num_rows, this->EmbListCount(dataset, lims, num_rows)));
     }
 
+    if (num_rows == 0) {
+        return Status::success;
+    }
     return Add(dataset, std::move(cfg), use_knowhere_build_pool);
 }
 
@@ -548,7 +551,14 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::CalcDistByIDs(const DataS
                                     this->emb_list_strategy_->NeedsBaseIndexIDMap();
     std::vector<int64_t> in_labels;
     // Public APIs pass public ids. EmbList rerank passes compact list ids.
-    const auto* labels_to_calc = is_emb_list_rerank ? labels : this->MapOutToIn(labels, labels_len, in_labels);
+    const int64_t* labels_to_calc = labels;
+    if (!is_emb_list_rerank) {
+        auto storage_labels = this->CompactOutToIn(labels, labels_len, in_labels, static_cast<size_t>(Count()));
+        if (!storage_labels.has_value()) {
+            return expected<DataSetPtr>::Err(storage_labels.error(), storage_labels.what());
+        }
+        labels_to_calc = storage_labels.value();
+    }
 
     auto num_queries = dataset->GetRows();
     auto query_data = dataset->GetTensor();

--- a/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
+++ b/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
@@ -73,12 +73,6 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
         return refine_offset_index_->GetQueryCodeSize();
     }
 
-    Status
-    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) override {
-        internal_offset_to_most_external_id_ = std::move(map);
-        return Status::success;
-    }
-
     expected<DataSetPtr>
     CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
                   const bool is_cosine, milvus::OpContext* op_context) const override;
@@ -121,6 +115,20 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
     bool
     HasRawData(const std::string& metric_type) const override {
         return false;
+    }
+
+    bool
+    NeedBitsetExactCount() const override {
+        return base_index_ != nullptr && base_index_->NeedBitsetExactCount();
+    }
+
+    void
+    SetIdMapType(IdMap::Type type) override {
+        // DataView and its nested base index share one compact id domain.
+        IndexNode::SetIdMapType(type);
+        if (base_index_ != nullptr) {
+            base_index_->SetIdMapType(type);
+        }
     }
 
     expected<DataSetPtr>
@@ -249,7 +257,7 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
                         UpdateNext();
                     }
                 }
-                return std::make_pair(ret.id, ret.val * sign_);
+                return std::make_pair(MapResultId(ret.id), ret.val * sign_);
             }
         }
 
@@ -330,7 +338,6 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
     std::unique_ptr<IndexNode> base_index_;  // base_index will hold data codes in memory, datatype is fp32
     std::unique_ptr<FairRWLock>
         base_index_lock_;  // base_index_lock_ protect all concurrent writes/reads access of base_index_
-    std::vector<uint32_t> internal_offset_to_most_external_id_;
 };
 
 namespace {
@@ -439,7 +446,6 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::AddEmbList(const DataSetP
         return Status::emb_list_inner_error;
     }
 
-    // 1. split metric_type to el_metric_type and sub_metric_type
     auto& config = static_cast<BaseConfig&>(*cfg);
     auto original_metric_type = config.metric_type.value();
     auto el_metric_type_or = get_el_metric_type(original_metric_type);
@@ -453,45 +459,14 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::AddEmbList(const DataSetP
         LOG_KNOWHERE_WARNING_ << "Invalid sub metric type for emb_list: " << original_metric_type;
         return Status::emb_list_inner_error;
     }
-    // set sub metric type as the metric type for build
     auto sub_metric_type = sub_metric_type_or.value();
     config.metric_type = sub_metric_type;
 
-    // 2. update emb list offset and id map
-    size_t old_num_el = emb_list_offset_->num_el();
-    size_t old_rows_cnt = Count();
-    size_t new_rows_cnt = old_rows_cnt + num_rows;
     {
         FairWriteLockGuard guard(*this->base_index_lock_);
-        size_t idx = 0;
-        if (lims[0] != emb_list_offset_->offset[old_num_el]) {
-            LOG_KNOWHERE_WARNING_ << "emb list offset is not continuous";
-            return Status::emb_list_inner_error;
-        }
-        idx++;
-        internal_offset_to_most_external_id_.resize(new_rows_cnt);
-        while (lims[idx] < new_rows_cnt) {
-            if (lims[idx] < lims[idx - 1]) {
-                LOG_KNOWHERE_WARNING_ << "emb list offset is not increasing";
-                return Status::emb_list_inner_error;
-            }
-            emb_list_offset_->offset.push_back(lims[idx]);
-            auto cur_el_id = old_num_el + idx - 1;
-            std::fill_n(internal_offset_to_most_external_id_.begin() + lims[idx - 1], lims[idx] - lims[idx - 1],
-                        cur_el_id);
-            idx++;
-        }
-        if (lims[idx] != new_rows_cnt) {
-            LOG_KNOWHERE_WARNING_ << "emb list offset should end with the total_cnt of the whole index";
-            return Status::emb_list_inner_error;
-        }
-        emb_list_offset_->offset.push_back(new_rows_cnt);
-        auto cur_el_id = old_num_el + idx - 1;
-        std::fill_n(internal_offset_to_most_external_id_.begin() + lims[idx - 1], new_rows_cnt - lims[idx - 1],
-                    cur_el_id);
+        RETURN_IF_ERROR(this->AppendEmbListOffsetAndIdMap(lims, num_rows));
     }
 
-    // 3. add to index
     return Add(dataset, std::move(cfg), use_knowhere_build_pool);
 }
 
@@ -521,21 +496,7 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::Search(const DataSetPtr d
     knowhere::expected<knowhere::DataSetPtr> quant_res;
     {
         FairReadLockGuard guard(*this->base_index_lock_);
-        BitsetView new_bitset(bitset);
-        if (!internal_offset_to_most_external_id_.empty()) {
-            size_t num_filtered_out_ids = 0;
-            if (!bitset.empty()) {
-                // todo: optimize the calculation
-                for (size_t i = 0; i < new_bitset.size(); i++) {
-                    if (new_bitset.test(i)) {
-                        num_filtered_out_ids += emb_list_offset_->offset[i + 1] - emb_list_offset_->offset[i];
-                    }
-                }
-            }
-            new_bitset.set_out_ids(internal_offset_to_most_external_id_.data(),
-                                   internal_offset_to_most_external_id_.size(), num_filtered_out_ids);
-        }
-        quant_res = base_index_->Search(base_index_ds, std::move(cfg), new_bitset, op_context);
+        quant_res = base_index_->Search(base_index_ds, std::move(cfg), bitset, op_context);
     }
     if (!quant_res.has_value()) {
         return quant_res;
@@ -556,7 +517,9 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::Search(const DataSetPtr d
         LOG_KNOWHERE_WARNING_ << "data view index inner error: " << e.what();
         return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
     }
-    return GenResultDataSet(nq, topk, std::move(labels), std::move(distances));
+    auto res = GenResultDataSet(nq, topk, std::move(labels), std::move(distances));
+    this->MapSearchResultIdsToOutIds(res);
+    return res;
 }
 
 template <typename DataType, typename BaseIndexNode>
@@ -574,14 +537,25 @@ expected<DataSetPtr>
 IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::CalcDistByIDs(const DataSetPtr dataset,
                                                                      const BitsetView& /*bitset*/,
                                                                      const int64_t* labels, const size_t labels_len,
-                                                                     const bool /*is_cosine*/,
+                                                                     const bool is_cosine,
                                                                      milvus::OpContext* op_context) const {
+    if (this->emb_list_raw_index_) {
+        return CalcDistByRawIndex(dataset, labels, labels_len, is_cosine, ThreadPool::GetGlobalSearchThreadPool(),
+                                  op_context);
+    }
+
+    const bool is_emb_list_rerank = this->emb_list_offset_ != nullptr && this->emb_list_strategy_ != nullptr &&
+                                    this->emb_list_strategy_->NeedsBaseIndexIDMap();
+    std::vector<int64_t> in_labels;
+    // Public APIs pass public ids. EmbList rerank passes compact list ids.
+    const auto* labels_to_calc = is_emb_list_rerank ? labels : this->MapOutToIn(labels, labels_len, in_labels);
+
     auto num_queries = dataset->GetRows();
     auto query_data = dataset->GetTensor();
     auto distances = std::make_unique<float[]>(num_queries * labels_len);
     try {
         bool refine_with_quant = false;
-        refine_offset_index_->CalcDistByIDs(num_queries, query_data, labels_len, labels, distances.get(),
+        refine_offset_index_->CalcDistByIDs(num_queries, query_data, labels_len, labels_to_calc, distances.get(),
                                             refine_with_quant);
     } catch (const std::exception& e) {
         LOG_KNOWHERE_WARNING_ << "data view index inner error: " << e.what();
@@ -633,15 +607,19 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::AnnIterator(const DataSet
         return expected<std::vector<IndexNode::IteratorPtr>>::Err(
             Status::internal_error, "quant workspace is not equal to the rows count of input dataset.");
     }
+    const auto& id_map = this->GetIdMap();
+    const auto* result_id_map = this->SearchResultIdMap(id_map);
     auto vec = std::vector<IndexNode::IteratorPtr>(nq, nullptr);
     for (auto i = 0; i < nq; i++) {
         auto cur_query = (const DataType*)data + i * dim;
         std::unique_ptr<DataType[]> copied_query = nullptr;
         copied_query = std::make_unique<DataType[]>(dim);
         std::copy_n(cur_query, dim, copied_query.get());
-        vec[i] = std::shared_ptr<iterator>(new iterator(this->refine_offset_index_, base_workspace_iters[i],
-                                                        std::move(copied_query), larger_is_closer, refine_with_quant,
-                                                        refine_ratio));
+        auto it = std::shared_ptr<iterator>(new iterator(this->refine_offset_index_, base_workspace_iters[i],
+                                                         std::move(copied_query), larger_is_closer, refine_with_quant,
+                                                         refine_ratio));
+        it->SetResultIdMap(result_id_map);
+        vec[i] = it;
     }
     return vec;
 }

--- a/src/index/diskann/diskann.cc
+++ b/src/index/diskann/diskann.cc
@@ -67,6 +67,11 @@ class DiskANNIndexNode : public IndexNode {
         return Status::not_implemented;
     }
 
+    bool
+    NeedBitsetExactCount() const override {
+        return true;
+    }
+
     expected<DataSetPtr>
     Search(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset,
            milvus::OpContext* op_context) const override;
@@ -90,12 +95,6 @@ class DiskANNIndexNode : public IndexNode {
         }
         LOG_KNOWHERE_ERROR_ << "Invalid data type: " << typeid(DataType).name();
         return std::nullopt;
-    }
-
-    Status
-    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) override {
-        internal_id_to_most_external_id_map_ = std::move(map);
-        return Status::success;
     }
 
     expected<DataSetPtr>
@@ -221,6 +220,10 @@ class DiskANNIndexNode : public IndexNode {
     AnnIterator(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset,
                 bool use_knowhere_search_pool, milvus::OpContext* op_context) const override;
 
+ protected:
+    expected<DataSetPtr>
+    GetVectorByStorageIds(const DataSetPtr dataset, milvus::OpContext* op_context) const override;
+
  private:
     class iterator : public IndexIterator {
      public:
@@ -282,7 +285,6 @@ class DiskANNIndexNode : public IndexNode {
     std::atomic_int64_t dim_;
     std::atomic_int64_t count_;
     std::shared_ptr<ThreadPool> search_pool_;
-    std::vector<uint32_t> internal_id_to_most_external_id_map_;  // for 1-hop bitset check
 };
 
 }  // namespace knowhere
@@ -822,8 +824,7 @@ DiskANNIndexNode<DataType>::DeserializeEmbListIfNeed(const BinarySet& binset, st
     LOG_KNOWHERE_INFO_ << "Created emb_list strategy: " << emb_list_strategy_->Type()
                        << ", doc_count=" << emb_list_strategy_->GetDocCount();
 
-    // Step 5: Set base index id map for 1-hop bitset check
-    return SetBaseIndexIDMap();
+    return Status::success;
 }
 
 template <typename DataType>
@@ -853,12 +854,15 @@ DiskANNIndexNode<DataType>::AnnIterator(const DataSetPtr dataset, std::unique_pt
     auto vec = std::vector<IndexNode::IteratorPtr>(nq, nullptr);
     auto metric = search_conf.metric_type.value();
     bool transform = metric != knowhere::metric::L2;
+    const auto& id_map = this->GetIdMap();
+    const auto* result_id_map = this->SearchResultIdMap(id_map);
 
     try {
         for (int i = 0; i < nq; i++) {
             auto single_query = static_cast<const DataType*>(xq) + i * dim;
             auto it = std::make_shared<iterator>(transform, single_query, lsearch, beamwidth, filter_ratio, bitset,
                                                  pq_flash_index_.get(), use_knowhere_search_pool);
+            it->SetResultIdMap(result_id_map);
             vec[i] = it;
         }
     } catch (const std::exception& e) {
@@ -899,31 +903,6 @@ DiskANNIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Con
                                                  search_conf.search_list_size.value(), search_conf.beamwidth.value());
     }
 
-    BitsetView bitset(bitset_);
-    if (!internal_id_to_most_external_id_map_.empty()) {
-        if (emb_list_offset_ != nullptr) {
-            // if emb list, manually calculate the number of filtered out ids
-            size_t num_filtered_out_ids = 0;
-            const auto num_el = std::min(
-                bitset.size(), emb_list_offset_->offset.empty() ? size_t{0} : emb_list_offset_->offset.size() - 1);
-            if (emb_list_offset_->offset.size() < bitset.size() + 1) {
-                LOG_KNOWHERE_WARNING_ << "Bitset size(" << bitset.size() << ") doesn't match emb_list offset size("
-                                      << emb_list_offset_->offset.size()
-                                      << "), will compute filtered ids using min size(" << num_el << ")";
-            }
-            for (size_t i = 0; i < num_el; i++) {
-                if (bitset.test(i)) {
-                    num_filtered_out_ids += emb_list_offset_->offset[i + 1] - emb_list_offset_->offset[i];
-                }
-            }
-            bitset.set_out_ids(internal_id_to_most_external_id_map_.data(), internal_id_to_most_external_id_map_.size(),
-                               num_filtered_out_ids);
-        } else {
-            bitset.set_out_ids(internal_id_to_most_external_id_map_.data(),
-                               internal_id_to_most_external_id_map_.size());
-        }
-    }
-
     auto p_id = std::make_unique<int64_t[]>(k * nq);
     auto p_dist = std::make_unique<DistType[]>(k * nq);
 
@@ -935,7 +914,7 @@ DiskANNIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Con
             diskann::QueryStats stats;
             pq_flash_index_->cached_beam_search(xq + (index * dim), k, lsearch, p_id_ptr + (index * k),
                                                 p_dist_ptr + (index * k), beamwidth, false, &stats, feder_result,
-                                                bitset, filter_ratio);
+                                                bitset_, filter_ratio);
 #ifdef NOT_COMPILE_FOR_SWIG
             knowhere_diskann_search_hops.Observe(stats.n_hops);
 #endif
@@ -947,6 +926,7 @@ DiskANNIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Con
     }
 
     auto res = GenResultDataSet(nq, k, std::move(p_id), std::move(p_dist));
+    MapSearchResultIdsToOutIds(res);
 
     // set visit_info json string into result dataset
     if (feder_result != nullptr) {
@@ -988,13 +968,18 @@ DiskANNIndexNode<DataType>::CalcDistByIDs(const DataSetPtr dataset, const Bitset
     auto dim = dataset->GetDim();
     auto xq = static_cast<const DataType*>(dataset->GetTensor());
     auto p_dist = std::make_unique<DistType[]>(nq * labels_len);
+    const bool is_emb_list_rerank = this->emb_list_offset_ != nullptr && this->emb_list_strategy_ != nullptr &&
+                                    this->emb_list_strategy_->NeedsBaseIndexIDMap();
+    std::vector<int64_t> in_labels;
+    // Public APIs pass public ids. EmbList rerank passes compact list ids.
+    const auto* labels_to_calc = is_emb_list_rerank ? labels : this->MapOutToIn(labels, labels_len, in_labels);
 
     std::vector<folly::Future<folly::Unit>> futures;
     futures.reserve(nq);
     for (int64_t row = 0; row < nq; ++row) {
         futures.emplace_back(search_pool_->push([&, index = row, p_dist_ptr = p_dist.get()]() {
             knowhere::checkCancellation(op_context);
-            pq_flash_index_->calc_dist_by_ids(xq + (index * dim), labels, static_cast<int64_t>(labels_len),
+            pq_flash_index_->calc_dist_by_ids(xq + (index * dim), labels_to_calc, static_cast<int64_t>(labels_len),
                                               p_dist_ptr + index * labels_len);
         }));
     }
@@ -1014,6 +999,17 @@ DiskANNIndexNode<DataType>::CalcDistByIDs(const DataSetPtr dataset, const Bitset
 template <typename DataType>
 expected<DataSetPtr>
 DiskANNIndexNode<DataType>::GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context) const {
+    auto rows = dataset->GetRows();
+    auto ids = dataset->GetIds();
+    std::vector<int64_t> in_ids;
+    ids = this->MapOutToIn(ids, rows, in_ids);
+    auto storage_ds = GenIdsDataSet(rows, ids);
+    return GetVectorByStorageIds(storage_ds, op_context);
+}
+
+template <typename DataType>
+expected<DataSetPtr>
+DiskANNIndexNode<DataType>::GetVectorByStorageIds(const DataSetPtr dataset, milvus::OpContext* op_context) const {
     if (!is_prepared_.load() || !pq_flash_index_) {
         LOG_KNOWHERE_ERROR_ << "Failed to load diskann.";
         return expected<DataSetPtr>::Err(Status::empty_index, "index not loaded");

--- a/src/index/diskann/diskann.cc
+++ b/src/index/diskann/diskann.cc
@@ -561,7 +561,8 @@ DiskANNIndexNode<DataType>::BuildEmbListIfNeed(const DataSetPtr dataset, std::sh
     LOG_KNOWHERE_INFO_ << "Read emb_list offset from file: " << input_file_path << ", size: " << offset.size()
                        << ", first offset: " << offset.front() << ", last offset: " << offset.back();
 
-    auto build_status = BuildEmbList(dataset, std::move(cfg), offset.data(), offset.back(), use_knowhere_build_pool);
+    auto build_status =
+        BuildEmbList(dataset, std::move(cfg), offset.data(), offset.back(), offset.size() - 1, use_knowhere_build_pool);
     if (build_status != Status::success) {
         LOG_KNOWHERE_ERROR_ << "Failed to build base index.";
         return build_status;
@@ -946,14 +947,6 @@ DiskANNIndexNode<DataType>::CalcDistByIDs(const DataSetPtr dataset, const Bitset
                                           milvus::OpContext* op_context) const {
     (void)bitset;
     (void)is_cosine;
-    if (!is_prepared_.load() || !pq_flash_index_) {
-        LOG_KNOWHERE_ERROR_ << "Failed to load diskann.";
-        return expected<DataSetPtr>::Err(Status::empty_index, "DiskANN not loaded");
-    }
-    if (!search_pool_) {
-        LOG_KNOWHERE_ERROR_ << "Search thread pool is not initialized.";
-        return expected<DataSetPtr>::Err(Status::internal_error, "search pool not initialized");
-    }
     if (dataset == nullptr || dataset->GetTensor() == nullptr) {
         return expected<DataSetPtr>::Err(Status::invalid_args, "empty query dataset");
     }
@@ -972,7 +965,22 @@ DiskANNIndexNode<DataType>::CalcDistByIDs(const DataSetPtr dataset, const Bitset
                                     this->emb_list_strategy_->NeedsBaseIndexIDMap();
     std::vector<int64_t> in_labels;
     // Public APIs pass public ids. EmbList rerank passes compact list ids.
-    const auto* labels_to_calc = is_emb_list_rerank ? labels : this->MapOutToIn(labels, labels_len, in_labels);
+    const int64_t* labels_to_calc = labels;
+    if (!is_emb_list_rerank) {
+        auto storage_labels = this->CompactOutToIn(labels, labels_len, in_labels, static_cast<size_t>(Count()));
+        if (!storage_labels.has_value()) {
+            return expected<DataSetPtr>::Err(storage_labels.error(), storage_labels.what());
+        }
+        labels_to_calc = storage_labels.value();
+    }
+    if (!is_prepared_.load() || !pq_flash_index_) {
+        LOG_KNOWHERE_ERROR_ << "Failed to load diskann.";
+        return expected<DataSetPtr>::Err(Status::empty_index, "DiskANN not loaded");
+    }
+    if (!search_pool_) {
+        LOG_KNOWHERE_ERROR_ << "Search thread pool is not initialized.";
+        return expected<DataSetPtr>::Err(Status::internal_error, "search pool not initialized");
+    }
 
     std::vector<folly::Future<folly::Unit>> futures;
     futures.reserve(nq);
@@ -999,10 +1007,17 @@ DiskANNIndexNode<DataType>::CalcDistByIDs(const DataSetPtr dataset, const Bitset
 template <typename DataType>
 expected<DataSetPtr>
 DiskANNIndexNode<DataType>::GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context) const {
+    if (dataset == nullptr) {
+        return expected<DataSetPtr>::Err(Status::invalid_args, "GetVectorByIds dataset is null");
+    }
     auto rows = dataset->GetRows();
     auto ids = dataset->GetIds();
     std::vector<int64_t> in_ids;
-    ids = this->MapOutToIn(ids, rows, in_ids);
+    auto storage_ids = this->CompactOutToIn(ids, rows, in_ids, static_cast<size_t>(Count()));
+    if (!storage_ids.has_value()) {
+        return expected<DataSetPtr>::Err(storage_ids.error(), storage_ids.what());
+    }
+    ids = storage_ids.value();
     auto storage_ds = GenIdsDataSet(rows, ids);
     return GetVectorByStorageIds(storage_ds, op_context);
 }

--- a/src/index/diskann/diskann_aisaq.cc
+++ b/src/index/diskann/diskann_aisaq.cc
@@ -54,6 +54,11 @@ class AisaqIndexNode : public IndexNode {
         return Status::not_implemented;
     }
 
+    bool
+    NeedBitsetExactCount() const override {
+        return true;
+    }
+
     expected<DataSetPtr>
     Search(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset,
            milvus::OpContext* op_context) const override;
@@ -715,6 +720,7 @@ AisaqIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
     }
 
     auto res = GenResultDataSet(nq, k, std::move(p_id), std::move(p_dist));
+    MapSearchResultIdsToOutIds(res);
 
     // set visit_info json string into result dataset
     if (feder_result != nullptr) {
@@ -742,6 +748,8 @@ AisaqIndexNode<DataType>::GetVectorByIds(const DataSetPtr dataset, milvus::OpCon
     auto dim = Dim();
     auto rows = dataset->GetRows();
     auto ids = dataset->GetIds();
+    std::vector<int64_t> in_ids;
+    ids = MapOutToIn(ids, rows, in_ids);
     auto* data = new DataType[dim * rows];
     if (data == nullptr) {
         LOG_KNOWHERE_ERROR_ << "Failed to allocate memory for data.";

--- a/src/index/diskann/diskann_aisaq.cc
+++ b/src/index/diskann/diskann_aisaq.cc
@@ -745,11 +745,18 @@ AisaqIndexNode<DataType>::GetVectorByIds(const DataSetPtr dataset, milvus::OpCon
         LOG_KNOWHERE_ERROR_ << "Failed to load AiSAQ.";
         return expected<DataSetPtr>::Err(Status::empty_index, "index not loaded");
     }
+    if (dataset == nullptr) {
+        return expected<DataSetPtr>::Err(Status::invalid_args, "GetVectorByIds dataset is null");
+    }
     auto dim = Dim();
     auto rows = dataset->GetRows();
     auto ids = dataset->GetIds();
     std::vector<int64_t> in_ids;
-    ids = MapOutToIn(ids, rows, in_ids);
+    auto storage_ids = CompactOutToIn(ids, rows, in_ids, static_cast<size_t>(Count()));
+    if (!storage_ids.has_value()) {
+        return expected<DataSetPtr>::Err(storage_ids.error(), storage_ids.what());
+    }
+    ids = storage_ids.value();
     auto* data = new DataType[dim * rows];
     if (data == nullptr) {
         LOG_KNOWHERE_ERROR_ << "Failed to allocate memory for data.";

--- a/src/index/emb_list/emb_list_strategy_lemur.cc
+++ b/src/index/emb_list/emb_list_strategy_lemur.cc
@@ -367,6 +367,15 @@ class LemurEmbListStrategy : public EmbListStrategy {
             return expected<DataSetPtr>::Err(Status::emb_list_inner_error, "ANN search failed");
         }
         const auto* ann_ids = ann_result.value()->GetIds();
+        // Encoded-list ANN search crosses the normal IndexNode boundary and returns
+        // public list out ids. Map them back to compact list ids before using
+        // emb_list_offset_ and rerank state.
+        auto to_in_list_id = [&](int64_t out_id) -> int64_t {
+            if (out_id < 0) {
+                return -1;
+            }
+            return index->MapOutToIn(out_id);
+        };
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
         auto time = rc.ElapseFromBegin("done");
@@ -385,7 +394,7 @@ class LemurEmbListStrategy : public EmbListStrategy {
             for (size_t q = 0; q < num_query_docs; ++q) {
                 for (int32_t i = 0; i < k; ++i) {
                     if (i < ann_k) {
-                        ids[q * k + i] = ann_ids[q * ann_k + i];
+                        ids[q * k + i] = to_in_list_id(ann_ids[q * ann_k + i]);
                         dists[q * k + i] = ann_dists[q * ann_k + i];
                     } else {
                         ids[q * k + i] = -1;
@@ -420,10 +429,10 @@ class LemurEmbListStrategy : public EmbListStrategy {
             size_t nq = q_vec_end - q_vec_start;
             total_query_vecs += nq;
 
-            // Collect candidate doc IDs (no dedup needed — ANN returns doc-level IDs)
+            // Convert stage1 list/doc out ids to list/doc in ids for rerank.
             candidate_docs.clear();
             for (int32_t i = 0; i < ann_k; ++i) {
-                int64_t doc_id = ann_ids[q * ann_k + i];
+                int64_t doc_id = to_in_list_id(ann_ids[q * ann_k + i]);
                 if (doc_id >= 0 && doc_id < num_docs_) {
                     candidate_docs.push_back(doc_id);
                 }

--- a/src/index/emb_list/emb_list_strategy_lemur.cc
+++ b/src/index/emb_list/emb_list_strategy_lemur.cc
@@ -370,11 +370,11 @@ class LemurEmbListStrategy : public EmbListStrategy {
         // Encoded-list ANN search crosses the normal IndexNode boundary and returns
         // public list out ids. Map them back to compact list ids before using
         // emb_list_offset_ and rerank state.
-        auto to_in_list_id = [&](int64_t out_id) -> int64_t {
+        auto to_in_list_id = [&](int64_t out_id) -> expected<int64_t> {
             if (out_id < 0) {
                 return -1;
             }
-            return index->MapOutToIn(out_id);
+            return index->CompactOutToIn(out_id, static_cast<size_t>(num_docs_));
         };
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
@@ -394,7 +394,11 @@ class LemurEmbListStrategy : public EmbListStrategy {
             for (size_t q = 0; q < num_query_docs; ++q) {
                 for (int32_t i = 0; i < k; ++i) {
                     if (i < ann_k) {
-                        ids[q * k + i] = to_in_list_id(ann_ids[q * ann_k + i]);
+                        auto list_id = to_in_list_id(ann_ids[q * ann_k + i]);
+                        if (!list_id.has_value()) {
+                            return expected<DataSetPtr>::Err(list_id.error(), list_id.what());
+                        }
+                        ids[q * k + i] = list_id.value();
                         dists[q * k + i] = ann_dists[q * ann_k + i];
                     } else {
                         ids[q * k + i] = -1;
@@ -432,7 +436,11 @@ class LemurEmbListStrategy : public EmbListStrategy {
             // Convert stage1 list/doc out ids to list/doc in ids for rerank.
             candidate_docs.clear();
             for (int32_t i = 0; i < ann_k; ++i) {
-                int64_t doc_id = to_in_list_id(ann_ids[q * ann_k + i]);
+                auto doc_id_or = to_in_list_id(ann_ids[q * ann_k + i]);
+                if (!doc_id_or.has_value()) {
+                    return expected<DataSetPtr>::Err(doc_id_or.error(), doc_id_or.what());
+                }
+                int64_t doc_id = doc_id_or.value();
                 if (doc_id >= 0 && doc_id < num_docs_) {
                     candidate_docs.push_back(doc_id);
                 }

--- a/src/index/emb_list/emb_list_strategy_muvera.cc
+++ b/src/index/emb_list/emb_list_strategy_muvera.cc
@@ -212,11 +212,11 @@ class MuveraEmbListStrategy : public EmbListStrategy {
         // Encoded-list ANN search crosses the normal IndexNode boundary and returns
         // public list out ids. Map them back to compact list ids before using
         // emb_list_offset_ and rerank state.
-        auto to_in_list_id = [&](int64_t out_id) -> int64_t {
+        auto to_in_list_id = [&](int64_t out_id) -> expected<int64_t> {
             if (out_id < 0) {
                 return -1;
             }
-            return index->MapOutToIn(out_id);
+            return index->CompactOutToIn(out_id, static_cast<size_t>(num_docs_));
         };
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
@@ -237,7 +237,11 @@ class MuveraEmbListStrategy : public EmbListStrategy {
             for (size_t q = 0; q < num_query_docs; ++q) {
                 for (int32_t i = 0; i < k; ++i) {
                     if (i < ann_k) {
-                        ids[q * k + i] = to_in_list_id(ann_ids[q * ann_k + i]);
+                        auto list_id = to_in_list_id(ann_ids[q * ann_k + i]);
+                        if (!list_id.has_value()) {
+                            return expected<DataSetPtr>::Err(list_id.error(), list_id.what());
+                        }
+                        ids[q * k + i] = list_id.value();
                         dists[q * k + i] = ann_dists[q * ann_k + i];
                     } else {
                         ids[q * k + i] = -1;
@@ -274,7 +278,11 @@ class MuveraEmbListStrategy : public EmbListStrategy {
             // Convert stage1 list/doc out ids to list/doc in ids for rerank.
             candidate_docs.clear();
             for (int32_t i = 0; i < ann_k; ++i) {
-                int64_t doc_id = to_in_list_id(ann_ids[q * ann_k + i]);
+                auto doc_id_or = to_in_list_id(ann_ids[q * ann_k + i]);
+                if (!doc_id_or.has_value()) {
+                    return expected<DataSetPtr>::Err(doc_id_or.error(), doc_id_or.what());
+                }
+                int64_t doc_id = doc_id_or.value();
                 if (doc_id >= 0 && doc_id < num_docs_) {
                     candidate_docs.push_back(doc_id);
                 }

--- a/src/index/emb_list/emb_list_strategy_muvera.cc
+++ b/src/index/emb_list/emb_list_strategy_muvera.cc
@@ -209,6 +209,15 @@ class MuveraEmbListStrategy : public EmbListStrategy {
             return expected<DataSetPtr>::Err(Status::emb_list_inner_error, "ANN search failed");
         }
         const auto* ann_ids = ann_result.value()->GetIds();
+        // Encoded-list ANN search crosses the normal IndexNode boundary and returns
+        // public list out ids. Map them back to compact list ids before using
+        // emb_list_offset_ and rerank state.
+        auto to_in_list_id = [&](int64_t out_id) -> int64_t {
+            if (out_id < 0) {
+                return -1;
+            }
+            return index->MapOutToIn(out_id);
+        };
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
         auto time = rc.ElapseFromBegin("done");
@@ -228,7 +237,7 @@ class MuveraEmbListStrategy : public EmbListStrategy {
             for (size_t q = 0; q < num_query_docs; ++q) {
                 for (int32_t i = 0; i < k; ++i) {
                     if (i < ann_k) {
-                        ids[q * k + i] = ann_ids[q * ann_k + i];
+                        ids[q * k + i] = to_in_list_id(ann_ids[q * ann_k + i]);
                         dists[q * k + i] = ann_dists[q * ann_k + i];
                     } else {
                         ids[q * k + i] = -1;
@@ -262,10 +271,10 @@ class MuveraEmbListStrategy : public EmbListStrategy {
             size_t nq = q_vec_end - q_vec_start;
             total_query_vecs += nq;
 
-            // Collect candidate doc IDs (no dedup needed — ANN returns doc-level IDs)
+            // Convert stage1 list/doc out ids to list/doc in ids for rerank.
             candidate_docs.clear();
             for (int32_t i = 0; i < ann_k; ++i) {
-                int64_t doc_id = ann_ids[q * ann_k + i];
+                int64_t doc_id = to_in_list_id(ann_ids[q * ann_k + i]);
                 if (doc_id >= 0 && doc_id < num_docs_) {
                     candidate_docs.push_back(doc_id);
                 }

--- a/src/index/emb_list/emb_list_strategy_token_ann.cc
+++ b/src/index/emb_list/emb_list_strategy_token_ann.cc
@@ -28,7 +28,7 @@
 
 namespace knowhere {
 
-// TokenANNEmbListStrategy indexes all vectors and aggregates scores at search time.
+// TokenANN indexes vectors and aggregates scores by embedding list.
 class TokenANNEmbListStrategy : public EmbListStrategy {
  public:
     [[nodiscard]] std::string
@@ -42,9 +42,10 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
         return std::optional<DataSetPtr>(dataset);
     }
 
+    // Base ANN searches vector ids; filters are public list-id based.
     [[nodiscard]] bool
     NeedsBaseIndexIDMap() const override {
-        return true;  // needs vector_id -> doc_id mapping for bitset filtering
+        return true;
     }
 
     expected<DataSetPtr>
@@ -54,7 +55,6 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
             return expected<DataSetPtr>::Err(Status::emb_list_inner_error, "emb_list_offset not initialized");
         }
 
-        // Parse config and metric
         auto& config = static_cast<BaseConfig&>(*cfg);
         auto k = config.k.value();
         auto metric_or = ParseEmbListMetric(config);
@@ -74,7 +74,6 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
         }
         auto query_code_size = query_code_size_opt.value();
 
-        // Stage 1: Batch ANN search to retrieve top k' vectors per query vector
         auto retrieval_ann_ratio = config.retrieval_ann_ratio.value();
         if (retrieval_ann_ratio <= 0.0f) {
             auto err_msg = "retrieval_ann_ratio could not be less than or equal to 0";
@@ -91,6 +90,7 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
 
         config.k = vec_topk;
         config.metric_type = mi.sub_metric_type;
+        // Base search returns compact vector ids for list candidate lookup.
         auto ann_search_res = index->Search(query_dataset, std::move(cfg), bitset, op_context);
         if (!ann_search_res.has_value()) {
             LOG_KNOWHERE_ERROR_ << "Failed ANN search: " << ann_search_res.what();
@@ -112,7 +112,6 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
         auto ids = std::make_unique<int64_t[]>(num_q_el * k);
         auto dists = std::make_unique<float[]>(num_q_el * k);
 
-        // Stage 2: For each query doc, collect unique docs from stage 1, then rerank
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
         TimeRecorder rc2("Emb List Search - 2nd round bf and agg");
 #endif
@@ -127,7 +126,6 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
             auto end_offset = query_offset.offset[i + 1];
             auto nq = end_offset - start_offset;
 
-            // Collect unique doc IDs from stage 1 results
             el_ids_set.clear();
             for (size_t j = start_offset * vec_topk; j < end_offset * vec_topk; j++) {
                 if (stage1_ids[j] < 0) {
@@ -136,7 +134,6 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
                 el_ids_set.emplace(emb_list_offset_->get_el_id(static_cast<size_t>(stage1_ids[j])));
             }
 
-            // Convert to vector for RerankByCalcDistByIDs
             candidate_docs.clear();
             for (const auto& el_id : el_ids_set) {
                 if (el_id >= emb_list_offset_->num_el()) {
@@ -147,7 +144,6 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
             }
             total_candidates += candidate_docs.size();
 
-            // Compute aggregated score for each candidate
             auto tensor = static_cast<const char*>(query_dataset->GetTensor());
             size_t tensor_offset = start_offset * query_code_size;
             auto bf_query_dataset = GenDataSet(nq, dim, tensor + tensor_offset);

--- a/src/index/faiss/faiss.cc
+++ b/src/index/faiss/faiss.cc
@@ -215,7 +215,9 @@ class FaissIndexNode : public IndexNode {
             LOG_KNOWHERE_ERROR_ << "faiss search failed: " << e.what();
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
         }
-        return GenResultDataSet(nq, k, std::move(ids), std::move(distances));
+        auto res = GenResultDataSet(nq, k, std::move(ids), std::move(distances));
+        MapSearchResultIdsToOutIds(res);
+        return res;
     }
 
     expected<DataSetPtr>
@@ -282,7 +284,9 @@ class FaissIndexNode : public IndexNode {
 
             const bool is_ip = is_cosine_ || IsMetricType(fc->metric_type.value(), knowhere::metric::IP);
             auto rr = GetRangeSearchResult(result_distances, result_labels, is_ip, nq, radius, range_filter);
-            return GenResultDataSet(nq, std::move(rr));
+            auto res = GenResultDataSet(nq, std::move(rr));
+            MapSearchResultIdsToOutIds(res);
+            return res;
         }
     }
 

--- a/src/index/flat/flat.cc
+++ b/src/index/flat/flat.cc
@@ -146,7 +146,9 @@ class FlatIndexNode : public IndexNode {
             LOG_KNOWHERE_WARNING_ << "error inner faiss: " << e.what();
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
         }
-        return GenResultDataSet(nq, k, ids, distances);
+        auto res = GenResultDataSet(nq, k, ids, distances);
+        MapSearchResultIdsToOutIds(res);
+        return res;
     }
 
     expected<DataSetPtr>
@@ -226,7 +228,9 @@ class FlatIndexNode : public IndexNode {
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
         }
 
-        return GenResultDataSet(nq, std::move(range_search_result));
+        auto res = GenResultDataSet(nq, std::move(range_search_result));
+        MapSearchResultIdsToOutIds(res);
+        return res;
     }
 
     expected<DataSetPtr>
@@ -234,6 +238,8 @@ class FlatIndexNode : public IndexNode {
         auto dim = Dim();
         auto rows = dataset->GetRows();
         auto ids = dataset->GetIds();
+        std::vector<int64_t> in_ids;
+        ids = this->MapOutToIn(ids, rows, in_ids);
         if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
             DataType* data = nullptr;
             try {

--- a/src/index/flat/flat.cc
+++ b/src/index/flat/flat.cc
@@ -235,11 +235,18 @@ class FlatIndexNode : public IndexNode {
 
     expected<DataSetPtr>
     GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context) const override {
+        if (dataset == nullptr) {
+            return expected<DataSetPtr>::Err(Status::invalid_args, "GetVectorByIds dataset is null");
+        }
         auto dim = Dim();
         auto rows = dataset->GetRows();
         auto ids = dataset->GetIds();
         std::vector<int64_t> in_ids;
-        ids = this->MapOutToIn(ids, rows, in_ids);
+        auto storage_ids = this->CompactOutToIn(ids, rows, in_ids, static_cast<size_t>(index_->ntotal));
+        if (!storage_ids.has_value()) {
+            return expected<DataSetPtr>::Err(storage_ids.error(), storage_ids.what());
+        }
+        ids = storage_ids.value();
         if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
             DataType* data = nullptr;
             try {

--- a/src/index/gpu_cuvs/gpu_cuvs.h
+++ b/src/index/gpu_cuvs/gpu_cuvs.h
@@ -17,10 +17,12 @@
 #ifndef GPU_CUVS_H
 #define GPU_CUVS_H
 
+#include <algorithm>
 #include <cstdint>
 #include <exception>
 #include <fstream>
 #include <istream>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <thread>
@@ -75,6 +77,11 @@ struct GpuCuvsIndexNode : public IndexNode {
     using data_type = typename cuvs_knowhere::cuvs_data_type_mapper<DataType>::data_type;
 
     GpuCuvsIndexNode(int32_t, const Object& object) {
+    }
+
+    bool
+    NeedBitsetExactCount() const override {
+        return true;
     }
 
     Status
@@ -133,11 +140,46 @@ struct GpuCuvsIndexNode : public IndexNode {
                     LOG_KNOWHERE_ERROR_ << "Empty index.";
                     return expected<DataSetPtr>::Err(Status::empty_index, "empty index");
                 }
-                auto search_result =
-                    index_->search(cuvs_cfg, data, rows, dim, bitset.data(), bitset.byte_size(), bitset.size());
+                std::vector<uint8_t> in_bitset;
+                BitsetView in_bitset_view;
+                const BitsetView* search_bitset = nullptr;
+                const auto has_bitset = bitset.data() != nullptr && bitset.num_bits() != 0;
+                if (has_bitset && bitset.has_out_ids()) {
+                    // cuVS accepts a contiguous bitset in the searched id domain. If PrepareBitset()
+                    // installed an internal-id -> public-id view, materialize the equivalent
+                    // internal-id bitset before calling cuVS.
+                    const auto in_bit_count = bitset.out_ids_count();
+                    in_bitset.assign((in_bit_count + 7) / 8, 0);
+                    for (size_t in_id = 0; in_id < in_bit_count; ++in_id) {
+                        if (bitset.test(in_id)) {
+                            in_bitset[in_id >> 3] |= static_cast<uint8_t>(1U << (in_id & 7));
+                        }
+                    }
+                    in_bitset_view = BitsetView(in_bitset.data(), in_bit_count, bitset.count());
+                    search_bitset = &in_bitset_view;
+                } else if (has_bitset) {
+                    search_bitset = &bitset;
+                }
+                if (search_bitset != nullptr) {
+                    const auto filtered_count = search_bitset->count();
+                    if (filtered_count >= search_bitset->size()) {
+                        const auto output_count = static_cast<size_t>(cuvs_cfg.k) * rows;
+                        auto p_id = std::make_unique<int64_t[]>(output_count);
+                        auto p_dist = std::make_unique<float[]>(output_count);
+                        std::fill_n(p_id.get(), output_count, -1);
+                        std::fill_n(p_dist.get(), output_count, std::numeric_limits<float>::infinity());
+                        return GenResultDataSet(rows, cuvs_cfg.k, p_id.release(), p_dist.release());
+                    }
+                }
+                auto search_result = search_bitset == nullptr
+                                         ? index_->search(cuvs_cfg, data, rows, dim)
+                                         : index_->search(cuvs_cfg, data, rows, dim, search_bitset->data(),
+                                                          search_bitset->byte_size(), search_bitset->size());
                 std::this_thread::yield();
                 index_->synchronize();
-                return GenResultDataSet(rows, cuvs_cfg.k, std::get<0>(search_result), std::get<1>(search_result));
+                auto res = GenResultDataSet(rows, cuvs_cfg.k, std::get<0>(search_result), std::get<1>(search_result));
+                MapSearchResultIdsToOutIds(res);
+                return res;
             } catch (const std::exception& e) {
                 err_msg = std::string{e.what()};
                 LOG_KNOWHERE_ERROR_ << e.what();

--- a/src/index/gpu_cuvs/gpu_cuvs_cagra.cc
+++ b/src/index/gpu_cuvs/gpu_cuvs_cagra.cc
@@ -81,7 +81,7 @@ class GpuCuvsCagraHybridIndexNode : public GpuCuvsCagraIndexNode<DataType> {
         }
 
         auto res = GenResultDataSet(nq, k, p_id.release(), p_dist.release());
-
+        this->MapSearchResultIdsToOutIds(res);
         return res;
     }
     Status

--- a/src/index/hnsw/faiss_hnsw.cc
+++ b/src/index/hnsw/faiss_hnsw.cc
@@ -1172,10 +1172,17 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
     expected<DataSetPtr>
     GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context) const override {
+        if (dataset == nullptr) {
+            return expected<DataSetPtr>::Err(Status::invalid_args, "GetVectorByIds dataset is null");
+        }
         auto rows = dataset->GetRows();
         auto ids = dataset->GetIds();
         std::vector<int64_t> in_ids;
-        ids = this->MapOutToIn(ids, rows, in_ids);
+        auto storage_ids = this->CompactOutToIn(ids, rows, in_ids, static_cast<size_t>(Count()));
+        if (!storage_ids.has_value()) {
+            return expected<DataSetPtr>::Err(storage_ids.error(), storage_ids.what());
+        }
+        ids = storage_ids.value();
         auto storage_ds = GenIdsDataSet(rows, ids);
         return GetVectorByStorageIds(storage_ds, op_context);
     }
@@ -1559,7 +1566,14 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                                         this->emb_list_strategy_->NeedsBaseIndexIDMap();
         std::vector<int64_t> in_labels;
         // Public APIs pass public ids. EmbList rerank passes compact list ids.
-        const auto* labels_to_calc = is_emb_list_rerank ? labels : this->MapOutToIn(labels, labels_len, in_labels);
+        const int64_t* labels_to_calc = labels;
+        if (!is_emb_list_rerank) {
+            auto storage_labels = this->CompactOutToIn(labels, labels_len, in_labels, static_cast<size_t>(Count()));
+            if (!storage_labels.has_value()) {
+                return expected<DataSetPtr>::Err(storage_labels.error(), storage_labels.what());
+            }
+            labels_to_calc = storage_labels.value();
+        }
 
         BitsetView bitset(bitset_);
         auto index_id = getIndexToSearchByScalarInfo(bitset);
@@ -2327,21 +2341,22 @@ class HNSWIndexNodeWithFallback : public IndexNode {
         }
     }
 
-    int64_t
-    MapOutToIn(int64_t out_id) const override {
+    expected<int64_t>
+    CompactOutToIn(int64_t out_id, size_t compact_count) const override {
         if (use_base_index) {
-            return base_index->MapOutToIn(out_id);
+            return base_index->CompactOutToIn(out_id, compact_count);
         } else {
-            return fallback_search_index->MapOutToIn(out_id);
+            return fallback_search_index->CompactOutToIn(out_id, compact_count);
         }
     }
 
-    const int64_t*
-    MapOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& in_ids) const override {
+    expected<const int64_t*>
+    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids,
+                   size_t compact_count) const override {
         if (use_base_index) {
-            return base_index->MapOutToIn(out_ids, count, in_ids);
+            return base_index->CompactOutToIn(out_ids, count, compact_ids, compact_count);
         } else {
-            return fallback_search_index->MapOutToIn(out_ids, count, in_ids);
+            return fallback_search_index->CompactOutToIn(out_ids, count, compact_ids, compact_count);
         }
     }
 

--- a/src/index/hnsw/faiss_hnsw.cc
+++ b/src/index/hnsw/faiss_hnsw.cc
@@ -83,6 +83,11 @@ class BaseFaissIndexNode : public IndexNode {
         return false;
     }
 
+    bool
+    NeedBitsetExactCount() const override {
+        return true;
+    }
+
     //
     Status
     Train(const DataSetPtr dataset, std::shared_ptr<Config> cfg, bool use_knowhere_build_pool) override {
@@ -345,51 +350,90 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
         return writer.total_size;
     }
 
-    std::shared_ptr<std::vector<uint32_t>>
-    GetInternalIdToExternalIdMap() const override {
-        auto internal_offset_to_label = std::make_shared<std::vector<uint32_t>>();
-        assert(indexes.size() > 0);
-        if (indexes.size() == 1) {
-            // without mv-only labels, the id mapping is the same as the internal offset.
-            internal_offset_to_label->resize(Count());
-            std::iota(internal_offset_to_label->begin(), internal_offset_to_label->end(), 0);
-        } else {
-            // faiss_hnsw has stored mv-only labels (id mapping for each mv-index) *separately*, not a contiguous
-            // memory block. Note that the mv-only labels have a fixed serialization format; changing the design of
-            // labels would affect index version compatibility.
-            // so a temporary vector must be created to memcpy all id mappings.
-            auto total_size = index_rows_sum[index_rows_sum.size() - 1];
-            assert(total_size == Count());
-            internal_offset_to_label->resize(total_size);
-            for (auto par_idx = 0; par_idx < index_rows_sum.size() - 1; ++par_idx) {
-                auto par_size = index_rows_sum[par_idx + 1] - index_rows_sum[par_idx];
-                assert(par_size == labels[par_idx]->size());
-                std::memcpy(internal_offset_to_label->data() + index_rows_sum[par_idx], labels[par_idx]->data(),
-                            par_size * sizeof(uint32_t));
-            }
+    Status
+    FinalizeIdMap() override {
+        auto status = IndexNode::FinalizeIdMap();
+        if (status != Status::success) {
+            return status;
         }
-        return internal_offset_to_label;
+        BuildBitsetOutIds();
+        return Status::success;
     }
 
-    Status
-    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) override {
-        internal_offset_to_most_external_id = std::move(map);
-        return Status::success;
+ protected:
+    int64_t
+    MapLocalIdToSearchResultId(size_t index_id, int64_t local_id) const {
+        if (local_id < 0) {
+            return local_id;
+        }
+        if (!labels.empty()) {
+            return labels[index_id]->operator[](local_id);
+        }
+        return local_id;
+    }
+
+    void
+    BuildBitsetOutIds() {
+        // Multi-index HNSW selectors see local FAISS ids; filters use public ids.
+        bitset_out_ids_.clear();
+        if (labels.size() <= 1) {
+            return;
+        }
+        const auto use_ebl_map =
+            emb_list_offset_ != nullptr && emb_list_strategy_ != nullptr && emb_list_strategy_->NeedsBaseIndexIDMap();
+        const auto& id_map = GetIdMap();
+        const auto& in_to_out_ebl_ids = id_map.InToOutIds(IdMap::Domain::EMB_LIST);
+        const auto& in_to_out_ids = id_map.InToOutIds();
+
+        bitset_out_ids_.resize(labels.size());
+        for (size_t index_id = 0; index_id < labels.size(); ++index_id) {
+            const auto& local_labels = *labels[index_id];
+            std::vector<int32_t> mapped_out_ids;
+            mapped_out_ids.reserve(local_labels.size());
+            for (const auto in_id : local_labels) {
+                int64_t out_id = in_id;
+                if (use_ebl_map && !in_to_out_ebl_ids.empty()) {
+                    out_id = in_to_out_ebl_ids[in_id];
+                } else if (!use_ebl_map && !in_to_out_ids.empty()) {
+                    out_id = in_to_out_ids[in_id];
+                }
+                mapped_out_ids.push_back(static_cast<int32_t>(out_id));
+            }
+
+            IdArray out_ids;
+            out_ids.SetType(IdArray::Type::ARRAY);
+            if (!mapped_out_ids.empty()) {
+                out_ids.Set(mapped_out_ids.data(), mapped_out_ids.size());
+            }
+            bitset_out_ids_[index_id] = std::move(out_ids);
+        }
+    }
+
+    void
+    PrepareBitsetForSubIndex(BitsetView& bitset, size_t index_id) const {
+        const auto& out_ids = bitset_out_ids_[index_id];
+        // The prepared count is global; only selector id translation changes.
+        const auto valid_count = bitset.size() - bitset.count();
+
+        bitset.set_id_offset(0);
+        bitset.set_out_ids(out_ids, out_ids.size());
+        bitset.set_vector_count(out_ids.size());
+        bitset.set_filter_count(out_ids.size() - valid_count);
     }
 
  protected:
     // it is std::shared_ptr, not std::unique_ptr, because it can be
     //    shared with FaissHnswIterator
     std::vector<std::shared_ptr<faiss::Index>> indexes;
-    // each index's out ids(label), can be shared with FaissHnswIterator
+    // Local FAISS id -> global vector id labels for each sub-index.
     std::vector<std::shared_ptr<std::vector<uint32_t>>> labels;
+    // Local FAISS id -> public id for multi-index selectors.
+    std::vector<IdArray> bitset_out_ids_;
 
-    // index rows, help to locate index id by offset
+    // Prefix sums of sub-index row counts.
     std::vector<uint32_t> index_rows_sum;
-    // label to locate internal offset
+    // Global vector id -> internal offset in multi-index storage.
     std::vector<uint32_t> label_to_internal_offset;
-    // internal offset to most external id, only for 1-hop bitset check
-    std::vector<uint32_t> internal_offset_to_most_external_id;
 
     int
     getIndexToSearchByScalarInfo(const BitsetView& bitset) const {
@@ -400,19 +444,15 @@ class BaseFaissRegularIndexNode : public BaseFaissIndexNode {
             LOG_KNOWHERE_WARNING_ << "partition key value not correctly set";
             return -1;
         }
-        // all data is filtered, just pick the first one
-        // this will not happen combined with milvus, which will not call knowhere and just return
-        if (bitset.count() == bitset.size()) {
+        size_t first_valid_index = bitset.get_first_valid_index();
+        if (first_valid_index >= label_to_internal_offset.size()) {
             return 0;
         }
-        size_t first_valid_index = bitset.get_first_valid_index();
-        if (!bitset.has_out_ids()) {
-            first_valid_index = label_to_internal_offset[first_valid_index];
-        }
+        first_valid_index = label_to_internal_offset[first_valid_index];
         auto it = std::upper_bound(index_rows_sum.begin(), index_rows_sum.end(), first_valid_index);
 
         if (it == index_rows_sum.end()) {
-            LOG_KNOWHERE_WARNING_ << "can not find vector of offset " << label_to_internal_offset[first_valid_index];
+            LOG_KNOWHERE_WARNING_ << "can not find vector of offset " << first_valid_index;
             return -1;
         }
         return std::distance(index_rows_sum.begin(), it) - 1;
@@ -1132,6 +1172,17 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
     expected<DataSetPtr>
     GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context) const override {
+        auto rows = dataset->GetRows();
+        auto ids = dataset->GetIds();
+        std::vector<int64_t> in_ids;
+        ids = this->MapOutToIn(ids, rows, in_ids);
+        auto storage_ds = GenIdsDataSet(rows, ids);
+        return GetVectorByStorageIds(storage_ds, op_context);
+    }
+
+ protected:
+    expected<DataSetPtr>
+    GetVectorByStorageIds(const DataSetPtr dataset, milvus::OpContext* op_context) const override {
         if (indexes.empty()) {
             return expected<DataSetPtr>::Err(Status::empty_index, "index not loaded");
         }
@@ -1163,19 +1214,25 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         auto rows = dataset->GetRows();
         auto ids = dataset->GetIds();
 
-        auto get_vector = [&](int64_t id, float* result) -> bool {
+        auto get_internal_offset = [&](int64_t id) -> int64_t {
             if (indexes.size() == 1) {
-                indexes_to_reconstruct_from[0]->reconstruct(id, result);
-            } else {
-                auto it =
-                    std::lower_bound(index_rows_sum.begin(), index_rows_sum.end(), label_to_internal_offset[id] + 1);
-                if (it == index_rows_sum.end()) {
-                    return false;
-                }
-                auto index_id = std::distance(index_rows_sum.begin(), it) - 1;
-                indexes_to_reconstruct_from[index_id]->reconstruct(
-                    label_to_internal_offset[id] - index_rows_sum[index_id], result);
+                return id;
             }
+            return label_to_internal_offset[static_cast<size_t>(id)];
+        };
+
+        auto get_vector = [&](int64_t id, float* result) -> bool {
+            auto offset = get_internal_offset(id);
+            if (indexes.size() == 1) {
+                indexes_to_reconstruct_from[0]->reconstruct(offset, result);
+                return true;
+            }
+            auto it = std::lower_bound(index_rows_sum.begin(), index_rows_sum.end(), offset + 1);
+            if (it == index_rows_sum.end()) {
+                return false;
+            }
+            auto index_id = std::distance(index_rows_sum.begin(), it) - 1;
+            indexes_to_reconstruct_from[index_id]->reconstruct(offset - index_rows_sum[index_id], result);
             return true;
         };
 
@@ -1188,7 +1245,6 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                 auto data = std::make_unique<float[]>(dim * rows);
                 for (int64_t i = 0; i < rows; i++) {
                     const int64_t id = ids[i];
-                    assert(id >= 0 && id < Count());
                     if (!get_vector(id, data.get() + i * dim)) {
                         return expected<DataSetPtr>::Err(Status::invalid_index_error,
                                                          "index inner error, cannot proceed with GetVectorByIds");
@@ -1202,7 +1258,6 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                 auto tmp = std::make_unique<float[]>(dim);
                 for (int64_t i = 0; i < rows; i++) {
                     const int64_t id = ids[i];
-                    assert(id >= 0 && id < Count());
                     if (!get_vector(id, tmp.get())) {
                         return expected<DataSetPtr>::Err(Status::invalid_index_error,
                                                          "index inner error, cannot proceed with GetVectorByIds");
@@ -1219,7 +1274,6 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                 auto tmp = std::make_unique<float[]>(dim);
                 for (int64_t i = 0; i < rows; i++) {
                     const int64_t id = ids[i];
-                    assert(id >= 0 && id < Count());
                     if (!get_vector(id, tmp.get())) {
                         return expected<DataSetPtr>::Err(Status::invalid_index_error,
                                                          "index inner error, cannot proceed with GetVectorByIds");
@@ -1236,7 +1290,6 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                 auto tmp = std::make_unique<float[]>(dim);
                 for (int64_t i = 0; i < rows; i++) {
                     const int64_t id = ids[i];
-                    assert(id >= 0 && id < Count());
                     if (!get_vector(id, tmp.get())) {
                         return expected<DataSetPtr>::Err(Status::invalid_index_error,
                                                          "index inner error, cannot proceed with GetVectorByIds");
@@ -1254,7 +1307,6 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                 auto tmp = std::make_unique<float[]>(uint8_dim);
                 for (int64_t i = 0; i < rows; i++) {
                     const int64_t id = ids[i];
-                    assert(id >= 0 && id < Count());
                     if (!get_vector(id, tmp.get())) {
                         return expected<DataSetPtr>::Err(Status::invalid_index_error,
                                                          "index inner error, cannot proceed with GetVectorByIds");
@@ -1273,6 +1325,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         }
     }
 
+ public:
     expected<DataSetPtr>
     Search(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset_,
            milvus::OpContext* op_context) const override {
@@ -1296,36 +1349,12 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         const auto k = hnsw_cfg.k.value();
 
         BitsetView bitset(bitset_);
-        if (!internal_offset_to_most_external_id.empty()) {
-            if (emb_list_offset_ != nullptr) {
-                // if emb list, manually calculate the number of filtered out ids
-                size_t num_filtered_out_ids = 0;
-                for (size_t i = 0; i < bitset.size(); i++) {
-                    if (bitset.test(i)) {
-                        num_filtered_out_ids += emb_list_offset_->offset[i + 1] - emb_list_offset_->offset[i];
-                    }
-                }
-                bitset.set_out_ids(internal_offset_to_most_external_id.data(),
-                                   internal_offset_to_most_external_id.size(), num_filtered_out_ids);
-            } else {
-                bitset.set_out_ids(internal_offset_to_most_external_id.data(),
-                                   internal_offset_to_most_external_id.size());
-            }
-        }
         auto index_id = getIndexToSearchByScalarInfo(bitset);
         if (index_id < 0) {
             return expected<DataSetPtr>::Err(Status::invalid_args, "partition key value not correctly set");
         }
         if (indexes.size() > 1) {
-            // calculate more accurate filter statistics for the single mv-index.
-            size_t num_mv_ids = labels[index_id].get()->size();
-            size_t num_mv_filtered_out_ids = num_mv_ids - (bitset.size() - bitset.count());
-            if (!bitset.has_out_ids()) {
-                bitset.set_out_ids(labels[index_id].get()->data(), num_mv_ids, num_mv_filtered_out_ids);
-            } else {
-                bitset.set_out_ids(internal_offset_to_most_external_id.data(), num_mv_ids, num_mv_filtered_out_ids);
-                bitset.set_id_offset(index_rows_sum[index_id]);
-            }
+            PrepareBitsetForSubIndex(bitset, index_id);
         }
 
         feder::hnsw::FederResultUniq feder_result;
@@ -1383,7 +1412,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
         // set up a selector
         BitsetViewIDSelector bw_idselector(bitset);
-        faiss::IDSelector* id_selector = &bw_idselector;
+        faiss::IDSelector* id_selector = !bitset.empty() ? &bw_idselector : nullptr;
         hnsw_search_params.sel = id_selector;
 
         // run
@@ -1456,10 +1485,8 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                         }
                     }
 
-                    if (!labels.empty()) {
-                        for (int j = 0; j < k; ++j) {
-                            local_ids[j] = local_ids[j] < 0 ? local_ids[j] : labels[index_id]->operator[](local_ids[j]);
-                        }
+                    for (int j = 0; j < k; ++j) {
+                        local_ids[j] = MapLocalIdToSearchResultId(index_id, local_ids[j]);
                     }
                 }));
             }
@@ -1472,6 +1499,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         }
 
         auto res = GenResultDataSet(rows, k, std::move(ids), std::move(distances));
+        MapSearchResultIdsToOutIds(res);
 
         // set visit_info json string into result dataset
         if (feder_result != nullptr) {
@@ -1527,15 +1555,13 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         const auto rows = dataset->GetRows();
         const float* data = static_cast<const float*>(dataset->GetTensor());
         auto distances = std::make_unique<float[]>(rows * labels_len);
+        const bool is_emb_list_rerank = this->emb_list_offset_ != nullptr && this->emb_list_strategy_ != nullptr &&
+                                        this->emb_list_strategy_->NeedsBaseIndexIDMap();
+        std::vector<int64_t> in_labels;
+        // Public APIs pass public ids. EmbList rerank passes compact list ids.
+        const auto* labels_to_calc = is_emb_list_rerank ? labels : this->MapOutToIn(labels, labels_len, in_labels);
 
         BitsetView bitset(bitset_);
-        if (!internal_offset_to_most_external_id.empty()) {
-            // Note: We do not need to calculate the actual number of filtered ids here;
-            // we only need the bitset to determine the index_id.
-            int32_t num_filtered_out_ids = 0;
-            bitset.set_out_ids(internal_offset_to_most_external_id.data(), internal_offset_to_most_external_id.size(),
-                               num_filtered_out_ids);
-        }
         auto index_id = getIndexToSearchByScalarInfo(bitset);
         if (index_id < 0) {
             return expected<DataSetPtr>::Err(Status::invalid_args, "partition key value not correctly set");
@@ -1569,9 +1595,9 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
                     dist_computer->set_query(cur_query);
                     for (size_t j = 0; j < labels_len; j++) {
-                        auto id = labels[j];
+                        auto id = labels_to_calc[j];
                         if (indexes.size() > 1) {
-                            id = label_to_internal_offset[labels[j]] - index_rows_sum[index_id];
+                            id = label_to_internal_offset[labels_to_calc[j]] - index_rows_sum[index_id];
                         }
                         distances[idx * labels_len + j] = (*dist_computer)(id);
                     }
@@ -1600,13 +1626,12 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
             BitsetView bitset_check(bitset_);
             auto whether_bf = WhetherPerformBruteForceRangeSearch(indexes[0].get(), hnsw_cfg_check, bitset_check);
             if (!whether_bf.has_value() || !whether_bf.value()) {
-                // Not brute-force worthy: use iterator path
                 return IndexNode::RangeSearch(dataset, std::move(cfg), bitset_, op_context);
             }
-            // Fall through to brute-force range search path below
         } else if (is_ann_iterator_supported()) {
             return IndexNode::RangeSearch(dataset, std::move(cfg), bitset_, op_context);
         }
+
         if (this->indexes.empty()) {
             return expected<DataSetPtr>::Err(Status::empty_index, "index not loaded");
         }
@@ -1625,22 +1650,12 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
         const auto hnsw_cfg = static_cast<const FaissHnswConfig&>(*cfg);
         BitsetView bitset(bitset_);
-        if (!internal_offset_to_most_external_id.empty()) {
-            bitset.set_out_ids(internal_offset_to_most_external_id.data(), internal_offset_to_most_external_id.size());
-        }
         auto index_id = getIndexToSearchByScalarInfo(bitset);
         if (index_id < 0) {
             return expected<DataSetPtr>::Err(Status::invalid_args, "partition key value not correctly set");
         }
         if (indexes.size() > 1) {
-            size_t num_mv_ids = labels[index_id].get()->size();
-            size_t num_mv_filtered_out_ids = num_mv_ids - (bitset.size() - bitset.count());
-            if (!bitset.has_out_ids()) {
-                bitset.set_out_ids(labels[index_id].get()->data(), num_mv_ids, num_mv_filtered_out_ids);
-            } else {
-                bitset.set_out_ids(internal_offset_to_most_external_id.data(), num_mv_ids, num_mv_filtered_out_ids);
-                bitset.set_id_offset(index_rows_sum[index_id]);
-            }
+            PrepareBitsetForSubIndex(bitset, index_id);
         }
 
         const bool is_similarity_metric =
@@ -1693,7 +1708,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
         // set up a selector
         BitsetViewIDSelector bw_idselector(bitset);
-        faiss::IDSelector* id_selector = &bw_idselector;
+        faiss::IDSelector* id_selector = !bitset.empty() ? &bw_idselector : nullptr;
         hnsw_search_params.sel = id_selector;
 
         ////////////////////////////////////////////////////////////////
@@ -1748,17 +1763,9 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                         result_dist_array[idx].resize(elem_cnt);
                         result_id_array[idx].resize(elem_cnt);
 
-                        if (labels.empty()) {
-                            for (size_t j = 0; j < elem_cnt; j++) {
-                                result_dist_array[idx][j] = res.distances[j];
-                                result_id_array[idx][j] = res.labels[j];
-                            }
-                        } else {
-                            for (size_t j = 0; j < elem_cnt; j++) {
-                                result_dist_array[idx][j] = res.distances[j];
-                                result_id_array[idx][j] =
-                                    res.labels[j] < 0 ? res.labels[j] : labels[index_id]->operator[](res.labels[j]);
-                            }
+                        for (size_t j = 0; j < elem_cnt; j++) {
+                            result_dist_array[idx][j] = res.distances[j];
+                            result_id_array[idx][j] = MapLocalIdToSearchResultId(index_id, res.labels[j]);
                         }
 
                         if (hnsw_cfg.range_filter.value() != defaultRangeFilter) {
@@ -1779,7 +1786,9 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         RangeSearchResult range_search_result =
             GetRangeSearchResult(result_dist_array, result_id_array, is_similarity_metric, rows, radius, range_filter);
 
-        return GenResultDataSet(rows, std::move(range_search_result));
+        auto res = GenResultDataSet(rows, std::move(range_search_result));
+        MapSearchResultIdsToOutIds(res);
+        return res;
     }
 
  protected:
@@ -1960,28 +1969,20 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
 
         const FaissHnswConfig& hnsw_cfg = static_cast<const FaissHnswConfig&>(*cfg);
         BitsetView bitset(bitset_);
-        if (!internal_offset_to_most_external_id.empty()) {
-            bitset.set_out_ids(internal_offset_to_most_external_id.data(), internal_offset_to_most_external_id.size());
-        }
         int index_id = getIndexToSearchByScalarInfo(bitset);
         if (index_id < 0) {
             return expected<std::vector<IndexNode::IteratorPtr>>::Err(Status::invalid_args,
                                                                       "partition key value not correctly set");
         }
         if (indexes.size() > 1) {
-            size_t num_mv_ids = labels[index_id].get()->size();
-            size_t num_mv_filtered_out_ids = num_mv_ids - (bitset.size() - bitset.count());
-            if (!bitset.has_out_ids()) {
-                bitset.set_out_ids(labels[index_id].get()->data(), num_mv_ids, num_mv_filtered_out_ids);
-            } else {
-                bitset.set_out_ids(internal_offset_to_most_external_id.data(), num_mv_ids, num_mv_filtered_out_ids);
-                bitset.set_id_offset(index_rows_sum[index_id]);
-            }
+            PrepareBitsetForSubIndex(bitset, index_id);
         }
         const bool is_cosine = IsMetricType(hnsw_cfg.metric_type.value(), knowhere::metric::COSINE);
         const bool larger_is_closer = (IsMetricType(hnsw_cfg.metric_type.value(), knowhere::metric::IP) || is_cosine);
 
         const auto ef = hnsw_cfg.ef.value_or(kIteratorSeedEf);
+        const auto& id_map = GetIdMap();
+        const auto* result_id_map = SearchResultIdMap(id_map);
 
         try {
             for (int64_t i = 0; i < n_queries; i++) {
@@ -1999,7 +2000,6 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                         convert_rows_to_fp32(data, cur_query.get(), data_format, i, 1, dim);
                         break;
                     default:
-                        // invalid one. Should not be triggered, bcz input parameters are validated.
                         LOG_KNOWHERE_ERROR_ << "unsupported data format: " << static_cast<int>(data_format);
                         return expected<std::vector<IndexNode::IteratorPtr>>::Err(
                             Status::invalid_args,
@@ -2022,6 +2022,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
                     indexes[index_id], labels.empty() ? nullptr : labels[index_id], std::move(cur_query), bitset, ef,
                     larger_is_closer, iterator_refine_ratio, label_to_internal_offset, mv_base_offset,
                     use_knowhere_search_pool);
+                it->SetResultIdMap(result_id_map);
                 // store
                 vec[i] = it;
             }
@@ -2208,6 +2209,24 @@ class HNSWIndexNodeWithFallback : public IndexNode {
         }
     }
 
+    bool
+    NeedBitsetExactCount() const override {
+        if (use_base_index) {
+            return base_index->NeedBitsetExactCount();
+        } else {
+            return fallback_search_index->NeedBitsetExactCount();
+        }
+    }
+
+    Status
+    FinalizeIdMap() override {
+        if (use_base_index) {
+            return base_index->FinalizeIdMap();
+        } else {
+            return fallback_search_index->FinalizeIdMap();
+        }
+    }
+
     Status
     Train(const DataSetPtr dataset, std::shared_ptr<Config> cfg, bool use_knowhere_build_pool) override {
         if (use_base_index) {
@@ -2280,6 +2299,61 @@ class HNSWIndexNodeWithFallback : public IndexNode {
         }
     }
 
+    IdMap&
+    GetIdMap() override {
+        if (use_base_index) {
+            return base_index->GetIdMap();
+        } else {
+            return fallback_search_index->GetIdMap();
+        }
+    }
+
+    const IdMap&
+    GetIdMap() const override {
+        if (use_base_index) {
+            return base_index->GetIdMap();
+        } else {
+            return fallback_search_index->GetIdMap();
+        }
+    }
+
+    void
+    SetIdMapType(IdMap::Type type) override {
+        if (base_index != nullptr) {
+            base_index->SetIdMapType(type);
+        }
+        if (fallback_search_index != nullptr) {
+            fallback_search_index->SetIdMapType(type);
+        }
+    }
+
+    int64_t
+    MapOutToIn(int64_t out_id) const override {
+        if (use_base_index) {
+            return base_index->MapOutToIn(out_id);
+        } else {
+            return fallback_search_index->MapOutToIn(out_id);
+        }
+    }
+
+    const int64_t*
+    MapOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& in_ids) const override {
+        if (use_base_index) {
+            return base_index->MapOutToIn(out_ids, count, in_ids);
+        } else {
+            return fallback_search_index->MapOutToIn(out_ids, count, in_ids);
+        }
+    }
+
+    expected<PreparedBitset>
+    PrepareBitset(BitsetView bitset) const override {
+        if (use_base_index) {
+            return base_index->PrepareBitset(bitset);
+        } else {
+            return fallback_search_index->PrepareBitset(bitset);
+        }
+    }
+
     int64_t
     Size() const override {
         if (use_base_index) {
@@ -2344,24 +2418,6 @@ class HNSWIndexNodeWithFallback : public IndexNode {
         } else {
             return fallback_search_index->AnnIterator(dataset, std::move(cfg), bitset, use_knowhere_search_pool,
                                                       op_context);
-        }
-    }
-
-    std::shared_ptr<std::vector<uint32_t>>
-    GetInternalIdToExternalIdMap() const override {
-        if (use_base_index) {
-            return base_index->GetInternalIdToExternalIdMap();
-        } else {
-            return fallback_search_index->GetInternalIdToExternalIdMap();
-        }
-    }
-
-    Status
-    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) override {
-        if (use_base_index) {
-            return base_index->SetInternalIdToMostExternalIdMap(std::move(map));
-        } else {
-            return fallback_search_index->SetInternalIdToMostExternalIdMap(std::move(map));
         }
     }
 

--- a/src/index/hnsw/hnsw.h
+++ b/src/index/hnsw/hnsw.h
@@ -42,6 +42,11 @@ class HnswIndexNode : public IndexNode {
         search_pool_ = ThreadPool::GetGlobalSearchThreadPool();
     }
 
+    bool
+    NeedBitsetExactCount() const override {
+        return true;
+    }
+
     Status
     Train(const DataSetPtr dataset, std::shared_ptr<Config> cfg, bool use_knowhere_build_pool) override {
         auto rows = dataset->GetRows();
@@ -255,6 +260,7 @@ class HnswIndexNode : public IndexNode {
         WaitAllSuccess(futs);
 
         auto res = GenResultDataSet(nq, k, std::move(p_id), std::move(p_dist));
+        MapSearchResultIdsToOutIds(res);
 
         // set visit_info json string into result dataset
         if (feder_result != nullptr) {
@@ -327,11 +333,14 @@ class HnswIndexNode : public IndexNode {
         bool transform =
             (index_->metric_type_ == hnswlib::Metric::INNER_PRODUCT || index_->metric_type_ == hnswlib::Metric::COSINE);
         auto vec = std::vector<IndexNode::IteratorPtr>(nq, nullptr);
+        const auto& id_map = this->GetIdMap();
+        const auto* result_id_map = this->SearchResultIdMap(id_map);
         try {
             for (int i = 0; i < nq; ++i) {
                 auto single_query = (const char*)xq + i * index_->data_size_;
                 auto it = std::make_shared<iterator>(this->index_, single_query, transform, bitset, ef,
                                                      hnsw_cfg.iterator_refine_ratio.value(), use_knowhere_search_pool);
+                it->SetResultIdMap(result_id_map);
                 vec[i] = it;
             }
         } catch (const std::exception& e) {
@@ -409,6 +418,7 @@ class HnswIndexNode : public IndexNode {
             res->SetJsonInfo(json_visit_info.dump());
             res->SetJsonIdSet(json_id_set.dump());
         }
+        MapSearchResultIdsToOutIds(res);
         return res;
     }
 

--- a/src/index/hnsw/impl/IndexBruteForceWrapper.cc
+++ b/src/index/hnsw/impl/IndexBruteForceWrapper.cc
@@ -64,8 +64,8 @@ IndexBruteForceWrapper::search(faiss::idx_t n, const float* __restrict x, faiss:
         dis->set_query(x + i * index->d);
 
         // allocate heap
-        idx_t* const __restrict local_ids = labels + i * index->d;
-        float* const __restrict local_distances = distances + i * index->d;
+        idx_t* const __restrict local_ids = labels + i * k;
+        float* const __restrict local_distances = distances + i * k;
 
         // set up a filter
         faiss::IDSelector* sel = (params == nullptr) ? nullptr : params->sel;

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -11,7 +11,8 @@
 
 #include "knowhere/index/index.h"
 
-#include "fmt/format.h"
+#include <string>
+
 #include "folly/futures/Future.h"
 #include "knowhere/comp/time_recorder.h"
 #include "knowhere/dataset.h"
@@ -38,6 +39,59 @@ LoadConfig(BaseConfig* cfg, const Json& json, knowhere::PARAM_TYPE param_type, c
     return Config::Load(*cfg, json_, param_type, msg);
 }
 
+inline void
+ThrowInvalidIdMapData(const std::string& msg) {
+    throw StatusException(Status::invalid_args, msg);
+}
+
+inline bool
+AddDatasetIdMapData(const DataSetPtr& dataset, IdMap& id_map) {
+    if (dataset == nullptr || !dataset->HasIdMapData()) {
+        return false;
+    }
+
+    try {
+        // Consume nullable id-map input into index-owned state.
+        id_map.AddFromData(dataset->GetIdMapData());
+    } catch (const std::exception& e) {
+        ThrowInvalidIdMapData(e.what());
+    }
+    return true;
+}
+
+// Owns prepared filter state for lazy iterator calls.
+class PreparedBitsetIterator : public IndexNode::iterator {
+ public:
+    PreparedBitsetIterator(IndexNode::IteratorPtr iterator, std::shared_ptr<const IndexNode::PreparedBitset> bitset)
+        : iterator_(std::move(iterator)), bitset_(std::move(bitset)) {
+    }
+
+    expected<std::pair<int64_t, float>>
+    Next() override {
+        return iterator_->Next();
+    }
+
+    [[nodiscard]] expected<bool>
+    HasNext() override {
+        return iterator_->HasNext();
+    }
+
+ private:
+    IndexNode::IteratorPtr iterator_;
+    std::shared_ptr<const IndexNode::PreparedBitset> bitset_;
+};
+
+inline void
+WrapIteratorsWithPreparedBitset(std::vector<IndexNode::IteratorPtr>& iterators,
+                                const std::shared_ptr<const IndexNode::PreparedBitset>& bitset) {
+    if (bitset == nullptr || !bitset->bitset.has_out_ids()) {
+        return;
+    }
+    for (auto& iterator : iterators) {
+        iterator = std::make_shared<PreparedBitsetIterator>(std::move(iterator), bitset);
+    }
+}
+
 #ifdef KNOWHERE_WITH_CARDINAL
 template <typename T>
 inline const std::shared_ptr<Interrupt>
@@ -49,15 +103,27 @@ Index<T>::BuildAsync(const DataSetPtr dataset, const Json& json, const std::chro
             return GuardedCall([&]() -> Status {
                 auto cfg = this->node->CreateConfig();
                 RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Build"));
+                auto& id_map = this->node->GetIdMap();
+                const auto has_id_map = AddDatasetIdMapData(dataset, id_map);
+                if (has_id_map && dataset != nullptr && dataset->GetRows() == 0) {
+                    // All-null nullable build produces id-map metadata only.
+                    return this->node->FinalizeIdMap();
+                }
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
                 TimeRecorder rc("BuildAsync index ", 2);
                 auto res = this->node->BulidAsyncEmbListIfNeed(dataset, std::move(cfg), interrupt.get());
+                if (res == Status::success) {
+                    res = this->node->FinalizeIdMap();
+                }
                 auto time = rc.ElapseFromBegin("done");
                 time *= 0.000001;  // convert to s
                 this->node->GetBuildLatencyMetric().Observe(time);
 #else
-                auto res = this->node->BulidAsyncEmbListIfNeed(dataset, std::move(cfg), Interrupt.get());
+                auto res = this->node->BulidAsyncEmbListIfNeed(dataset, std::move(cfg), interrupt.get());
+                if (res == Status::success) {
+                    res = this->node->FinalizeIdMap();
+                }
 #endif
                 return res;
             });
@@ -86,15 +152,27 @@ Index<T>::Build(const DataSetPtr dataset, const Json& json, bool use_knowhere_bu
     return GuardedCall([&]() -> Status {
         auto cfg = this->node->CreateConfig();
         RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Build"));
+        auto& id_map = this->node->GetIdMap();
+        const auto has_id_map = AddDatasetIdMapData(dataset, id_map);
+        if (has_id_map && dataset != nullptr && dataset->GetRows() == 0) {
+            // All-null nullable build produces id-map metadata only.
+            return this->node->FinalizeIdMap();
+        }
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
         TimeRecorder rc("Build index", 2);
         auto res = this->node->BuildEmbListIfNeed(dataset, std::move(cfg), use_knowhere_build_pool);
+        if (res == Status::success) {
+            res = this->node->FinalizeIdMap();
+        }
         auto time = rc.ElapseFromBegin("done");
         time *= 0.000001;  // convert to s
         this->node->GetBuildLatencyMetric().Observe(time);
 #else
         auto res = this->node->BuildEmbListIfNeed(dataset, std::move(cfg), use_knowhere_build_pool);
+        if (res == Status::success) {
+            res = this->node->FinalizeIdMap();
+        }
 #endif
         return res;
     });
@@ -124,6 +202,11 @@ Index<T>::Add(const DataSetPtr dataset, const Json& json, bool use_knowhere_buil
         auto cfg = this->node->CreateConfig();
         std::string msg;
         RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Add", &msg));
+        auto& id_map = this->node->GetIdMap();
+        AddDatasetIdMapData(dataset, id_map);
+        if (dataset != nullptr && dataset->GetRows() == 0) {
+            return Status::success;
+        }
         return this->node->AddEmbListIfNeed(dataset, std::move(cfg), use_knowhere_build_pool);
     });
 }
@@ -139,26 +222,11 @@ Index<T>::Search(const DataSetPtr dataset, const Json& json, const BitsetView& b
         if (load_status != Status::success) {
             return expected<DataSetPtr>::Err(load_status, msg);
         }
-        // when index is immutable, bitset size should always equal to data count in index
-        // when index is mutable, it could happen that data count larger than bitset size, see
-        // https://github.com/zilliztech/knowhere/issues/70
-        // so something must be wrong at caller side when passed bitset size larger than data count
-        if (bitset_.size() > static_cast<size_t>(this->Count())) {
-            msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
-                              bitset_.size(), this->Count());
-            LOG_KNOWHERE_ERROR_ << msg;
-            return expected<DataSetPtr>::Err(Status::invalid_args, msg);
+        auto bitset_or = this->node->PrepareBitset(bitset_);
+        if (!bitset_or.has_value()) {
+            return expected<DataSetPtr>::Err(bitset_or.error(), bitset_or.what());
         }
-
-        BitsetView bitset;
-        if (bitset_.count() == 0) {
-            // traverse bitset to get the filtered out num
-            auto filtered_out_num = bitset_.get_filtered_out_num_();
-            bitset = BitsetView(bitset_.data(), bitset_.size(), filtered_out_num);
-        } else {
-            // if bitset has filtered out num, use it
-            bitset = bitset_;
-        }
+        auto prepared_bitset = std::move(bitset_or.value());
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
         const BaseConfig& b_cfg = static_cast<const BaseConfig&>(*cfg);
@@ -178,13 +246,13 @@ Index<T>::Search(const DataSetPtr dataset, const Json& json, const BitsetView& b
 
         TimeRecorder rc("Search");
         auto k = cfg->k.value();
-        auto res = this->node->SearchEmbListIfNeed(dataset, std::move(cfg), bitset, op_context);
+        auto res = this->node->SearchEmbListIfNeed(dataset, std::move(cfg), prepared_bitset.bitset, op_context);
         auto time = rc.ElapseFromBegin("done");
         time *= 0.001;  // convert to ms
         this->node->GetSearchLatencyMetric().Observe(time);
         knowhere_search_topk.Observe(k);
 #else
-        auto res = this->node->SearchEmbListIfNeed(dataset, std::move(cfg), bitset, op_context);
+        auto res = this->node->SearchEmbListIfNeed(dataset, std::move(cfg), prepared_bitset.bitset, op_context);
 #endif
         return res;
     });
@@ -201,31 +269,28 @@ Index<T>::AnnIterator(const DataSetPtr dataset, const Json& json, const BitsetVi
         if (status != Status::success) {
             return expected<std::vector<std::shared_ptr<IndexNode::iterator>>>::Err(status, msg);
         }
-        // when index is immutable, bitset size should always equal to data count in index
-        // when index is mutable, it could happen that data count larger than bitset size, see
-        // https://github.com/zilliztech/knowhere/issues/70
-        // so something must be wrong at caller side when passed bitset size larger than data count
-        if (bitset_.size() > static_cast<size_t>(this->Count())) {
-            msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
-                              bitset_.size(), this->Count());
-            LOG_KNOWHERE_ERROR_ << msg;
-            return expected<std::vector<std::shared_ptr<IndexNode::iterator>>>::Err(Status::invalid_args, msg);
+        auto bitset_or = this->node->PrepareBitset(bitset_);
+        if (!bitset_or.has_value()) {
+            return expected<std::vector<std::shared_ptr<IndexNode::iterator>>>::Err(bitset_or.error(),
+                                                                                    bitset_or.what());
         }
-
-        const auto bitset = BitsetView(bitset_.data(), bitset_.size(), bitset_.get_filtered_out_num_());
+        auto prepared_bitset = std::make_shared<IndexNode::PreparedBitset>(std::move(bitset_or.value()));
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
         // note that this time includes only the initial search phase of iterator.
         TimeRecorder rc("AnnIterator");
-        auto res =
-            this->node->AnnIteratorEmbListIfNeed(dataset, std::move(cfg), bitset, use_knowhere_search_pool, op_context);
+        auto res = this->node->AnnIteratorEmbListIfNeed(dataset, std::move(cfg), prepared_bitset->bitset,
+                                                        use_knowhere_search_pool, op_context);
         auto time = rc.ElapseFromBegin("done");
         time *= 0.001;  // convert to ms
         this->node->GetSearchLatencyMetric().Observe(time);
 #else
-        auto res =
-            this->node->AnnIteratorEmbListIfNeed(dataset, std::move(cfg), bitset, use_knowhere_search_pool, op_context);
+        auto res = this->node->AnnIteratorEmbListIfNeed(dataset, std::move(cfg), prepared_bitset->bitset,
+                                                        use_knowhere_search_pool, op_context);
 #endif
+        if (res.has_value()) {
+            WrapIteratorsWithPreparedBitset(res.value(), prepared_bitset);
+        }
         return res;
     });
 }
@@ -241,18 +306,11 @@ Index<T>::RangeSearch(const DataSetPtr dataset, const Json& json, const BitsetVi
         if (status != Status::success) {
             return expected<DataSetPtr>::Err(status, std::move(msg));
         }
-        // when index is immutable, bitset size should always equal to data count in index
-        // when index is mutable, it could happen that data count larger than bitset size, see
-        // https://github.com/zilliztech/knowhere/issues/70
-        // so something must be wrong at caller side when passed bitset size larger than data count
-        if (bitset_.size() > static_cast<size_t>(this->Count())) {
-            msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
-                              bitset_.size(), this->Count());
-            LOG_KNOWHERE_ERROR_ << msg;
-            return expected<DataSetPtr>::Err(Status::invalid_args, msg);
+        auto bitset_or = this->node->PrepareBitset(bitset_);
+        if (!bitset_or.has_value()) {
+            return expected<DataSetPtr>::Err(bitset_or.error(), bitset_or.what());
         }
-
-        const auto bitset = BitsetView(bitset_.data(), bitset_.size(), bitset_.get_filtered_out_num_());
+        auto prepared_bitset = std::move(bitset_or.value());
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
         const BaseConfig& b_cfg = static_cast<const BaseConfig&>(*cfg);
@@ -274,12 +332,12 @@ Index<T>::RangeSearch(const DataSetPtr dataset, const Json& json, const BitsetVi
         // LCOV_EXCL_STOP
 
         TimeRecorder rc("Range Search");
-        auto res = this->node->RangeSearchEmbListIfNeed(dataset, std::move(cfg), bitset, op_context);
+        auto res = this->node->RangeSearchEmbListIfNeed(dataset, std::move(cfg), prepared_bitset.bitset, op_context);
         auto time = rc.ElapseFromBegin("done");
         time *= 0.001;  // convert to ms
         this->node->GetRangeSearchLatencyMetric().Observe(time);
 #else
-        auto res = this->node->RangeSearchEmbListIfNeed(dataset, std::move(cfg), bitset, op_context);
+        auto res = this->node->RangeSearchEmbListIfNeed(dataset, std::move(cfg), prepared_bitset.bitset, op_context);
 #endif
         return res;
     });
@@ -302,8 +360,14 @@ template <typename T>
 inline expected<DataSetPtr>
 Index<T>::CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels,
                         const size_t labels_len, const bool is_cosine, milvus::OpContext* op_context) const noexcept {
-    return GuardedCall(
-        [&]() { return this->node->CalcDistByIDs(dataset, bitset, labels, labels_len, is_cosine, op_context); });
+    return GuardedCall([&]() -> expected<DataSetPtr> {
+        auto bitset_or = this->node->PrepareBitset(bitset);
+        if (!bitset_or.has_value()) {
+            return expected<DataSetPtr>::Err(bitset_or.error(), bitset_or.what());
+        }
+        auto prepared_bitset = std::move(bitset_or.value());
+        return this->node->CalcDistByIDs(dataset, prepared_bitset.bitset, labels, labels_len, is_cosine, op_context);
+    });
 }
 
 template <typename T>
@@ -365,11 +429,17 @@ Index<T>::Deserialize(const BinarySet& binset, const Json& json) noexcept {
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
         TimeRecorder rc("Load index", 2);
         res = this->node->DeserializeEmbListIfNeed(binset, std::move(cfg));
+        if (res == Status::success) {
+            res = this->node->FinalizeIdMap();
+        }
         auto time = rc.ElapseFromBegin("done");
         time *= 0.001;  // convert to ms
         this->node->GetLoadLatencyMetric().Observe(time);
 #else
         res = this->node->DeserializeEmbListIfNeed(binset, std::move(cfg));
+        if (res == Status::success) {
+            res = this->node->FinalizeIdMap();
+        }
 #endif
         return res;
     });
@@ -396,11 +466,17 @@ Index<T>::DeserializeFromFile(const std::string& filename, const Json& json) noe
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
         TimeRecorder rc("Load index from file", 2);
         res = this->node->DeserializeFromFileIfNeed(filename, std::move(cfg));
+        if (res == Status::success) {
+            res = this->node->FinalizeIdMap();
+        }
         auto time = rc.ElapseFromBegin("done");
         time *= 0.001;  // convert to ms
         this->node->GetLoadLatencyMetric().Observe(time);
 #else
         res = this->node->DeserializeFromFileIfNeed(filename, std::move(cfg));
+        if (res == Status::success) {
+            res = this->node->FinalizeIdMap();
+        }
 #endif
         return res;
     });

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -45,9 +45,19 @@ ThrowInvalidIdMapData(const std::string& msg) {
 }
 
 inline bool
-AddDatasetIdMapData(const DataSetPtr& dataset, IdMap& id_map) {
-    if (dataset == nullptr || !dataset->HasIdMapData()) {
+AddDatasetIdMapData(const DataSetPtr& dataset, IdMap& id_map, int64_t indexed_count) {
+    const auto has_id_map_data = dataset != nullptr && dataset->HasIdMapData();
+    if (!has_id_map_data) {
+        if (id_map.IsEnabled()) {
+            ThrowInvalidIdMapData("mapped id map requires id map data for every build/add batch");
+        }
         return false;
+    }
+    if (!id_map.IsEnabled()) {
+        ThrowInvalidIdMapData("id map data requires enabled id map storage");
+    }
+    if (indexed_count > 0 && !id_map.HasVectorMap()) {
+        ThrowInvalidIdMapData("cannot append id map data to a plain index");
     }
 
     try {
@@ -104,7 +114,7 @@ Index<T>::BuildAsync(const DataSetPtr dataset, const Json& json, const std::chro
                 auto cfg = this->node->CreateConfig();
                 RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Build"));
                 auto& id_map = this->node->GetIdMap();
-                const auto has_id_map = AddDatasetIdMapData(dataset, id_map);
+                const auto has_id_map = AddDatasetIdMapData(dataset, id_map, 0);
                 if (has_id_map && dataset != nullptr && dataset->GetRows() == 0) {
                     // All-null nullable build produces id-map metadata only.
                     return this->node->FinalizeIdMap();
@@ -153,7 +163,7 @@ Index<T>::Build(const DataSetPtr dataset, const Json& json, bool use_knowhere_bu
         auto cfg = this->node->CreateConfig();
         RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Build"));
         auto& id_map = this->node->GetIdMap();
-        const auto has_id_map = AddDatasetIdMapData(dataset, id_map);
+        const auto has_id_map = AddDatasetIdMapData(dataset, id_map, 0);
         if (has_id_map && dataset != nullptr && dataset->GetRows() == 0) {
             // All-null nullable build produces id-map metadata only.
             return this->node->FinalizeIdMap();
@@ -203,8 +213,10 @@ Index<T>::Add(const DataSetPtr dataset, const Json& json, bool use_knowhere_buil
         std::string msg;
         RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Add", &msg));
         auto& id_map = this->node->GetIdMap();
-        AddDatasetIdMapData(dataset, id_map);
-        if (dataset != nullptr && dataset->GetRows() == 0) {
+        AddDatasetIdMapData(dataset, id_map, this->node->Count());
+        const auto is_emb_list =
+            dataset != nullptr && dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET) != nullptr;
+        if (dataset != nullptr && dataset->GetRows() == 0 && !is_emb_list) {
             return Status::success;
         }
         return this->node->AddEmbListIfNeed(dataset, std::move(cfg), use_knowhere_build_pool);

--- a/src/index/index_node.cc
+++ b/src/index/index_node.cc
@@ -255,7 +255,6 @@ IndexNode::SearchEmbList(const DataSetPtr dataset, std::unique_ptr<Config> cfg, 
         return expected<DataSetPtr>::Err(Status::emb_list_inner_error, "strategy not initialized");
     }
 
-    // 1. Parse query offset
     const size_t* lims = dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
     if (lims == nullptr) {
         return expected<DataSetPtr>::Err(Status::emb_list_inner_error, "missing emb_list offset, could not search");
@@ -263,8 +262,12 @@ IndexNode::SearchEmbList(const DataSetPtr dataset, std::unique_ptr<Config> cfg, 
     auto num_q_vecs = static_cast<size_t>(dataset->GetRows());
     EmbListOffset query_offset(lims, num_q_vecs);
 
-    // 2. Delegate search to strategy
-    return emb_list_strategy_->Search(dataset, query_offset, this, std::move(cfg), bitset, op_context);
+    auto result = emb_list_strategy_->Search(dataset, query_offset, this, std::move(cfg), bitset, op_context);
+    if (result.has_value()) {
+        // Compact list ids -> public list ids.
+        MapEmbListResultIdsToOutIds(result.value());
+    }
+    return result;
 }
 
 expected<DataSetPtr>
@@ -332,7 +335,7 @@ IndexNode::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_t
                                          "GetEmbListByIds: invalid metric type " + metric_type);
     }
 
-    // Raw data can come from emb_list_raw_index_ (MUVERA/LEMUR) or base index (TokenANN)
+    // Raw vectors come from strategy-owned storage or the base index.
     bool use_raw_index = (emb_list_raw_index_ != nullptr);
     if (!use_raw_index && !HasRawData(sub_metric.value())) {
         return expected<DataSetPtr>::Err(
@@ -343,12 +346,14 @@ IndexNode::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_t
     auto num_el_ids = dataset->GetRows();
     auto el_ids = dataset->GetIds();
     auto dim = use_raw_index ? emb_list_raw_index_->d : Dim();
+    std::vector<int64_t> in_el_ids;
+    // emb_list_offset_ is indexed by compact list id.
+    const auto* ids_to_retrieve = MapOutToIn(el_ids, num_el_ids, in_el_ids);
 
-    // Build the output offset array
     std::vector<size_t> out_offsets(num_el_ids + 1);
     out_offsets[0] = 0;
     for (int64_t i = 0; i < num_el_ids; i++) {
-        auto el_id = el_ids[i];
+        auto el_id = ids_to_retrieve[i];
         if (el_id < 0 || static_cast<size_t>(el_id) >= emb_list_offset_->num_el()) {
             return expected<DataSetPtr>::Err(Status::invalid_args,
                                              "GetEmbListByIds: el_id " + std::to_string(el_id) + " out of range [0, " +
@@ -371,11 +376,11 @@ IndexNode::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_t
     const void* tensor = nullptr;
 
     if (use_raw_index) {
-        // MUVERA/LEMUR: vectors are contiguous per el in emb_list_raw_index_, use reconstruct_n
+        // Strategy-owned raw storage is contiguous per compact list id.
         auto data = std::make_unique<float[]>(total_vecs * dim);
         float* ptr = data.get();
         for (int64_t i = 0; i < num_el_ids; i++) {
-            auto start = static_cast<int64_t>(emb_list_offset_->offset[el_ids[i]]);
+            auto start = static_cast<int64_t>(emb_list_offset_->offset[ids_to_retrieve[i]]);
             auto len = static_cast<int64_t>(out_offsets[i + 1] - out_offsets[i]);
             if (len > 0) {
                 emb_list_raw_index_->reconstruct_n(start, len, ptr);
@@ -384,28 +389,19 @@ IndexNode::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_t
         }
         tensor = data.release();
     } else {
-        // TokenANN: collect vec_ids and use base index GetVectorByIds
-        //
-        // TODO(perf): Vectors within each embedding list are contiguous in the index. However, the current
-        // implementation collects all these contiguous IDs into a flat array and passes them to GetVectorByIds,
-        // which internally calls reconstruct(id, ...) one vector at a time. This could be optimized by using
-        // reconstruct_n(start, len, ...) or direct memcpy from raw data storage, avoiding both the redundant
-        // ID array allocation and per-vector overhead. We don't do this yet because it would require
-        // index-type-specific implementations (HNSW, IVF, FLAT, etc. each store raw data differently),
-        // whereas the current approach works generically across all index types via the GetVectorByIds interface.
+        // Base indexes retrieve by explicit base-vector storage ids.
         std::vector<int64_t> vec_ids;
         vec_ids.reserve(total_vecs);
         for (int64_t i = 0; i < num_el_ids; i++) {
-            size_t start = emb_list_offset_->offset[el_ids[i]];
+            size_t start = emb_list_offset_->offset[ids_to_retrieve[i]];
             size_t len = out_offsets[i + 1] - out_offsets[i];
             for (size_t j = 0; j < len; j++) {
                 vec_ids.push_back(static_cast<int64_t>(start + j));
             }
         }
 
-        // Build result: transfer tensor ownership from GetVectorByIds result to new dataset
         auto vec_dataset = GenIdsDataSet(vec_ids.size(), vec_ids.data());
-        auto res = GetVectorByIds(vec_dataset, op_context);
+        auto res = GetVectorByStorageIds(vec_dataset, op_context);
         if (!res.has_value()) {
             return res;
         }
@@ -429,7 +425,6 @@ IndexNode::BuildEmbList(const DataSetPtr dataset, std::shared_ptr<Config> cfg, c
                         bool use_knowhere_build_pool) {
     auto& config = static_cast<BaseConfig&>(*cfg);
 
-    // 1. Parse metric types
     auto metric_info_or = ParseEmbListMetric(config);
     if (!metric_info_or.has_value()) {
         return metric_info_or.error();
@@ -437,10 +432,8 @@ IndexNode::BuildEmbList(const DataSetPtr dataset, std::shared_ptr<Config> cfg, c
     el_metric_type_ = metric_info_or.value().el_metric_type;
     auto sub_metric_type = metric_info_or.value().sub_metric_type;
 
-    // 2. Create document offset structure
     EmbListOffset doc_offset(lims, num_rows);
 
-    // 3. Create emb_list strategy
     auto strategy_type = config.emb_list_strategy.value_or(meta::EMB_LIST_STRATEGY_TOKENANN);
     auto strategy_or = CreateEmbListStrategy(strategy_type, config);
     if (!strategy_or.has_value()) {
@@ -449,24 +442,20 @@ IndexNode::BuildEmbList(const DataSetPtr dataset, std::shared_ptr<Config> cfg, c
     }
     emb_list_strategy_ = std::move(strategy_or.value());
 
-    // 4. Prepare data for build (strategy may transform data, e.g., FDE encoding in MUVERA)
     auto build_data_or = emb_list_strategy_->PrepareDataForBuild(dataset, doc_offset, config);
     if (!build_data_or.has_value()) {
         LOG_KNOWHERE_WARNING_ << "Failed to prepare data for build";
         return build_data_or.error();
     }
 
-    // Override metric_type to sub_metric for base index build
     config.metric_type = sub_metric_type;
 
-    // 5. Build underlying index (if strategy provides data)
     LOG_KNOWHERE_INFO_ << "Build EmbList-Index with strategy: " << strategy_type << ", metric type: " << el_metric_type_
                        << ", sub metric type: " << sub_metric_type;
     if (build_data_or.value().has_value()) {
         RETURN_IF_ERROR(Build(build_data_or.value().value(), cfg, use_knowhere_build_pool));
     }
 
-    // 6. Create raw vector storage if strategy needs it
     if (emb_list_strategy_->NeedsRawVectorStorage()) {
         auto original_dim = dataset->GetDim();
         auto total_vectors = dataset->GetRows();
@@ -483,15 +472,9 @@ IndexNode::BuildEmbList(const DataSetPtr dataset, std::shared_ptr<Config> cfg, c
         LOG_KNOWHERE_INFO_ << "Created raw vector storage: " << total_vectors << " vectors, dim=" << original_dim;
     }
 
-    // 7. Strategy post-build hook
     RETURN_IF_ERROR(emb_list_strategy_->OnBuildComplete(dataset, doc_offset, config));
 
-    // 8. Set ID mapping if strategy requires it (Direct needs vector->doc mapping)
     emb_list_offset_ = emb_list_strategy_->GetEmbListOffset();
-    if (emb_list_strategy_->NeedsBaseIndexIDMap()) {
-        return SetBaseIndexIDMap();
-    }
-
     return Status::success;
 }
 
@@ -516,12 +499,10 @@ Status
 IndexNode::SerializeEmbList(BinarySet& binset) const {
     LOG_KNOWHERE_INFO_ << "Serialize emb_list with strategy: " << emb_list_strategy_->Type();
     try {
-        // 1. Get strategy blob
         std::shared_ptr<uint8_t[]> strategy_data;
         int64_t strategy_size = 0;
         RETURN_IF_ERROR(emb_list_strategy_->Serialize(strategy_data, strategy_size));
 
-        // 2. Build EMB_LIST_META = [magic][type_len][type][strategy_blob]
         auto strategy_type = emb_list_strategy_->Type();
         size_t type_len = strategy_type.size();
 
@@ -535,7 +516,6 @@ IndexNode::SerializeEmbList(BinarySet& binset) const {
         std::shared_ptr<uint8_t[]> meta_data(writer.data());
         binset.Append(meta::EMB_LIST_META, meta_data, writer.tellg());
 
-        // 3. Raw vector index as separate key (large, needs mmap in file path)
         if (emb_list_raw_index_) {
             MemoryIOWriter writer;
             faiss::cppcontrib::knowhere::write_index(emb_list_raw_index_.get(), &writer);
@@ -547,7 +527,6 @@ IndexNode::SerializeEmbList(BinarySet& binset) const {
         return Status::emb_list_inner_error;
     }
 
-    // 4. Serialize base index
     return Serialize(binset);
 }
 
@@ -555,19 +534,16 @@ Status
 IndexNode::DeserializeEmbListFromBinarySet(const BinarySet& binset, std::shared_ptr<Config> config) {
     auto& cfg = static_cast<knowhere::BaseConfig&>(*config);
 
-    // 1. Parse metric type
     auto metric_info_or = ParseEmbListMetric(cfg);
     if (!metric_info_or.has_value()) {
         return metric_info_or.error();
     }
     el_metric_type_ = metric_info_or.value().el_metric_type;
 
-    // 2. Deserialize base index from BinarySet (override metric_type for base index)
     cfg.metric_type = metric_info_or.value().sub_metric_type;
     RETURN_IF_ERROR(Deserialize(binset, config));
 
     try {
-        // 3. Read EMB_LIST_META and parse strategy type + strategy blob
         auto meta_bin = binset.GetByName(meta::EMB_LIST_META);
         if (!meta_bin) {
             LOG_KNOWHERE_WARNING_ << "EMB_LIST_META not found in binary set";
@@ -577,7 +553,6 @@ IndexNode::DeserializeEmbListFromBinarySet(const BinarySet& binset, std::shared_
         auto [strategy_type, strategy_blob, strategy_blob_size] =
             ParseEmbListMetaHeader(meta_bin->data.get(), meta_bin->size);
 
-        // 4. Create strategy and deserialize strategy-specific data
         auto strategy_or = CreateEmbListStrategy(strategy_type, cfg);
         if (!strategy_or.has_value()) {
             LOG_KNOWHERE_WARNING_ << "Failed to create emb_list strategy: " << strategy_type;
@@ -588,7 +563,6 @@ IndexNode::DeserializeEmbListFromBinarySet(const BinarySet& binset, std::shared_
         LOG_KNOWHERE_INFO_ << "Deserialize emb_list with strategy: " << strategy_type;
         RETURN_IF_ERROR(emb_list_strategy_->Deserialize(strategy_blob, strategy_blob_size, cfg));
 
-        // 5. Deserialize raw vector index from BinarySet (if present)
         auto raw_index_bin = binset.GetByName(meta::EMB_LIST_RAW_INDEX);
         if (raw_index_bin) {
             MemoryIOReader reader(raw_index_bin->data.get(), raw_index_bin->size);
@@ -606,11 +580,8 @@ IndexNode::DeserializeEmbListFromBinarySet(const BinarySet& binset, std::shared_
             return Status::emb_list_inner_error;
         }
 
-        // 6. Set ID mapping if needed
         emb_list_offset_ = emb_list_strategy_->GetEmbListOffset();
-        if (emb_list_strategy_->NeedsBaseIndexIDMap()) {
-            return SetBaseIndexIDMap();
-        }
+        return Status::success;
     } catch (const std::exception& e) {
         LOG_KNOWHERE_WARNING_ << "deserialize emb_list error: " << e.what();
         return Status::emb_list_inner_error;
@@ -623,25 +594,21 @@ Status
 IndexNode::DeserializeEmbListFromFile(const std::string& filename, std::shared_ptr<Config> config) {
     auto& cfg = static_cast<knowhere::BaseConfig&>(*config);
 
-    // 1. Parse metric type
     auto metric_info_or = ParseEmbListMetric(cfg);
     if (!metric_info_or.has_value()) {
         return metric_info_or.error();
     }
     el_metric_type_ = metric_info_or.value().el_metric_type;
 
-    // 2. Deserialize base index from file (override metric_type for base index)
     cfg.metric_type = metric_info_or.value().sub_metric_type;
     RETURN_IF_ERROR(DeserializeFromFile(filename, config));
 
-    // 3. Read meta file and parse strategy type + strategy blob
     if (!cfg.emb_list_meta_file_path.has_value() || cfg.emb_list_meta_file_path.value().empty()) {
         LOG_KNOWHERE_WARNING_ << "emb_list_meta_file is empty, but metric type is emb_list";
         return Status::emb_list_inner_error;
     }
     auto emb_list_meta_file_path = cfg.emb_list_meta_file_path.value();
 
-    // Read entire meta file into memory
     std::shared_ptr<uint8_t[]> file_data;
     int64_t file_size = 0;
     {
@@ -668,7 +635,6 @@ IndexNode::DeserializeEmbListFromFile(const std::string& filename, std::shared_p
     auto [strategy_type, strategy_blob, strategy_blob_size] = ParseEmbListMetaHeader(file_data.get(), file_size);
 
     try {
-        // 4. Create strategy and deserialize strategy-specific data
         auto strategy_or = CreateEmbListStrategy(strategy_type, cfg);
         if (!strategy_or.has_value()) {
             LOG_KNOWHERE_WARNING_ << "Failed to create emb_list strategy: " << strategy_type;
@@ -679,7 +645,6 @@ IndexNode::DeserializeEmbListFromFile(const std::string& filename, std::shared_p
         LOG_KNOWHERE_INFO_ << "Deserialize emb_list from file with strategy: " << strategy_type;
         RETURN_IF_ERROR(emb_list_strategy_->Deserialize(strategy_blob, strategy_blob_size, cfg));
 
-        // 5. Load raw vector index from separate file (if strategy needs it)
         if (emb_list_strategy_->NeedsRawVectorStorage()) {
             if (!cfg.emb_list_raw_index_file_path.has_value() || cfg.emb_list_raw_index_file_path.value().empty()) {
                 LOG_KNOWHERE_WARNING_ << "Strategy requires raw vector storage but "
@@ -705,11 +670,8 @@ IndexNode::DeserializeEmbListFromFile(const std::string& filename, std::shared_p
                                << " vectors, mmap=" << cfg.enable_mmap.value();
         }
 
-        // 6. Set ID mapping if needed
         emb_list_offset_ = emb_list_strategy_->GetEmbListOffset();
-        if (emb_list_strategy_->NeedsBaseIndexIDMap()) {
-            return SetBaseIndexIDMap();
-        }
+        return Status::success;
     } catch (const std::exception& e) {
         LOG_KNOWHERE_WARNING_ << "deserialize emb_list from file error: " << e.what();
         return Status::emb_list_inner_error;

--- a/src/index/index_node.cc
+++ b/src/index/index_node.cc
@@ -343,22 +343,23 @@ IndexNode::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_t
             "GetEmbListByIds requires raw data support, but the index does not store raw vectors");
     }
 
+    if (dataset == nullptr) {
+        return expected<DataSetPtr>::Err(Status::invalid_args, "GetEmbListByIds dataset is null");
+    }
     auto num_el_ids = dataset->GetRows();
     auto el_ids = dataset->GetIds();
     auto dim = use_raw_index ? emb_list_raw_index_->d : Dim();
     std::vector<int64_t> in_el_ids;
-    // emb_list_offset_ is indexed by compact list id.
-    const auto* ids_to_retrieve = MapOutToIn(el_ids, num_el_ids, in_el_ids);
+    auto storage_ids = CompactOutToIn(el_ids, num_el_ids, in_el_ids, emb_list_offset_->num_el());
+    if (!storage_ids.has_value()) {
+        return expected<DataSetPtr>::Err(storage_ids.error(), storage_ids.what());
+    }
+    const auto* ids_to_retrieve = storage_ids.value();
 
     std::vector<size_t> out_offsets(num_el_ids + 1);
     out_offsets[0] = 0;
     for (int64_t i = 0; i < num_el_ids; i++) {
         auto el_id = ids_to_retrieve[i];
-        if (el_id < 0 || static_cast<size_t>(el_id) >= emb_list_offset_->num_el()) {
-            return expected<DataSetPtr>::Err(Status::invalid_args,
-                                             "GetEmbListByIds: el_id " + std::to_string(el_id) + " out of range [0, " +
-                                                 std::to_string(emb_list_offset_->num_el()) + ")");
-        }
         out_offsets[i + 1] = out_offsets[i] + emb_list_offset_->get_el_len(el_id);
     }
 
@@ -422,7 +423,7 @@ IndexNode::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_t
 
 Status
 IndexNode::BuildEmbList(const DataSetPtr dataset, std::shared_ptr<Config> cfg, const size_t* lims, size_t num_rows,
-                        bool use_knowhere_build_pool) {
+                        size_t num_el, bool use_knowhere_build_pool) {
     auto& config = static_cast<BaseConfig&>(*cfg);
 
     auto metric_info_or = ParseEmbListMetric(config);
@@ -432,7 +433,7 @@ IndexNode::BuildEmbList(const DataSetPtr dataset, std::shared_ptr<Config> cfg, c
     el_metric_type_ = metric_info_or.value().el_metric_type;
     auto sub_metric_type = metric_info_or.value().sub_metric_type;
 
-    EmbListOffset doc_offset(lims, num_rows);
+    EmbListOffset doc_offset(lims, num_rows, num_el);
 
     auto strategy_type = config.emb_list_strategy.value_or(meta::EMB_LIST_STRATEGY_TOKENANN);
     auto strategy_or = CreateEmbListStrategy(strategy_type, config);

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -92,10 +92,10 @@ class IvfIndexNode : public IndexNode {
 
     Status
     BuildEmbList(const DataSetPtr dataset, std::shared_ptr<Config> cfg, const size_t* lims, size_t num_rows,
-                 bool use_knowhere_build_pool) override {
+                 size_t num_el, bool use_knowhere_build_pool) override {
         if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlat> ||
                       std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexIVFFlatCC>) {
-            return IndexNode::BuildEmbList(dataset, std::move(cfg), lims, num_rows, use_knowhere_build_pool);
+            return IndexNode::BuildEmbList(dataset, std::move(cfg), lims, num_rows, num_el, use_knowhere_build_pool);
         }
 
         LOG_KNOWHERE_ERROR_ << "BuildEmbList not implemented for current index type";
@@ -875,9 +875,12 @@ IvfIndexNode<DataType, IndexType>::AddEmbList(const DataSetPtr dataset, std::sha
 
     {
         FairWriteLockGuard guard(*this->base_index_lock_);
-        RETURN_IF_ERROR(this->AppendEmbListOffsetAndIdMap(lims, num_rows));
+        RETURN_IF_ERROR(this->AppendEmbListOffsetAndIdMap(lims, num_rows, this->EmbListCount(dataset, lims, num_rows)));
     }
 
+    if (num_rows == 0) {
+        return Status::success;
+    }
     return Add(dataset, std::move(cfg), use_knowhere_build_pool);
 }
 
@@ -1193,7 +1196,14 @@ IvfIndexNode<DataType, IndexType>::CalcDistByIDs(const DataSetPtr dataset, const
                                         this->emb_list_strategy_->NeedsBaseIndexIDMap();
         std::vector<int64_t> in_labels;
         // Public APIs pass public ids. EmbList rerank passes compact list ids.
-        const auto* labels_to_calc = is_emb_list_rerank ? labels : this->MapOutToIn(labels, labels_len, in_labels);
+        const int64_t* labels_to_calc = labels;
+        if (!is_emb_list_rerank) {
+            auto storage_labels = this->CompactOutToIn(labels, labels_len, in_labels, static_cast<size_t>(Count()));
+            if (!storage_labels.has_value()) {
+                return expected<DataSetPtr>::Err(storage_labels.error(), storage_labels.what());
+            }
+            labels_to_calc = storage_labels.value();
+        }
 
         try {
             std::vector<folly::Future<folly::Unit>> futs;
@@ -1573,10 +1583,17 @@ IvfIndexNode<DataType, IndexType>::AnnIterator(const DataSetPtr dataset, std::un
 template <typename DataType, typename IndexType>
 expected<DataSetPtr>
 IvfIndexNode<DataType, IndexType>::GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context) const {
+    if (dataset == nullptr) {
+        return expected<DataSetPtr>::Err(Status::invalid_args, "GetVectorByIds dataset is null");
+    }
     auto rows = dataset->GetRows();
     auto ids = dataset->GetIds();
     std::vector<int64_t> in_ids;
-    ids = this->MapOutToIn(ids, rows, in_ids);
+    auto storage_ids = this->CompactOutToIn(ids, rows, in_ids, static_cast<size_t>(Count()));
+    if (!storage_ids.has_value()) {
+        return expected<DataSetPtr>::Err(storage_ids.error(), storage_ids.what());
+    }
+    ids = storage_ids.value();
     auto storage_ds = GenIdsDataSet(rows, ids);
     return GetVectorByStorageIds(storage_ds, op_context);
 }

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -84,6 +84,12 @@ class IvfIndexNode : public IndexNode {
         build_pool_ = ThreadPool::GetGlobalBuildThreadPool();
         base_index_lock_ = std::make_unique<FairRWLock>();
     }
+
+    bool
+    NeedBitsetExactCount() const override {
+        return true;
+    }
+
     Status
     BuildEmbList(const DataSetPtr dataset, std::shared_ptr<Config> cfg, const size_t* lims, size_t num_rows,
                  bool use_knowhere_build_pool) override {
@@ -133,12 +139,6 @@ class IvfIndexNode : public IndexNode {
     expected<DataSetPtr>
     CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
                   const bool is_cosine, milvus::OpContext* op_context) const override;
-    Status
-    SetInternalIdToMostExternalIdMap(std::vector<uint32_t>&& map) override {
-        internal_offset_to_most_external_id_ = std::move(map);
-        return Status::success;
-    };
-
     static Status
     StaticConfigCheck(const Config& cfg, PARAM_TYPE paramType, std::string& msg) {
         auto ivf_cfg = static_cast<const IvfConfig&>(cfg);
@@ -370,6 +370,10 @@ class IvfIndexNode : public IndexNode {
         }
     };
 
+ protected:
+    expected<DataSetPtr>
+    GetVectorByStorageIds(const DataSetPtr dataset, milvus::OpContext* op_context) const override;
+
  private:
     expected<DataSetPtr>
     GetIndexMetaImpl(std::unique_ptr<Config> cfg, IVFBaseTag) const {
@@ -464,7 +468,6 @@ class IvfIndexNode : public IndexNode {
     // spawded during index training/building can inherit the low nice value of
     // threads in build_pool_.
     std::shared_ptr<ThreadPool> build_pool_;
-    std::vector<uint32_t> internal_offset_to_most_external_id_;
     std::unique_ptr<FairRWLock> base_index_lock_;
 };
 
@@ -854,7 +857,6 @@ IvfIndexNode<DataType, IndexType>::AddEmbList(const DataSetPtr dataset, std::sha
         return Status::emb_list_inner_error;
     }
 
-    // 1. split metric_type to el_metric_type and sub_metric_type
     auto& config = static_cast<BaseConfig&>(*cfg);
     auto original_metric_type = config.metric_type.value();
     auto el_metric_type_or = get_el_metric_type(original_metric_type);
@@ -871,43 +873,11 @@ IvfIndexNode<DataType, IndexType>::AddEmbList(const DataSetPtr dataset, std::sha
     auto sub_metric_type = sub_metric_type_or.value();
     config.metric_type = sub_metric_type;
 
-    // 2. update emb_list_offset and id map
     {
         FairWriteLockGuard guard(*this->base_index_lock_);
-        auto old_num_rows = Count();
-        auto old_num_el = emb_list_offset_->num_el();
-        auto dataset_rows = dataset->GetRows();
-        auto new_num_rows = old_num_rows + dataset_rows;
-        if (lims[0] != old_num_rows) {
-            LOG_KNOWHERE_WARNING_ << "lims[0] is not equal to the total_cnt of the old index";
-            return Status::emb_list_inner_error;
-        }
-        size_t idx = 1;
-        internal_offset_to_most_external_id_.resize(new_num_rows);
-        while (lims[idx] < new_num_rows) {
-            if (lims[idx] < lims[idx - 1]) {
-                LOG_KNOWHERE_WARNING_ << "lims is not increasing, lims[" << idx << "] = " << lims[idx] << " < lims["
-                                      << idx - 1 << "] = " << lims[idx - 1];
-                return Status::emb_list_inner_error;
-            }
-            emb_list_offset_->offset.push_back(lims[idx]);
-            auto cur_el_id = old_num_el + idx - 1;
-            std::fill_n(internal_offset_to_most_external_id_.begin() + lims[idx - 1], lims[idx] - lims[idx - 1],
-                        cur_el_id);
-            idx++;
-        }
-        if (lims[idx] != new_num_rows) {
-            LOG_KNOWHERE_WARNING_ << "lims should end with the total_cnt of the new index, lims[" << idx
-                                  << "] = " << lims[idx] << " != " << new_num_rows;
-            return Status::emb_list_inner_error;
-        }
-        emb_list_offset_->offset.push_back(new_num_rows);
-        auto cur_el_id = old_num_el + idx - 1;
-        std::fill_n(internal_offset_to_most_external_id_.begin() + lims[idx - 1], new_num_rows - lims[idx - 1],
-                    cur_el_id);
+        RETURN_IF_ERROR(this->AppendEmbListOffsetAndIdMap(lims, num_rows));
     }
 
-    // 3. add to index
     return Add(dataset, std::move(cfg), use_knowhere_build_pool);
 }
 
@@ -934,23 +904,7 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, std::unique_
     auto k = ivf_cfg.k.value();
     auto nprobe = ivf_cfg.nprobe.value();
 
-    BitsetView bitset(bitset_);
-    if (!internal_offset_to_most_external_id_.empty()) {
-        if (emb_list_offset_ != nullptr) {
-            // if emb list, manually calculate the number of filtered out ids
-            size_t num_filtered_out_ids = 0;
-            for (size_t i = 0; i < bitset.size(); i++) {
-                if (bitset.test(i)) {
-                    num_filtered_out_ids += emb_list_offset_->offset[i + 1] - emb_list_offset_->offset[i];
-                }
-            }
-            bitset.set_out_ids(internal_offset_to_most_external_id_.data(), internal_offset_to_most_external_id_.size(),
-                               num_filtered_out_ids);
-        } else {
-            bitset.set_out_ids(internal_offset_to_most_external_id_.data(),
-                               internal_offset_to_most_external_id_.size());
-        }
-    }
+    const auto& bitset = bitset_;
 
     auto ids = std::make_unique<int64_t[]>(rows * k);
     auto distances = std::make_unique<float[]>(rows * k);
@@ -1206,6 +1160,7 @@ IvfIndexNode<DataType, IndexType>::Search(const DataSetPtr dataset, std::unique_
     }
 
     auto res = GenResultDataSet(rows, k, std::move(ids), std::move(distances));
+    MapSearchResultIdsToOutIds(res);
     return res;
 }
 
@@ -1234,6 +1189,11 @@ IvfIndexNode<DataType, IndexType>::CalcDistByIDs(const DataSetPtr dataset, const
         auto query_data = dataset->GetTensor();
         auto dim = dataset->GetDim();
         auto distances = std::make_unique<float[]>(num_queries * labels_len);
+        const bool is_emb_list_rerank = this->emb_list_offset_ != nullptr && this->emb_list_strategy_ != nullptr &&
+                                        this->emb_list_strategy_->NeedsBaseIndexIDMap();
+        std::vector<int64_t> in_labels;
+        // Public APIs pass public ids. EmbList rerank passes compact list ids.
+        const auto* labels_to_calc = is_emb_list_rerank ? labels : this->MapOutToIn(labels, labels_len, in_labels);
 
         try {
             std::vector<folly::Future<folly::Unit>> futs;
@@ -1248,7 +1208,7 @@ IvfIndexNode<DataType, IndexType>::CalcDistByIDs(const DataSetPtr dataset, const
                         query = copied_query.get();
                     }
                     auto cur_distances = distances.get() + index * labels_len;
-                    index_->calc_dist_by_ids(1, query, labels_len, labels, cur_distances);
+                    index_->calc_dist_by_ids(1, query, labels_len, labels_to_calc, cur_distances);
                 }));
             }
             WaitAllSuccess(futs);
@@ -1532,7 +1492,9 @@ IvfIndexNode<DataType, IndexType>::RangeSearch(const DataSetPtr dataset, std::un
         return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
     }
 
-    return GenResultDataSet(nq, std::move(range_search_result));
+    auto res = GenResultDataSet(nq, std::move(range_search_result));
+    MapSearchResultIdsToOutIds(res);
+    return res;
 }
 
 template <typename DataType, typename IndexType>
@@ -1595,6 +1557,8 @@ IvfIndexNode<DataType, IndexType>::AnnIterator(const DataSetPtr dataset, std::un
                 // iterator only own the copied_query.
                 auto it = std::make_shared<iterator>(index_.get(), std::move(copied_query), bitset, nprobe,
                                                      larger_is_closer, iterator_refine_ratio, use_knowhere_search_pool);
+                const auto& id_map = GetIdMap();
+                it->SetResultIdMap(SearchResultIdMap(id_map));
                 vec[i] = it;
             }
 
@@ -1609,6 +1573,18 @@ IvfIndexNode<DataType, IndexType>::AnnIterator(const DataSetPtr dataset, std::un
 template <typename DataType, typename IndexType>
 expected<DataSetPtr>
 IvfIndexNode<DataType, IndexType>::GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context) const {
+    auto rows = dataset->GetRows();
+    auto ids = dataset->GetIds();
+    std::vector<int64_t> in_ids;
+    ids = this->MapOutToIn(ids, rows, in_ids);
+    auto storage_ds = GenIdsDataSet(rows, ids);
+    return GetVectorByStorageIds(storage_ds, op_context);
+}
+
+template <typename DataType, typename IndexType>
+expected<DataSetPtr>
+IvfIndexNode<DataType, IndexType>::GetVectorByStorageIds(const DataSetPtr dataset,
+                                                         milvus::OpContext* op_context) const {
     if (!this->index_) {
         return expected<DataSetPtr>::Err(Status::empty_index, "index not loaded");
     }

--- a/src/index/minhash/minhash_index_node.cc
+++ b/src/index/minhash/minhash_index_node.cc
@@ -332,6 +332,7 @@ MinHashLSHNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
         return expected<DataSetPtr>::Err(Status::internal_error, e.what());
     }
     auto res = GenResultDataSet(nq, topk, std::move(p_id), std::move(p_dist));
+    MapSearchResultIdsToOutIds(res);
     return res;
 }
 

--- a/src/index/sparse/sparse_index_node.cc
+++ b/src/index/sparse/sparse_index_node.cc
@@ -982,11 +982,18 @@ class SparseInvertedIndexNodeCC : public SparseInvertedIndexNode<T, use_wand> {
         if (raw_data_.empty()) {
             return expected<DataSetPtr>::Err(Status::invalid_args, "GetVectorByIds failed: raw data is empty");
         }
+        if (dataset == nullptr) {
+            return expected<DataSetPtr>::Err(Status::invalid_args, "GetVectorByIds dataset is null");
+        }
 
         auto rows = dataset->GetRows();
         auto ids = dataset->GetIds();
         std::vector<int64_t> in_ids;
-        ids = this->MapOutToIn(ids, rows, in_ids);
+        auto storage_ids = this->CompactOutToIn(ids, rows, in_ids, raw_data_.size());
+        if (!storage_ids.has_value()) {
+            return expected<DataSetPtr>::Err(storage_ids.error(), storage_ids.what());
+        }
+        ids = storage_ids.value();
         auto data = std::make_unique<sparse::SparseRow<value_type>[]>(rows);
         int64_t dim = 0;
 

--- a/src/index/sparse/sparse_index_node.cc
+++ b/src/index/sparse/sparse_index_node.cc
@@ -205,7 +205,9 @@ class SparseInvertedIndexNode : public IndexNode {
         }
         WaitAllSuccess(futs);
 
-        return GenResultDataSet(nq, k, p_id.release(), p_dist.release());
+        auto res = GenResultDataSet(nq, k, p_id.release(), p_dist.release());
+        this->MapSearchResultIdsToOutIds(res);
+        return res;
     }
 
     // TODO: for now inverted index and wand use the same impl for AnnIterator.
@@ -230,6 +232,8 @@ class SparseInvertedIndexNode : public IndexNode {
         auto search_params = search_params_or.value();
 
         auto vec = std::vector<std::shared_ptr<IndexNode::iterator>>(nq, nullptr);
+        const auto& id_map = this->GetIdMap();
+        const auto* result_id_map = this->SearchResultIdMap(id_map);
         try {
             for (int i = 0; i < nq; ++i) {
                 // Heavy computations with `compute_dist_func` will be deferred until the first call to
@@ -252,6 +256,7 @@ class SparseInvertedIndexNode : public IndexNode {
 
                 auto it =
                     std::make_shared<PrecomputedDistanceIterator>(compute_dist_func, true, use_knowhere_search_pool);
+                it->SetResultIdMap(result_id_map);
                 vec[i] = it;
             }
         } catch (const std::exception& e) {
@@ -980,6 +985,8 @@ class SparseInvertedIndexNodeCC : public SparseInvertedIndexNode<T, use_wand> {
 
         auto rows = dataset->GetRows();
         auto ids = dataset->GetIds();
+        std::vector<int64_t> in_ids;
+        ids = this->MapOutToIn(ids, rows, in_ids);
         auto data = std::make_unique<sparse::SparseRow<value_type>[]>(rows);
         int64_t dim = 0;
 

--- a/src/index/svs/svs_flat.cc
+++ b/src/index/svs/svs_flat.cc
@@ -68,6 +68,11 @@ class SvsFlatIndexNode : public IndexNode {
         return Status::success;
     }
 
+    bool
+    NeedBitsetExactCount() const override {
+        return true;
+    }
+
     expected<DataSetPtr>
     Search(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset,
            milvus::OpContext* op_context) const override {
@@ -76,7 +81,7 @@ class SvsFlatIndexNode : public IndexNode {
             return expected<DataSetPtr>::Err(Status::empty_index, "index not loaded");
         }
 
-        if (!bitset.empty() && bitset.count() > 0) {
+        if (!bitset.empty()) {
             return expected<DataSetPtr>::Err(Status::not_implemented, "SVS Flat does not support bitset filtering");
         }
 
@@ -116,7 +121,9 @@ class SvsFlatIndexNode : public IndexNode {
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
         }
 
-        return GenResultDataSet(nq, k, std::move(ids), std::move(distances));
+        auto res = GenResultDataSet(nq, k, std::move(ids), std::move(distances));
+        MapSearchResultIdsToOutIds(res);
+        return res;
     }
 
     expected<DataSetPtr>

--- a/src/index/svs/svs_vamana.cc
+++ b/src/index/svs/svs_vamana.cc
@@ -187,7 +187,9 @@ class SvsVamanaIndexNode : public IndexNode {
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());
         }
 
-        return GenResultDataSet(nq, k, std::move(ids), std::move(distances));
+        auto res = GenResultDataSet(nq, k, std::move(ids), std::move(distances));
+        MapSearchResultIdsToOutIds(res);
+        return res;
     }
 
     expected<DataSetPtr>
@@ -253,7 +255,9 @@ class SvsVamanaIndexNode : public IndexNode {
             WaitAllSuccess(futs);
             auto range_search_result =
                 GetRangeSearchResult(result_dist_array, result_id_array, is_similarity, nq, radius, range_filter);
-            return GenResultDataSet(nq, std::move(range_search_result));
+            auto res = GenResultDataSet(nq, std::move(range_search_result));
+            MapSearchResultIdsToOutIds(res);
+            return res;
         } catch (const std::exception& e) {
             LOG_KNOWHERE_WARNING_ << "error inner faiss: " << e.what();
             return expected<DataSetPtr>::Err(Status::faiss_inner_error, e.what());

--- a/tests/ut/test_bitsetview.cc
+++ b/tests/ut/test_bitsetview.cc
@@ -1,0 +1,219 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+#include "catch2/catch_approx.hpp"
+#include "catch2/catch_test_macros.hpp"
+#include "knowhere/bitsetview.h"
+
+namespace {
+
+std::vector<uint8_t>
+MakeBitmap(size_t num_bits, const std::vector<int64_t>& ids) {
+    std::vector<uint8_t> bitset((num_bits + 7) / 8, 0);
+    for (auto id : ids) {
+        bitset[static_cast<size_t>(id) >> 3] |= static_cast<uint8_t>(1U << (static_cast<size_t>(id) & 7));
+    }
+    return bitset;
+}
+
+knowhere::IdArray
+MakeIdArray(const std::vector<int32_t>& ids, knowhere::IdArray::Type type = knowhere::IdArray::Type::ARRAY) {
+    knowhere::IdArray array;
+    array.SetType(type);
+    if (!ids.empty()) {
+        if (type == knowhere::IdArray::Type::ARRAY) {
+            array.Set(ids.data(), ids.size());
+        } else {
+            array.Append(ids.data(), ids.size());
+        }
+    }
+    return array;
+}
+
+}  // namespace
+
+TEST_CASE("BitsetView test filters ids outside the visible bitset", "[bitset]") {
+    auto bits = MakeBitmap(4, {1});
+    knowhere::BitsetView bitset(bits.data(), 4);
+
+    REQUIRE_FALSE(bitset.test(0));
+    REQUIRE(bitset.test(1));
+    REQUIRE_FALSE(bitset.test(3));
+    REQUIRE(bitset.test(4));
+    REQUIRE(bitset.test(6));
+    REQUIRE(bitset.test(-1));
+}
+
+TEST_CASE("BitsetView test filters mapped ids outside out id view", "[bitset][id_map]") {
+    auto bits = MakeBitmap(4, {2});
+    const std::vector<int32_t> out_ids = {0, 2, 4};
+    auto out_id_array = MakeIdArray(out_ids);
+
+    knowhere::BitsetView bitset(bits.data(), 4);
+    bitset.set_out_ids(out_id_array, out_ids.size());
+
+    REQUIRE_FALSE(bitset.test(0));
+    REQUIRE(bitset.test(1));
+    REQUIRE(bitset.test(2));
+    REQUIRE(bitset.test(3));
+    REQUIRE(bitset.test(-1));
+}
+
+TEST_CASE("BitsetView helpers respect mapped out ids", "[bitset][id_map]") {
+    auto bits = MakeBitmap(10, {2, 6});
+    const std::vector<int32_t> out_ids = {6, 2, 8, 4};
+    auto out_id_array = MakeIdArray(out_ids);
+
+    knowhere::BitsetView bitset(bits.data(), 10);
+    bitset.set_out_ids(out_id_array, out_ids.size());
+    bitset.set_vector_count(out_ids.size());
+    bitset.set_filter_count(2);
+
+    REQUIRE(bitset.get_out_ids().is_array());
+    REQUIRE(bitset.out_ids_count() == out_ids.size());
+    REQUIRE(bitset.range_all_filtered(0, 2));
+    REQUIRE_FALSE(bitset.range_all_filtered(0, 3));
+    REQUIRE_FALSE(bitset.range_all_filtered(2, 4));
+    REQUIRE_FALSE(bitset.previous_valid_index(2).has_value());
+    REQUIRE(bitset.previous_valid_index(3).value() == 2);
+    REQUIRE(bitset.previous_valid_index(4).value() == 3);
+    REQUIRE(bitset.get_first_valid_index() == 2);
+    REQUIRE(bitset.filter_ratio() == Catch::Approx(0.5F));
+}
+
+TEST_CASE("BitsetView helpers respect append mapped out ids", "[bitset][id_map]") {
+    auto bits = MakeBitmap(10, {2, 6});
+    const std::vector<int32_t> values = {6, 2, 8, 4};
+    auto out_id_array = MakeIdArray(values, knowhere::IdArray::Type::APPEND_ARRAY);
+    knowhere::BitsetView bitset(bits.data(), 10);
+    bitset.set_out_ids(out_id_array, values.size());
+    bitset.set_vector_count(values.size());
+    bitset.set_filter_count(2);
+
+    REQUIRE(bitset.get_out_ids().is_append_array());
+    REQUIRE(bitset.out_ids_count() == values.size());
+    REQUIRE(bitset.range_all_filtered(0, 2));
+    REQUIRE_FALSE(bitset.range_all_filtered(0, 3));
+    REQUIRE_FALSE(bitset.range_all_filtered(2, 4));
+    REQUIRE_FALSE(bitset.previous_valid_index(2).has_value());
+    REQUIRE(bitset.previous_valid_index(3).value() == 2);
+    REQUIRE(bitset.previous_valid_index(4).value() == 3);
+    REQUIRE(bitset.get_first_valid_index() == 2);
+    REQUIRE(bitset.filter_ratio() == Catch::Approx(0.5F));
+}
+
+TEST_CASE("BitsetView helpers respect mapped out id windows", "[bitset][id_map]") {
+    auto bits = MakeBitmap(8, {1});
+    const std::vector<int32_t> values = {0, 1, 5};
+    auto out_id_array = MakeIdArray(values);
+
+    knowhere::BitsetView bitset(bits.data(), 8);
+    bitset.set_id_offset(1);
+    bitset.set_out_ids(out_id_array, values.size());
+    bitset.set_vector_count(2);
+    bitset.set_filter_count(1);
+
+    REQUIRE(bitset.test(0));
+    REQUIRE_FALSE(bitset.test(1));
+    REQUIRE(bitset.range_all_filtered(0, 1));
+    REQUIRE_FALSE(bitset.range_all_filtered(0, 2));
+    REQUIRE(bitset.previous_valid_index(2).value() == 1);
+    REQUIRE(bitset.get_first_valid_index() == 1);
+}
+
+TEST_CASE("BitsetView helpers respect contiguous id windows", "[bitset]") {
+    auto bits = MakeBitmap(8, {2});
+    knowhere::BitsetView bitset(bits.data(), 8);
+    bitset.set_id_offset(2);
+    bitset.set_vector_count(2);
+    bitset.set_filter_count(1);
+
+    REQUIRE(bitset.test(0));
+    REQUIRE_FALSE(bitset.test(1));
+    REQUIRE(bitset.range_all_filtered(0, 1));
+    REQUIRE_FALSE(bitset.range_all_filtered(0, 2));
+    REQUIRE(bitset.previous_valid_index(2).value() == 1);
+    REQUIRE(bitset.get_first_valid_index() == 1);
+}
+
+TEST_CASE("BitsetView counts filtered bits across bytes", "[bitset][count]") {
+    auto bits = MakeBitmap(70, {0, 2, 7, 8, 31, 63, 69});
+    knowhere::BitsetView bitset(bits.data(), 70);
+
+    bitset.count_filtered_bits(0, 70);
+
+    REQUIRE(bitset.size() == 70);
+    REQUIRE(bitset.count() == 7);
+    REQUIRE(bitset.filter_ratio() == Catch::Approx(0.1f));
+    REQUIRE_FALSE(bitset.empty());
+}
+
+TEST_CASE("BitsetView distinguishes unknown count from known zero", "[bitset][count]") {
+    auto bits = MakeBitmap(8, {1});
+    knowhere::BitsetView bitset(bits.data(), 8);
+
+    REQUIRE_FALSE(bitset.has_known_count());
+    REQUIRE_FALSE(bitset.empty());
+    REQUIRE_THROWS_AS(bitset.count(), std::logic_error);
+
+    bitset.set_filter_count(0);
+    REQUIRE(bitset.has_known_count());
+    REQUIRE(bitset.empty());
+    REQUIRE(bitset.count() == 0);
+}
+
+TEST_CASE("BitsetView counts only valid filtered bits with valid bitmap", "[bitset][count]") {
+    auto bits = MakeBitmap(70, {0, 2, 7, 8, 31, 63, 69});
+    auto valid_bitmap = MakeBitmap(70, {1, 2, 3, 7, 31, 32, 63, 68});
+    knowhere::BitsetView bitset(bits.data(), 70);
+
+    bitset.count_filtered_bits(0, 70, valid_bitmap.data());
+
+    REQUIRE(bitset.size() == 8);
+    REQUIRE(bitset.count() == 4);
+    REQUIRE(bitset.filter_ratio() == Catch::Approx(0.5f));
+    REQUIRE_FALSE(bitset.empty());
+}
+
+TEST_CASE("BitsetView counts append valid bitmap", "[bitset][count][id_map]") {
+    auto bits = MakeBitmap(8, {2, 5});
+    auto valid_bytes = MakeBitmap(8, {1, 2, 4, 5, 7});
+    knowhere::BitmapArray valid_bitmap;
+    valid_bitmap.SetType(knowhere::BitmapArray::Type::APPEND_ARRAY);
+    valid_bitmap.Append(valid_bytes.data(), 8);
+
+    knowhere::BitsetView bitset(bits.data(), 8);
+    bitset.count_filtered_bits(0, 8, valid_bitmap);
+
+    REQUIRE(bitset.size() == 5);
+    REQUIRE(bitset.count() == 2);
+    REQUIRE(bitset.filter_ratio() == Catch::Approx(0.4f));
+    REQUIRE_FALSE(bitset.empty());
+}
+
+TEST_CASE("BitsetView counts filtered bits in non-byte-aligned valid range", "[bitset][count]") {
+    auto bits = MakeBitmap(80, {5, 7, 8, 11, 14, 15, 16, 18, 23, 24, 25, 70});
+    auto valid_bitmap = MakeBitmap(80, {4, 5, 6, 7, 8, 9, 10, 11, 14, 16, 17, 18, 22, 23, 25, 26, 27});
+    knowhere::BitsetView bitset(bits.data(), 80);
+
+    bitset.count_filtered_bits(5, 21, valid_bitmap.data());
+
+    REQUIRE(bitset.size() == 14);
+    REQUIRE(bitset.count() == 9);
+    REQUIRE(bitset.filter_ratio() == Catch::Approx(9.0f / 14.0f));
+    REQUIRE_FALSE(bitset.empty());
+}

--- a/tests/ut/test_bruteforce.cc
+++ b/tests/ut/test_bruteforce.cc
@@ -9,6 +9,14 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <initializer_list>
+#include <map>
+#include <memory>
+#include <vector>
+
 #include "catch2/catch_approx.hpp"
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/generators/catch_generators.hpp"
@@ -18,6 +26,33 @@
 #include "knowhere/utils.h"
 #include "simd/hook.h"
 #include "utils.h"
+
+namespace {
+
+std::vector<uint8_t>
+MakeBitset(size_t num_bits, std::initializer_list<size_t> filtered_ids) {
+    std::vector<uint8_t> bits((num_bits + 7) / 8, 0);
+    for (auto id : filtered_ids) {
+        bits[id >> 3] |= static_cast<uint8_t>(1U << (id & 7));
+    }
+    return bits;
+}
+
+knowhere::IdArray
+MakeIdArray(const std::vector<int32_t>& ids, knowhere::IdArray::Type type = knowhere::IdArray::Type::ARRAY) {
+    knowhere::IdArray array;
+    array.SetType(type);
+    if (!ids.empty()) {
+        if (type == knowhere::IdArray::Type::ARRAY) {
+            array.Set(ids.data(), ids.size());
+        } else {
+            array.Append(ids.data(), ids.size());
+        }
+    }
+    return array;
+}
+
+}  // namespace
 
 template <typename T>
 void
@@ -273,4 +308,266 @@ TEST_CASE("Test Brute Force with input ids", "[float vector]") {
     check_search_with_out_ids<knowhere::fp16>(nb, nq, dim, k, metric, conf);
     check_search_with_out_ids<knowhere::bf16>(nb, nq, dim, k, metric, conf);
     check_search_with_out_ids<knowhere::int8>(nb, nq, dim, k, metric, conf);
+}
+
+TEST_CASE("Brute Force filters internal rows through out ids", "[float vector][id_map]") {
+    constexpr int64_t nb = 3;
+    constexpr int64_t nq = 1;
+    constexpr int64_t dim = 2;
+    constexpr int64_t k = 2;
+
+    const std::vector<float> base = {
+        2.0F, 0.0F,  // internal row 0 -> out id 1
+        0.0F, 0.0F,  // internal row 1 -> out id 3, filtered
+        4.0F, 0.0F,  // internal row 2 -> out id 5
+    };
+    const std::vector<float> query = {0.0F, 0.0F};
+    const std::vector<int32_t> out_ids = {1, 3, 5};
+    auto out_id_array = MakeIdArray(out_ids);
+    auto filter_bits = MakeBitset(6, {3});
+    knowhere::BitsetView bitset(filter_bits.data(), 6);
+    bitset.set_out_ids(out_id_array, out_ids.size());
+    bitset.set_vector_count(out_ids.size());
+    bitset.set_filter_count(1);
+
+    auto base_ds = knowhere::GenDataSet(nb, dim, base.data());
+    auto query_ds = knowhere::GenDataSet(nq, dim, query.data());
+    const knowhere::Json conf = {
+        {knowhere::meta::DIM, dim},
+        {knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
+        {knowhere::meta::TOPK, k},
+    };
+
+    SECTION("SearchWithBuf returns logical out ids") {
+        std::vector<int64_t> ids(nq * k, -1);
+        std::vector<float> distances(nq * k, 0.0F);
+        auto status = knowhere::BruteForce::SearchWithBuf<knowhere::fp32>(base_ds, query_ds, ids.data(),
+                                                                          distances.data(), conf, bitset, nullptr);
+        REQUIRE(status == knowhere::Status::success);
+        REQUIRE(ids == std::vector<int64_t>{1, 5});
+        REQUIRE(distances[0] == Catch::Approx(4.0F));
+        REQUIRE(distances[1] == Catch::Approx(16.0F));
+    }
+
+    SECTION("Search returns logical out ids") {
+        auto result = knowhere::BruteForce::Search<knowhere::fp32>(base_ds, query_ds, conf, bitset, nullptr);
+        REQUIRE(result.has_value());
+        REQUIRE(std::vector<int64_t>(result.value()->GetIds(), result.value()->GetIds() + nq * k) ==
+                std::vector<int64_t>{1, 5});
+    }
+
+    SECTION("RangeSearch returns logical out ids") {
+        auto range_conf = conf;
+        range_conf[knowhere::meta::RADIUS] = 20.0F;
+        auto result = knowhere::BruteForce::RangeSearch<knowhere::fp32>(base_ds, query_ds, range_conf, bitset, nullptr);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetLims()[0] == 0);
+        REQUIRE(result.value()->GetLims()[1] == 2);
+        REQUIRE(std::vector<int64_t>(result.value()->GetIds(), result.value()->GetIds() + 2) ==
+                std::vector<int64_t>{1, 5});
+    }
+
+    SECTION("AnnIterator returns logical out ids") {
+        auto iterators = knowhere::BruteForce::AnnIterator<knowhere::fp32>(base_ds, query_ds, conf, bitset, false);
+        REQUIRE(iterators.has_value());
+        REQUIRE(iterators.value().size() == 1);
+        auto first = iterators.value()[0]->Next();
+        REQUIRE(first.has_value());
+        REQUIRE(first.value().first == 1);
+        REQUIRE(first.value().second == Catch::Approx(4.0F));
+    }
+
+    SECTION("Out ids override tensor begin id") {
+        auto offset_base_ds = knowhere::GenDataSet(nb, dim, base.data(), 100);
+        auto result = knowhere::BruteForce::Search<knowhere::fp32>(offset_base_ds, query_ds, conf, bitset, nullptr);
+        REQUIRE(result.has_value());
+        REQUIRE(std::vector<int64_t>(result.value()->GetIds(), result.value()->GetIds() + nq * k) ==
+                std::vector<int64_t>{1, 5});
+    }
+
+    SECTION("Out ids use the active bitset window") {
+        const std::vector<float> window_base = {
+            2.0F, 0.0F,  // internal row 0 -> out id 1, filtered
+            4.0F, 0.0F,  // internal row 1 -> out id 5
+        };
+        const std::vector<int32_t> window_out_ids = {0, 1, 5};
+        auto window_out_id_array = MakeIdArray(window_out_ids);
+        auto window_filter_bits = MakeBitset(6, {1});
+        knowhere::BitsetView window_bitset(window_filter_bits.data(), 6);
+        window_bitset.set_id_offset(1);
+        window_bitset.set_out_ids(window_out_id_array, window_out_ids.size());
+        window_bitset.set_vector_count(window_base.size() / dim);
+        window_bitset.set_filter_count(1);
+
+        auto window_base_ds = knowhere::GenDataSet(2, dim, window_base.data(), 1);
+        auto result =
+            knowhere::BruteForce::Search<knowhere::fp32>(window_base_ds, query_ds, conf, window_bitset, nullptr);
+        REQUIRE(result.has_value());
+        REQUIRE(std::vector<int64_t>(result.value()->GetIds(), result.value()->GetIds() + nq * k) ==
+                std::vector<int64_t>{5, -1});
+    }
+
+    SECTION("Chunk search slices out ids by chunk") {
+        const std::vector<float> chunk0 = {
+            2.0F, 0.0F,  // internal row 0 -> out id 1
+            0.0F, 0.0F,  // internal row 1 -> out id 3, filtered
+        };
+        const std::vector<float> chunk1 = {
+            4.0F, 0.0F,  // internal row 2 -> out id 5
+            6.0F, 0.0F,  // internal row 3 -> out id 7
+        };
+        const std::array<const float*, 2> chunks = {chunk0.data(), chunk1.data()};
+        const std::array<size_t, 3> chunk_lims = {0, 2, 4};
+        const std::vector<int32_t> chunk_out_ids = {1, 3, 5, 7};
+        auto chunk_out_id_array = MakeIdArray(chunk_out_ids);
+        auto chunk_filter_bits = MakeBitset(8, {3});
+        knowhere::BitsetView chunk_bitset(chunk_filter_bits.data(), 8);
+        chunk_bitset.set_out_ids(chunk_out_id_array, chunk_out_ids.size());
+
+        auto chunk_ds = knowhere::GenDataSet(4, dim, chunks.data());
+        chunk_ds->SetIsChunk(true);
+        chunk_ds->SetNumChunk(static_cast<int64_t>(chunks.size()));
+        chunk_ds->Set(knowhere::meta::EMB_LIST_OFFSET, chunk_lims.data());
+
+        auto result = knowhere::BruteForce::Search<knowhere::fp32>(chunk_ds, query_ds, conf, chunk_bitset, nullptr);
+        REQUIRE(result.has_value());
+        REQUIRE(std::vector<int64_t>(result.value()->GetIds(), result.value()->GetIds() + nq * k) ==
+                std::vector<int64_t>{1, 5});
+    }
+
+    SECTION("Chunk search slices concurrent out ids by chunk") {
+        const std::vector<float> chunk0 = {
+            2.0F, 0.0F,  // internal row 0 -> out id 1
+            0.0F, 0.0F,  // internal row 1 -> out id 3, filtered
+        };
+        const std::vector<float> chunk1 = {
+            4.0F, 0.0F,  // internal row 2 -> out id 5
+            6.0F, 0.0F,  // internal row 3 -> out id 7
+        };
+        const std::array<const float*, 2> chunks = {chunk0.data(), chunk1.data()};
+        const std::array<size_t, 3> chunk_lims = {0, 2, 4};
+        const std::vector<int32_t> values = {1, 3, 5, 7};
+        auto chunk_out_id_array = MakeIdArray(values, knowhere::IdArray::Type::APPEND_ARRAY);
+        auto chunk_filter_bits = MakeBitset(8, {3});
+        knowhere::BitsetView chunk_bitset(chunk_filter_bits.data(), 8);
+        chunk_bitset.set_out_ids(chunk_out_id_array, values.size());
+
+        auto chunk_ds = knowhere::GenDataSet(4, dim, chunks.data());
+        chunk_ds->SetIsChunk(true);
+        chunk_ds->SetNumChunk(static_cast<int64_t>(chunks.size()));
+        chunk_ds->Set(knowhere::meta::EMB_LIST_OFFSET, chunk_lims.data());
+
+        auto result = knowhere::BruteForce::Search<knowhere::fp32>(chunk_ds, query_ds, conf, chunk_bitset, nullptr);
+        REQUIRE(result.has_value());
+        REQUIRE(std::vector<int64_t>(result.value()->GetIds(), result.value()->GetIds() + nq * k) ==
+                std::vector<int64_t>{1, 5});
+    }
+
+    SECTION("Chunk iterator slices out ids by chunk") {
+        const std::vector<float> chunk0 = {
+            2.0F, 0.0F,  // internal row 0 -> out id 1
+            0.0F, 0.0F,  // internal row 1 -> out id 3, filtered
+        };
+        const std::vector<float> chunk1 = {
+            4.0F, 0.0F,  // internal row 2 -> out id 5
+            6.0F, 0.0F,  // internal row 3 -> out id 7
+        };
+        const std::array<const float*, 2> chunks = {chunk0.data(), chunk1.data()};
+        const std::array<size_t, 3> chunk_lims = {0, 2, 4};
+        const std::vector<int32_t> chunk_out_ids = {1, 3, 5, 7};
+        auto chunk_out_id_array = MakeIdArray(chunk_out_ids);
+        auto chunk_filter_bits = MakeBitset(8, {3});
+        knowhere::BitsetView chunk_bitset(chunk_filter_bits.data(), 8);
+        chunk_bitset.set_out_ids(chunk_out_id_array, chunk_out_ids.size());
+
+        auto chunk_ds = knowhere::GenDataSet(4, dim, chunks.data());
+        chunk_ds->SetIsChunk(true);
+        chunk_ds->SetNumChunk(static_cast<int64_t>(chunks.size()));
+        chunk_ds->Set(knowhere::meta::EMB_LIST_OFFSET, chunk_lims.data());
+
+        auto iterators =
+            knowhere::BruteForce::AnnIterator<knowhere::fp32>(chunk_ds, query_ds, conf, chunk_bitset, false);
+        REQUIRE(iterators.has_value());
+        REQUIRE(iterators.value().size() == 1);
+        auto first = iterators.value()[0]->Next();
+        REQUIRE(first.has_value());
+        REQUIRE(first.value().first == 1);
+        auto second = iterators.value()[0]->Next();
+        REQUIRE(second.has_value());
+        REQUIRE(second.value().first == 5);
+    }
+}
+
+TEST_CASE("Sparse Brute Force maps logical out ids", "[sparse][id_map]") {
+    constexpr int64_t nq = 1;
+    constexpr int64_t dim = 8;
+    constexpr int64_t k = 2;
+
+    const std::vector<std::map<int32_t, float>> base = {
+        {{1, 2.0F}},  // internal row 0 -> out id 1, filtered
+        {{1, 1.0F}},  // internal row 1 -> out id 3
+        {{1, 0.5F}},  // internal row 2 -> out id 5
+    };
+    const std::vector<std::map<int32_t, float>> query = {{{1, 1.0F}}};
+    const std::vector<int32_t> out_ids = {1, 3, 5};
+    auto out_id_array = MakeIdArray(out_ids);
+    auto filter_bits = MakeBitset(6, {1});
+    knowhere::BitsetView bitset(filter_bits.data(), 6);
+    bitset.set_out_ids(out_id_array, out_ids.size());
+    bitset.set_vector_count(out_ids.size());
+    bitset.set_filter_count(1);
+
+    auto base_ds = GenSparseDataSet(base, dim);
+    auto query_ds = GenSparseDataSet(query, dim);
+    const knowhere::Json conf = {
+        {knowhere::meta::DIM, dim},
+        {knowhere::meta::METRIC_TYPE, knowhere::metric::IP},
+        {knowhere::meta::TOPK, k},
+    };
+
+    SECTION("SearchSparseWithBuf returns logical out ids") {
+        std::vector<knowhere::sparse::label_t> ids(nq * k, -1);
+        std::vector<float> distances(nq * k, 0.0F);
+        auto status = knowhere::BruteForce::SearchSparseWithBuf(base_ds, query_ds, ids.data(), distances.data(), conf,
+                                                                bitset, nullptr);
+        REQUIRE(status == knowhere::Status::success);
+        REQUIRE(ids == std::vector<knowhere::sparse::label_t>{3, 5});
+        REQUIRE(distances[0] == Catch::Approx(1.0F));
+        REQUIRE(distances[1] == Catch::Approx(0.5F));
+    }
+
+    SECTION("SearchSparse returns logical out ids") {
+        auto result = knowhere::BruteForce::SearchSparse(base_ds, query_ds, conf, bitset, nullptr);
+        REQUIRE(result.has_value());
+        REQUIRE(std::vector<int64_t>(result.value()->GetIds(), result.value()->GetIds() + nq * k) ==
+                std::vector<int64_t>{3, 5});
+    }
+
+    SECTION("RangeSearch returns logical out ids") {
+        auto range_conf = conf;
+        range_conf[knowhere::meta::RADIUS] = 0.0F;
+        range_conf[knowhere::meta::RANGE_FILTER] = 2.0F;
+        auto result = knowhere::BruteForce::RangeSearch<knowhere::sparse::SparseRow<float>>(
+            base_ds, query_ds, range_conf, bitset, nullptr);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetLims()[0] == 0);
+        REQUIRE(result.value()->GetLims()[1] == 2);
+        REQUIRE(std::vector<int64_t>(result.value()->GetIds(), result.value()->GetIds() + 2) ==
+                std::vector<int64_t>{3, 5});
+    }
+
+    SECTION("AnnIterator returns logical out ids") {
+        auto iterators = knowhere::BruteForce::AnnIterator<knowhere::sparse::SparseRow<float>>(base_ds, query_ds, conf,
+                                                                                               bitset, false);
+        REQUIRE(iterators.has_value());
+        REQUIRE(iterators.value().size() == 1);
+        auto first = iterators.value()[0]->Next();
+        REQUIRE(first.has_value());
+        REQUIRE(first.value().first == 3);
+        REQUIRE(first.value().second == Catch::Approx(1.0F));
+        auto second = iterators.value()[0]->Next();
+        REQUIRE(second.has_value());
+        REQUIRE(second.value().first == 5);
+        REQUIRE(second.value().second == Catch::Approx(0.5F));
+    }
 }

--- a/tests/ut/test_data_view_index.cc
+++ b/tests/ut/test_data_view_index.cc
@@ -9,6 +9,8 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
+#include <numeric>
+
 #include "catch2/catch_approx.hpp"
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/generators/catch_generators.hpp"
@@ -376,6 +378,10 @@ EmbListAddTest(const knowhere::DataSetPtr train_ds_in, const knowhere::DataSetPt
     scann_with_dv_refiner.SetIdMapType(knowhere::IdMap::Type::GROWING);
     for (size_t i = 0; i < train_ds_list.size(); i++) {
         auto& base = train_ds_list[i];
+        auto part_num_el = static_cast<size_t>(base->template Get<int64_t>(knowhere::meta::NQ));
+        std::vector<int32_t> part_ids(part_num_el);
+        std::iota(part_ids.begin(), part_ids.end(), 0);
+        base->SetIdMapData(knowhere::IdMapData::FromIds(part_ids.data(), part_ids.size(), part_ids.size()));
         if (i == 0) {
             REQUIRE(scann_with_dv_refiner.Build(base, conf, false) == knowhere::Status::success);
         } else {

--- a/tests/ut/test_data_view_index.cc
+++ b/tests/ut/test_data_view_index.cc
@@ -373,6 +373,7 @@ EmbListAddTest(const knowhere::DataSetPtr train_ds_in, const knowhere::DataSetPt
         knowhere::IndexFactory::Instance()
             .Create<DataType>(knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, version, data_view_pack)
             .value();
+    scann_with_dv_refiner.SetIdMapType(knowhere::IdMap::Type::GROWING);
     for (size_t i = 0; i < train_ds_list.size(); i++) {
         auto& base = train_ds_list[i];
         if (i == 0) {

--- a/tests/ut/test_emb_list.cc
+++ b/tests/ut/test_emb_list.cc
@@ -1007,7 +1007,7 @@ TEST_CASE("Search for EMBList Indices (Float)", "Benchmark and validation on flo
                             // provide a default one if nbits_set == 0
                             knowhere::BitsetView bitset_view = nullptr;
                             if (bitset_rate != 0.0f || mv_only_enable) {
-                                bitset_view = knowhere::BitsetView(bitset_data.data(), num_el, num_el * bitset_rate);
+                                bitset_view = knowhere::BitsetView(bitset_data.data(), num_el);
                             }
 
                             // get a golden result
@@ -1236,7 +1236,7 @@ TEST_CASE("Search for EMBList Indices (Float)", "Benchmark and validation on flo
                             // provide a default one if nbits_set == 0
                             knowhere::BitsetView bitset_view = nullptr;
                             if (bitset_rate != 0.0f || mv_only_enable) {
-                                bitset_view = knowhere::BitsetView(bitset_data.data(), num_el, num_el * bitset_rate);
+                                bitset_view = knowhere::BitsetView(bitset_data.data(), num_el);
                             }
 
                             // get a golden result
@@ -1457,7 +1457,7 @@ TEST_CASE("Search for EMBList Indices (Float)", "Benchmark and validation on flo
                             // provide a default one if nbits_set == 0
                             knowhere::BitsetView bitset_view = nullptr;
                             if (bitset_rate != 0.0f || mv_only_enable) {
-                                bitset_view = knowhere::BitsetView(bitset_data.data(), num_el, num_el * bitset_rate);
+                                bitset_view = knowhere::BitsetView(bitset_data.data(), num_el);
                             }
 
                             // get a golden result
@@ -1991,6 +1991,7 @@ EmbListAddTest(const knowhere::DataSetPtr train_ds_in, const knowhere::DataSetPt
     auto num_el = (rows + each_el_len - 1) / each_el_len;
 
     auto index = knowhere::IndexFactory::Instance().Create<DataType>(conf[knowhere::meta::INDEX_TYPE], version).value();
+    index.SetIdMapType(knowhere::IdMap::Type::GROWING);
     for (size_t i = 0; i < train_ds_list.size(); i++) {
         auto& base = train_ds_list[i];
         if (i == 0) {

--- a/tests/ut/test_emb_list.cc
+++ b/tests/ut/test_emb_list.cc
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -1994,6 +1995,10 @@ EmbListAddTest(const knowhere::DataSetPtr train_ds_in, const knowhere::DataSetPt
     index.SetIdMapType(knowhere::IdMap::Type::GROWING);
     for (size_t i = 0; i < train_ds_list.size(); i++) {
         auto& base = train_ds_list[i];
+        auto part_num_el = static_cast<size_t>(base->template Get<int64_t>(knowhere::meta::NQ));
+        std::vector<int32_t> part_ids(part_num_el);
+        std::iota(part_ids.begin(), part_ids.end(), 0);
+        base->SetIdMapData(knowhere::IdMapData::FromIds(part_ids.data(), part_ids.size(), part_ids.size()));
         if (i == 0) {
             REQUIRE(index.Build(base, conf, false) == knowhere::Status::success);
         } else {

--- a/tests/ut/test_faiss_hnsw.cc
+++ b/tests/ut/test_faiss_hnsw.cc
@@ -2301,7 +2301,7 @@ TEST_CASE("hnswlib to FAISS HNSW for HNSW_FLAT", "Check search fallback") {
     }
 }
 
-TEST_CASE("External ID Map for 1-hop Bitset Check", "[external_id_map]") {
+TEST_CASE("External ID Map for 1-hop Bitset Check", "[id_map]") {
     const int64_t NB = 1000;
     const int64_t dim = 128;
     const int64_t NQ = 10;
@@ -2353,15 +2353,23 @@ TEST_CASE("External ID Map for 1-hop Bitset Check", "[external_id_map]") {
             continue;
 #endif
 
-            // Verify the external id mapping
-            std::shared_ptr<std::vector<uint32_t>> external_id_map = index.Node()->GetInternalIdToExternalIdMap();
-            REQUIRE(external_id_map != nullptr);
-            REQUIRE(external_id_map->size() == NB);
-
-            // generate a 8-bits bitset data with only 0-idx set to 0 (bit==1 means filter out)
-            // with the external id map, we can map NB-ids to {0, 1}.
-            const std::vector<uint8_t> bitset_data = std::vector<uint8_t>(1, 0xe);
-            knowhere::BitsetView bitset_view = knowhere::BitsetView(bitset_data.data(), 8, 7);
+            auto make_bitset_view = [&](std::vector<uint8_t>& bitset_data, uint32_t valid_cnt,
+                                        int64_t selected_partition_idx) {
+                bitset_data.assign((NB + 7) / 8, 0);
+                size_t filtered_count = 0;
+                for (int64_t external_id = 0; external_id < NB; ++external_id) {
+                    bool keep = external_id < valid_cnt;
+                    if (keep && selected_partition_idx >= 0) {
+                        const auto& partition = scalar_info[0][selected_partition_idx];
+                        keep = std::find(partition.begin(), partition.end(), external_id) != partition.end();
+                    }
+                    if (!keep) {
+                        bitset_data[external_id >> 3] |= static_cast<uint8_t>(1U << (external_id & 0x7));
+                        ++filtered_count;
+                    }
+                }
+                return knowhere::BitsetView(bitset_data.data(), NB, filtered_count);
+            };
 
             for (const float filter_rate : FILTER_RATES) {
                 printf("mv_only_enable: %d, partition_num: %ld, filter_rate: %f\n", mv_only_enable, partition_num,
@@ -2407,16 +2415,8 @@ TEST_CASE("External ID Map for 1-hop Bitset Check", "[external_id_map]") {
                          ++selected_partition_idx) {
                         printf("selected_partition_idx: %d\n", selected_partition_idx);
 
-                        std::vector<uint32_t> internal_id_to_most_external_id_map(NB, 1);
-                        for (int64_t i = 0; i < NB; ++i) {
-                            if (external_id_map->at(i) < valid_cnt &&
-                                std::find(scalar_info[0][selected_partition_idx].begin(),
-                                          scalar_info[0][selected_partition_idx].end(),
-                                          external_id_map->at(i)) != scalar_info[0][selected_partition_idx].end()) {
-                                internal_id_to_most_external_id_map[i] = 0;
-                            }
-                        }
-                        index.Node()->SetInternalIdToMostExternalIdMap(std::move(internal_id_to_most_external_id_map));
+                        std::vector<uint8_t> bitset_data;
+                        auto bitset_view = make_bitset_view(bitset_data, valid_cnt, selected_partition_idx);
                         auto knn_result = index.Search(query_dataset, conf, bitset_view).value();
                         check_mv_only_result(knn_result, selected_partition_idx);
 
@@ -2424,13 +2424,8 @@ TEST_CASE("External ID Map for 1-hop Bitset Check", "[external_id_map]") {
                         check_mv_only_result(range_result, selected_partition_idx);
                     }
                 } else {
-                    std::vector<uint32_t> internal_id_to_most_external_id_map(NB, 1);
-                    for (int64_t i = 0; i < NB; ++i) {
-                        if (external_id_map->at(i) < valid_cnt) {
-                            internal_id_to_most_external_id_map[i] = 0;
-                        }
-                    }
-                    index.Node()->SetInternalIdToMostExternalIdMap(std::move(internal_id_to_most_external_id_map));
+                    std::vector<uint8_t> bitset_data;
+                    auto bitset_view = make_bitset_view(bitset_data, valid_cnt, -1);
                     auto knn_result = index.Search(query_dataset, conf, bitset_view).value();
                     check_not_mv_only_result(knn_result);
 

--- a/tests/ut/test_nullable_id_map.cc
+++ b/tests/ut/test_nullable_id_map.cc
@@ -1,0 +1,4304 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and limitations under the License.
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <functional>
+#include <initializer_list>
+#include <limits>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <set>
+#include <string>
+#include <system_error>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "catch2/catch_approx.hpp"
+#include "catch2/catch_test_macros.hpp"
+#include "filemanager/impl/LocalFileManager.h"
+#include "index/data_view_dense_index/data_view_dense_index.h"
+#include "knowhere/binaryset.h"
+#include "knowhere/bitsetview.h"
+#include "knowhere/comp/brute_force.h"
+#include "knowhere/comp/index_param.h"
+#include "knowhere/dataset.h"
+#include "knowhere/expected.h"
+#include "knowhere/id_map.h"
+#include "knowhere/index/index.h"
+#include "knowhere/index/index_factory.h"
+#include "knowhere/index/index_node_data_mock_wrapper.h"
+#include "knowhere/index/index_node_thread_pool_wrapper.h"
+#include "knowhere/object.h"
+#include "knowhere/thread_pool.h"
+#include "knowhere/version.h"
+#include "utils.h"
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#error "Missing the <filesystem> header."
+#endif
+
+namespace {
+
+using knowhere::Status;
+
+class NullableWrapperFakeIndexNode : public knowhere::IndexNode {
+ public:
+    NullableWrapperFakeIndexNode() = default;
+
+    Status
+    Train(const knowhere::DataSetPtr dataset, std::shared_ptr<knowhere::Config> cfg,
+          bool use_knowhere_build_pool) override {
+        return Status::success;
+    }
+
+    Status
+    Add(const knowhere::DataSetPtr dataset, std::shared_ptr<knowhere::Config> cfg,
+        bool use_knowhere_build_pool) override {
+        return Status::success;
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    Search(const knowhere::DataSetPtr dataset, std::unique_ptr<knowhere::Config> cfg,
+           const knowhere::BitsetView& bitset, milvus::OpContext* op_context) const override {
+        return knowhere::expected<knowhere::DataSetPtr>::Err(Status::not_implemented, "Search not implemented");
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    RangeSearch(const knowhere::DataSetPtr dataset, std::unique_ptr<knowhere::Config> cfg,
+                const knowhere::BitsetView& bitset, milvus::OpContext* op_context) const override {
+        return knowhere::expected<knowhere::DataSetPtr>::Err(Status::not_implemented, "RangeSearch not implemented");
+    }
+
+    knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
+    AnnIterator(const knowhere::DataSetPtr dataset, std::unique_ptr<knowhere::Config> cfg,
+                const knowhere::BitsetView& bitset, bool use_knowhere_search_pool,
+                milvus::OpContext* op_context) const override {
+        return knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>::Err(Status::not_implemented,
+                                                                                      "AnnIterator not implemented");
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    GetVectorByIds(const knowhere::DataSetPtr dataset, milvus::OpContext* op_context) const override {
+        return knowhere::expected<knowhere::DataSetPtr>::Err(Status::not_implemented, "GetVectorByIds not implemented");
+    }
+
+    bool
+    HasRawData(const std::string& metric_type) const override {
+        return true;
+    }
+
+    bool
+    NeedBitsetExactCount() const override {
+        return true;
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    GetIndexMeta(std::unique_ptr<knowhere::Config> cfg) const override {
+        return knowhere::expected<knowhere::DataSetPtr>::Err(Status::not_implemented, "GetIndexMeta not implemented");
+    }
+
+    Status
+    Serialize(knowhere::BinarySet& binset) const override {
+        return Status::success;
+    }
+
+    Status
+    Deserialize(const knowhere::BinarySet& binset, std::shared_ptr<knowhere::Config> config) override {
+        return Status::success;
+    }
+
+    Status
+    DeserializeFromFile(const std::string& filename, std::shared_ptr<knowhere::Config> config) override {
+        return Status::success;
+    }
+
+    std::unique_ptr<knowhere::BaseConfig>
+    CreateConfig() const override {
+        return std::make_unique<knowhere::BaseConfig>();
+    }
+
+    int64_t
+    Dim() const override {
+        return 0;
+    }
+
+    int64_t
+    Size() const override {
+        return 0;
+    }
+
+    int64_t
+    Count() const override {
+        return 0;
+    }
+
+    std::string
+    Type() const override {
+        return "NULLABLE_WRAPPER_FAKE";
+    }
+};
+
+class FailingAddFakeIndexNode : public NullableWrapperFakeIndexNode {
+ public:
+    Status
+    Add(const knowhere::DataSetPtr dataset, std::shared_ptr<knowhere::Config> cfg,
+        bool use_knowhere_build_pool) override {
+        return Status::invalid_args;
+    }
+
+    std::string
+    Type() const override {
+        return "FAILING_ADD_FAKE";
+    }
+};
+
+struct CapturedBitsetState {
+    bool empty = true;
+    bool need_filter = false;
+    bool has_out_ids = false;
+    size_t size = 0;
+    size_t num_bits = 0;
+    size_t count = 0;
+    std::vector<int> filtered_in_ids;
+};
+
+class EmptyIterator : public knowhere::IndexNode::iterator {
+ public:
+    knowhere::expected<std::pair<int64_t, float>>
+    Next() override {
+        return {-1, 0.0f};
+    }
+
+    [[nodiscard]] knowhere::expected<bool>
+    HasNext() override {
+        return false;
+    }
+};
+
+class CapturingBitsetFakeIndexNode : public knowhere::IndexNode {
+ public:
+    explicit CapturingBitsetFakeIndexNode(int64_t count, int64_t dim) : count_(count), dim_(dim) {
+    }
+
+    Status
+    Train(const knowhere::DataSetPtr dataset, std::shared_ptr<knowhere::Config> cfg,
+          bool use_knowhere_build_pool) override {
+        return Status::success;
+    }
+
+    Status
+    Add(const knowhere::DataSetPtr dataset, std::shared_ptr<knowhere::Config> cfg,
+        bool use_knowhere_build_pool) override {
+        return Status::success;
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    Search(const knowhere::DataSetPtr dataset, std::unique_ptr<knowhere::Config> cfg,
+           const knowhere::BitsetView& bitset, milvus::OpContext* op_context) const override {
+        last_search_bitset = Capture(bitset);
+        auto ids = std::make_unique<int64_t[]>(1);
+        auto distances = std::make_unique<float[]>(1);
+        ids[0] = -1;
+        distances[0] = 0.0f;
+        return knowhere::GenResultDataSet(1, 1, std::move(ids), std::move(distances));
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    RangeSearch(const knowhere::DataSetPtr dataset, std::unique_ptr<knowhere::Config> cfg,
+                const knowhere::BitsetView& bitset, milvus::OpContext* op_context) const override {
+        last_range_bitset = Capture(bitset);
+        knowhere::RangeSearchResult range;
+        range.lims = std::make_unique<size_t[]>(2);
+        range.lims[0] = 0;
+        range.lims[1] = 0;
+        return knowhere::GenResultDataSet(1, std::move(range));
+    }
+
+    knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
+    AnnIterator(const knowhere::DataSetPtr dataset, std::unique_ptr<knowhere::Config> cfg,
+                const knowhere::BitsetView& bitset, bool use_knowhere_search_pool,
+                milvus::OpContext* op_context) const override {
+        last_iterator_bitset = Capture(bitset);
+        return std::vector<knowhere::IndexNode::IteratorPtr>{std::make_shared<EmptyIterator>()};
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    GetVectorByIds(const knowhere::DataSetPtr dataset, milvus::OpContext* op_context) const override {
+        return knowhere::expected<knowhere::DataSetPtr>::Err(Status::not_implemented, "not implemented");
+    }
+
+    bool
+    HasRawData(const std::string& metric_type) const override {
+        return true;
+    }
+
+    bool
+    NeedBitsetExactCount() const override {
+        return true;
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    GetIndexMeta(std::unique_ptr<knowhere::Config> cfg) const override {
+        return knowhere::expected<knowhere::DataSetPtr>::Err(Status::not_implemented, "not implemented");
+    }
+
+    Status
+    Serialize(knowhere::BinarySet& binset) const override {
+        return Status::success;
+    }
+
+    Status
+    Deserialize(const knowhere::BinarySet& binset, std::shared_ptr<knowhere::Config> config) override {
+        return Status::success;
+    }
+
+    Status
+    DeserializeFromFile(const std::string& filename, std::shared_ptr<knowhere::Config> config) override {
+        return Status::success;
+    }
+
+    std::unique_ptr<knowhere::BaseConfig>
+    CreateConfig() const override {
+        return std::make_unique<knowhere::BaseConfig>();
+    }
+
+    int64_t
+    Dim() const override {
+        return dim_;
+    }
+
+    int64_t
+    Size() const override {
+        return count_ * dim_ * static_cast<int64_t>(sizeof(float));
+    }
+
+    int64_t
+    Count() const override {
+        return count_;
+    }
+
+    std::string
+    Type() const override {
+        return "CAPTURING_BITSET_FAKE";
+    }
+
+    void
+    SetEmbListOffsetForTest(std::vector<size_t> offsets) {
+        emb_list_offset_ = std::make_shared<knowhere::EmbListOffset>(std::move(offsets));
+    }
+
+    void
+    BuildInToOutEblIdsForTest(const std::vector<size_t>& offsets) {
+        id_map_.FinalizeEmbListIds(offsets.data(), offsets.size() - 1);
+    }
+
+    mutable CapturedBitsetState last_search_bitset;
+    mutable CapturedBitsetState last_range_bitset;
+    mutable CapturedBitsetState last_iterator_bitset;
+
+ private:
+    static CapturedBitsetState
+    Capture(const knowhere::BitsetView& bitset) {
+        CapturedBitsetState state;
+        state.empty = bitset.empty();
+        state.need_filter = !bitset.empty();
+        state.has_out_ids = bitset.has_out_ids();
+        state.size = bitset.size();
+        state.num_bits = bitset.num_bits();
+        state.count = bitset.count();
+        const auto test_size = state.has_out_ids ? state.size : std::min(state.size, state.num_bits);
+        for (size_t i = 0; i < test_size; ++i) {
+            if (bitset.test(static_cast<int64_t>(i))) {
+                state.filtered_in_ids.push_back(static_cast<int>(i));
+            }
+        }
+        return state;
+    }
+
+    int64_t count_;
+    int64_t dim_;
+};
+
+constexpr int64_t kTotalRows = 32;
+constexpr int64_t kDenseDim = 16;
+constexpr int64_t kGpuRows = 64;
+constexpr int64_t kGpuDim = 32;
+constexpr int64_t kFileRows = 64;
+constexpr int64_t kFileDim = 32;
+constexpr int64_t kEmbDocs = 32;
+constexpr int64_t kEmbVectorsPerDoc = 2;
+constexpr int64_t kTopK = 3;
+constexpr int64_t kEmbTopK = 2;
+constexpr int64_t kQueryCount = 3;
+
+enum class DataKind {
+    DenseFp32,
+    DenseBin,
+    Sparse,
+    MinHash,
+    DiskAnn,
+    Aisaq,
+    GpuFp32,
+};
+
+enum class Mode {
+    Vector,
+    EmbList,
+    MultiIndex,
+};
+
+enum class Operation {
+    Build,
+    Search,
+    Range,
+    Iterator,
+    SearchFilter,
+    RangeFilter,
+    IteratorFilter,
+    BinarySetSerialize,
+    BinarySetDeserialize,
+    FileSerialize,
+    FileDeserialize,
+};
+
+enum class IndexSource {
+    Fresh,
+    BinarySet,
+    File,
+};
+
+enum class NullableRatio {
+    R0,
+    R50,
+};
+
+enum class FilterRatio {
+    None,
+    R0,
+    R50,
+    R100,
+    Collapsed,
+};
+
+struct Capabilities {
+    bool build = false;
+    bool search = false;
+    bool range = false;
+    bool iterator = false;
+    bool search_filter = false;
+    bool range_filter = false;
+    bool iterator_filter = false;
+    bool binaryset_serialize = false;
+    bool binaryset_deserialize = false;
+    bool file_serialize = false;
+    bool file_deserialize = false;
+    bool emb_build = false;
+    bool emb_search = false;
+    bool emb_range = false;
+    bool emb_iterator = false;
+    bool emb_search_filter = false;
+    bool emb_range_filter = false;
+    bool emb_iterator_filter = false;
+    bool multi_build = false;
+    bool multi_search = false;
+    bool multi_range = false;
+    bool multi_iterator = false;
+    bool multi_search_filter = false;
+    bool multi_range_filter = false;
+    bool multi_iterator_filter = false;
+};
+
+struct IndexRow {
+    std::string label;
+    std::string index_type;
+    DataKind data_kind = DataKind::DenseFp32;
+    Capabilities caps;
+    bool maybe_unavailable = false;
+    bool requires_current_version = false;
+    bool requires_svs = false;
+    bool requires_gpu = false;
+    bool exact = false;
+};
+
+IndexRow
+NativeFaissHnswRow() {
+#ifdef KNOWHERE_WITH_CARDINAL
+    return {"HNSW_DEPRECATED", "HNSW_DEPRECATED", DataKind::DenseFp32};
+#else
+    return {"HNSW Knowhere Faiss", knowhere::IndexEnum::INDEX_HNSW, DataKind::DenseFp32};
+#endif
+}
+
+IndexRow
+NativeDiskAnnRow() {
+#ifdef KNOWHERE_WITH_CARDINAL
+    return {"DISKANN_DEPRECATED", "DISKANN_DEPRECATED", DataKind::DiskAnn};
+#else
+    return {"DISKANN (Knowhere native)", knowhere::IndexEnum::INDEX_DISKANN, DataKind::DiskAnn};
+#endif
+}
+
+struct Scenario {
+    std::string name;
+    NullableRatio nullable_ratio = NullableRatio::R0;
+    FilterRatio filter_ratio = FilterRatio::None;
+    Mode mode = Mode::Vector;
+    Operation op = Operation::Build;
+    IndexSource source = IndexSource::Fresh;
+    std::string emb_list_strategy;
+    bool force_raw_data = false;
+    int64_t total_count_override = 0;
+};
+
+struct MatrixData {
+    int64_t total_count = 0;
+    int64_t dim = 0;
+    std::vector<int32_t> valid_ids;
+    std::vector<int32_t> query_ids;
+    std::vector<int32_t> selected_ids;
+    knowhere::DataSetPtr full_ds;
+    knowhere::DataSetPtr train_ds;
+    knowhere::DataSetPtr query_ds;
+};
+
+void
+RemoveAllNoThrow(const fs::path& path) {
+    if (path.empty()) {
+        return;
+    }
+    std::error_code ec;
+    fs::remove_all(path, ec);
+}
+
+class ScopedWorkDir {
+ public:
+    explicit ScopedWorkDir(fs::path path) : path_(std::move(path)) {
+        RemoveAllNoThrow(path_);
+        fs::create_directories(path_);
+    }
+
+    ~ScopedWorkDir() {
+        RemoveAllNoThrow(path_);
+    }
+
+ private:
+    fs::path path_;
+};
+
+struct BuiltArtifact {
+    IndexRow row;
+    Scenario scenario;
+    MatrixData data;
+    knowhere::Json json;
+    knowhere::Index<knowhere::IndexNode> index;
+    knowhere::Index<knowhere::IndexNode> binary_loaded;
+    knowhere::Index<knowhere::IndexNode> file_loaded;
+    knowhere::BinarySet binset;
+    std::shared_ptr<milvus::FileManager> file_manager;
+    knowhere::Status create_status = knowhere::Status::success;
+    knowhere::Status build_status = knowhere::Status::success;
+    knowhere::Status serialize_status = knowhere::Status::success;
+    knowhere::Status binary_deserialize_status = knowhere::Status::success;
+    knowhere::Status file_serialize_status = knowhere::Status::success;
+    knowhere::Status file_deserialize_status = knowhere::Status::success;
+    bool create_ok = false;
+    bool serialized = false;
+    bool binary_loaded_ready = false;
+    bool file_serialized = false;
+    bool file_loaded_ready = false;
+    fs::path work_dir;
+    fs::path main_file;
+    fs::path emb_meta_file;
+    fs::path emb_raw_file;
+    fs::path emb_offset_file;
+    fs::path raw_data_file;
+    fs::path file_index_prefix;
+
+    ~BuiltArtifact() {
+        RemoveAllNoThrow(work_dir);
+    }
+};
+
+knowhere::Status
+BuildRuntimeIdMap(const std::vector<int32_t>& valid_ids, int64_t total_count, knowhere::IdMap& id_map);
+
+knowhere::Status
+BuildRuntimeValidBitmap(const std::vector<int32_t>& valid_ids, int64_t total_count, knowhere::IdMap& id_map);
+
+int32_t
+VersionForRow(const IndexRow& row) {
+#ifdef KNOWHERE_WITH_CARDINAL
+    if (!row.requires_current_version &&
+        (row.index_type == knowhere::IndexEnum::INDEX_HNSW || row.index_type == knowhere::IndexEnum::INDEX_DISKANN)) {
+        return knowhere::Version::GetDefaultVersion().VersionNumber();
+    }
+    if (row.requires_current_version) {
+        return std::max(knowhere::Version::GetCurrentVersion().VersionNumber(), 9);
+    }
+#endif
+    return knowhere::Version::GetCurrentVersion().VersionNumber();
+}
+
+std::string
+NullableName(NullableRatio ratio) {
+    switch (ratio) {
+        case NullableRatio::R0:
+            return "nullable0";
+        case NullableRatio::R50:
+            return "nullable50";
+    }
+    return "nullable_unknown";
+}
+
+std::string
+FilterName(FilterRatio ratio) {
+    switch (ratio) {
+        case FilterRatio::None:
+            return "filter_none";
+        case FilterRatio::R0:
+            return "filter0";
+        case FilterRatio::R50:
+            return "filter50";
+        case FilterRatio::R100:
+            return "filter100";
+        case FilterRatio::Collapsed:
+            return "filter_collapsed";
+    }
+    return "filter_unknown";
+}
+
+std::string
+ModeName(Mode mode) {
+    switch (mode) {
+        case Mode::Vector:
+            return "vector";
+        case Mode::EmbList:
+            return "emblist";
+        case Mode::MultiIndex:
+            return "multi";
+    }
+    return "unknown_mode";
+}
+
+std::string
+SourceName(IndexSource source) {
+    switch (source) {
+        case IndexSource::Fresh:
+            return "fresh";
+        case IndexSource::BinarySet:
+            return "binary";
+        case IndexSource::File:
+            return "file";
+    }
+    return "unknown_source";
+}
+
+std::string
+OperationName(Operation op) {
+    switch (op) {
+        case Operation::Build:
+            return "build";
+        case Operation::Search:
+            return "search";
+        case Operation::Range:
+            return "range";
+        case Operation::Iterator:
+            return "iterator";
+        case Operation::SearchFilter:
+            return "search_filter";
+        case Operation::RangeFilter:
+            return "range_filter";
+        case Operation::IteratorFilter:
+            return "iterator_filter";
+        case Operation::BinarySetSerialize:
+            return "binaryset_serialize";
+        case Operation::BinarySetDeserialize:
+            return "binaryset_deserialize";
+        case Operation::FileSerialize:
+            return "file_serialize";
+        case Operation::FileDeserialize:
+            return "file_deserialize";
+    }
+    return "unknown_operation";
+}
+
+std::vector<int32_t>
+AllIds(int64_t count) {
+    std::vector<int32_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 0);
+    return ids;
+}
+
+std::vector<int32_t>
+EvenIds(int64_t count) {
+    std::vector<int32_t> ids;
+    ids.reserve((count + 1) / 2);
+    for (int32_t id = 0; id < count; id += 2) {
+        ids.push_back(id);
+    }
+    return ids;
+}
+
+std::vector<int32_t>
+PairedIds(int64_t count) {
+    std::vector<int32_t> ids;
+    ids.reserve((count + 3) / 4 * 2);
+    for (int32_t id = 0; id < count; id += 8) {
+        ids.push_back(id);
+        if (id + 1 < count) {
+            ids.push_back(id + 1);
+        }
+        if (id + 4 < count) {
+            ids.push_back(id + 4);
+        }
+        if (id + 5 < count) {
+            ids.push_back(id + 5);
+        }
+    }
+    return ids;
+}
+
+std::vector<int32_t>
+ValidIdsFor(NullableRatio ratio, int64_t count, bool paired_for_multi = false) {
+    switch (ratio) {
+        case NullableRatio::R0:
+            return AllIds(count);
+        case NullableRatio::R50:
+            return paired_for_multi ? PairedIds(count) : EvenIds(count);
+    }
+    return {};
+}
+
+bool
+ContainsId(const std::vector<int32_t>& ids, int64_t id) {
+    return std::find(ids.begin(), ids.end(), static_cast<int32_t>(id)) != ids.end();
+}
+
+int64_t
+FirstMissingOutId(const std::vector<int32_t>& valid_ids, int64_t total_count) {
+    for (int64_t id = 0; id < total_count; ++id) {
+        if (!ContainsId(valid_ids, id)) {
+            return id;
+        }
+    }
+    return total_count;
+}
+
+std::vector<int32_t>
+FirstQueryIds(const std::vector<int32_t>& valid_ids, int64_t total_count, int64_t query_count = kQueryCount) {
+    std::vector<int32_t> ids;
+    ids.reserve(query_count);
+    for (auto id : valid_ids) {
+        ids.push_back(id);
+        if (static_cast<int64_t>(ids.size()) == query_count) {
+            return ids;
+        }
+    }
+    for (int32_t id = 0; static_cast<int64_t>(ids.size()) < query_count && id < total_count; ++id) {
+        ids.push_back(id);
+    }
+    while (static_cast<int64_t>(ids.size()) < query_count) {
+        ids.push_back(0);
+    }
+    return ids;
+}
+
+std::vector<int32_t>
+PartitionIds(const std::vector<int32_t>& valid_ids, int partition) {
+    std::vector<int32_t> ids;
+    for (auto id : valid_ids) {
+        if ((id & 1) == partition) {
+            ids.push_back(id);
+        }
+    }
+    return ids;
+}
+
+void
+FillDenseVector(float* data, int64_t row, int64_t dim, int32_t logical_id) {
+    auto* dst = data + row * dim;
+    std::fill(dst, dst + dim, 0.0f);
+    dst[0] = static_cast<float>(logical_id * 100 + 1);
+    dst[logical_id % dim] += 1.0f;
+}
+
+knowhere::DataSetPtr
+GenFullDenseDataSet(int64_t total_count, int64_t dim) {
+    auto data = std::make_unique<float[]>(std::max<int64_t>(total_count * dim, 1));
+    for (int64_t logical_id = 0; logical_id < total_count; ++logical_id) {
+        FillDenseVector(data.get(), logical_id, dim, static_cast<int32_t>(logical_id));
+    }
+    auto ds = knowhere::GenDataSet(total_count, dim, data.release());
+    ds->SetIsOwner(true);
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenNullableDenseDataSet(int64_t total_count, const std::vector<int32_t>& valid_ids, int64_t dim) {
+    const auto rows = static_cast<int64_t>(valid_ids.size());
+    auto data = std::make_unique<float[]>(std::max<int64_t>(rows * dim, 1));
+    for (int64_t row = 0; row < rows; ++row) {
+        FillDenseVector(data.get(), row, dim, valid_ids[row]);
+    }
+    auto ds = knowhere::GenDataSet(rows, dim, data.release());
+    ds->SetIsOwner(true);
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenDenseQueryDataSet(const std::vector<int32_t>& logical_ids, int64_t dim) {
+    auto data = std::make_unique<float[]>(std::max<int64_t>(static_cast<int64_t>(logical_ids.size()) * dim, 1));
+    for (int64_t row = 0; row < static_cast<int64_t>(logical_ids.size()); ++row) {
+        FillDenseVector(data.get(), row, dim, logical_ids[row]);
+    }
+    auto ds = knowhere::GenDataSet(static_cast<int64_t>(logical_ids.size()), dim, data.release());
+    ds->SetIsOwner(true);
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenNullableBinaryDataSet(int64_t total_count, const std::vector<int32_t>& valid_ids, int64_t dim,
+                         const knowhere::DataSetPtr& full_ds, std::vector<uint8_t>& owned_data) {
+    const auto bytes_per_row = dim / 8;
+    const auto* full_data = static_cast<const uint8_t*>(full_ds->GetTensor());
+    owned_data.assign(std::max<int64_t>(static_cast<int64_t>(valid_ids.size()) * bytes_per_row, 1), 0);
+    for (size_t i = 0; i < valid_ids.size(); ++i) {
+        std::memcpy(owned_data.data() + i * bytes_per_row, full_data + valid_ids[i] * bytes_per_row, bytes_per_row);
+    }
+    auto ds = knowhere::GenDataSet(static_cast<int64_t>(valid_ids.size()), dim, owned_data.data());
+    ds->SetIsOwner(false);
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenBinaryQueryDataSet(const std::vector<int32_t>& query_ids, int64_t dim, const knowhere::DataSetPtr& full_ds,
+                      std::vector<uint8_t>& owned_data) {
+    const auto bytes_per_row = dim / 8;
+    const auto* full_data = static_cast<const uint8_t*>(full_ds->GetTensor());
+    owned_data.assign(std::max<int64_t>(static_cast<int64_t>(query_ids.size()) * bytes_per_row, 1), 0);
+    for (size_t i = 0; i < query_ids.size(); ++i) {
+        std::memcpy(owned_data.data() + i * bytes_per_row, full_data + query_ids[i] * bytes_per_row, bytes_per_row);
+    }
+    auto ds = knowhere::GenDataSet(static_cast<int64_t>(query_ids.size()), dim, owned_data.data());
+    ds->SetIsOwner(false);
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenNullableSparseDataSet(int64_t total_count, const std::vector<int32_t>& valid_ids) {
+    std::vector<std::map<int32_t, float>> rows;
+    rows.reserve(valid_ids.size());
+    for (auto logical_id : valid_ids) {
+        rows.push_back({{logical_id + 1, 1.0f}});
+    }
+    return GenSparseDataSet(rows, static_cast<int32_t>(total_count + 2));
+}
+
+knowhere::DataSetPtr
+GenSparseQueryDataSet(const std::vector<int32_t>& logical_ids, int64_t total_count) {
+    std::vector<std::map<int32_t, float>> rows;
+    rows.reserve(logical_ids.size());
+    for (auto logical_id : logical_ids) {
+        rows.push_back({{logical_id + 1, 1.0f}});
+    }
+    return GenSparseDataSet(rows, static_cast<int32_t>(total_count + 2));
+}
+
+knowhere::DataSetPtr
+GenNullableEmbListDataSet(int64_t total_docs, const std::vector<int32_t>& valid_doc_ids, int64_t dim,
+                          int64_t vectors_per_doc) {
+    const auto rows = static_cast<int64_t>(valid_doc_ids.size()) * vectors_per_doc;
+    auto data = std::make_unique<float[]>(std::max<int64_t>(rows * dim, 1));
+    std::vector<size_t> offsets(valid_doc_ids.size() + 1, 0);
+    for (size_t doc = 0; doc < valid_doc_ids.size(); ++doc) {
+        offsets[doc] = doc * vectors_per_doc;
+        for (int64_t v = 0; v < vectors_per_doc; ++v) {
+            FillDenseVector(data.get(), static_cast<int64_t>(doc) * vectors_per_doc + v, dim, valid_doc_ids[doc]);
+        }
+    }
+    offsets[valid_doc_ids.size()] = static_cast<size_t>(rows);
+    auto ds = knowhere::GenDataSet(rows, dim, data.release());
+    ds->SetIsOwner(true);
+    auto offset_data = std::make_unique<size_t[]>(offsets.size());
+    std::copy(offsets.begin(), offsets.end(), offset_data.get());
+    ds->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(offset_data.release()));
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenEmbListQueryDataSet(const std::vector<int32_t>& logical_doc_ids, int64_t dim) {
+    auto ds = GenDenseQueryDataSet(logical_doc_ids, dim);
+    auto offsets = std::make_unique<size_t[]>(logical_doc_ids.size() + 1);
+    for (size_t i = 0; i <= logical_doc_ids.size(); ++i) {
+        offsets[i] = i;
+    }
+    ds->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(offsets.release()));
+    return ds;
+}
+
+std::unordered_map<int64_t, std::vector<std::vector<uint32_t>>>
+ScalarInfoForEvenOddPartitions(const std::vector<int32_t>& valid_ids) {
+    std::unordered_map<int64_t, std::vector<std::vector<uint32_t>>> scalar_info;
+    scalar_info[0].resize(2);
+    for (size_t row = 0; row < valid_ids.size(); ++row) {
+        scalar_info[0][valid_ids[row] & 1].push_back(static_cast<uint32_t>(row));
+    }
+    return scalar_info;
+}
+
+std::vector<uint8_t>
+MakeBitmap(size_t total_count, const std::vector<int32_t>& filtered_ids) {
+    std::vector<uint8_t> bitmap((total_count + 7) / 8, 0);
+    for (auto id : filtered_ids) {
+        if (id >= 0 && static_cast<size_t>(id) < total_count) {
+            bitmap[id >> 3] |= static_cast<uint8_t>(1U << (id & 7));
+        }
+    }
+    return bitmap;
+}
+
+std::vector<int32_t>
+HalfFilteredIds(size_t total_count, const std::vector<int32_t>& candidate_ids) {
+    std::vector<int32_t> ids;
+    const auto target = candidate_ids.size() / 2;
+    ids.reserve(target);
+    for (size_t i = 0; i < candidate_ids.size() && ids.size() < target; i += 2) {
+        ids.push_back(candidate_ids[i]);
+    }
+    return ids;
+}
+
+std::vector<int32_t>
+FilterIdsFor(FilterRatio filter_ratio, int64_t total_count, const std::vector<int32_t>& valid_ids, Mode mode,
+             const std::vector<int32_t>& selected_ids) {
+    if (filter_ratio == FilterRatio::None || filter_ratio == FilterRatio::R0) {
+        if (mode != Mode::MultiIndex) {
+            return {};
+        }
+    }
+    if (filter_ratio == FilterRatio::R100 || filter_ratio == FilterRatio::Collapsed) {
+        return AllIds(total_count);
+    }
+
+    std::vector<int32_t> filtered_ids;
+    if (mode == Mode::MultiIndex) {
+        std::set<int32_t> selected(selected_ids.begin(), selected_ids.end());
+        for (int32_t id = 0; id < total_count; ++id) {
+            if (selected.find(id) == selected.end()) {
+                filtered_ids.push_back(id);
+            }
+        }
+        if (filter_ratio == FilterRatio::R50) {
+            auto half_selected = HalfFilteredIds(total_count, selected_ids);
+            filtered_ids.insert(filtered_ids.end(), half_selected.begin(), half_selected.end());
+        }
+        return filtered_ids;
+    }
+
+    if (filter_ratio == FilterRatio::R50) {
+        return HalfFilteredIds(total_count, valid_ids);
+    }
+    return {};
+}
+
+std::vector<int32_t>
+AllowedIdsAfterFilter(const std::vector<int32_t>& valid_ids, const std::vector<int32_t>& filtered_ids) {
+    std::vector<int32_t> allowed;
+    for (auto id : valid_ids) {
+        if (!ContainsId(filtered_ids, id)) {
+            allowed.push_back(id);
+        }
+    }
+    return allowed;
+}
+
+knowhere::BitsetView
+BitsetViewFrom(std::vector<uint8_t>& bitmap, int64_t total_count, const std::vector<int32_t>& filtered_ids) {
+    bitmap = MakeBitmap(total_count, filtered_ids);
+    knowhere::BitsetView bitset(bitmap.data(), total_count);
+    bitset.count_filtered_bits(0, total_count);
+    return bitset;
+}
+
+knowhere::IndexNode::PreparedBitset
+NormalizedBitsetFrom(std::vector<uint8_t>& bitmap, const knowhere::IdMap& id_map, int64_t total_count,
+                     const std::vector<int32_t>& filtered_ids) {
+    knowhere::IndexNode::PreparedBitset prepared(BitsetViewFrom(bitmap, total_count, filtered_ids));
+    const auto& out_ids = id_map.InToOutIds();
+    if (!out_ids.empty()) {
+        prepared.bitset.set_id_offset(0);
+        prepared.bitset.set_out_ids(out_ids, out_ids.size());
+        const auto& valid_bitmap = id_map.ValidBitmap();
+        prepared.bitset.count_filtered_bits(0, prepared.bitset.num_bits(), valid_bitmap.data());
+    }
+    return prepared;
+}
+
+knowhere::Json
+BaseDenseConfig(const std::string& metric = knowhere::metric::L2, int64_t dim = kDenseDim, int64_t topk = kTopK) {
+    knowhere::Json json;
+    json[knowhere::meta::DIM] = dim;
+    json[knowhere::meta::METRIC_TYPE] = metric;
+    json[knowhere::meta::TOPK] = topk;
+    json[knowhere::meta::RADIUS] = 100000000.0f;
+    json[knowhere::meta::RANGE_FILTER] = 0.0f;
+    json[knowhere::meta::RANGE_SEARCH_K] = 64;
+    return json;
+}
+
+std::string
+EmbListStrategyFor(const Scenario& scenario) {
+    if (scenario.emb_list_strategy.empty()) {
+        return knowhere::meta::EMB_LIST_STRATEGY_TOKENANN;
+    }
+    return scenario.emb_list_strategy;
+}
+
+std::vector<std::string>
+EmbListStrategies() {
+    return {knowhere::meta::EMB_LIST_STRATEGY_TOKENANN, knowhere::meta::EMB_LIST_STRATEGY_MUVERA,
+            knowhere::meta::EMB_LIST_STRATEGY_LEMUR};
+}
+
+void
+ApplyEmbListStrategyConfig(knowhere::Json& json, const std::string& strategy) {
+    json["emb_list_strategy"] = strategy;
+    if (strategy == knowhere::meta::EMB_LIST_STRATEGY_MUVERA) {
+        json["muvera_num_projections"] = 2;
+        json["muvera_num_repeats"] = 2;
+        json["muvera_seed"] = 42;
+    } else if (strategy == knowhere::meta::EMB_LIST_STRATEGY_LEMUR) {
+        json["lemur_hidden_dim"] = 8;
+        json["lemur_num_train_samples"] = 1000;
+        json["lemur_num_epochs"] = 1;
+        json["lemur_batch_size"] = 8;
+        json["lemur_learning_rate"] = 0.001f;
+        json["lemur_seed"] = 42;
+        json["lemur_num_layers"] = 1;
+    }
+}
+
+knowhere::Json
+DenseConfigFor(const IndexRow& row, Mode mode,
+               const std::string& emb_list_strategy = knowhere::meta::EMB_LIST_STRATEGY_TOKENANN) {
+    const auto dim = row.data_kind == DataKind::GpuFp32 ? kGpuDim : kDenseDim;
+    auto json = BaseDenseConfig(mode == Mode::EmbList ? "MAX_SIM_L2" : knowhere::metric::L2, dim,
+                                mode == Mode::EmbList ? kEmbTopK : kTopK);
+    if (row.index_type == knowhere::IndexEnum::INDEX_FAISS) {
+        json["faiss_index_name"] = "Flat";
+        return json;
+    }
+    json[knowhere::meta::INDEX_TYPE] = row.index_type;
+    json[knowhere::indexparam::NLIST] = 4;
+    json[knowhere::indexparam::NPROBE] = 4;
+    json[knowhere::indexparam::HNSW_M] = 8;
+    json[knowhere::indexparam::EFCONSTRUCTION] = 40;
+    json[knowhere::indexparam::EF] = 64;
+    json[knowhere::indexparam::M] = 4;
+    json[knowhere::indexparam::NBITS] = 4;
+    json[knowhere::indexparam::PRQ_NUM] = 2;
+    json[knowhere::indexparam::SQ_TYPE] = "SQ8";
+    json[knowhere::indexparam::REORDER_K] = 8;
+    json[knowhere::indexparam::SUB_DIM] = 2;
+    json[knowhere::indexparam::WITH_RAW_DATA] = true;
+    json[knowhere::indexparam::ENSURE_TOPK_FULL] = true;
+    json[knowhere::indexparam::REFINE_RATIO] = 2.0f;
+    json[knowhere::indexparam::RETRIEVAL_ANN_RATIO] = 2.0f;
+    if (mode == Mode::EmbList) {
+        ApplyEmbListStrategyConfig(json, emb_list_strategy);
+    }
+    if (mode == Mode::EmbList && row.index_type == knowhere::IndexEnum::INDEX_HNSW_PRQ &&
+        emb_list_strategy == knowhere::meta::EMB_LIST_STRATEGY_MUVERA) {
+        json[knowhere::indexparam::M] = 16;
+        json[knowhere::indexparam::PRQ_NUM] = 1;
+    }
+
+    if (row.index_type == "IVF_SQ") {
+        json[knowhere::indexparam::SQ_TYPE] = "SQ8";
+    }
+    if (row.index_type == knowhere::IndexEnum::INDEX_SVS_VAMANA ||
+        row.index_type == knowhere::IndexEnum::INDEX_SVS_VAMANA_LVQ ||
+        row.index_type == knowhere::IndexEnum::INDEX_SVS_VAMANA_LEANVEC) {
+        json[knowhere::indexparam::SVS_GRAPH_MAX_DEGREE] = 16;
+        json[knowhere::indexparam::SVS_CONSTRUCTION_WINDOW_SIZE] = 40;
+        json[knowhere::indexparam::SVS_SEARCH_WINDOW_SIZE] = 40;
+        json[knowhere::indexparam::SVS_SEARCH_BUFFER_CAPACITY] = 40;
+        json[knowhere::indexparam::SVS_ALPHA] = 1.2f;
+        json[knowhere::indexparam::SVS_STORAGE_KIND] = std::string("fp32");
+        if (row.index_type == knowhere::IndexEnum::INDEX_SVS_VAMANA_LEANVEC) {
+            json[knowhere::indexparam::SVS_LEANVEC_DIM] = 8;
+        }
+    }
+    if (row.data_kind == DataKind::GpuFp32) {
+        json[knowhere::meta::DIM] = kGpuDim;
+        json[knowhere::meta::RADIUS] = 100000000.0f;
+        if (row.index_type == knowhere::IndexEnum::INDEX_CUVS_CAGRA ||
+            row.index_type == knowhere::IndexEnum::INDEX_GPU_CAGRA) {
+            json[knowhere::indexparam::INTERMEDIATE_GRAPH_DEGREE] = 32;
+            json[knowhere::indexparam::GRAPH_DEGREE] = 16;
+            json[knowhere::indexparam::ITOPK_SIZE] = 32;
+        }
+    }
+    return json;
+}
+
+void
+UseRawDataMode(knowhere::Json& json) {
+    json[knowhere::meta::RETRIEVE_FRIENDLY] = true;
+    json["build_quant_type"] = "NONE";
+    json["search_quant_type"] = "NONE";
+    json["refine_quant_type"] = "NONE";
+}
+
+knowhere::Json
+BinaryConfigFor(const IndexRow& row) {
+    knowhere::Json json;
+    const auto dim = row.index_type == knowhere::IndexEnum::INDEX_MINHASH_LSH ? 1024 : 128;
+    json[knowhere::meta::DIM] = dim;
+    json[knowhere::meta::METRIC_TYPE] = row.index_type == knowhere::IndexEnum::INDEX_MINHASH_LSH
+                                            ? knowhere::metric::MHJACCARD
+                                            : knowhere::metric::HAMMING;
+    json[knowhere::meta::TOPK] = kTopK;
+    json[knowhere::meta::RADIUS] = 1024.0f;
+    json[knowhere::meta::RANGE_FILTER] = 0.0f;
+    if (row.index_type == knowhere::IndexEnum::INDEX_FAISS) {
+        json["faiss_index_name"] = "BFlat";
+        return json;
+    }
+    json[knowhere::indexparam::NLIST] = 4;
+    json[knowhere::indexparam::NPROBE] = 4;
+    json["faiss_index_name"] = "Flat";
+    json["refine_k"] = 12;
+    json["mh_lsh_band"] = 4;
+    json["mh_element_bit_width"] = 32;
+    json["mh_search_with_jaccard"] = true;
+    json["mh_lsh_batch_search"] = true;
+    json["mh_lsh_aligned_block_size"] = 4096;
+    json["mh_lsh_shared_bloom_filter"] = true;
+    json["mh_lsh_bloom_false_positive_prob"] = 0.01;
+    json["with_raw_data"] = true;
+    json["hash_code_in_memory"] = true;
+    return json;
+}
+
+knowhere::Json
+SparseConfig() {
+    knowhere::Json json;
+    json[knowhere::meta::DIM] = kTotalRows + 2;
+    json[knowhere::meta::METRIC_TYPE] = knowhere::metric::IP;
+    json[knowhere::meta::TOPK] = kTopK;
+    json[knowhere::meta::RADIUS] = 0.5f;
+    json[knowhere::meta::RANGE_FILTER] = 2.0f;
+    json[knowhere::indexparam::DROP_RATIO_BUILD] = 0.0f;
+    json[knowhere::indexparam::DROP_RATIO_SEARCH] = 0.0f;
+    json[knowhere::indexparam::INVERTED_INDEX_ALGO] = "DAAT_MAXSCORE";
+    return json;
+}
+
+knowhere::Json
+DiskAnnConfig(const IndexRow& row, const fs::path& raw_data_file, const fs::path& index_prefix) {
+    auto json = BaseDenseConfig(knowhere::metric::L2, kFileDim, kTopK);
+    json[knowhere::meta::INDEX_TYPE] = row.index_type;
+    json[knowhere::meta::DATA_PATH] = raw_data_file.string();
+    json[knowhere::meta::INDEX_PREFIX] = index_prefix.string();
+    json[knowhere::indexparam::MAX_DEGREE] = 16;
+    json[knowhere::indexparam::SEARCH_LIST_SIZE] = 32;
+    json[knowhere::indexparam::PQ_CODE_BUDGET_GB] = 0.01;
+    json[knowhere::indexparam::SEARCH_CACHE_BUDGET_GB] = 0.0;
+    json[knowhere::indexparam::BUILD_DRAM_BUDGET_GB] = 1.0;
+    json[knowhere::indexparam::BEAMWIDTH] = 8;
+    json["min_k"] = 3;
+    json["max_k"] = 64;
+    if (row.data_kind == DataKind::Aisaq) {
+        json[knowhere::indexparam::REARRANGE] = false;
+        json[knowhere::indexparam::INLINE_PQ] = 0;
+        json[knowhere::indexparam::PQ_CACHE_SIZE] = 0;
+        json[knowhere::indexparam::PQ_READ_PAGE_CACHE_SIZE] = 0;
+        json[knowhere::indexparam::VECTORS_BEAMWIDTH] = 4;
+    }
+    return json;
+}
+
+Capabilities
+VectorCaps(bool range, bool iterator, bool search_filter, bool range_filter, bool iterator_filter, bool binaryset_io,
+           bool file_io) {
+    Capabilities caps;
+    caps.build = true;
+    caps.search = true;
+    caps.range = range;
+    caps.iterator = iterator;
+    caps.search_filter = search_filter;
+    caps.range_filter = range_filter;
+    caps.iterator_filter = iterator_filter;
+    caps.binaryset_serialize = binaryset_io;
+    caps.binaryset_deserialize = binaryset_io;
+    caps.file_serialize = file_io;
+    caps.file_deserialize = file_io;
+    return caps;
+}
+
+void
+AddEmbCaps(Capabilities& caps, bool search, bool range, bool iterator, bool search_filter, bool range_filter,
+           bool iterator_filter) {
+    caps.emb_build = search || range || iterator || search_filter || range_filter || iterator_filter;
+    caps.emb_search = search;
+    caps.emb_range = range;
+    caps.emb_iterator = iterator;
+    caps.emb_search_filter = search_filter;
+    caps.emb_range_filter = range_filter;
+    caps.emb_iterator_filter = iterator_filter;
+}
+
+void
+AddMultiCaps(Capabilities& caps, bool search, bool range, bool iterator, bool search_filter, bool range_filter,
+             bool iterator_filter) {
+    caps.multi_build = search || range || iterator || search_filter || range_filter || iterator_filter;
+    caps.multi_search = search;
+    caps.multi_range = range;
+    caps.multi_iterator = iterator;
+    caps.multi_search_filter = search_filter;
+    caps.multi_range_filter = range_filter;
+    caps.multi_iterator_filter = iterator_filter;
+}
+
+std::vector<IndexRow>
+IndexRows() {
+    std::vector<IndexRow> rows;
+    auto add = [&](IndexRow row) { rows.push_back(std::move(row)); };
+
+    auto flat = VectorCaps(true, false, true, true, false, true, true);
+    add({"FLAT", knowhere::IndexEnum::INDEX_FAISS_IDMAP, DataKind::DenseFp32, flat, false, false, false, false, true});
+    add({"BIN_FLAT / BINFLAT", knowhere::IndexEnum::INDEX_FAISS_BIN_IDMAP, DataKind::DenseBin, flat, false, false,
+         false, false, false});
+    add({"FAISS (fp32)", knowhere::IndexEnum::INDEX_FAISS, DataKind::DenseFp32, flat, false, false, false, false,
+         true});
+    auto faiss_bin = VectorCaps(false, false, true, false, false, true, true);
+    add({"FAISS (bin1)", knowhere::IndexEnum::INDEX_FAISS, DataKind::DenseBin, faiss_bin});
+
+    add({"BIN_IVF_FLAT / IVFBIN", knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT, DataKind::DenseBin,
+         VectorCaps(true, false, true, true, false, true, true)});
+    auto ivf_flat = VectorCaps(true, true, true, true, true, true, true);
+    AddEmbCaps(ivf_flat, true, false, false, true, false, false);
+    add({"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32, ivf_flat});
+    add({"IVF_FLAT_CC / IVFFLATCC", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, DataKind::DenseFp32, ivf_flat});
+    add({"IVF_PQ / IVFPQ", knowhere::IndexEnum::INDEX_FAISS_IVFPQ, DataKind::DenseFp32,
+         VectorCaps(true, false, true, true, false, true, true)});
+    add({"IVF_SQ8", knowhere::IndexEnum::INDEX_FAISS_IVFSQ8, DataKind::DenseFp32,
+         VectorCaps(true, true, true, true, true, true, true)});
+    add({"IVF_SQ / IVFSQ", "IVF_SQ", DataKind::DenseFp32, VectorCaps(true, true, true, true, true, true, true)});
+    add({"IVF_SQ_CC", knowhere::IndexEnum::INDEX_FAISS_IVFSQ_CC, DataKind::DenseFp32,
+         VectorCaps(true, true, true, true, true, true, true)});
+    add({"IVF_RABITQ / IVFRABITQ", knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ, DataKind::DenseFp32,
+         VectorCaps(true, true, true, true, true, true, true)});
+    add({"IVF_RABITQ_FASTSCAN", knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ_FASTSCAN, DataKind::DenseFp32,
+         VectorCaps(true, false, true, true, false, true, true)});
+    add({"SCANN", knowhere::IndexEnum::INDEX_FAISS_SCANN, DataKind::DenseFp32,
+         VectorCaps(true, true, true, true, true, true, true), true});
+    auto scann_dvr = VectorCaps(true, true, true, true, true, false, false);
+    AddEmbCaps(scann_dvr, true, false, false, true, false, false);
+    add({"SCANN_DVR", knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, DataKind::DenseFp32, scann_dvr, true});
+
+    auto hnsw_native = VectorCaps(true, true, true, true, true, true, true);
+    AddMultiCaps(hnsw_native, true, true, true, true, true, true);
+    add({"HNSW (Knowhere/Faiss)", knowhere::IndexEnum::INDEX_HNSW, DataKind::DenseFp32, hnsw_native});
+    auto hnsw = hnsw_native;
+    AddEmbCaps(hnsw, true, false, false, true, false, false);
+    add({"HNSW_SQ", knowhere::IndexEnum::INDEX_HNSW_SQ, DataKind::DenseFp32, hnsw});
+    auto hnsw_quantized = VectorCaps(true, true, true, true, true, true, true);
+    AddEmbCaps(hnsw_quantized, true, false, false, true, false, false);
+    add({"HNSW_PQ", knowhere::IndexEnum::INDEX_HNSW_PQ, DataKind::DenseFp32, hnsw_quantized});
+    add({"HNSW_PRQ", knowhere::IndexEnum::INDEX_HNSW_PRQ, DataKind::DenseFp32, hnsw_quantized});
+    add({"HNSWLIB_DEPRECATED", "HNSWLIB_DEPRECATED", DataKind::DenseFp32,
+         VectorCaps(true, true, true, true, true, true, true)});
+
+    auto diskann = VectorCaps(true, true, true, true, true, false, true);
+    add({"DISKANN (Knowhere native)", knowhere::IndexEnum::INDEX_DISKANN, DataKind::DiskAnn, diskann, true});
+    add({"AISAQ", knowhere::IndexEnum::INDEX_AISAQ, DataKind::Aisaq,
+         VectorCaps(false, false, true, false, false, false, true), true});
+
+    add({"SPARSE_INVERTED_INDEX (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX, DataKind::Sparse,
+         VectorCaps(true, true, true, true, true, true, true), false, false, false, false, true});
+    add({"SPARSE_WAND (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_WAND, DataKind::Sparse,
+         VectorCaps(true, true, true, true, true, true, true), false, false, false, false, true});
+    add({"SPARSE_INVERTED_INDEX_CC (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC,
+         DataKind::Sparse, VectorCaps(true, true, true, true, true, false, false), false, false, false, false, true});
+    add({"SPARSE_WAND_CC (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_WAND_CC, DataKind::Sparse,
+         VectorCaps(true, true, true, true, true, false, false), false, false, false, false, true});
+    add({"MINHASH_LSH", knowhere::IndexEnum::INDEX_MINHASH_LSH, DataKind::MinHash,
+         VectorCaps(false, false, true, false, false, false, false)});
+
+    add({"GPU_CUVS_BRUTE_FORCE", knowhere::IndexEnum::INDEX_CUVS_BRUTEFORCE, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_BRUTE_FORCE", knowhere::IndexEnum::INDEX_GPU_BRUTEFORCE, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_CUVS_IVF_FLAT", knowhere::IndexEnum::INDEX_CUVS_IVFFLAT, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_IVF_FLAT", knowhere::IndexEnum::INDEX_GPU_IVFFLAT, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_CUVS_IVF_PQ", knowhere::IndexEnum::INDEX_CUVS_IVFPQ, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_IVF_PQ", knowhere::IndexEnum::INDEX_GPU_IVFPQ, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_CUVS_CAGRA", knowhere::IndexEnum::INDEX_CUVS_CAGRA, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_CAGRA", knowhere::IndexEnum::INDEX_GPU_CAGRA, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_FAISS_FLAT", knowhere::IndexEnum::INDEX_FAISS_GPU_IDMAP, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_FAISS_IVF_FLAT", knowhere::IndexEnum::INDEX_FAISS_GPU_IVFFLAT, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_FAISS_IVF_PQ", knowhere::IndexEnum::INDEX_FAISS_GPU_IVFPQ, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+    add({"GPU_FAISS_IVF_SQ8", knowhere::IndexEnum::INDEX_FAISS_GPU_IVFSQ8, DataKind::GpuFp32,
+         VectorCaps(false, false, true, false, false, true, false), true, false, false, true});
+
+    add({"SVS_FLAT", knowhere::IndexEnum::INDEX_SVS_FLAT, DataKind::DenseFp32,
+         VectorCaps(false, false, false, false, false, true, true), true, false, true});
+    add({"SVS_VAMANA", knowhere::IndexEnum::INDEX_SVS_VAMANA, DataKind::DenseFp32,
+         VectorCaps(true, false, true, true, false, true, true), true, false, true});
+    add({"SVS_VAMANA_LVQ", knowhere::IndexEnum::INDEX_SVS_VAMANA_LVQ, DataKind::DenseFp32,
+         VectorCaps(true, false, true, true, false, true, true), true, false, true});
+    add({"SVS_VAMANA_LEANVEC", knowhere::IndexEnum::INDEX_SVS_VAMANA_LEANVEC, DataKind::DenseFp32,
+         VectorCaps(true, false, true, true, false, true, true), true, false, true});
+
+    return rows;
+}
+
+void
+AddScenario(std::vector<Scenario>& scenarios, NullableRatio nullable_ratio, Mode mode, Operation op, IndexSource source,
+            FilterRatio filter_ratio = FilterRatio::None, const std::string& emb_list_strategy = "") {
+    Scenario scenario;
+    scenario.nullable_ratio = nullable_ratio;
+    scenario.mode = mode;
+    scenario.op = op;
+    scenario.source = source;
+    scenario.filter_ratio = filter_ratio;
+    scenario.emb_list_strategy = mode == Mode::EmbList ? emb_list_strategy : "";
+    scenario.name = NullableName(nullable_ratio) + "/" + ModeName(mode) + "/" + OperationName(op) + "/" +
+                    SourceName(source) + "/" + FilterName(filter_ratio);
+    if (mode == Mode::EmbList) {
+        scenario.name += "/" + EmbListStrategyFor(scenario);
+    }
+    scenarios.push_back(std::move(scenario));
+}
+
+void
+AddNonFilterScenarios(std::vector<Scenario>& scenarios, NullableRatio ratio, Mode mode,
+                      const std::string& emb_list_strategy = "") {
+    AddScenario(scenarios, ratio, mode, Operation::Build, IndexSource::Fresh, FilterRatio::None, emb_list_strategy);
+    AddScenario(scenarios, ratio, mode, Operation::Search, IndexSource::Fresh, FilterRatio::None, emb_list_strategy);
+    AddScenario(scenarios, ratio, mode, Operation::Range, IndexSource::Fresh, FilterRatio::None, emb_list_strategy);
+    AddScenario(scenarios, ratio, mode, Operation::Iterator, IndexSource::Fresh, FilterRatio::None, emb_list_strategy);
+    AddScenario(scenarios, ratio, mode, Operation::BinarySetSerialize, IndexSource::Fresh, FilterRatio::None,
+                emb_list_strategy);
+    AddScenario(scenarios, ratio, mode, Operation::BinarySetDeserialize, IndexSource::BinarySet, FilterRatio::None,
+                emb_list_strategy);
+    AddScenario(scenarios, ratio, mode, Operation::Search, IndexSource::BinarySet, FilterRatio::None,
+                emb_list_strategy);
+    AddScenario(scenarios, ratio, mode, Operation::Range, IndexSource::BinarySet, FilterRatio::None, emb_list_strategy);
+    AddScenario(scenarios, ratio, mode, Operation::Iterator, IndexSource::BinarySet, FilterRatio::None,
+                emb_list_strategy);
+    AddScenario(scenarios, ratio, mode, Operation::FileSerialize, IndexSource::Fresh, FilterRatio::None,
+                emb_list_strategy);
+    AddScenario(scenarios, ratio, mode, Operation::FileDeserialize, IndexSource::File, FilterRatio::None,
+                emb_list_strategy);
+    AddScenario(scenarios, ratio, mode, Operation::Search, IndexSource::File, FilterRatio::None, emb_list_strategy);
+    AddScenario(scenarios, ratio, mode, Operation::Iterator, IndexSource::File, FilterRatio::None, emb_list_strategy);
+}
+
+std::vector<Scenario>
+BuildScenarios() {
+    std::vector<Scenario> scenarios;
+    for (auto ratio : {NullableRatio::R0, NullableRatio::R50}) {
+        AddNonFilterScenarios(scenarios, ratio, Mode::Vector);
+        for (const auto& strategy : EmbListStrategies()) {
+            AddNonFilterScenarios(scenarios, ratio, Mode::EmbList, strategy);
+        }
+        AddNonFilterScenarios(scenarios, ratio, Mode::MultiIndex);
+        const std::vector<FilterRatio> filter_ratios = {FilterRatio::R0, FilterRatio::R50, FilterRatio::R100};
+        for (auto filter_ratio : filter_ratios) {
+            AddScenario(scenarios, ratio, Mode::Vector, Operation::SearchFilter, IndexSource::Fresh, filter_ratio);
+            AddScenario(scenarios, ratio, Mode::Vector, Operation::RangeFilter, IndexSource::Fresh, filter_ratio);
+            AddScenario(scenarios, ratio, Mode::Vector, Operation::IteratorFilter, IndexSource::Fresh, filter_ratio);
+            for (const auto& strategy : EmbListStrategies()) {
+                AddScenario(scenarios, ratio, Mode::EmbList, Operation::SearchFilter, IndexSource::Fresh, filter_ratio,
+                            strategy);
+                AddScenario(scenarios, ratio, Mode::EmbList, Operation::RangeFilter, IndexSource::Fresh, filter_ratio,
+                            strategy);
+                AddScenario(scenarios, ratio, Mode::EmbList, Operation::IteratorFilter, IndexSource::Fresh,
+                            filter_ratio, strategy);
+            }
+            AddScenario(scenarios, ratio, Mode::MultiIndex, Operation::SearchFilter, IndexSource::Fresh, filter_ratio);
+            AddScenario(scenarios, ratio, Mode::MultiIndex, Operation::RangeFilter, IndexSource::Fresh, filter_ratio);
+            AddScenario(scenarios, ratio, Mode::MultiIndex, Operation::IteratorFilter, IndexSource::Fresh,
+                        filter_ratio);
+        }
+    }
+    return scenarios;
+}
+
+bool
+SupportsEmbListStrategy(const IndexRow& row, const Scenario& scenario) {
+    if (scenario.mode != Mode::EmbList) {
+        return true;
+    }
+    const auto strategy = EmbListStrategyFor(scenario);
+    if (strategy == knowhere::meta::EMB_LIST_STRATEGY_TOKENANN) {
+        return row.index_type != knowhere::IndexEnum::INDEX_FAISS_IVFFLAT;
+    }
+    if (row.requires_current_version) {
+        return false;
+    }
+    if (row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq || row.data_kind == DataKind::DenseBin ||
+        row.data_kind == DataKind::Sparse || row.data_kind == DataKind::MinHash || row.data_kind == DataKind::GpuFp32) {
+        return false;
+    }
+    return strategy == knowhere::meta::EMB_LIST_STRATEGY_MUVERA || strategy == knowhere::meta::EMB_LIST_STRATEGY_LEMUR;
+}
+
+bool
+SupportsModeBuild(const IndexRow& row, Mode mode) {
+    switch (mode) {
+        case Mode::Vector:
+            return row.caps.build;
+        case Mode::EmbList:
+            return row.caps.emb_build;
+        case Mode::MultiIndex:
+            return row.caps.multi_build;
+    }
+    return false;
+}
+
+bool
+SupportsScenario(const IndexRow& row, const Scenario& scenario) {
+    const auto& caps = row.caps;
+    if (row.index_type == knowhere::IndexEnum::INDEX_HNSW && !row.requires_current_version && VersionForRow(row) < 6 &&
+        scenario.nullable_ratio != NullableRatio::R0) {
+        return false;
+    }
+    if (!SupportsEmbListStrategy(row, scenario)) {
+        return false;
+    }
+#ifdef KNOWHERE_WITH_CARDINAL
+    if (row.data_kind == DataKind::Sparse && !row.requires_current_version &&
+        scenario.nullable_ratio != NullableRatio::R0) {
+        return false;
+    }
+    const bool current_version_reads_index =
+        scenario.op == Operation::Search || scenario.op == Operation::Range || scenario.op == Operation::Iterator ||
+        scenario.op == Operation::SearchFilter || scenario.op == Operation::RangeFilter ||
+        scenario.op == Operation::IteratorFilter;
+    if (row.requires_current_version && current_version_reads_index && scenario.source == IndexSource::Fresh) {
+        return false;
+    }
+#endif
+    if (row.requires_current_version && row.index_type == knowhere::IndexEnum::INDEX_DISKANN &&
+        scenario.mode != Mode::Vector &&
+        (scenario.op == Operation::FileSerialize || scenario.op == Operation::FileDeserialize ||
+         scenario.source == IndexSource::File)) {
+        return false;
+    }
+    const bool reads_index =
+        scenario.op == Operation::Search || scenario.op == Operation::Range || scenario.op == Operation::Iterator;
+    if (reads_index && scenario.source == IndexSource::BinarySet && !caps.binaryset_deserialize) {
+        return false;
+    }
+    if (reads_index && scenario.source == IndexSource::File && !caps.file_deserialize) {
+        return false;
+    }
+    if (row.data_kind == DataKind::MinHash &&
+        (scenario.op == Operation::Search || scenario.op == Operation::SearchFilter ||
+         scenario.op == Operation::Range || scenario.op == Operation::RangeFilter ||
+         scenario.op == Operation::Iterator || scenario.op == Operation::IteratorFilter) &&
+        scenario.source == IndexSource::Fresh) {
+        return false;
+    }
+    switch (scenario.op) {
+        case Operation::Build:
+            return SupportsModeBuild(row, scenario.mode);
+        case Operation::Search:
+            return scenario.mode == Mode::Vector    ? caps.search
+                   : scenario.mode == Mode::EmbList ? caps.emb_search
+                                                    : caps.multi_search;
+        case Operation::Range:
+            return scenario.mode == Mode::Vector    ? caps.range
+                   : scenario.mode == Mode::EmbList ? caps.emb_range
+                                                    : caps.multi_range;
+        case Operation::Iterator:
+            return scenario.mode == Mode::Vector    ? caps.iterator
+                   : scenario.mode == Mode::EmbList ? caps.emb_iterator
+                                                    : caps.multi_iterator;
+        case Operation::SearchFilter:
+            return scenario.mode == Mode::Vector    ? caps.search_filter
+                   : scenario.mode == Mode::EmbList ? caps.emb_search_filter
+                                                    : caps.multi_search_filter;
+        case Operation::RangeFilter:
+            return scenario.mode == Mode::Vector    ? caps.range_filter
+                   : scenario.mode == Mode::EmbList ? caps.emb_range_filter
+                                                    : caps.multi_range_filter;
+        case Operation::IteratorFilter:
+            return scenario.mode == Mode::Vector    ? caps.iterator_filter
+                   : scenario.mode == Mode::EmbList ? caps.emb_iterator_filter
+                                                    : caps.multi_iterator_filter;
+        case Operation::BinarySetSerialize:
+            return SupportsModeBuild(row, scenario.mode) && caps.binaryset_serialize;
+        case Operation::BinarySetDeserialize:
+            return SupportsModeBuild(row, scenario.mode) && caps.binaryset_deserialize;
+        case Operation::FileSerialize:
+            return SupportsModeBuild(row, scenario.mode) && caps.file_serialize;
+        case Operation::FileDeserialize:
+            return SupportsModeBuild(row, scenario.mode) && caps.file_deserialize;
+    }
+    return false;
+}
+
+bool
+IsReadOperation(Operation op) {
+    return op == Operation::Search || op == Operation::Range || op == Operation::Iterator ||
+           op == Operation::SearchFilter || op == Operation::RangeFilter || op == Operation::IteratorFilter;
+}
+
+bool
+IsFreshFileBackedRead(const IndexRow& row, const Scenario& scenario) {
+    return scenario.source == IndexSource::Fresh && IsReadOperation(scenario.op) &&
+           (row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq);
+}
+
+bool
+IsExpectedEmptySearchError(knowhere::Status status) {
+    return status == knowhere::Status::empty_index || status == knowhere::Status::invalid_args ||
+           status == knowhere::Status::not_implemented || status == knowhere::Status::faiss_inner_error ||
+           status == knowhere::Status::hnsw_inner_error || status == knowhere::Status::diskann_inner_error ||
+           status == knowhere::Status::aisaq_error || status == knowhere::Status::cardinal_inner_error ||
+           status == knowhere::Status::sparse_inner_error || status == knowhere::Status::emb_list_inner_error ||
+           status == knowhere::Status::cuda_runtime_error;
+}
+
+void
+RequireAllResultIdsNegative(const knowhere::DataSet& result) {
+    const auto nq = result.GetRows();
+    const auto k = result.GetDim();
+    const auto* lims = result.GetLims();
+    const auto* ids = result.GetIds();
+    const auto length = k == 0 ? lims[nq] : static_cast<size_t>(nq * k);
+    for (size_t i = 0; i < length; ++i) {
+        REQUIRE(ids[i] < 0);
+    }
+}
+
+void
+RequireRangeResultEmpty(const knowhere::DataSet& result) {
+    REQUIRE(result.GetLims()[result.GetRows()] == 0);
+}
+
+void
+RequireResultIdsIn(const knowhere::DataSet& result, const std::vector<int32_t>& allowed_ids,
+                   const std::vector<int32_t>& filtered_ids, bool expect_empty) {
+    if (expect_empty) {
+        RequireAllResultIdsNegative(result);
+        return;
+    }
+
+    const auto nq = result.GetRows();
+    const auto k = result.GetDim();
+    const auto* lims = result.GetLims();
+    const auto* ids = result.GetIds();
+    const auto length = k == 0 ? lims[nq] : static_cast<size_t>(nq * k);
+    bool has_result = false;
+    for (size_t i = 0; i < length; ++i) {
+        if (ids[i] < 0) {
+            continue;
+        }
+        CAPTURE(i, ids[i], allowed_ids, filtered_ids);
+        has_result = true;
+        REQUIRE(ContainsId(allowed_ids, ids[i]));
+        REQUIRE(!ContainsId(filtered_ids, ids[i]));
+    }
+    REQUIRE(has_result);
+}
+
+void
+RequireRangeIdsIn(const knowhere::DataSet& result, const std::vector<int32_t>& allowed_ids,
+                  const std::vector<int32_t>& filtered_ids, bool expect_empty) {
+    if (expect_empty) {
+        RequireRangeResultEmpty(result);
+        return;
+    }
+    RequireResultIdsIn(result, allowed_ids, filtered_ids, false);
+}
+
+void
+RequireIteratorResults(const std::vector<knowhere::IndexNode::IteratorPtr>& iterators,
+                       const std::vector<int32_t>& allowed_ids, const std::vector<int32_t>& filtered_ids,
+                       bool expect_empty, const std::vector<int32_t>* query_ids = nullptr) {
+    if (expect_empty) {
+        for (const auto& iterator : iterators) {
+            auto has_next = iterator->HasNext();
+            REQUIRE(has_next.has_value());
+            REQUIRE(!has_next.value());
+        }
+        return;
+    }
+
+    bool checked = false;
+    for (size_t i = 0; i < iterators.size(); ++i) {
+        const auto& iterator = iterators[i];
+        auto has_next = iterator->HasNext();
+        REQUIRE(has_next.has_value());
+        if (!has_next.value()) {
+            continue;
+        }
+        auto next = iterator->Next();
+        REQUIRE(next.has_value());
+        auto [id, dist] = next.value();
+        (void)dist;
+        REQUIRE(ContainsId(allowed_ids, id));
+        REQUIRE(!ContainsId(filtered_ids, id));
+        if (query_ids != nullptr && i < query_ids->size() && ContainsId(allowed_ids, (*query_ids)[i])) {
+            REQUIRE(id == (*query_ids)[i]);
+        }
+        checked = true;
+    }
+    REQUIRE(checked);
+}
+
+void
+RequireExpectedVectorResult(const knowhere::expected<knowhere::DataSetPtr>& result,
+                            const std::vector<int32_t>& allowed_ids, const std::vector<int32_t>& filtered_ids,
+                            bool expect_empty) {
+    if (!result.has_value()) {
+        REQUIRE(expect_empty);
+        REQUIRE(IsExpectedEmptySearchError(result.error()));
+        return;
+    }
+    RequireResultIdsIn(*result.value(), allowed_ids, filtered_ids, expect_empty);
+}
+
+void
+RequireExactFirstHits(const knowhere::DataSet& result, const std::vector<int32_t>& query_ids,
+                      const std::vector<int32_t>& allowed_ids) {
+    const auto nq = result.GetRows();
+    const auto k = result.GetDim();
+    const auto* ids = result.GetIds();
+    for (int64_t i = 0; i < nq && i < static_cast<int64_t>(query_ids.size()); ++i) {
+        if (!ContainsId(allowed_ids, query_ids[i])) {
+            continue;
+        }
+        REQUIRE(k > 0);
+        REQUIRE(ids[i * k] == query_ids[i]);
+    }
+}
+
+void
+RequireExactRangeHits(const knowhere::DataSet& result, const std::vector<int32_t>& query_ids,
+                      const std::vector<int32_t>& allowed_ids) {
+    const auto nq = result.GetRows();
+    const auto* lims = result.GetLims();
+    const auto* ids = result.GetIds();
+    for (int64_t i = 0; i < nq && i < static_cast<int64_t>(query_ids.size()); ++i) {
+        if (!ContainsId(allowed_ids, query_ids[i])) {
+            continue;
+        }
+        bool found = false;
+        for (size_t j = lims[i]; j < lims[i + 1]; ++j) {
+            found = found || ids[j] == query_ids[i];
+        }
+        REQUIRE(found);
+    }
+}
+
+void
+RequireBufferedExactFirstHits(const std::vector<int64_t>& ids, int64_t topk, const std::vector<int32_t>& query_ids,
+                              const std::vector<int32_t>& allowed_ids) {
+    for (int64_t i = 0; i < static_cast<int64_t>(query_ids.size()); ++i) {
+        if (!ContainsId(allowed_ids, query_ids[i])) {
+            continue;
+        }
+        REQUIRE(topk > 0);
+        REQUIRE(ids[i * topk] == query_ids[i]);
+    }
+}
+
+void
+RequireExpectedRangeResult(const knowhere::expected<knowhere::DataSetPtr>& result,
+                           const std::vector<int32_t>& allowed_ids, const std::vector<int32_t>& filtered_ids,
+                           bool expect_empty) {
+    if (!result.has_value()) {
+        REQUIRE(expect_empty);
+        REQUIRE(IsExpectedEmptySearchError(result.error()));
+        return;
+    }
+    RequireRangeIdsIn(*result.value(), allowed_ids, filtered_ids, expect_empty);
+}
+
+void
+RequireExpectedIteratorResult(const knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>& result,
+                              const std::vector<int32_t>& allowed_ids, const std::vector<int32_t>& filtered_ids,
+                              bool expect_empty, const std::vector<int32_t>* query_ids = nullptr) {
+    if (!result.has_value()) {
+        REQUIRE(expect_empty);
+        REQUIRE(IsExpectedEmptySearchError(result.error()));
+        return;
+    }
+    RequireIteratorResults(result.value(), allowed_ids, filtered_ids, expect_empty, query_ids);
+}
+
+void
+RequireBufferedIdsIn(const std::vector<int64_t>& ids, const std::vector<int32_t>& allowed_ids,
+                     const std::vector<int32_t>& filtered_ids, bool expect_empty) {
+    bool has_result = false;
+    for (auto id : ids) {
+        if (id < 0) {
+            continue;
+        }
+        has_result = true;
+        REQUIRE(ContainsId(allowed_ids, id));
+        REQUIRE(!ContainsId(filtered_ids, id));
+    }
+    REQUIRE(has_result != expect_empty);
+}
+
+void
+RequireBufferedStatus(knowhere::Status status, const std::vector<int64_t>& ids, const std::vector<int32_t>& allowed_ids,
+                      const std::vector<int32_t>& filtered_ids, bool expect_empty) {
+    if (status != knowhere::Status::success) {
+        REQUIRE(expect_empty);
+        REQUIRE(IsExpectedEmptySearchError(status));
+        return;
+    }
+    RequireBufferedIdsIn(ids, allowed_ids, filtered_ids, expect_empty);
+}
+
+void
+RequireIdArrayEquals(const knowhere::IdArray& view, const std::vector<int32_t>& expected) {
+    REQUIRE(view.size() == expected.size());
+    if (!expected.empty()) {
+        REQUIRE_FALSE(view.empty());
+    }
+    for (size_t i = 0; i < expected.size(); ++i) {
+        CAPTURE(i);
+        REQUIRE(view[i] == expected[i]);
+    }
+}
+
+knowhere::IdArray
+RequireIdMapArrayContent(const knowhere::Index<knowhere::IndexNode>& index, const std::vector<int32_t>& valid_ids,
+                         int64_t count) {
+    REQUIRE(index.Node() != nullptr);
+    const auto& map = index.Node()->GetIdMap();
+    REQUIRE(map.OutCount() == static_cast<size_t>(count));
+    auto valid = map.ValidBitmap();
+    REQUIRE(valid.size() == static_cast<size_t>(count));
+    REQUIRE(valid.data() != nullptr);
+    auto in_to_out_ids = map.InToOutIds();
+    RequireIdArrayEquals(in_to_out_ids, valid_ids);
+    return in_to_out_ids;
+}
+
+void
+RequireIdMapContent(const knowhere::Index<knowhere::IndexNode>& index, const std::vector<int32_t>& valid_ids,
+                    int64_t count) {
+    auto in_to_out_ids = RequireIdMapArrayContent(index, valid_ids, count);
+    const auto& map = index.Node()->GetIdMap();
+    for (size_t i = 0; i < valid_ids.size(); ++i) {
+        CAPTURE(i, valid_ids[i]);
+        REQUIRE(map.MapInToOut(static_cast<int64_t>(i)) == valid_ids[i]);
+        REQUIRE(index.Node()->MapOutToIn(valid_ids[i]) == static_cast<int64_t>(i));
+    }
+}
+
+void
+RequireIdMapBitmap(const knowhere::Index<knowhere::IndexNode>& index, int64_t count) {
+    REQUIRE(index.Node() != nullptr);
+    const auto& map = index.Node()->GetIdMap();
+    REQUIRE(map.OutCount() == static_cast<size_t>(count));
+    auto valid = map.ValidBitmap();
+    REQUIRE(valid.size() == static_cast<size_t>(count));
+    REQUIRE(valid.data() != nullptr);
+}
+
+void
+RequireVectorIdMapCompacted(const knowhere::Index<knowhere::IndexNode>& index, int64_t count) {
+    REQUIRE(index.Node() != nullptr);
+    const auto& map = index.Node()->GetIdMap();
+    REQUIRE(map.OutCount() == static_cast<size_t>(count));
+    auto valid = map.ValidBitmap();
+    REQUIRE(valid.size() == static_cast<size_t>(count));
+    REQUIRE(valid.data() != nullptr);
+    REQUIRE(map.InToOutIds().empty());
+    REQUIRE(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST).empty());
+}
+
+void
+RequireEmbListIdMapCompacted(const knowhere::Index<knowhere::IndexNode>& index, const std::vector<int32_t>& valid_ids,
+                             int64_t count) {
+    REQUIRE(index.Node() != nullptr);
+    const auto& map = index.Node()->GetIdMap();
+    REQUIRE(map.OutCount() == static_cast<size_t>(count));
+    auto valid = map.ValidBitmap();
+    REQUIRE(valid.size() == static_cast<size_t>(count));
+    REQUIRE(valid.data() != nullptr);
+    RequireIdArrayEquals(map.InToOutIds(), valid_ids);
+    REQUIRE(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST).empty());
+    for (size_t i = 0; i < valid_ids.size(); ++i) {
+        CAPTURE(i, valid_ids[i]);
+        REQUIRE(index.Node()->GetIdMap().MapOutToIn(valid_ids[i]) == static_cast<int64_t>(i));
+        REQUIRE(index.Node()->MapOutToIn(valid_ids[i]) == static_cast<int64_t>(i));
+    }
+}
+
+std::vector<float>
+DenseVectorForLogicalId(int32_t logical_id, int64_t dim) {
+    std::vector<float> data(dim);
+    FillDenseVector(data.data(), 0, dim, logical_id);
+    return data;
+}
+
+float
+DenseL2ForLogicalIds(int32_t lhs, int32_t rhs, int64_t dim) {
+    auto lhs_vec = DenseVectorForLogicalId(lhs, dim);
+    auto rhs_vec = DenseVectorForLogicalId(rhs, dim);
+    float dist = 0.0f;
+    for (int64_t i = 0; i < dim; ++i) {
+        const auto diff = lhs_vec[i] - rhs_vec[i];
+        dist += diff * diff;
+    }
+    return dist;
+}
+
+void
+RequireDenseVectorsMatchLogicalIds(const knowhere::DataSet& vectors, const std::vector<int32_t>& logical_ids,
+                                   int64_t dim) {
+    REQUIRE(vectors.GetRows() == static_cast<int64_t>(logical_ids.size()));
+    REQUIRE(vectors.GetDim() == dim);
+    const auto* tensor = static_cast<const float*>(vectors.GetTensor());
+    REQUIRE(tensor != nullptr);
+    for (size_t i = 0; i < logical_ids.size(); ++i) {
+        auto expected = DenseVectorForLogicalId(logical_ids[i], dim);
+        for (int64_t j = 0; j < dim; ++j) {
+            CAPTURE(i, j, logical_ids[i]);
+            REQUIRE(tensor[i * dim + j] == Catch::Approx(expected[j]));
+        }
+    }
+}
+
+void
+RequireDenseCalcDistByIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
+    std::vector<int64_t> labels(data.query_ids.begin(), data.query_ids.end());
+    auto result = index.CalcDistByIDs(data.query_ds, knowhere::BitsetView{}, labels.data(), labels.size(), false);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetRows() == data.query_ds->GetRows());
+    REQUIRE(result.value()->GetDim() == static_cast<int64_t>(labels.size()));
+    const auto* distances = result.value()->GetDistance();
+    REQUIRE(distances != nullptr);
+    for (size_t i = 0; i < data.query_ids.size(); ++i) {
+        for (size_t j = 0; j < labels.size(); ++j) {
+            const auto expected = DenseL2ForLogicalIds(data.query_ids[i], static_cast<int32_t>(labels[j]), data.dim);
+            CAPTURE(i, j, data.query_ids[i], labels[j]);
+            REQUIRE(distances[i * labels.size() + j] == Catch::Approx(expected));
+        }
+    }
+}
+
+void
+RequireDenseVectorPublicApisUseOutIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data,
+                                      const knowhere::Json& json, bool require_exact_first_hit) {
+    auto search = index.Search(data.query_ds, json, knowhere::BitsetView{});
+    REQUIRE(search.has_value());
+    if (require_exact_first_hit) {
+        RequireExactFirstHits(*search.value(), data.query_ids, data.valid_ids);
+    } else {
+        RequireExpectedVectorResult(search, data.valid_ids, {}, false);
+    }
+
+    std::vector<int64_t> ids(data.query_ids.begin(), data.query_ids.end());
+    auto retrieve = index.GetVectorByIds(knowhere::GenIdsDataSet(static_cast<int64_t>(ids.size()), ids.data()));
+    REQUIRE(retrieve.has_value());
+    RequireDenseVectorsMatchLogicalIds(*retrieve.value(), data.query_ids, data.dim);
+
+    RequireDenseCalcDistByIds(index, data);
+}
+
+void
+RequireDenseVectorApisUseOutIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data,
+                                const knowhere::Json& json) {
+    RequireIdMapContent(index, data.valid_ids, data.total_count);
+    RequireDenseVectorPublicApisUseOutIds(index, data, json, true);
+}
+
+void
+RequireEmbListVectorsMatchLogicalIds(const knowhere::DataSet& vectors, const std::vector<int32_t>& logical_ids,
+                                     int64_t dim, int64_t vectors_per_doc) {
+    REQUIRE(vectors.GetRows() == static_cast<int64_t>(logical_ids.size()));
+    REQUIRE(vectors.GetDim() == dim);
+    const auto* offsets = vectors.Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+    REQUIRE(offsets != nullptr);
+    const auto* tensor = static_cast<const float*>(vectors.GetTensor());
+    REQUIRE(tensor != nullptr);
+    for (size_t i = 0; i < logical_ids.size(); ++i) {
+        REQUIRE(offsets[i + 1] - offsets[i] == static_cast<size_t>(vectors_per_doc));
+        auto expected = DenseVectorForLogicalId(logical_ids[i], dim);
+        for (int64_t v = 0; v < vectors_per_doc; ++v) {
+            for (int64_t j = 0; j < dim; ++j) {
+                CAPTURE(i, v, j, logical_ids[i]);
+                REQUIRE(tensor[(offsets[i] + v) * dim + j] == Catch::Approx(expected[j]));
+            }
+        }
+    }
+}
+
+void
+RequireEmbListApisUseOutIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data,
+                            const knowhere::Json& json) {
+    RequireIdMapContent(index, data.valid_ids, data.total_count);
+
+    auto search = index.Search(data.query_ds, json, knowhere::BitsetView{});
+    REQUIRE(search.has_value());
+    RequireExactFirstHits(*search.value(), data.query_ids, data.valid_ids);
+
+    std::vector<int64_t> ids(data.query_ids.begin(), data.query_ids.end());
+    auto retrieve =
+        index.GetEmbListByIds(knowhere::GenIdsDataSet(static_cast<int64_t>(ids.size()), ids.data()), "MAX_SIM_L2");
+    REQUIRE(retrieve.has_value());
+    RequireEmbListVectorsMatchLogicalIds(*retrieve.value(), data.query_ids, data.dim, kEmbVectorsPerDoc);
+}
+
+void
+RequireEmbListRetrieveUsesOutIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
+    REQUIRE(data.query_ids.size() >= 2);
+    std::vector<int32_t> logical_ids = {data.query_ids[1], data.query_ids[0], data.query_ids[1]};
+    std::vector<int64_t> ids(logical_ids.begin(), logical_ids.end());
+    auto retrieve =
+        index.GetEmbListByIds(knowhere::GenIdsDataSet(static_cast<int64_t>(ids.size()), ids.data()), "MAX_SIM_L2");
+    REQUIRE(retrieve.has_value());
+    RequireEmbListVectorsMatchLogicalIds(*retrieve.value(), logical_ids, data.dim, kEmbVectorsPerDoc);
+}
+
+std::vector<std::vector<float>>
+BuildChunkStorage(const knowhere::DataSetPtr& dense_ds, int64_t chunks, std::vector<size_t>& chunk_lims) {
+    const auto rows = dense_ds->GetRows();
+    const auto dim = dense_ds->GetDim();
+    auto* dense = static_cast<const float*>(dense_ds->GetTensor());
+    chunk_lims.resize(chunks + 1);
+    std::vector<std::vector<float>> chunk_storage(chunks);
+    int64_t offset = 0;
+    for (int64_t chunk = 0; chunk < chunks; ++chunk) {
+        chunk_lims[chunk] = static_cast<size_t>(offset);
+        const auto chunk_rows = (rows * (chunk + 1)) / chunks - (rows * chunk) / chunks;
+        chunk_storage[chunk].resize(chunk_rows * dim);
+        if (chunk_rows > 0) {
+            std::memcpy(chunk_storage[chunk].data(), dense + offset * dim, chunk_rows * dim * sizeof(float));
+        }
+        offset += chunk_rows;
+    }
+    chunk_lims[chunks] = static_cast<size_t>(rows);
+    return chunk_storage;
+}
+
+knowhere::DataSetPtr
+GenNullableDenseChunkDataSet(int64_t total_count, const std::vector<int32_t>& valid_ids, int64_t dim,
+                             std::vector<std::vector<float>>& chunk_storage, std::vector<const float*>& chunk_ptrs,
+                             std::vector<size_t>& chunk_lims) {
+    auto dense_ds = GenNullableDenseDataSet(total_count, valid_ids, dim);
+    chunk_storage = BuildChunkStorage(dense_ds, 2, chunk_lims);
+    chunk_ptrs.resize(chunk_storage.size());
+    for (size_t i = 0; i < chunk_storage.size(); ++i) {
+        chunk_ptrs[i] = chunk_storage[i].data();
+    }
+    auto ds = knowhere::GenDataSet(dense_ds->GetRows(), dim, chunk_ptrs.data());
+    ds->SetIsChunk(true);
+    ds->SetIsOwner(false);
+    ds->SetNumChunk(static_cast<int64_t>(chunk_ptrs.size()));
+    ds->SetTensorBeginId(dense_ds->GetTensorBeginId());
+    ds->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(chunk_lims.data()));
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenNullableEmbListChunkDataSet(int64_t total_docs, const std::vector<int32_t>& valid_doc_ids, int64_t dim,
+                               int64_t vectors_per_doc, std::vector<std::vector<float>>& chunk_storage,
+                               std::vector<const float*>& chunk_ptrs, std::vector<size_t>& chunk_lims,
+                               std::vector<size_t>& emb_offsets) {
+    auto dense_ds = GenNullableEmbListDataSet(total_docs, valid_doc_ids, dim, vectors_per_doc);
+    chunk_storage =
+        BuildChunkStorage(dense_ds, std::max<int64_t>(static_cast<int64_t>(valid_doc_ids.size()), 1), chunk_lims);
+    chunk_ptrs.resize(chunk_storage.size());
+    for (size_t i = 0; i < chunk_storage.size(); ++i) {
+        chunk_ptrs[i] = chunk_storage[i].data();
+    }
+    emb_offsets.resize(valid_doc_ids.size() + 1);
+    for (size_t i = 0; i <= valid_doc_ids.size(); ++i) {
+        emb_offsets[i] = i * vectors_per_doc;
+    }
+    auto ds = knowhere::GenDataSet(dense_ds->GetRows(), dim, chunk_ptrs.data());
+    ds->SetIsChunk(true);
+    ds->SetIsOwner(false);
+    ds->SetNumChunk(static_cast<int64_t>(chunk_ptrs.size()));
+    ds->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(chunk_lims.data()));
+    return ds;
+}
+
+std::shared_ptr<milvus::FileManager>
+LocalFileManager() {
+    return std::make_shared<milvus::LocalFileManager>();
+}
+
+MatrixData
+BuildMatrixData(const IndexRow& row, const Scenario& scenario, const fs::path& work_dir) {
+    MatrixData data;
+    const bool multi = scenario.mode == Mode::MultiIndex;
+    if (scenario.mode == Mode::EmbList) {
+        data.total_count = scenario.total_count_override > 0 ? scenario.total_count_override : kEmbDocs;
+        data.dim = kDenseDim;
+        data.valid_ids = ValidIdsFor(scenario.nullable_ratio, data.total_count);
+        data.selected_ids = data.valid_ids;
+        data.query_ids = FirstQueryIds(data.valid_ids, data.total_count, 2);
+        data.train_ds = GenNullableEmbListDataSet(data.total_count, data.valid_ids, data.dim, kEmbVectorsPerDoc);
+        data.full_ds = row.index_type == knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR
+                           ? data.train_ds
+                           : GenFullDenseDataSet(data.total_count, data.dim);
+        data.query_ds = GenEmbListQueryDataSet(data.query_ids, data.dim);
+        return data;
+    }
+
+    if (scenario.total_count_override > 0) {
+        data.total_count = scenario.total_count_override;
+        data.dim = row.data_kind == DataKind::DenseBin ? 128 : kDenseDim;
+    } else if (row.data_kind == DataKind::GpuFp32) {
+        data.total_count = kGpuRows;
+        data.dim = kGpuDim;
+    } else if (row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq ||
+               row.data_kind == DataKind::MinHash) {
+        data.total_count = kFileRows;
+        data.dim = row.data_kind == DataKind::MinHash ? 1024 : kFileDim;
+    } else if (row.data_kind == DataKind::DenseBin) {
+        data.total_count = kTotalRows;
+        data.dim = 128;
+    } else {
+        data.total_count = kTotalRows;
+        data.dim = kDenseDim;
+    }
+    data.valid_ids = ValidIdsFor(scenario.nullable_ratio, data.total_count, multi);
+    data.selected_ids = multi ? PartitionIds(data.valid_ids, 0) : data.valid_ids;
+    if (multi && data.selected_ids.empty() && !data.valid_ids.empty()) {
+        data.selected_ids = PartitionIds(data.valid_ids, 1);
+    }
+    data.query_ids = FirstQueryIds(multi ? data.selected_ids : data.valid_ids, data.total_count);
+
+    if (row.data_kind == DataKind::DenseFp32 || row.data_kind == DataKind::GpuFp32 ||
+        row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq) {
+        data.full_ds = GenFullDenseDataSet(data.total_count, data.dim);
+        data.train_ds = GenNullableDenseDataSet(data.total_count, data.valid_ids, data.dim);
+        data.query_ds = GenDenseQueryDataSet(data.query_ids, data.dim);
+    } else if (row.data_kind == DataKind::DenseBin || row.data_kind == DataKind::MinHash) {
+        data.full_ds = GenBinDataSet(static_cast<int>(data.total_count), static_cast<int>(data.dim), 22);
+        static std::map<std::string, std::vector<uint8_t>> owned_binary;
+        const auto key = work_dir.string() + "/bin_train";
+        const auto query_key = work_dir.string() + "/bin_query";
+        data.train_ds =
+            GenNullableBinaryDataSet(data.total_count, data.valid_ids, data.dim, data.full_ds, owned_binary[key]);
+        data.query_ds = GenBinaryQueryDataSet(data.query_ids, data.dim, data.full_ds, owned_binary[query_key]);
+    } else {
+        data.full_ds = nullptr;
+        data.train_ds = GenNullableSparseDataSet(data.total_count, data.valid_ids);
+        data.query_ds = GenSparseQueryDataSet(data.query_ids, data.total_count);
+    }
+
+    if (multi) {
+        data.train_ds->Set(knowhere::meta::SCALAR_INFO, ScalarInfoForEvenOddPartitions(data.valid_ids));
+    }
+    return data;
+}
+
+knowhere::Json
+BuildJson(const IndexRow& row, const Scenario& scenario, const MatrixData& data, const fs::path& raw_data_file,
+          const fs::path& file_index_prefix) {
+    auto mode = scenario.mode;
+    auto emb_list_strategy = EmbListStrategyFor(scenario);
+    if (row.index_type == "HNSW_V1") {
+        auto json = DenseConfigFor(row, mode, emb_list_strategy);
+        json[knowhere::meta::DIM] = data.train_ds->GetDim();
+        json[knowhere::meta::METRIC_TYPE] = knowhere::metric::IP;
+        json[knowhere::meta::RADIUS] = 0.5f;
+        json[knowhere::meta::RANGE_FILTER] = 2.0f;
+        json[knowhere::meta::RETRIEVE_FRIENDLY] = true;
+        return json;
+    }
+    if (row.data_kind == DataKind::Sparse) {
+        return SparseConfig();
+    }
+    if (row.data_kind == DataKind::DenseBin || row.data_kind == DataKind::MinHash) {
+        auto json = BinaryConfigFor(row);
+        if (row.data_kind == DataKind::MinHash) {
+            json[knowhere::meta::DATA_PATH] = raw_data_file.string();
+            json[knowhere::meta::INDEX_PREFIX] = file_index_prefix.string();
+        }
+        return json;
+    }
+    if (row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq) {
+        auto json = DiskAnnConfig(row, raw_data_file, file_index_prefix);
+        if (mode == Mode::EmbList) {
+            json[knowhere::meta::METRIC_TYPE] = "MAX_SIM_L2";
+            json[knowhere::meta::TOPK] = kEmbTopK;
+            ApplyEmbListStrategyConfig(json, emb_list_strategy);
+        }
+        return json;
+    }
+    return DenseConfigFor(row, mode, emb_list_strategy);
+}
+
+void
+WriteRawDataIfNeeded(const IndexRow& row, const MatrixData& data, const fs::path& raw_data_file) {
+    if (row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq) {
+        auto* tensor = static_cast<const float*>(data.train_ds->GetTensor());
+        WriteRawDataToDisk<float>(raw_data_file.string(), tensor, static_cast<uint32_t>(data.train_ds->GetRows()),
+                                  static_cast<uint32_t>(data.dim));
+    } else if (row.data_kind == DataKind::MinHash) {
+        auto* tensor = static_cast<const knowhere::bin1*>(data.train_ds->GetTensor());
+        WriteRawDataToDisk<knowhere::bin1>(raw_data_file.string(), tensor,
+                                           static_cast<uint32_t>(data.train_ds->GetRows()),
+                                           static_cast<uint32_t>(data.dim));
+    }
+}
+
+struct CreateResult {
+    knowhere::Index<knowhere::IndexNode> index;
+    knowhere::Status status = knowhere::Status::success;
+    bool ok = false;
+};
+
+CreateResult
+CreateIndex(const IndexRow& row, const MatrixData& data, std::shared_ptr<milvus::FileManager> file_manager = nullptr) {
+    CreateResult result;
+
+#ifndef KNOWHERE_WITH_CARDINAL
+    if (row.requires_current_version) {
+        result.status = knowhere::Status::invalid_index_error;
+        return result;
+    }
+#endif
+#ifndef KNOWHERE_WITH_SVS
+    if (row.requires_svs) {
+        result.status = knowhere::Status::invalid_index_error;
+        return result;
+    }
+#endif
+#ifndef KNOWHERE_WITH_CUVS
+    if (row.requires_gpu) {
+        result.status = knowhere::Status::invalid_index_error;
+        return result;
+    }
+#endif
+
+    const auto version = VersionForRow(row);
+    auto create_with_object = [&](const knowhere::Object& object) {
+        if (row.data_kind == DataKind::DenseBin || row.data_kind == DataKind::MinHash) {
+            auto created = knowhere::IndexFactory::Instance().Create<knowhere::bin1>(row.index_type, version, object);
+            if (!created.has_value()) {
+                result.status = created.error();
+                return result;
+            }
+            result.index = std::move(created.value());
+        } else if (row.data_kind == DataKind::Sparse) {
+            auto created =
+                knowhere::IndexFactory::Instance().Create<knowhere::sparse_u32_f32>(row.index_type, version, object);
+            if (!created.has_value()) {
+                result.status = created.error();
+                return result;
+            }
+            result.index = std::move(created.value());
+        } else {
+            auto created = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(row.index_type, version, object);
+            if (!created.has_value()) {
+                result.status = created.error();
+                return result;
+            }
+            result.index = std::move(created.value());
+        }
+        result.ok = true;
+        return result;
+    };
+
+    if (row.index_type == knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR && data.train_ds != nullptr) {
+        knowhere::ViewDataOp view_data = [train = data.train_ds, dim = data.train_ds->GetDim()](size_t in_id) {
+            auto* tensor = static_cast<const float*>(train->GetTensor());
+            return tensor + in_id * dim;
+        };
+        auto object = knowhere::Pack(view_data);
+        return create_with_object(object);
+    } else if (row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq ||
+               row.data_kind == DataKind::MinHash) {
+        auto object = knowhere::Pack(file_manager != nullptr ? file_manager : LocalFileManager());
+        return create_with_object(object);
+    }
+
+    return create_with_object(knowhere::Object(nullptr));
+}
+
+std::string
+PathSafe(std::string value) {
+    for (auto& c : value) {
+        if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-')) {
+            c = '_';
+        }
+    }
+    return value;
+}
+
+fs::path
+NullableIdMapWorkDir(std::string name) {
+    return fs::temp_directory_path() / ("knowhere_nullable_id_map_matrix_" + PathSafe(std::move(name)));
+}
+
+knowhere::Status
+WriteEmbListOffsetToFile(const knowhere::DataSetPtr& dataset, size_t offset_count, const fs::path& path);
+
+std::shared_ptr<BuiltArtifact>
+BuildArtifactForScenario(const IndexRow& row, const Scenario& scenario) {
+    auto artifact = std::make_shared<BuiltArtifact>();
+    artifact->row = row;
+    artifact->scenario = scenario;
+    auto work_dir_name = row.label + "_" + ModeName(scenario.mode) + "_" + NullableName(scenario.nullable_ratio);
+    if (scenario.mode == Mode::EmbList) {
+        work_dir_name += "_" + EmbListStrategyFor(scenario);
+    }
+    artifact->work_dir = NullableIdMapWorkDir(work_dir_name);
+    RemoveAllNoThrow(artifact->work_dir);
+    fs::create_directories(artifact->work_dir);
+    artifact->main_file = artifact->work_dir / "main.index";
+    artifact->emb_meta_file = artifact->work_dir / "emb_list_meta.bin";
+    artifact->emb_raw_file = artifact->work_dir / "emb_list_raw.index";
+    artifact->emb_offset_file = artifact->work_dir / "emb_list_offset.bin";
+    artifact->raw_data_file = artifact->work_dir / "raw_data.bin";
+    artifact->file_index_prefix = artifact->work_dir / "file_index";
+    fs::create_directories(artifact->file_index_prefix.parent_path());
+
+    artifact->data = BuildMatrixData(row, scenario, artifact->work_dir);
+    if (row.data_kind == DataKind::DiskAnn || row.data_kind == DataKind::Aisaq || row.data_kind == DataKind::MinHash) {
+        artifact->file_manager = LocalFileManager();
+    }
+    WriteRawDataIfNeeded(row, artifact->data, artifact->raw_data_file);
+    artifact->json = BuildJson(row, scenario, artifact->data, artifact->raw_data_file, artifact->file_index_prefix);
+    if (scenario.force_raw_data) {
+        UseRawDataMode(artifact->json);
+    }
+    if (row.data_kind == DataKind::DiskAnn && scenario.mode == Mode::EmbList) {
+        auto status = WriteEmbListOffsetToFile(artifact->data.train_ds, artifact->data.valid_ids.size() + 1,
+                                               artifact->emb_offset_file);
+        if (status == knowhere::Status::success) {
+            artifact->json["emb_list_offset_file_path"] = artifact->emb_offset_file.string();
+        } else {
+            artifact->build_status = status;
+        }
+    }
+
+    auto created = CreateIndex(row, artifact->data, artifact->file_manager);
+    artifact->create_ok = created.ok;
+    artifact->create_status = created.status;
+    if (!created.ok) {
+        return artifact;
+    }
+
+    artifact->index = std::move(created.index);
+    artifact->build_status =
+        BuildRuntimeIdMap(artifact->data.valid_ids, artifact->data.total_count, artifact->index.GetIdMap());
+    if (artifact->build_status == knowhere::Status::success) {
+        artifact->build_status = artifact->index.Build(artifact->data.train_ds, artifact->json);
+    }
+    return artifact;
+}
+
+knowhere::Status
+EnsureSerialized(BuiltArtifact& artifact) {
+    if (artifact.serialized) {
+        return artifact.serialize_status;
+    }
+    artifact.serialize_status = artifact.index.Serialize(artifact.binset);
+    // Serialized index payloads do not carry validity input.
+    if (artifact.serialize_status == knowhere::Status::success &&
+        artifact.binset.GetByName("EXTERNAL_ID_MAP") != nullptr) {
+        artifact.serialize_status = knowhere::Status::invalid_binary_set;
+    }
+    artifact.serialized = true;
+    return artifact.serialize_status;
+}
+
+knowhere::Status
+BuildRuntimeIdMap(const std::vector<int32_t>& valid_ids, int64_t total_count, knowhere::IdMap& id_map) {
+    if (total_count < 0 || static_cast<int64_t>(valid_ids.size()) > total_count) {
+        return knowhere::Status::invalid_args;
+    }
+    try {
+        if (total_count > std::numeric_limits<int32_t>::max()) {
+            return knowhere::Status::invalid_args;
+        }
+        for (auto id : valid_ids) {
+            if (id < 0 || id >= total_count) {
+                return knowhere::Status::invalid_args;
+            }
+        }
+        id_map.AddFromData(knowhere::IdMapData::FromIds(valid_ids.empty() ? nullptr : valid_ids.data(),
+                                                        valid_ids.size(), static_cast<size_t>(total_count)));
+        return knowhere::Status::success;
+    } catch (const std::exception&) {
+        return knowhere::Status::invalid_args;
+    }
+}
+
+knowhere::Status
+BuildRuntimeValidBitmap(const std::vector<int32_t>& valid_ids, int64_t total_count, knowhere::IdMap& id_map) {
+    if (total_count < 0 || static_cast<int64_t>(valid_ids.size()) > total_count) {
+        return knowhere::Status::invalid_args;
+    }
+    try {
+        auto valid_data = std::make_unique<bool[]>(static_cast<size_t>(total_count));
+        std::fill_n(valid_data.get(), static_cast<size_t>(total_count), false);
+        for (auto id : valid_ids) {
+            if (id < 0 || id >= total_count) {
+                return knowhere::Status::invalid_args;
+            }
+            valid_data[static_cast<size_t>(id)] = true;
+        }
+        id_map.AddFromData(knowhere::IdMapData::FromValidData(valid_data.get(), static_cast<size_t>(total_count)));
+        return knowhere::Status::success;
+    } catch (const std::exception&) {
+        return knowhere::Status::invalid_args;
+    }
+}
+
+knowhere::Status
+SetRuntimeIdMap(knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
+    if (index.Node() == nullptr) {
+        return knowhere::Status::invalid_args;
+    }
+    RETURN_IF_ERROR(BuildRuntimeIdMap(data.valid_ids, data.total_count, index.GetIdMap()));
+    return knowhere::Status::success;
+}
+
+knowhere::Status
+SetRuntimeValidBitmap(knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
+    if (index.Node() == nullptr) {
+        return knowhere::Status::invalid_args;
+    }
+    RETURN_IF_ERROR(BuildRuntimeValidBitmap(data.valid_ids, data.total_count, index.GetIdMap()));
+    return knowhere::Status::success;
+}
+
+knowhere::Status
+EnsureBinaryLoaded(BuiltArtifact& artifact) {
+    if (artifact.binary_loaded_ready || artifact.binary_deserialize_status != knowhere::Status::success) {
+        return artifact.binary_deserialize_status;
+    }
+    RETURN_IF_ERROR(EnsureSerialized(artifact));
+    auto created = CreateIndex(artifact.row, artifact.data, artifact.file_manager);
+    if (!created.ok) {
+        artifact.binary_deserialize_status = created.status;
+        return artifact.binary_deserialize_status;
+    }
+    artifact.binary_loaded = std::move(created.index);
+    artifact.binary_deserialize_status = SetRuntimeValidBitmap(artifact.binary_loaded, artifact.data);
+    if (artifact.binary_deserialize_status == knowhere::Status::success) {
+        artifact.binary_deserialize_status = artifact.binary_loaded.Deserialize(artifact.binset, artifact.json);
+    }
+    artifact.binary_loaded_ready = artifact.binary_deserialize_status == knowhere::Status::success;
+    return artifact.binary_deserialize_status;
+}
+
+knowhere::Status
+WriteBinaryToFile(const knowhere::BinaryPtr& binary, const fs::path& path) {
+    if (binary == nullptr) {
+        return knowhere::Status::invalid_binary_set;
+    }
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        return knowhere::Status::disk_file_error;
+    }
+    out.write(reinterpret_cast<const char*>(binary->data.get()), binary->size);
+    if (!out) {
+        return knowhere::Status::disk_file_error;
+    }
+    return knowhere::Status::success;
+}
+
+knowhere::Status
+WriteEmbListOffsetToFile(const knowhere::DataSetPtr& dataset, size_t offset_count, const fs::path& path) {
+    auto offsets = dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+    if (offsets == nullptr) {
+        return knowhere::Status::emb_list_inner_error;
+    }
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        return knowhere::Status::disk_file_error;
+    }
+    out.write(reinterpret_cast<const char*>(&offset_count), sizeof(size_t));
+    out.write(reinterpret_cast<const char*>(offsets), offset_count * sizeof(size_t));
+    if (!out) {
+        return knowhere::Status::disk_file_error;
+    }
+    return knowhere::Status::success;
+}
+
+knowhere::BinaryPtr
+MainIndexBinary(const knowhere::BinarySet& binset) {
+    for (const auto& [key, binary] : binset.binary_map_) {
+        if (key == knowhere::meta::EMB_LIST_META || key == knowhere::meta::EMB_LIST_RAW_INDEX) {
+            continue;
+        }
+        return binary;
+    }
+    return nullptr;
+}
+
+knowhere::Json
+FileLoadJson(const BuiltArtifact& artifact) {
+    auto json = artifact.json;
+    if (artifact.scenario.mode == Mode::EmbList) {
+        if (fs::exists(artifact.emb_meta_file)) {
+            json["emb_list_meta_file_path"] = artifact.emb_meta_file.string();
+        }
+        if (fs::exists(artifact.emb_raw_file)) {
+            json["emb_list_raw_index_file_path"] = artifact.emb_raw_file.string();
+        }
+    }
+    return json;
+}
+
+knowhere::Status
+EnsureFileSerialized(BuiltArtifact& artifact) {
+    if (artifact.file_serialized) {
+        return artifact.file_serialize_status;
+    }
+    if (artifact.row.data_kind == DataKind::DiskAnn || artifact.row.data_kind == DataKind::Aisaq ||
+        artifact.row.data_kind == DataKind::MinHash) {
+        artifact.file_serialize_status = artifact.index.Serialize(artifact.binset);
+        artifact.file_serialized = true;
+        return artifact.file_serialize_status;
+    }
+
+    RETURN_IF_ERROR(EnsureSerialized(artifact));
+    RETURN_IF_ERROR(WriteBinaryToFile(MainIndexBinary(artifact.binset), artifact.main_file));
+
+    if (artifact.scenario.mode == Mode::EmbList) {
+        auto meta_binary = artifact.binset.GetByName(knowhere::meta::EMB_LIST_META);
+        if (meta_binary != nullptr) {
+            RETURN_IF_ERROR(WriteBinaryToFile(meta_binary, artifact.emb_meta_file));
+        }
+        auto raw_binary = artifact.binset.GetByName(knowhere::meta::EMB_LIST_RAW_INDEX);
+        if (raw_binary != nullptr) {
+            RETURN_IF_ERROR(WriteBinaryToFile(raw_binary, artifact.emb_raw_file));
+        }
+    }
+
+    artifact.file_serialize_status = knowhere::Status::success;
+    artifact.file_serialized = true;
+    return artifact.file_serialize_status;
+}
+
+knowhere::Status
+EnsureFileLoaded(BuiltArtifact& artifact) {
+    if (artifact.file_loaded_ready || artifact.file_deserialize_status != knowhere::Status::success) {
+        return artifact.file_deserialize_status;
+    }
+    RETURN_IF_ERROR(EnsureFileSerialized(artifact));
+    auto created = CreateIndex(artifact.row, artifact.data, artifact.file_manager);
+    if (!created.ok) {
+        artifact.file_deserialize_status = created.status;
+        return artifact.file_deserialize_status;
+    }
+    artifact.file_loaded = std::move(created.index);
+    artifact.file_deserialize_status = SetRuntimeValidBitmap(artifact.file_loaded, artifact.data);
+    if (artifact.file_deserialize_status == knowhere::Status::success) {
+        if (artifact.row.data_kind == DataKind::DiskAnn || artifact.row.data_kind == DataKind::Aisaq ||
+            artifact.row.data_kind == DataKind::MinHash) {
+            artifact.file_deserialize_status = artifact.file_loaded.Deserialize(artifact.binset, artifact.json);
+        } else {
+            artifact.file_deserialize_status =
+                artifact.file_loaded.DeserializeFromFile(artifact.main_file.string(), FileLoadJson(artifact));
+        }
+    }
+    artifact.file_loaded_ready = artifact.file_deserialize_status == knowhere::Status::success;
+    return artifact.file_deserialize_status;
+}
+
+const knowhere::Index<knowhere::IndexNode>&
+IndexForSource(BuiltArtifact& artifact, IndexSource source) {
+    switch (source) {
+        case IndexSource::Fresh:
+            return artifact.index;
+        case IndexSource::BinarySet:
+            REQUIRE(EnsureBinaryLoaded(artifact) == knowhere::Status::success);
+            return artifact.binary_loaded;
+        case IndexSource::File:
+            REQUIRE(EnsureFileLoaded(artifact) == knowhere::Status::success);
+            return artifact.file_loaded;
+    }
+    return artifact.index;
+}
+
+void
+RequireBuildReady(const BuiltArtifact& artifact) {
+    REQUIRE(artifact.build_status == knowhere::Status::success);
+}
+
+void
+ExecuteSearchLike(BuiltArtifact& artifact, const Scenario& scenario, Operation op) {
+    const auto& index = IndexForSource(artifact, scenario.source);
+    auto filtered_ids = FilterIdsFor(scenario.filter_ratio, artifact.data.total_count, artifact.data.valid_ids,
+                                     scenario.mode, artifact.data.selected_ids);
+    auto candidates = scenario.mode == Mode::MultiIndex ? artifact.data.selected_ids : artifact.data.valid_ids;
+    auto allowed_ids = AllowedIdsAfterFilter(candidates, filtered_ids);
+    const bool expect_empty = allowed_ids.empty();
+
+    std::vector<uint8_t> bitset_data;
+    knowhere::BitsetView bitset;
+    const bool needs_bitset = scenario.filter_ratio != FilterRatio::None || scenario.mode == Mode::MultiIndex;
+    if (needs_bitset) {
+        bitset = BitsetViewFrom(bitset_data, artifact.data.total_count, filtered_ids);
+    }
+    milvus::OpContext op_context;
+
+    if (op == Operation::Search || op == Operation::SearchFilter) {
+        auto result = index.Search(artifact.data.query_ds, artifact.json, needs_bitset ? bitset : nullptr, &op_context);
+        if (IsFreshFileBackedRead(artifact.row, scenario) && !result.has_value()) {
+            REQUIRE(IsExpectedEmptySearchError(result.error()));
+            return;
+        }
+        RequireExpectedVectorResult(result, allowed_ids, filtered_ids, expect_empty);
+        if (artifact.row.exact && result.has_value() && !expect_empty) {
+            RequireExactFirstHits(*result.value(), artifact.data.query_ids, allowed_ids);
+        }
+    } else if (op == Operation::Range || op == Operation::RangeFilter) {
+        auto result =
+            index.RangeSearch(artifact.data.query_ds, artifact.json, needs_bitset ? bitset : nullptr, &op_context);
+        if (IsFreshFileBackedRead(artifact.row, scenario) && !result.has_value()) {
+            REQUIRE(IsExpectedEmptySearchError(result.error()));
+            return;
+        }
+        RequireExpectedRangeResult(result, allowed_ids, filtered_ids, expect_empty);
+        if (artifact.row.exact && result.has_value() && !expect_empty) {
+            RequireExactRangeHits(*result.value(), artifact.data.query_ids, allowed_ids);
+        }
+    } else if (op == Operation::Iterator || op == Operation::IteratorFilter) {
+        auto result = index.AnnIterator(artifact.data.query_ds, artifact.json, needs_bitset ? bitset : nullptr, true,
+                                        &op_context);
+        if (IsFreshFileBackedRead(artifact.row, scenario) && !result.has_value()) {
+            REQUIRE(IsExpectedEmptySearchError(result.error()));
+            return;
+        }
+        RequireExpectedIteratorResult(result, allowed_ids, filtered_ids, expect_empty,
+                                      artifact.row.exact ? &artifact.data.query_ids : nullptr);
+    }
+}
+
+void
+ExecuteSupportedScenario(const IndexRow& row, const Scenario& scenario) {
+    auto artifact = BuildArtifactForScenario(row, scenario);
+    CAPTURE(row.label, row.index_type, scenario.name, artifact->json.dump());
+
+    if (!artifact->create_ok) {
+        REQUIRE(row.maybe_unavailable);
+        REQUIRE(artifact->create_status != knowhere::Status::success);
+        return;
+    }
+
+    if (scenario.op == Operation::Build) {
+        RequireBuildReady(*artifact);
+        return;
+    }
+
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+
+    switch (scenario.op) {
+        case Operation::Search:
+        case Operation::Range:
+        case Operation::Iterator:
+        case Operation::SearchFilter:
+        case Operation::RangeFilter:
+        case Operation::IteratorFilter:
+            ExecuteSearchLike(*artifact, scenario, scenario.op);
+            return;
+        case Operation::BinarySetSerialize:
+            REQUIRE(EnsureSerialized(*artifact) == knowhere::Status::success);
+            REQUIRE(artifact->binset.Size() > 0);
+            return;
+        case Operation::BinarySetDeserialize:
+            REQUIRE(EnsureBinaryLoaded(*artifact) == knowhere::Status::success);
+            {
+                const auto& loaded_id_map = artifact->binary_loaded.Node()->GetIdMap();
+                const auto& index_id_map = artifact->index.Node()->GetIdMap();
+                REQUIRE(loaded_id_map.OutCount() == index_id_map.OutCount());
+            }
+            return;
+        case Operation::FileSerialize:
+            REQUIRE(EnsureFileSerialized(*artifact) == knowhere::Status::success);
+            return;
+        case Operation::FileDeserialize:
+            REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
+            {
+                const auto& loaded_id_map = artifact->file_loaded.Node()->GetIdMap();
+                if (artifact->row.data_kind == DataKind::MinHash && scenario.nullable_ratio == NullableRatio::R0) {
+                    REQUIRE(loaded_id_map.OutCount() == static_cast<size_t>(artifact->data.total_count));
+                } else {
+                    const auto& index_id_map = artifact->index.Node()->GetIdMap();
+                    REQUIRE(loaded_id_map.OutCount() == index_id_map.OutCount());
+                }
+            }
+            return;
+        case Operation::Build:
+            return;
+    }
+}
+
+bool
+IsExpectedUnsupportedStatus(knowhere::Status status) {
+    return status != knowhere::Status::success;
+}
+
+void
+RequireExpectedUnsupportedStatus(knowhere::Status status) {
+    REQUIRE(IsExpectedUnsupportedStatus(status));
+}
+
+void
+ExecuteUnsupportedScenario(const IndexRow& row, const Scenario& scenario) {
+    if (!SupportsModeBuild(row, scenario.mode)) {
+        REQUIRE_FALSE(SupportsScenario(row, scenario));
+        return;
+    }
+
+    auto artifact = BuildArtifactForScenario(row, scenario);
+    CAPTURE(row.label, row.index_type, scenario.name, artifact->json.dump());
+
+    if (!artifact->create_ok) {
+        RequireExpectedUnsupportedStatus(artifact->create_status);
+        return;
+    }
+
+    if (scenario.op == Operation::Build) {
+        return;
+    }
+
+    if (artifact->build_status != knowhere::Status::success) {
+        RequireExpectedUnsupportedStatus(artifact->build_status);
+        return;
+    }
+
+    switch (scenario.op) {
+        case Operation::Search:
+        case Operation::Range:
+        case Operation::Iterator:
+        case Operation::SearchFilter:
+        case Operation::RangeFilter:
+        case Operation::IteratorFilter:
+            SUCCEED("unsupported read operation is covered by capability matrix");
+            return;
+        case Operation::BinarySetSerialize:
+            (void)EnsureSerialized(*artifact);
+            return;
+        case Operation::BinarySetDeserialize: {
+            auto serialize_status = EnsureSerialized(*artifact);
+            if (serialize_status != knowhere::Status::success) {
+                RequireExpectedUnsupportedStatus(serialize_status);
+                return;
+            }
+            (void)EnsureBinaryLoaded(*artifact);
+            return;
+        }
+        case Operation::FileSerialize:
+            (void)EnsureFileSerialized(*artifact);
+            return;
+        case Operation::FileDeserialize: {
+            auto serialize_status = EnsureFileSerialized(*artifact);
+            if (serialize_status != knowhere::Status::success) {
+                RequireExpectedUnsupportedStatus(serialize_status);
+                return;
+            }
+            (void)EnsureFileLoaded(*artifact);
+            return;
+        }
+        case Operation::Build:
+            return;
+    }
+}
+
+void
+ExecuteScenario(const IndexRow& row, const Scenario& scenario) {
+    const bool supported = SupportsScenario(row, scenario);
+    if (!supported) {
+        ExecuteUnsupportedScenario(row, scenario);
+        return;
+    }
+    ExecuteSupportedScenario(row, scenario);
+}
+
+std::vector<uint8_t>
+MakeValidBitmap(size_t total_count, const std::vector<int32_t>& valid_ids) {
+    return MakeBitmap(total_count, valid_ids);
+}
+
+std::unique_ptr<bool[]>
+MakeValidData(size_t total_count, const std::vector<int32_t>& valid_ids) {
+    auto valid_data = std::make_unique<bool[]>(total_count);
+    std::fill_n(valid_data.get(), total_count, false);
+    for (auto id : valid_ids) {
+        valid_data[static_cast<size_t>(id)] = true;
+    }
+    return valid_data;
+}
+
+void
+SetIdMapIds(knowhere::IdMap& map, const std::vector<int32_t>& ids, int64_t count) {
+    map.AddFromData(
+        knowhere::IdMapData::FromIds(ids.empty() ? nullptr : ids.data(), ids.size(), static_cast<size_t>(count)));
+}
+
+void
+RequireIdMapForwarding(knowhere::IndexNode& node) {
+    knowhere::IdMap map;
+    const std::vector<int32_t> ids = {1, 3};
+    map.AddFromData(knowhere::IdMapData::FromIds(ids.data(), ids.size(), 4));
+    node.GetIdMap() = std::move(map);
+    const auto& id_map = node.GetIdMap();
+    REQUIRE(id_map.OutCount() == 4);
+    REQUIRE(id_map.ValidBitmap().size() == 4);
+    REQUIRE(id_map.MapInToOut(1) == 3);
+}
+
+void
+RequireReadApisReturnError(knowhere::IndexNode& node) {
+    auto dataset = GenNullableDenseDataSet(4, {0, 2}, kDenseDim);
+    auto query = GenDenseQueryDataSet({0}, kDenseDim);
+    int64_t id = 0;
+    auto ids = knowhere::GenIdsDataSet(1, &id);
+    auto new_config = [] { return std::make_unique<knowhere::BaseConfig>(); };
+
+    auto search = node.Search(query, new_config(), knowhere::BitsetView{});
+    REQUIRE(!search.has_value());
+    REQUIRE(search.error() == Status::not_implemented);
+
+    auto range = node.RangeSearch(query, new_config(), knowhere::BitsetView{});
+    REQUIRE(!range.has_value());
+    REQUIRE(range.error() == Status::not_implemented);
+
+    auto iterator = node.AnnIterator(query, new_config(), knowhere::BitsetView{});
+    REQUIRE(!iterator.has_value());
+    REQUIRE(iterator.error() == Status::not_implemented);
+
+    auto vector = node.GetVectorByIds(ids);
+    REQUIRE(!vector.has_value());
+    REQUIRE(vector.error() == Status::not_implemented);
+
+    auto calc_dist = node.CalcDistByIDs(dataset, knowhere::BitsetView{}, &id, 1, false);
+    REQUIRE(!calc_dist.has_value());
+    REQUIRE(calc_dist.error() == Status::not_implemented);
+
+    auto emb_list = node.GetEmbListByIds(ids, knowhere::metric::L2);
+    REQUIRE(!emb_list.has_value());
+    REQUIRE(emb_list.error() == Status::emb_list_inner_error);
+}
+
+struct RequiredIndexRow {
+    RequiredIndexRow(const char* label, const char* index_type, DataKind data_kind)
+        : label(label), index_type(index_type), data_kind(data_kind) {
+    }
+
+    const char* label;
+    const char* index_type;
+    DataKind data_kind;
+};
+
+bool
+HasIndexRow(const std::vector<IndexRow>& rows, const RequiredIndexRow& required) {
+    return std::any_of(rows.begin(), rows.end(), [&](const IndexRow& row) {
+        return row.label == required.label && row.index_type == required.index_type &&
+               row.data_kind == required.data_kind;
+    });
+}
+
+}  // namespace
+
+TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
+    SECTION("IdMap maps compact vector ids") {
+        knowhere::IdMap map;
+        const std::vector<int32_t> ids = {0, 2, 4, 6};
+        SetIdMapIds(map, ids, 8);
+        REQUIRE(!map.InToOutIds().empty());
+        REQUIRE(map.OutCount() == 8);
+        REQUIRE(map.MapInToOut(2) == 4);
+        REQUIRE(map.MapInToOut(static_cast<int64_t>(ids.size())) == -1);
+        REQUIRE(map.MapOutToIn(4) == 2);
+        REQUIRE(map.MapOutToIn(5) == -1);
+
+        std::vector<int64_t> result_ids = {0, 1, 2, 3, 4, -1};
+        map.MapInToOut(result_ids.data(), result_ids.size());
+        REQUIRE(result_ids == std::vector<int64_t>{0, 2, 4, 6, -1, -1});
+    }
+
+    SECTION("IdMap can be built directly from valid data") {
+        auto valid_data = MakeValidData(10, {1, 4, 9});
+        knowhere::IdMap map;
+        map.AddFromData(knowhere::IdMapData::FromValidData(valid_data.get(), 10));
+        REQUIRE(map.OutCount() == 10);
+        RequireIdArrayEquals(map.InToOutIds(), {});
+
+        map.FinalizeVectorIds();
+        REQUIRE(!map.InToOutIds().empty());
+        RequireIdArrayEquals(map.InToOutIds(), {1, 4, 9});
+        REQUIRE(map.MapOutToIn(1) == 0);
+        REQUIRE(map.MapOutToIn(4) == 1);
+        REQUIRE(map.MapOutToIn(9) == 2);
+        REQUIRE(map.MapOutToIn(8) == -1);
+    }
+
+    SECTION("IdMap views keep array buffers alive") {
+        auto bitmap = MakeValidBitmap(10, {1, 4, 9});
+        knowhere::IdArray ids_array;
+        knowhere::BitmapArray valid_array;
+        {
+            knowhere::IdMap map;
+            map.AddFromData(knowhere::IdMapData::FromValidBitmap(bitmap.data(), 10));
+            REQUIRE(map.InToOutIds().empty());
+            map.FinalizeVectorIds();
+
+            ids_array = map.InToOutIds();
+            valid_array = map.ValidBitmap();
+        }
+
+        RequireIdArrayEquals(ids_array, {1, 4, 9});
+        REQUIRE(valid_array.size() == 10);
+        REQUIRE((valid_array.data()[1 >> 3] & (1U << (1 & 7))) != 0);
+        REQUIRE((valid_array.data()[4 >> 3] & (1U << (4 & 7))) != 0);
+        REQUIRE((valid_array.data()[9 >> 3] & (1U << (9 & 7))) != 0);
+    }
+
+    SECTION("IdMap appends ids and bitmap together") {
+        knowhere::IdMap map;
+        map.SetType(knowhere::IdMap::Type::GROWING);
+        const int32_t ids[] = {0, 2};
+        map.AddFromData(knowhere::IdMapData::FromIds(ids, 2, 4));
+        REQUIRE(map.OutCount() == 4);
+        REQUIRE(map.MapInToOut(1) == 2);
+        REQUIRE(map.MapOutToIn(2) == 1);
+        REQUIRE(map.MapOutToIn(1) == -1);
+
+        std::vector<int64_t> result_ids = {0, 1, -1};
+        map.MapInToOut(result_ids.data(), result_ids.size());
+        REQUIRE(result_ids == std::vector<int64_t>{0, 2, -1});
+    }
+
+    SECTION("BitsetView keeps a stable id window over a growing IdMap") {
+        knowhere::IdMap map;
+        map.SetType(knowhere::IdMap::Type::GROWING);
+        const int32_t base_ids[] = {0, 2};
+        map.AddFromData(knowhere::IdMapData::FromIds(base_ids, 2, 4));
+
+        std::vector<uint8_t> filter_bits(1, 0);
+        knowhere::BitsetView bitset(filter_bits.data(), 4);
+        const auto& out_ids = map.InToOutIds();
+        REQUIRE(out_ids.is_append_array());
+        bitset.set_out_ids(out_ids, out_ids.size());
+
+        const int32_t append_ids[] = {0, 1};
+        map.AddFromData(knowhere::IdMapData::FromIds(append_ids, 2, 2));
+
+        REQUIRE(bitset.out_ids_count() == 2);
+        REQUIRE_FALSE(bitset.test(0));
+        REQUIRE_FALSE(bitset.test(1));
+        REQUIRE(bitset.test(2));
+        RequireIdArrayEquals(map.InToOutIds(), {0, 2, 4, 5});
+    }
+
+    SECTION("Growing IdMap appends non-byte-aligned bitmap without changing visible prefix") {
+        knowhere::IdMap map;
+        map.SetType(knowhere::IdMap::Type::GROWING);
+
+        const bool first_batch[] = {true, false, true, true, false};
+        map.AddFromData(knowhere::IdMapData::FromValidData(first_batch, sizeof(first_batch) / sizeof(bool)));
+
+        const auto first_out_count = map.OutCount();
+        const auto first_in_count = map.InCount();
+        auto first_valid_bitmap = map.ValidBitmap();
+        auto first_out_ids = map.InToOutIds();
+
+        const bool second_batch[] = {true, true, false, true, false};
+        map.AddFromData(knowhere::IdMapData::FromValidData(second_batch, sizeof(second_batch) / sizeof(bool)));
+
+        REQUIRE(first_out_count == 5);
+        REQUIRE(first_in_count == 3);
+        REQUIRE(first_valid_bitmap.size() == 5);
+        REQUIRE((first_valid_bitmap[0] & 0x1F) == 0x0D);
+        RequireIdArrayEquals(first_out_ids, {0, 2, 3});
+
+        REQUIRE(map.OutCount() == 10);
+        REQUIRE(map.InCount() == 6);
+        REQUIRE((map.ValidBitmap()[0] & 0xFF) == 0x6D);
+        REQUIRE((map.ValidBitmap()[1] & 0x03) == 0x01);
+        RequireIdArrayEquals(map.InToOutIds(), {0, 2, 3, 5, 6, 8});
+    }
+
+    SECTION("Growing IdMap keeps search-side prefixes stable across appends") {
+        knowhere::IdMap map;
+        map.SetType(knowhere::IdMap::Type::GROWING);
+
+        const bool first_batch[] = {true, false, true, true, false};
+        map.AddFromData(knowhere::IdMapData::FromValidData(first_batch, sizeof(first_batch) / sizeof(bool)));
+
+        auto search_valid_bitmap = map.ValidBitmap();
+        auto search_out_ids = map.InToOutIds();
+        std::vector<uint8_t> filter_bits(1, 0);
+        knowhere::BitsetView search_bitset(filter_bits.data(), search_valid_bitmap.size());
+        search_bitset.set_out_ids(search_out_ids, search_out_ids.size());
+        search_bitset.set_vector_count(search_out_ids.size());
+        search_bitset.set_filter_count(0);
+
+        auto second_batch = MakeValidBitmap(7, {0, 3, 6});
+        map.AddFromData(knowhere::IdMapData::FromValidBitmap(second_batch.data(), 7));
+
+        REQUIRE(search_valid_bitmap.size() == 5);
+        REQUIRE((search_valid_bitmap[0] & 0x1F) == 0x0D);
+        RequireIdArrayEquals(search_out_ids, {0, 2, 3});
+        REQUIRE(search_bitset.out_ids_count() == 3);
+        REQUIRE_FALSE(search_bitset.test(0));
+        REQUIRE_FALSE(search_bitset.test(1));
+        REQUIRE_FALSE(search_bitset.test(2));
+        REQUIRE(search_bitset.test(3));
+
+        REQUIRE(map.OutCount() == 12);
+        REQUIRE(map.InCount() == 6);
+        RequireIdArrayEquals(map.InToOutIds(), {0, 2, 3, 5, 8, 11});
+        REQUIRE(map.MapOutToIn(11) == 5);
+    }
+
+    SECTION("Sealed IdMap uses array storage") {
+        const bool base_valid[] = {true, true, true, true};
+        knowhere::IdMap map;
+        map.AddFromData(knowhere::IdMapData::FromValidData(base_valid, 4));
+        map.FinalizeVectorIds();
+        RequireIdArrayEquals(map.InToOutIds(), {0, 1, 2, 3});
+        REQUIRE(map.MapOutToIn(3) == 3);
+
+        const int32_t append_ids[] = {0, 2};
+        map.AddFromData(knowhere::IdMapData::FromIds(append_ids, 2, 4));
+        REQUIRE(map.OutCount() == 4);
+        RequireIdArrayEquals(map.InToOutIds(), {0, 2});
+        REQUIRE(map.MapOutToIn(2) == 1);
+        REQUIRE(map.InToOutIds().is_array());
+    }
+
+    SECTION("IdMap appends emb-list ids without bitmap") {
+        knowhere::IdMap map;
+        map.SetType(knowhere::IdMap::Type::GROWING);
+        const size_t first_offsets[] = {0, 2, 5};
+        map.AppendEmbListIds(0, first_offsets, 2);
+
+        REQUIRE(map.OutCount() == 0);
+        REQUIRE(map.InToOutIds().empty());
+        REQUIRE(map.ValidBitmap().empty());
+        auto first_ebl_ids = map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST);
+        RequireIdArrayEquals(first_ebl_ids, {0, 0, 1, 1, 1});
+
+        const size_t second_offsets[] = {0, 2};
+        map.AppendEmbListIds(2, second_offsets, 1);
+
+        RequireIdArrayEquals(first_ebl_ids, {0, 0, 1, 1, 1});
+        REQUIRE(map.OutCount() == 0);
+        REQUIRE(map.InToOutIds().empty());
+        REQUIRE(map.ValidBitmap().empty());
+        RequireIdArrayEquals(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {0, 0, 1, 1, 1, 2, 2});
+    }
+
+    SECTION("IdMap builds derived emb-list ids without changing bitmap") {
+        auto bitmap = MakeValidBitmap(10, {1, 4, 9});
+        knowhere::IdMap map;
+        map.AddFromData(knowhere::IdMapData::FromValidBitmap(bitmap.data(), 10));
+        map.FinalizeVectorIds();
+
+        const size_t offsets[] = {0, 2, 3, 6};
+        map.FinalizeEmbListIds(offsets, 3);
+        RequireIdArrayEquals(map.InToOutIds(), {1, 4, 9});
+        RequireIdArrayEquals(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {1, 1, 4, 9, 9, 9});
+        REQUIRE(map.MapOutToIn(4) == 1);
+
+        auto valid_before_noop = map.ValidBitmap();
+        REQUIRE(valid_before_noop.size() == 10);
+        REQUIRE((valid_before_noop.data()[1 >> 3] & (1U << (1 & 7))) != 0);
+        REQUIRE((valid_before_noop.data()[4 >> 3] & (1U << (4 & 7))) != 0);
+        REQUIRE((valid_before_noop.data()[9 >> 3] & (1U << (9 & 7))) != 0);
+
+        map.FinalizeEmbListIds(nullptr, 0);
+        RequireIdArrayEquals(map.InToOutIds(), {1, 4, 9});
+        RequireIdArrayEquals(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {1, 1, 4, 9, 9, 9});
+        REQUIRE(map.MapOutToIn(4) == 1);
+
+        auto valid_after_noop = map.ValidBitmap();
+        REQUIRE(valid_after_noop.size() == 10);
+        REQUIRE((valid_after_noop.data()[1 >> 3] & (1U << (1 & 7))) != 0);
+        REQUIRE((valid_after_noop.data()[4 >> 3] & (1U << (4 & 7))) != 0);
+        REQUIRE((valid_after_noop.data()[9 >> 3] & (1U << (9 & 7))) != 0);
+    }
+
+    SECTION("IdMap supports mmap-backed id arrays") {
+        auto work_dir = NullableIdMapWorkDir("id_map_mmap");
+        RemoveAllNoThrow(work_dir);
+
+        knowhere::IdMapMmapOptions mmap_options;
+        mmap_options.enable_in_to_out_ids = true;
+        mmap_options.enable_out_to_in_ids = true;
+        mmap_options.mmap_dir_path = work_dir.string();
+
+        knowhere::IdArray ids_array;
+        knowhere::IdArray ebl_ids_array;
+        knowhere::BitmapArray valid_array;
+        {
+            auto valid_data = MakeValidData(10, {1, 4, 6, 9});
+            knowhere::IdMap map;
+            map.ConfigureMmap(mmap_options);
+            map.AddFromData(knowhere::IdMapData::FromValidData(valid_data.get(), 10));
+            map.FinalizeVectorIds();
+
+            const size_t offsets[] = {0, 1, 3, 3, 4};
+            map.FinalizeEmbListIds(offsets, 4);
+
+            ids_array = map.InToOutIds();
+            ebl_ids_array = map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST);
+            valid_array = map.ValidBitmap();
+            RequireIdArrayEquals(ids_array, {1, 4, 6, 9});
+            RequireIdArrayEquals(ebl_ids_array, {1, 4, 4, 9});
+            REQUIRE(map.MapOutToIn(6) == 2);
+            REQUIRE(map.MapOutToIn(5) == -1);
+            REQUIRE(valid_array.size() == 10);
+
+            size_t mmap_file_count = 0;
+            bool has_in_to_out_ids_file = false;
+            bool has_in_to_out_ebl_ids_file = false;
+            bool has_out_to_in_ids_file = false;
+            bool has_valid_bitmap_file = false;
+            for (const auto& entry : fs::directory_iterator(work_dir)) {
+                if (entry.is_regular_file()) {
+                    ++mmap_file_count;
+                    const auto filename = entry.path().filename().string();
+                    has_in_to_out_ids_file = has_in_to_out_ids_file || filename.find("in_to_out_ids.") == 0;
+                    has_in_to_out_ebl_ids_file = has_in_to_out_ebl_ids_file || filename.find("in_to_out_ebl_ids.") == 0;
+                    has_out_to_in_ids_file = has_out_to_in_ids_file || filename.find("out_to_in_ids.") == 0;
+                    has_valid_bitmap_file = has_valid_bitmap_file || filename.find("valid_bitmap.") == 0;
+                }
+            }
+            REQUIRE(mmap_file_count > 0);
+            REQUIRE(has_in_to_out_ids_file);
+            REQUIRE(has_in_to_out_ebl_ids_file);
+            REQUIRE(has_out_to_in_ids_file);
+            REQUIRE_FALSE(has_valid_bitmap_file);
+        }
+
+        RequireIdArrayEquals(ids_array, {1, 4, 6, 9});
+        RequireIdArrayEquals(ebl_ids_array, {1, 4, 4, 9});
+        REQUIRE(valid_array.size() == 10);
+    }
+
+    SECTION("Sealed all-null IdMap does not materialize mmap id arrays") {
+        auto work_dir = NullableIdMapWorkDir("all_null_id_map_mmap");
+        RemoveAllNoThrow(work_dir);
+
+        knowhere::IdMapMmapOptions mmap_options;
+        mmap_options.enable_in_to_out_ids = true;
+        mmap_options.enable_out_to_in_ids = true;
+        mmap_options.mmap_dir_path = work_dir.string();
+
+        auto valid_data = MakeValidData(10, {});
+        knowhere::IdMap map;
+        map.ConfigureMmap(mmap_options);
+        map.AddFromData(knowhere::IdMapData::FromValidData(valid_data.get(), 10));
+        map.FinalizeVectorIds();
+
+        REQUIRE(map.OutCount() == 10);
+        REQUIRE(map.InCount() == 0);
+        REQUIRE(map.InToOutIds().empty());
+        REQUIRE(map.MapOutToIn(0) == -1);
+        REQUIRE_FALSE(map.IsValidOutId(0));
+
+        size_t mmap_file_count = 0;
+        for (const auto& entry : fs::directory_iterator(work_dir)) {
+            if (entry.is_regular_file()) {
+                ++mmap_file_count;
+            }
+        }
+        REQUIRE(mmap_file_count == 0);
+    }
+
+    SECTION("BitsetView preserves zero mapped count") {
+        knowhere::IdMap map;
+        const std::vector<int32_t> ids = {0, 2, 4, 6};
+        SetIdMapIds(map, ids, 8);
+
+        std::vector<uint8_t> filter_bits(1, 0);
+        filter_bits[1 >> 3] |= static_cast<uint8_t>(1U << (1 & 7));
+        knowhere::BitsetView bitset(filter_bits.data(), 8);
+        const auto& out_ids = map.InToOutIds();
+        bitset.set_out_ids(out_ids, out_ids.size());
+        auto valid_bitmap = map.ValidBitmap();
+        bitset.count_filtered_bits(0, bitset.num_bits(), valid_bitmap.data());
+
+        REQUIRE(bitset.size() == 4);
+        REQUIRE(bitset.count() == 0);
+        REQUIRE(bitset.filter_ratio() == Catch::Approx(0.0f));
+        REQUIRE(bitset.empty());
+        for (size_t i = 0; i < bitset.size(); ++i) {
+            REQUIRE_FALSE(bitset.test(i));
+        }
+    }
+
+    SECTION("BitsetView counts unaligned buffers safely") {
+        constexpr size_t nbits = 73;
+        std::vector<uint8_t> bit_storage((nbits + 7) / 8 + 3, 0);
+        std::vector<uint8_t> valid_storage((nbits + 7) / 8 + 5, 0);
+        auto* bits = bit_storage.data() + 1;
+        auto* valid = valid_storage.data() + 3;
+
+        size_t expected = 0;
+        for (size_t i = 0; i < nbits; ++i) {
+            const bool filtered = i % 3 == 0 || i == 71;
+            const bool present = i % 5 != 0;
+            if (filtered) {
+                bits[i >> 3] |= static_cast<uint8_t>(1U << (i & 7));
+            }
+            if (present) {
+                valid[i >> 3] |= static_cast<uint8_t>(1U << (i & 7));
+            }
+            if (filtered && present) {
+                ++expected;
+            }
+        }
+
+        knowhere::BitsetView bitset(bits, nbits);
+        bitset.count_filtered_bits(0, bitset.num_bits(), valid);
+        REQUIRE(bitset.count() == expected);
+
+        constexpr size_t bit_offset = 9;
+        constexpr size_t bit_count = 51;
+        size_t expected_range = 0;
+        for (size_t i = bit_offset; i < bit_offset + bit_count; ++i) {
+            const bool filtered = i % 3 == 0 || i == 71;
+            const bool present = i % 5 != 0;
+            if (filtered && present) {
+                ++expected_range;
+            }
+        }
+        bitset.count_filtered_bits(bit_offset, bit_count, valid);
+        REQUIRE(bitset.count() == expected_range);
+    }
+
+    SECTION("BitsetView first valid index ignores padding bits") {
+        {
+            constexpr size_t nbits = 62;
+            std::vector<uint8_t> bits((nbits + 7) / 8, 0xFF);
+            bits.back() = 0x7F;
+            knowhere::BitsetView bitset(bits.data(), nbits, nbits);
+            REQUIRE(bitset.get_first_valid_index() == nbits);
+        }
+        {
+            constexpr size_t nbits = 65;
+            std::vector<uint8_t> bits((nbits + 7) / 8, 0xFF);
+            bits.back() = 0x03;
+            knowhere::BitsetView bitset(bits.data(), nbits, nbits);
+            REQUIRE(bitset.get_first_valid_index() == nbits);
+        }
+    }
+
+    SECTION("Data type conversion preserves row slicing and emb-list layout") {
+        auto vector_ds = GenFullDenseDataSet(8, 4);
+        vector_ds->SetTensorBeginId(10);
+        auto converted_vector = knowhere::ConvertToDataTypeIfNeeded<knowhere::fp16>(vector_ds, 1, 2);
+        REQUIRE(converted_vector->GetRows() == 2);
+        REQUIRE(converted_vector->GetTensorBeginId() == 11);
+        REQUIRE(converted_vector->GetDim() == 4);
+
+        auto emb_ds = GenNullableEmbListDataSet(8, {1, 3, 5}, 4, 2);
+        emb_ds->SetTensorBeginId(20);
+        auto converted_emb = knowhere::ConvertToDataTypeIfNeeded<knowhere::fp16>(emb_ds);
+        REQUIRE(converted_emb->GetRows() == emb_ds->GetRows());
+        REQUIRE(converted_emb->GetTensorBeginId() == 20);
+        auto offsets = converted_emb->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+        REQUIRE(offsets != nullptr);
+        REQUIRE(offsets[0] == 0);
+        REQUIRE(offsets[3] == 6);
+    }
+
+    SECTION("IndexNode wrappers forward nullable out id map state") {
+        auto data_mock =
+            knowhere::IndexNodeDataMockWrapper<knowhere::fp16>(std::make_unique<NullableWrapperFakeIndexNode>());
+        RequireIdMapForwarding(data_mock);
+        RequireReadApisReturnError(data_mock);
+
+        auto local_pool = std::make_shared<knowhere::ThreadPool>(1, "Knowhere_Nullable_Test");
+        {
+            auto thread_pool =
+                knowhere::IndexNodeThreadPoolWrapper(std::make_unique<NullableWrapperFakeIndexNode>(), local_pool);
+            RequireIdMapForwarding(thread_pool);
+        }
+    }
+}
+
+TEST_CASE("Nullable Index normalizes bitset before calling IndexNode", "[nullable][bitset][api]") {
+    auto concrete_index = knowhere::Index<CapturingBitsetFakeIndexNode>::Create(4, kDenseDim);
+    auto* node = concrete_index.Node();
+    knowhere::IdMap map;
+    SetIdMapIds(map, {0, 2, 4, 6}, 8);
+    node->GetIdMap() = std::move(map);
+
+    knowhere::Index<knowhere::IndexNode> index(std::move(concrete_index));
+    auto query_ds = GenDenseQueryDataSet({0}, kDenseDim);
+    auto json = BaseDenseConfig(knowhere::metric::L2, kDenseDim, 1);
+
+    std::vector<uint8_t> missing_only_bits;
+    auto missing_only_bitset = BitsetViewFrom(missing_only_bits, 8, {1});
+    REQUIRE_FALSE(missing_only_bitset.empty());
+    auto search = index.Search(query_ds, json, missing_only_bitset);
+    REQUIRE(search.has_value());
+    REQUIRE(node->last_search_bitset.has_out_ids);
+    REQUIRE(node->last_search_bitset.size == 4);
+    REQUIRE(node->last_search_bitset.num_bits == 8);
+    REQUIRE(node->last_search_bitset.count == 0);
+    REQUIRE_FALSE(node->last_search_bitset.need_filter);
+    REQUIRE(node->last_search_bitset.filtered_in_ids.empty());
+
+    std::vector<uint8_t> valid_bits;
+    auto valid_bitset = BitsetViewFrom(valid_bits, 8, {2});
+    auto range = index.RangeSearch(query_ds, json, valid_bitset);
+    REQUIRE(range.has_value());
+    REQUIRE(node->last_range_bitset.has_out_ids);
+    REQUIRE(node->last_range_bitset.size == 4);
+    REQUIRE(node->last_range_bitset.count == 1);
+    REQUIRE(node->last_range_bitset.need_filter);
+    REQUIRE(node->last_range_bitset.filtered_in_ids == std::vector<int>{1});
+
+    auto iterator = index.AnnIterator(query_ds, json, valid_bitset);
+    REQUIRE(iterator.has_value());
+    REQUIRE(node->last_iterator_bitset.has_out_ids);
+    REQUIRE(node->last_iterator_bitset.size == 4);
+    REQUIRE(node->last_iterator_bitset.count == 1);
+    REQUIRE(node->last_iterator_bitset.need_filter);
+    REQUIRE(node->last_iterator_bitset.filtered_in_ids == std::vector<int>{1});
+
+    auto emb_concrete_index = knowhere::Index<CapturingBitsetFakeIndexNode>::Create(6, kDenseDim);
+    auto* emb_node = emb_concrete_index.Node();
+    emb_node->SetEmbListOffsetForTest({0, 2, 5, 6});
+    knowhere::IdMap emb_map;
+    SetIdMapIds(emb_map, {0, 1, 2}, 3);
+    emb_node->GetIdMap() = std::move(emb_map);
+    emb_node->BuildInToOutEblIdsForTest({0, 2, 5, 6});
+    knowhere::Index<knowhere::IndexNode> emb_index(std::move(emb_concrete_index));
+
+    std::vector<uint8_t> emb_bits;
+    auto emb_bitset = BitsetViewFrom(emb_bits, 3, {1});
+    auto emb_search = emb_index.Search(query_ds, json, emb_bitset);
+    REQUIRE(emb_search.has_value());
+    REQUIRE(emb_node->last_search_bitset.has_out_ids);
+    REQUIRE(emb_node->last_search_bitset.size == 6);
+    REQUIRE(emb_node->last_search_bitset.num_bits == 3);
+    REQUIRE(emb_node->last_search_bitset.count == 3);
+    REQUIRE(emb_node->last_search_bitset.need_filter);
+    REQUIRE(emb_node->last_search_bitset.filtered_in_ids == std::vector<int>{2, 3, 4});
+
+    auto doc_level_concrete_index = knowhere::Index<CapturingBitsetFakeIndexNode>::Create(3, kDenseDim);
+    auto* doc_level_node = doc_level_concrete_index.Node();
+    doc_level_node->SetEmbListOffsetForTest({0, 2, 5, 6});
+    knowhere::Index<knowhere::IndexNode> doc_level_index(std::move(doc_level_concrete_index));
+
+    auto doc_level_search = doc_level_index.Search(query_ds, json, emb_bitset);
+    REQUIRE(doc_level_search.has_value());
+    REQUIRE_FALSE(doc_level_node->last_search_bitset.has_out_ids);
+    REQUIRE(doc_level_node->last_search_bitset.size == 6);
+    REQUIRE(doc_level_node->last_search_bitset.num_bits == 3);
+    REQUIRE(doc_level_node->last_search_bitset.count == 3);
+    REQUIRE(doc_level_node->last_search_bitset.need_filter);
+    REQUIRE(doc_level_node->last_search_bitset.filtered_in_ids == std::vector<int>{1});
+}
+
+TEST_CASE("Nullable growing Index keeps visible prefix as a filter boundary", "[nullable][bitset][growing]") {
+    bool first_batch_valid[] = {true, true, true, true};
+    bool second_batch_valid[] = {true, false, true, true};
+
+    knowhere::IdMap map;
+    map.SetType(knowhere::IdMap::Type::GROWING);
+    map.AddFromData(knowhere::IdMapData::FromValidData(first_batch_valid, 4));
+    map.AddFromData(knowhere::IdMapData::FromValidData(second_batch_valid, 4));
+    map.FinalizeVectorIds();
+
+    auto concrete_index = knowhere::Index<CapturingBitsetFakeIndexNode>::Create(7, kDenseDim);
+    auto* node = concrete_index.Node();
+    node->GetIdMap() = std::move(map);
+    knowhere::Index<knowhere::IndexNode> index(std::move(concrete_index));
+
+    auto query_ds = GenDenseQueryDataSet({0}, kDenseDim);
+    auto json = BaseDenseConfig(knowhere::metric::L2, kDenseDim, 1);
+    std::vector<uint8_t> visible_prefix_bits(1, 0);
+    knowhere::BitsetView visible_prefix(visible_prefix_bits.data(), 4);
+
+    auto search = index.Search(query_ds, json, visible_prefix);
+    REQUIRE(search.has_value());
+    REQUIRE(node->last_search_bitset.has_out_ids);
+    REQUIRE(node->last_search_bitset.size == 7);
+    REQUIRE(node->last_search_bitset.num_bits == 4);
+    REQUIRE(node->last_search_bitset.count == 3);
+    REQUIRE(node->last_search_bitset.need_filter);
+    REQUIRE(node->last_search_bitset.filtered_in_ids == std::vector<int>{4, 5, 6});
+}
+
+TEST_CASE("Nullable Index exact bitset count filters rows outside visible bitset", "[nullable][bitset][api]") {
+    auto json = BaseDenseConfig(knowhere::metric::L2, kDenseDim, 1);
+    auto query_ds = GenDenseQueryDataSet({0}, kDenseDim);
+
+    auto non_nullable_index = knowhere::Index<CapturingBitsetFakeIndexNode>::Create(6, kDenseDim);
+    auto* non_nullable_node = non_nullable_index.Node();
+    knowhere::Index<knowhere::IndexNode> non_nullable(std::move(non_nullable_index));
+    std::vector<uint8_t> non_nullable_bits;
+    auto non_nullable_bitset = BitsetViewFrom(non_nullable_bits, 4, {1});
+    auto non_nullable_search = non_nullable.Search(query_ds, json, non_nullable_bitset);
+    REQUIRE(non_nullable_search.has_value());
+    REQUIRE_FALSE(non_nullable_node->last_search_bitset.has_out_ids);
+    REQUIRE(non_nullable_node->last_search_bitset.size == 6);
+    REQUIRE(non_nullable_node->last_search_bitset.num_bits == 4);
+    REQUIRE(non_nullable_node->last_search_bitset.count == 3);
+
+    auto nullable_index = knowhere::Index<CapturingBitsetFakeIndexNode>::Create(4, kDenseDim);
+    auto* nullable_node = nullable_index.Node();
+    knowhere::IdMap nullable_map;
+    SetIdMapIds(nullable_map, {0, 2, 4, 6}, 7);
+    nullable_node->GetIdMap() = std::move(nullable_map);
+    knowhere::Index<knowhere::IndexNode> nullable(std::move(nullable_index));
+    std::vector<uint8_t> nullable_bits;
+    auto nullable_bitset = BitsetViewFrom(nullable_bits, 4, {2});
+    auto nullable_search = nullable.Search(query_ds, json, nullable_bitset);
+    REQUIRE(nullable_search.has_value());
+    REQUIRE(nullable_node->last_search_bitset.has_out_ids);
+    REQUIRE(nullable_node->last_search_bitset.size == 4);
+    REQUIRE(nullable_node->last_search_bitset.num_bits == 4);
+    REQUIRE(nullable_node->last_search_bitset.count == 3);
+    REQUIRE(nullable_node->last_search_bitset.filtered_in_ids == std::vector<int>{1, 2, 3});
+
+    const std::vector<size_t> emb_offsets = {0, 2, 5, 6, 8};
+    auto emb_non_nullable_index = knowhere::Index<CapturingBitsetFakeIndexNode>::Create(8, kDenseDim);
+    auto* emb_non_nullable_node = emb_non_nullable_index.Node();
+    emb_non_nullable_node->SetEmbListOffsetForTest(emb_offsets);
+    knowhere::Index<knowhere::IndexNode> emb_non_nullable(std::move(emb_non_nullable_index));
+    std::vector<uint8_t> emb_non_nullable_bits;
+    auto emb_non_nullable_bitset = BitsetViewFrom(emb_non_nullable_bits, 3, {1});
+    auto emb_non_nullable_search = emb_non_nullable.Search(query_ds, json, emb_non_nullable_bitset);
+    REQUIRE(emb_non_nullable_search.has_value());
+    REQUIRE_FALSE(emb_non_nullable_node->last_search_bitset.has_out_ids);
+    REQUIRE(emb_non_nullable_node->last_search_bitset.size == 8);
+    REQUIRE(emb_non_nullable_node->last_search_bitset.num_bits == 3);
+    REQUIRE(emb_non_nullable_node->last_search_bitset.count == 5);
+
+    const std::vector<size_t> compact_emb_offsets = {0, 2, 5, 6};
+    auto emb_nullable_index = knowhere::Index<CapturingBitsetFakeIndexNode>::Create(6, kDenseDim);
+    auto* emb_nullable_node = emb_nullable_index.Node();
+    emb_nullable_node->SetEmbListOffsetForTest(compact_emb_offsets);
+    knowhere::IdMap emb_nullable_map;
+    SetIdMapIds(emb_nullable_map, {0, 2, 4}, 5);
+    emb_nullable_node->GetIdMap() = std::move(emb_nullable_map);
+    knowhere::Index<knowhere::IndexNode> emb_nullable(std::move(emb_nullable_index));
+    std::vector<uint8_t> emb_nullable_bits;
+    auto emb_nullable_bitset = BitsetViewFrom(emb_nullable_bits, 3, {2});
+    auto emb_nullable_search = emb_nullable.Search(query_ds, json, emb_nullable_bitset);
+    REQUIRE(emb_nullable_search.has_value());
+    REQUIRE(emb_nullable_node->last_search_bitset.has_out_ids);
+    REQUIRE(emb_nullable_node->last_search_bitset.size == 6);
+    REQUIRE(emb_nullable_node->last_search_bitset.num_bits == 3);
+    REQUIRE(emb_nullable_node->last_search_bitset.count == 4);
+
+    auto tokenann_non_nullable_index = knowhere::Index<CapturingBitsetFakeIndexNode>::Create(8, kDenseDim);
+    auto* tokenann_non_nullable_node = tokenann_non_nullable_index.Node();
+    tokenann_non_nullable_node->SetEmbListOffsetForTest(emb_offsets);
+    tokenann_non_nullable_node->BuildInToOutEblIdsForTest(emb_offsets);
+    knowhere::Index<knowhere::IndexNode> tokenann_non_nullable(std::move(tokenann_non_nullable_index));
+    std::vector<uint8_t> tokenann_non_nullable_bits;
+    auto tokenann_non_nullable_bitset = BitsetViewFrom(tokenann_non_nullable_bits, 3, {1});
+    auto tokenann_non_nullable_search = tokenann_non_nullable.Search(query_ds, json, tokenann_non_nullable_bitset);
+    REQUIRE(tokenann_non_nullable_search.has_value());
+    REQUIRE(tokenann_non_nullable_node->last_search_bitset.has_out_ids);
+    REQUIRE(tokenann_non_nullable_node->last_search_bitset.size == 8);
+    REQUIRE(tokenann_non_nullable_node->last_search_bitset.num_bits == 3);
+    REQUIRE(tokenann_non_nullable_node->last_search_bitset.count == 5);
+
+    auto tokenann_nullable_index = knowhere::Index<CapturingBitsetFakeIndexNode>::Create(6, kDenseDim);
+    auto* tokenann_nullable_node = tokenann_nullable_index.Node();
+    tokenann_nullable_node->SetEmbListOffsetForTest(compact_emb_offsets);
+    knowhere::IdMap tokenann_nullable_map;
+    SetIdMapIds(tokenann_nullable_map, {0, 2, 4}, 5);
+    tokenann_nullable_node->GetIdMap() = std::move(tokenann_nullable_map);
+    tokenann_nullable_node->BuildInToOutEblIdsForTest(compact_emb_offsets);
+    knowhere::Index<knowhere::IndexNode> tokenann_nullable(std::move(tokenann_nullable_index));
+    std::vector<uint8_t> tokenann_nullable_bits;
+    auto tokenann_nullable_bitset = BitsetViewFrom(tokenann_nullable_bits, 3, {2});
+    auto tokenann_nullable_search = tokenann_nullable.Search(query_ds, json, tokenann_nullable_bitset);
+    REQUIRE(tokenann_nullable_search.has_value());
+    REQUIRE(tokenann_nullable_node->last_search_bitset.has_out_ids);
+    REQUIRE(tokenann_nullable_node->last_search_bitset.size == 6);
+    REQUIRE(tokenann_nullable_node->last_search_bitset.num_bits == 3);
+    REQUIRE(tokenann_nullable_node->last_search_bitset.count == 4);
+}
+
+TEST_CASE("Nullable Flat Add adds out id map", "[nullable][flat][add]") {
+    auto json = BaseDenseConfig(knowhere::metric::L2, kDenseDim, 1);
+    auto first_batch = GenNullableDenseDataSet(4, {0, 2}, kDenseDim);
+    auto second_batch = GenNullableDenseDataSet(4, {4, 6}, kDenseDim);
+    auto query = GenDenseQueryDataSet({0, 6}, kDenseDim);
+    const int32_t batch_ids[] = {0, 2};
+    first_batch->SetIdMapData(knowhere::IdMapData::FromIds(batch_ids, 2, 4));
+    second_batch->SetIdMapData(knowhere::IdMapData::FromIds(batch_ids, 2, 4));
+
+    auto version = knowhere::Version::GetCurrentVersion().VersionNumber();
+    auto index = knowhere::IndexFactory::Instance()
+                     .Create<knowhere::fp32>(knowhere::IndexEnum::INDEX_FAISS_IDMAP, version)
+                     .value();
+    index.SetIdMapType(knowhere::IdMap::Type::GROWING);
+    REQUIRE(index.Train(first_batch, json) == Status::success);
+    REQUIRE(index.Add(first_batch, json) == Status::success);
+    REQUIRE(index.Add(second_batch, json) == Status::success);
+
+    auto result = index.Search(query, json, knowhere::BitsetView{});
+    REQUIRE(result.has_value());
+    const auto* ids = result.value()->GetIds();
+    REQUIRE(ids[0] == 0);
+    REQUIRE(ids[1] == 6);
+
+    int64_t retrieve_ids[] = {0, 6};
+    auto retrieve = index.GetVectorByIds(knowhere::GenIdsDataSet(2, retrieve_ids));
+    REQUIRE(retrieve.has_value());
+    const auto* retrieved_data = static_cast<const float*>(retrieve.value()->GetTensor());
+    REQUIRE(retrieved_data[0] == 2.0f);
+    REQUIRE(retrieved_data[kDenseDim] == 601.0f);
+}
+
+TEST_CASE("Nullable Index Add keeps id map append when backend add fails", "[nullable][id_map][add]") {
+    auto concrete_index = knowhere::Index<FailingAddFakeIndexNode>::Create();
+    auto* node = concrete_index.Node();
+    knowhere::IdMap map;
+    map.SetType(knowhere::IdMap::Type::GROWING);
+    const int32_t base_ids[] = {1, 3};
+    map.AddFromData(knowhere::IdMapData::FromIds(base_ids, 2, 4));
+    node->GetIdMap() = std::move(map);
+
+    knowhere::Index<knowhere::IndexNode> index(std::move(concrete_index));
+    auto append_batch = GenNullableDenseDataSet(4, {4, 6}, kDenseDim);
+    const int32_t append_ids[] = {0, 2};
+    append_batch->SetIdMapData(knowhere::IdMapData::FromIds(append_ids, 2, 4));
+
+    auto json = BaseDenseConfig(knowhere::metric::L2, kDenseDim, 1);
+    REQUIRE(index.Add(append_batch, json) == Status::invalid_args);
+
+    REQUIRE(index.GetIdMap().OutCount() == 8);
+    RequireIdArrayEquals(index.GetIdMap().InToOutIds(), {1, 3, 4, 6});
+    REQUIRE(index.GetIdMap().MapOutToIn(1) == 0);
+    REQUIRE(index.GetIdMap().MapOutToIn(3) == 1);
+    REQUIRE(index.GetIdMap().MapOutToIn(4) == 2);
+    REQUIRE(index.GetIdMap().MapOutToIn(6) == 3);
+}
+
+TEST_CASE("Nullable DataView full-scan uses internal source ids", "[nullable][data_view][api]") {
+    constexpr int64_t total_count = 64;
+    const std::vector<int32_t> valid_ids = {20, 22, 24, 26, 28, 30, 32, 34};
+    const std::vector<int32_t> query_ids = {20, 26};
+    const std::vector<knowhere::idx_t> labels = {0, 2, 7};
+
+    std::vector<float> source(valid_ids.size() * kDenseDim, -1000.0f);
+    for (size_t i = 0; i < valid_ids.size(); ++i) {
+        FillDenseVector(source.data(), static_cast<int64_t>(i), kDenseDim, valid_ids[i]);
+    }
+
+    auto train_ds = GenNullableDenseDataSet(total_count, valid_ids, kDenseDim);
+    auto query_ds = GenDenseQueryDataSet(query_ids, kDenseDim);
+
+    knowhere::IdMap map;
+    SetIdMapIds(map, valid_ids, total_count);
+    knowhere::ViewDataOp view_data = [&](size_t in_id) -> const void* {
+        if (in_id >= valid_ids.size()) {
+            return source.data();
+        }
+        return source.data() + in_id * kDenseDim;
+    };
+
+    knowhere::DataViewIndexFlat refiner(kDenseDim, knowhere::DataFormatEnum::fp32, knowhere::metric::L2, view_data,
+                                        false, knowhere::DATA_VIEW, std::nullopt);
+    refiner.Train(train_ds->GetRows(), train_ds->GetTensor(), false);
+    refiner.Add(train_ds->GetRows(), train_ds->GetTensor(), nullptr, false);
+
+    std::vector<float> calc_dist(query_ids.size() * labels.size());
+    refiner.CalcDistByIDs(query_ids.size(), query_ds->GetTensor(), labels.size(), labels.data(), calc_dist.data(),
+                          false);
+    for (size_t i = 0; i < query_ids.size(); ++i) {
+        for (size_t j = 0; j < labels.size(); ++j) {
+            CAPTURE(i, j, query_ids[i], labels[j]);
+            REQUIRE(calc_dist[i * labels.size() + j] ==
+                    Catch::Approx(DenseL2ForLogicalIds(query_ids[i], valid_ids[labels[j]], kDenseDim)));
+        }
+    }
+
+    std::vector<float> distances(query_ids.size() * kTopK, -1.0f);
+    std::vector<knowhere::idx_t> result_ids(query_ids.size() * kTopK, -1);
+    refiner.Search(query_ids.size(), query_ds->GetTensor(), kTopK, distances.data(), result_ids.data(),
+                   knowhere::BitsetView{}, nullptr, false);
+    for (size_t i = 0; i < query_ids.size(); ++i) {
+        CAPTURE(i, query_ids[i]);
+        REQUIRE(result_ids[i * kTopK] == static_cast<knowhere::idx_t>(i == 0 ? 0 : 3));
+        REQUIRE(distances[i * kTopK] == Catch::Approx(0.0f));
+    }
+
+    std::vector<uint8_t> filtered_bits;
+    auto prepared_bitset = NormalizedBitsetFrom(filtered_bits, map, total_count, {query_ids[0]});
+    auto& bitset = prepared_bitset.bitset;
+    REQUIRE(bitset.has_out_ids());
+    REQUIRE_FALSE(bitset.empty());
+    REQUIRE(bitset.count() == 1);
+    std::fill(distances.begin(), distances.end(), -1.0f);
+    std::fill(result_ids.begin(), result_ids.end(), -1);
+    refiner.Search(query_ids.size(), query_ds->GetTensor(), kTopK, distances.data(), result_ids.data(), bitset, nullptr,
+                   false);
+    REQUIRE(result_ids[0] != 0);
+    REQUIRE(result_ids[kTopK] == 3);
+
+    auto range = refiner.RangeSearch(query_ids.size(), query_ds->GetTensor(), 0.5f, 0.0f, knowhere::BitsetView{},
+                                     nullptr, false);
+    REQUIRE(range.lims != nullptr);
+    REQUIRE(range.labels != nullptr);
+    REQUIRE(range.distances != nullptr);
+    for (size_t i = 0; i < query_ids.size(); ++i) {
+        CAPTURE(i, query_ids[i]);
+        REQUIRE(range.lims[i + 1] > range.lims[i]);
+        REQUIRE(range.labels[range.lims[i]] == static_cast<knowhere::idx_t>(i == 0 ? 0 : 3));
+        REQUIRE(range.distances[range.lims[i]] == Catch::Approx(0.0f));
+    }
+
+    auto filtered_range =
+        refiner.RangeSearch(query_ids.size(), query_ds->GetTensor(), 0.5f, 0.0f, bitset, nullptr, false);
+    REQUIRE(filtered_range.lims[1] == 0);
+    REQUIRE(filtered_range.lims[2] > filtered_range.lims[1]);
+    REQUIRE(filtered_range.labels[filtered_range.lims[1]] == 3);
+    REQUIRE(filtered_range.distances[filtered_range.lims[1]] == Catch::Approx(0.0f));
+}
+
+TEST_CASE("Nullable DataView selected-id APIs use internal source ids", "[nullable][data_view][api]") {
+    constexpr int64_t total_count = 64;
+    const std::vector<int32_t> valid_ids = {20, 22, 24, 26, 28, 30, 32, 34};
+    const std::vector<int32_t> query_ids = {20, 26};
+
+    std::vector<float> source(valid_ids.size() * kDenseDim, -1000.0f);
+    for (size_t i = 0; i < valid_ids.size(); ++i) {
+        FillDenseVector(source.data(), static_cast<int64_t>(i), kDenseDim, valid_ids[i]);
+    }
+
+    auto train_ds = GenNullableDenseDataSet(total_count, valid_ids, kDenseDim);
+    auto query_ds = GenDenseQueryDataSet(query_ids, kDenseDim);
+
+    knowhere::IdMap map;
+    SetIdMapIds(map, valid_ids, total_count);
+    knowhere::ViewDataOp view_data = [&](size_t in_id) -> const void* {
+        if (in_id >= valid_ids.size()) {
+            return source.data();
+        }
+        return source.data() + in_id * kDenseDim;
+    };
+
+    knowhere::DataViewIndexFlat refiner(kDenseDim, knowhere::DataFormatEnum::fp32, knowhere::metric::L2, view_data,
+                                        false, knowhere::DATA_VIEW, std::nullopt);
+    refiner.Train(train_ds->GetRows(), train_ds->GetTensor(), false);
+    refiner.Add(train_ds->GetRows(), train_ds->GetTensor(), nullptr, false);
+
+    const std::vector<knowhere::idx_t> ids_num_lims = {0, 4, 8};
+    const std::vector<knowhere::idx_t> ids = {7, 2, 0, 5, 0, 1, 3, 7};
+    constexpr knowhere::idx_t selected_topk = 2;
+    std::vector<float> distances(query_ids.size() * selected_topk, -1.0f);
+    std::vector<knowhere::idx_t> result_ids(query_ids.size() * selected_topk, -1);
+
+    refiner.SearchWithIds(query_ids.size(), query_ds->GetTensor(), ids_num_lims.data(), ids.data(), selected_topk,
+                          distances.data(), result_ids.data(), false);
+    REQUIRE(result_ids[0] == 0);
+    REQUIRE(distances[0] == Catch::Approx(0.0f));
+    REQUIRE(result_ids[selected_topk] == 3);
+    REQUIRE(distances[selected_topk] == Catch::Approx(0.0f));
+
+    auto range = refiner.RangeSearchWithIds(query_ids.size(), query_ds->GetTensor(), ids_num_lims.data(), ids.data(),
+                                            0.5f, 0.0f, false);
+    REQUIRE(range.lims != nullptr);
+    REQUIRE(range.labels != nullptr);
+    REQUIRE(range.distances != nullptr);
+    for (size_t i = 0; i < query_ids.size(); ++i) {
+        CAPTURE(i, query_ids[i]);
+        REQUIRE(range.lims[i + 1] == range.lims[i] + 1);
+        REQUIRE(range.labels[range.lims[i]] == static_cast<knowhere::idx_t>(i == 0 ? 0 : 3));
+        REQUIRE(range.distances[range.lims[i]] == Catch::Approx(0.0f));
+    }
+}
+
+TEST_CASE("Nullable DataView cosine uses internal source ids and internal norms", "[nullable][data_view][api]") {
+    constexpr int64_t total_count = 64;
+    const std::vector<int32_t> valid_ids = {20, 22, 24, 26, 28, 30, 32, 34};
+    const std::vector<int32_t> query_ids = {20, 26};
+    const std::vector<knowhere::idx_t> labels = {0, 2, 3};
+
+    auto fill_cosine_vector = [](float* dst, int32_t logical_id) {
+        std::fill(dst, dst + kDenseDim, 0.0f);
+        dst[logical_id % kDenseDim] = 1.0f;
+    };
+
+    std::vector<float> source(valid_ids.size() * kDenseDim, 0.0f);
+    for (size_t i = 0; i < valid_ids.size(); ++i) {
+        fill_cosine_vector(source.data() + i * kDenseDim, valid_ids[i]);
+    }
+
+    auto train_data = std::make_unique<float[]>(valid_ids.size() * kDenseDim);
+    for (size_t i = 0; i < valid_ids.size(); ++i) {
+        fill_cosine_vector(train_data.get() + i * kDenseDim, valid_ids[i]);
+    }
+    auto train_ds = knowhere::GenDataSet(static_cast<int64_t>(valid_ids.size()), kDenseDim, train_data.release());
+    train_ds->SetIsOwner(true);
+
+    auto query_data = std::make_unique<float[]>(query_ids.size() * kDenseDim);
+    for (size_t i = 0; i < query_ids.size(); ++i) {
+        fill_cosine_vector(query_data.get() + i * kDenseDim, query_ids[i]);
+    }
+    auto query_ds = knowhere::GenDataSet(static_cast<int64_t>(query_ids.size()), kDenseDim, query_data.release());
+    query_ds->SetIsOwner(true);
+
+    knowhere::IdMap map;
+    SetIdMapIds(map, valid_ids, total_count);
+    knowhere::ViewDataOp view_data = [&](size_t in_id) -> const void* {
+        if (in_id >= valid_ids.size()) {
+            return source.data();
+        }
+        return source.data() + in_id * kDenseDim;
+    };
+
+    knowhere::DataViewIndexFlat refiner(kDenseDim, knowhere::DataFormatEnum::fp32, knowhere::metric::IP, view_data,
+                                        true, knowhere::DATA_VIEW, std::nullopt);
+    refiner.Train(train_ds->GetRows(), train_ds->GetTensor(), false);
+    refiner.Add(train_ds->GetRows(), train_ds->GetTensor(), nullptr, false);
+
+    std::vector<float> calc_dist(query_ids.size() * labels.size(), 0.0f);
+    refiner.CalcDistByIDs(query_ids.size(), query_ds->GetTensor(), labels.size(), labels.data(), calc_dist.data(),
+                          false);
+    REQUIRE(calc_dist[0] == Catch::Approx(1.0f).epsilon(0.0001f));
+    REQUIRE(calc_dist[labels.size() + 2] == Catch::Approx(1.0f).epsilon(0.0001f));
+
+    std::vector<float> distances(query_ids.size(), -1.0f);
+    std::vector<knowhere::idx_t> result_ids(query_ids.size(), -1);
+    refiner.Search(query_ids.size(), query_ds->GetTensor(), 1, distances.data(), result_ids.data(),
+                   knowhere::BitsetView{}, nullptr, false);
+    REQUIRE(result_ids[0] == 0);
+    REQUIRE(distances[0] == Catch::Approx(1.0f).epsilon(0.0001f));
+    REQUIRE(result_ids[1] == 3);
+    REQUIRE(distances[1] == Catch::Approx(1.0f).epsilon(0.0001f));
+}
+
+TEST_CASE("Nullable SCANN_DVR emb-list cosine rerank maps calc-dist ids", "[nullable][scann_dvr][emblist]") {
+    IndexRow row{"SCANN_DVR", knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, DataKind::DenseFp32};
+    Scenario scenario;
+    scenario.mode = Mode::EmbList;
+    scenario.nullable_ratio = NullableRatio::R50;
+
+    auto work_dir = NullableIdMapWorkDir("scann_dvr_calc_dist");
+    ScopedWorkDir work_dir_guard(work_dir);
+    auto data = BuildMatrixData(row, scenario, work_dir);
+    auto json = DenseConfigFor(row, Mode::EmbList);
+    json[knowhere::meta::METRIC_TYPE] = "MAX_SIM_COSINE";
+
+    auto created = CreateIndex(row, data);
+    REQUIRE(created.ok);
+    REQUIRE(BuildRuntimeIdMap(data.valid_ids, data.total_count, created.index.GetIdMap()) == Status::success);
+    REQUIRE(created.index.Build(data.train_ds, json) == Status::success);
+
+    auto result = created.index.Search(data.query_ds, json, knowhere::BitsetView{});
+    REQUIRE(result.has_value());
+    RequireExpectedVectorResult(result, data.valid_ids, {}, false);
+
+    const auto* ids = result.value()->GetIds();
+    const auto* distances = result.value()->GetDistance();
+    REQUIRE(ids != nullptr);
+    REQUIRE(distances != nullptr);
+    const auto rows = result.value()->GetRows();
+    const auto k = result.value()->GetDim();
+    std::vector<int64_t> labels;
+    labels.reserve(static_cast<size_t>(rows * k));
+    for (int64_t i = 0; i < rows * k; ++i) {
+        if (ids[i] >= 0) {
+            REQUIRE(ContainsId(data.valid_ids, ids[i]));
+            labels.push_back(ids[i]);
+        }
+    }
+    REQUIRE_FALSE(labels.empty());
+    auto calc_dist =
+        created.index.CalcDistByIDs(data.query_ds, knowhere::BitsetView{}, labels.data(), labels.size(), true);
+    REQUIRE(calc_dist.has_value());
+    const auto* calc_distances = calc_dist.value()->GetDistance();
+    REQUIRE(calc_distances != nullptr);
+    size_t label_pos = 0;
+    for (int64_t i = 0; i < rows; ++i) {
+        for (int64_t j = 0; j < k; ++j) {
+            if (ids[i * k + j] < 0) {
+                continue;
+            }
+            CAPTURE(i, j, ids[i * k + j]);
+            REQUIRE(distances[i * k + j] ==
+                    Catch::Approx(calc_distances[i * labels.size() + label_pos]).epsilon(0.0001f));
+            ++label_pos;
+        }
+    }
+}
+
+TEST_CASE("Nullable SCANN_DVR CalcDistByIDs uses external source ids", "[nullable][scann_dvr][api]") {
+    IndexRow row{"SCANN_DVR", knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, DataKind::DenseFp32};
+    Scenario scenario;
+    scenario.mode = Mode::Vector;
+    scenario.nullable_ratio = NullableRatio::R50;
+
+    auto artifact = BuildArtifactForScenario(row, scenario);
+    REQUIRE(artifact->create_ok);
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+    RequireDenseCalcDistByIds(artifact->index, artifact->data);
+}
+
+TEST_CASE("Nullable IVF_FLAT vector APIs use restored logical-id map after reload", "[nullable][ivf][api]") {
+    IndexRow row{"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32};
+    Scenario scenario;
+    scenario.mode = Mode::Vector;
+    scenario.nullable_ratio = NullableRatio::R50;
+
+    auto artifact = BuildArtifactForScenario(row, scenario);
+    CAPTURE(artifact->json.dump());
+    REQUIRE(artifact->create_ok);
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+
+    REQUIRE(EnsureBinaryLoaded(*artifact) == knowhere::Status::success);
+    RequireDenseVectorApisUseOutIds(artifact->binary_loaded, artifact->data, artifact->json);
+
+    REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
+    RequireDenseVectorApisUseOutIds(artifact->file_loaded, artifact->data, artifact->json);
+}
+
+TEST_CASE("Nullable FAISS HNSW vector APIs use restored logical-id map after reload", "[nullable][hnsw][api]") {
+    IndexRow row = NativeFaissHnswRow();
+    Scenario scenario;
+    scenario.mode = Mode::Vector;
+    scenario.nullable_ratio = NullableRatio::R50;
+
+    auto artifact = BuildArtifactForScenario(row, scenario);
+    CAPTURE(artifact->json.dump());
+    REQUIRE(artifact->create_ok);
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+
+    auto require_vector_apis = [&](const knowhere::Index<knowhere::IndexNode>& index, bool require_ordered_ids) {
+        if (require_ordered_ids) {
+            RequireIdMapContent(index, artifact->data.valid_ids, artifact->data.total_count);
+        } else {
+            RequireIdMapBitmap(index, artifact->data.total_count);
+        }
+
+        std::vector<int64_t> ids(artifact->data.query_ids.begin(), artifact->data.query_ids.end());
+        auto retrieve = index.GetVectorByIds(knowhere::GenIdsDataSet(static_cast<int64_t>(ids.size()), ids.data()));
+        REQUIRE(retrieve.has_value());
+        RequireDenseVectorsMatchLogicalIds(*retrieve.value(), artifact->data.query_ids, artifact->data.dim);
+
+        RequireDenseCalcDistByIds(index, artifact->data);
+    };
+
+    require_vector_apis(artifact->index, true);
+
+    REQUIRE(EnsureBinaryLoaded(*artifact) == knowhere::Status::success);
+    require_vector_apis(artifact->binary_loaded, false);
+
+    REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
+    require_vector_apis(artifact->file_loaded, false);
+}
+
+TEST_CASE("Nullable IdMap state is reconstructed across serialize reload", "[nullable][ivf][api]") {
+    IndexRow row{"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32};
+    Scenario scenario;
+    scenario.mode = Mode::Vector;
+    scenario.nullable_ratio = NullableRatio::R50;
+
+    auto artifact = BuildArtifactForScenario(row, scenario);
+    REQUIRE(artifact->create_ok);
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+    RequireIdMapContent(artifact->index, artifact->data.valid_ids, artifact->data.total_count);
+
+    REQUIRE(EnsureSerialized(*artifact) == knowhere::Status::success);
+    REQUIRE(artifact->binset.GetByName("EXTERNAL_ID_MAP") == nullptr);
+
+    auto loaded_created = CreateIndex(row, artifact->data, artifact->file_manager);
+    REQUIRE(loaded_created.ok);
+    REQUIRE(SetRuntimeValidBitmap(loaded_created.index, artifact->data) == knowhere::Status::success);
+    REQUIRE(loaded_created.index.Deserialize(artifact->binset, artifact->json) == knowhere::Status::success);
+    RequireIdMapContent(loaded_created.index, artifact->data.valid_ids, artifact->data.total_count);
+}
+
+TEST_CASE("Nullable loaded indexes use restored external-id maps for filters", "[nullable][filter][reload]") {
+    IndexRow row{"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32};
+    Scenario scenario;
+    scenario.mode = Mode::Vector;
+    scenario.nullable_ratio = NullableRatio::R50;
+
+    auto artifact = BuildArtifactForScenario(row, scenario);
+    REQUIRE(artifact->create_ok);
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+    REQUIRE(artifact->data.query_ids.size() >= 2);
+
+    auto filtered_ids = std::vector<int32_t>{artifact->data.query_ids[0]};
+    auto allowed_ids = AllowedIdsAfterFilter(artifact->data.valid_ids, filtered_ids);
+    std::vector<uint8_t> bitset_data;
+    auto bitset = BitsetViewFrom(bitset_data, artifact->data.total_count, filtered_ids);
+    auto exact_range_json = artifact->json;
+    exact_range_json[knowhere::meta::RADIUS] = 0.5f;
+
+    auto require_filtered_reads = [&](const knowhere::Index<knowhere::IndexNode>& index) {
+        auto search = index.Search(artifact->data.query_ds, artifact->json, bitset);
+        REQUIRE(search.has_value());
+        RequireExpectedVectorResult(search, allowed_ids, filtered_ids, false);
+        REQUIRE(search.value()->GetIds()[0] != artifact->data.query_ids[0]);
+        REQUIRE(search.value()->GetIds()[kTopK] == artifact->data.query_ids[1]);
+        REQUIRE(search.value()->GetDistance()[kTopK] == Catch::Approx(0.0f));
+
+        auto range = index.RangeSearch(artifact->data.query_ds, exact_range_json, bitset);
+        REQUIRE(range.has_value());
+        RequireExpectedRangeResult(range, allowed_ids, filtered_ids, false);
+        REQUIRE(range.value()->GetLims()[1] == 0);
+        REQUIRE(range.value()->GetLims()[2] > range.value()->GetLims()[1]);
+        REQUIRE(range.value()->GetIds()[range.value()->GetLims()[1]] == artifact->data.query_ids[1]);
+
+        auto iterators = index.AnnIterator(artifact->data.query_ds, artifact->json, bitset);
+        REQUIRE(iterators.has_value());
+        REQUIRE(iterators.value().size() == static_cast<size_t>(artifact->data.query_ds->GetRows()));
+        auto first_has_next = iterators.value()[0]->HasNext();
+        REQUIRE(first_has_next.has_value());
+        REQUIRE(first_has_next.value());
+        auto first = iterators.value()[0]->Next();
+        REQUIRE(first.has_value());
+        auto [first_id, first_dist] = first.value();
+        (void)first_dist;
+        REQUIRE(first_id != artifact->data.query_ids[0]);
+        auto second_has_next = iterators.value()[1]->HasNext();
+        REQUIRE(second_has_next.has_value());
+        REQUIRE(second_has_next.value());
+        auto second = iterators.value()[1]->Next();
+        REQUIRE(second.has_value());
+        auto [second_id, second_dist] = second.value();
+        REQUIRE(second_id == artifact->data.query_ids[1]);
+        REQUIRE(second_dist == Catch::Approx(0.0f));
+    };
+
+    require_filtered_reads(artifact->index);
+
+    REQUIRE(EnsureBinaryLoaded(*artifact) == knowhere::Status::success);
+    require_filtered_reads(artifact->binary_loaded);
+
+    REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
+    require_filtered_reads(artifact->file_loaded);
+}
+
+TEST_CASE("Nullable HNSW multi-index keeps id map from valid bitmap", "[nullable][hnsw][multi]") {
+    IndexRow row{"HNSW_SQ", knowhere::IndexEnum::INDEX_HNSW_SQ, DataKind::DenseFp32};
+    Scenario scenario;
+    scenario.mode = Mode::MultiIndex;
+    scenario.nullable_ratio = NullableRatio::R0;
+    scenario.total_count_override = 512;
+
+    auto artifact = BuildArtifactForScenario(row, scenario);
+    REQUIRE(artifact->create_ok);
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+    RequireIdMapContent(artifact->index, artifact->data.valid_ids, artifact->data.total_count);
+    {
+        const auto& id_map = artifact->index.Node()->GetIdMap();
+        REQUIRE(id_map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST).empty());
+    }
+
+    auto filtered_ids = FilterIdsFor(FilterRatio::R0, artifact->data.total_count, artifact->data.valid_ids,
+                                     Mode::MultiIndex, artifact->data.selected_ids);
+    auto allowed_ids = AllowedIdsAfterFilter(artifact->data.selected_ids, filtered_ids);
+    REQUIRE(!allowed_ids.empty());
+    std::vector<uint8_t> bitset_data;
+    auto bitset = BitsetViewFrom(bitset_data, artifact->data.total_count, filtered_ids);
+
+    auto search = artifact->index.Search(artifact->data.query_ds, artifact->json, bitset);
+    REQUIRE(search.has_value());
+    RequireExpectedVectorResult(search, allowed_ids, filtered_ids, false);
+}
+
+TEST_CASE("Nullable HNSW multi-index filters use out ids with local partitions", "[nullable][hnsw][multi]") {
+    IndexRow row = NativeFaissHnswRow();
+    Scenario scenario;
+    scenario.mode = Mode::MultiIndex;
+    scenario.nullable_ratio = NullableRatio::R50;
+    scenario.total_count_override = 512;
+
+    auto artifact = BuildArtifactForScenario(row, scenario);
+    REQUIRE(artifact->create_ok);
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+    REQUIRE(!artifact->data.selected_ids.empty());
+
+    for (auto filter_ratio : {FilterRatio::R0, FilterRatio::R50}) {
+        CAPTURE(FilterName(filter_ratio));
+        auto filtered_ids = FilterIdsFor(filter_ratio, artifact->data.total_count, artifact->data.valid_ids,
+                                         Mode::MultiIndex, artifact->data.selected_ids);
+        auto allowed_ids = AllowedIdsAfterFilter(artifact->data.selected_ids, filtered_ids);
+        REQUIRE(!allowed_ids.empty());
+        std::vector<uint8_t> bitset_data;
+        auto bitset = BitsetViewFrom(bitset_data, artifact->data.total_count, filtered_ids);
+
+        auto search = artifact->index.Search(artifact->data.query_ds, artifact->json, bitset);
+        REQUIRE(search.has_value());
+        RequireExpectedVectorResult(search, allowed_ids, filtered_ids, false);
+
+        auto range_json = artifact->json;
+        range_json[knowhere::meta::RADIUS] = 0.5f;
+        auto range = artifact->index.RangeSearch(artifact->data.query_ds, range_json, bitset);
+        REQUIRE(range.has_value());
+        RequireExpectedRangeResult(range, allowed_ids, filtered_ids, false);
+
+        auto iterator = artifact->index.AnnIterator(artifact->data.query_ds, artifact->json, bitset);
+        REQUIRE(iterator.has_value());
+        RequireExpectedIteratorResult(iterator, allowed_ids, filtered_ids, false);
+    }
+}
+
+TEST_CASE("Nullable HNSW multi-index vector APIs use out ids after reload", "[nullable][hnsw][multi][api]") {
+    IndexRow row = NativeFaissHnswRow();
+    Scenario scenario;
+    scenario.mode = Mode::MultiIndex;
+    scenario.nullable_ratio = NullableRatio::R50;
+    scenario.total_count_override = 512;
+
+    auto artifact = BuildArtifactForScenario(row, scenario);
+    REQUIRE(artifact->create_ok);
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+    REQUIRE(!artifact->data.selected_ids.empty());
+
+    auto require_vector_apis = [&](const knowhere::Index<knowhere::IndexNode>& index, bool require_ordered_ids) {
+        if (require_ordered_ids) {
+            RequireIdMapContent(index, artifact->data.valid_ids, artifact->data.total_count);
+        } else {
+            RequireIdMapBitmap(index, artifact->data.total_count);
+        }
+
+        for (auto filter_ratio : {FilterRatio::R0, FilterRatio::R50}) {
+            CAPTURE(FilterName(filter_ratio));
+            auto filtered_ids = FilterIdsFor(filter_ratio, artifact->data.total_count, artifact->data.valid_ids,
+                                             Mode::MultiIndex, artifact->data.selected_ids);
+            auto allowed_ids = AllowedIdsAfterFilter(artifact->data.selected_ids, filtered_ids);
+            REQUIRE(!allowed_ids.empty());
+            std::vector<uint8_t> bitset_data;
+            auto bitset = BitsetViewFrom(bitset_data, artifact->data.total_count, filtered_ids);
+
+            auto search = index.Search(artifact->data.query_ds, artifact->json, bitset);
+            REQUIRE(search.has_value());
+            RequireExpectedVectorResult(search, allowed_ids, filtered_ids, false);
+        }
+
+        std::vector<int64_t> ids(artifact->data.query_ids.begin(), artifact->data.query_ids.end());
+        auto retrieve = index.GetVectorByIds(knowhere::GenIdsDataSet(static_cast<int64_t>(ids.size()), ids.data()));
+        REQUIRE(retrieve.has_value());
+        RequireDenseVectorsMatchLogicalIds(*retrieve.value(), artifact->data.query_ids, artifact->data.dim);
+    };
+
+    require_vector_apis(artifact->index, true);
+
+    REQUIRE(EnsureBinaryLoaded(*artifact) == knowhere::Status::success);
+    require_vector_apis(artifact->binary_loaded, false);
+
+    REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
+    require_vector_apis(artifact->file_loaded, false);
+}
+
+TEST_CASE("Nullable HNSW emb-list multi-index filters use external doc ids", "[nullable][hnsw][emblist][multi]") {
+    IndexRow row{"HNSW_SQ", knowhere::IndexEnum::INDEX_HNSW_SQ, DataKind::DenseFp32};
+    Scenario scenario;
+    scenario.mode = Mode::EmbList;
+    scenario.nullable_ratio = NullableRatio::R50;
+    scenario.emb_list_strategy = knowhere::meta::EMB_LIST_STRATEGY_TOKENANN;
+    scenario.total_count_override = 256;
+
+    auto work_dir = NullableIdMapWorkDir("hnsw_emblist_multi");
+    ScopedWorkDir work_dir_guard(work_dir);
+    auto data = BuildMatrixData(row, scenario, work_dir);
+    REQUIRE(data.valid_ids.size() >= 4);
+
+    std::vector<int32_t> selected_ids(data.valid_ids.begin(), data.valid_ids.begin() + data.valid_ids.size() / 2);
+    data.selected_ids = selected_ids;
+    data.query_ids = FirstQueryIds(selected_ids, data.total_count, 2);
+    data.query_ds = GenEmbListQueryDataSet(data.query_ids, data.dim);
+
+    std::unordered_map<int64_t, std::vector<std::vector<uint32_t>>> scalar_info;
+    scalar_info[0].resize(2);
+    for (size_t doc_id = 0; doc_id < data.valid_ids.size(); ++doc_id) {
+        const auto partition_id = doc_id < selected_ids.size() ? 0 : 1;
+        for (int64_t vector_id = 0; vector_id < kEmbVectorsPerDoc; ++vector_id) {
+            scalar_info[0][partition_id].push_back(static_cast<uint32_t>(doc_id * kEmbVectorsPerDoc + vector_id));
+        }
+    }
+    data.train_ds->Set(knowhere::meta::SCALAR_INFO, scalar_info);
+
+    auto json = BuildJson(row, scenario, data, work_dir / "raw_data.bin", work_dir / "file_index");
+    auto created = CreateIndex(row, data);
+    REQUIRE(created.ok);
+
+    REQUIRE(BuildRuntimeIdMap(data.valid_ids, data.total_count, created.index.GetIdMap()) == knowhere::Status::success);
+    REQUIRE(created.index.Build(data.train_ds, json) == knowhere::Status::success);
+    RequireIdMapContent(created.index, data.valid_ids, data.total_count);
+    {
+        const auto& created_id_map = created.index.Node()->GetIdMap();
+        REQUIRE(!created_id_map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST).empty());
+    }
+
+    std::set<int32_t> selected(selected_ids.begin(), selected_ids.end());
+    std::vector<int32_t> filtered_ids;
+    for (int32_t id = 0; id < data.total_count; ++id) {
+        if (selected.find(id) == selected.end()) {
+            filtered_ids.push_back(id);
+        }
+    }
+    filtered_ids.push_back(selected_ids.front());
+    auto allowed_ids = AllowedIdsAfterFilter(selected_ids, filtered_ids);
+    REQUIRE(!allowed_ids.empty());
+
+    std::vector<uint8_t> bitset_data;
+    auto bitset = BitsetViewFrom(bitset_data, data.total_count, filtered_ids);
+    auto search = created.index.Search(data.query_ds, json, bitset);
+    REQUIRE(search.has_value());
+    RequireExpectedVectorResult(search, allowed_ids, filtered_ids, false);
+}
+
+TEST_CASE("Nullable TokenANN GetEmbListByIds uses logical ids", "[nullable][emblist][api]") {
+    struct RetrieveCase {
+        std::string label;
+        IndexRow row;
+        bool check_built = true;
+        bool check_binary_load = false;
+        bool check_file_load = false;
+    };
+
+    auto diskann = NativeDiskAnnRow();
+    diskann.maybe_unavailable = true;
+
+    std::vector<RetrieveCase> cases = {
+        {"HNSW", NativeFaissHnswRow(), true, true, true},
+        {"IVF_FLAT",
+         {"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32},
+         false,
+         true,
+         true},
+        {"IVF_FLAT_CC",
+         {"IVF_FLAT_CC / IVFFLATCC", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, DataKind::DenseFp32},
+         true,
+         true,
+         true},
+        {"DISKANN", diskann, false, false, false},
+    };
+
+    for (const auto& test_case : cases) {
+        CAPTURE(test_case.label);
+        Scenario scenario;
+        scenario.mode = Mode::EmbList;
+        scenario.nullable_ratio = NullableRatio::R50;
+        scenario.emb_list_strategy = knowhere::meta::EMB_LIST_STRATEGY_TOKENANN;
+
+        auto artifact = BuildArtifactForScenario(test_case.row, scenario);
+        CAPTURE(artifact->json.dump());
+        if (!artifact->create_ok) {
+            REQUIRE(test_case.row.maybe_unavailable);
+            REQUIRE(artifact->create_status != knowhere::Status::success);
+            continue;
+        }
+        REQUIRE(artifact->create_ok);
+        REQUIRE(artifact->build_status == knowhere::Status::success);
+
+        if (test_case.check_built) {
+            RequireEmbListRetrieveUsesOutIds(artifact->index, artifact->data);
+        }
+
+        if (test_case.check_binary_load) {
+            REQUIRE(EnsureBinaryLoaded(*artifact) == knowhere::Status::success);
+            RequireEmbListRetrieveUsesOutIds(artifact->binary_loaded, artifact->data);
+        }
+        if (test_case.check_file_load) {
+            REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
+            RequireEmbListRetrieveUsesOutIds(artifact->file_loaded, artifact->data);
+        }
+    }
+}
+
+TEST_CASE("Nullable SCANN_DVR TokenANN GetEmbListByIds reports unsupported raw retrieve",
+          "[nullable][scann_dvr][emblist][api]") {
+    IndexRow row{"SCANN_DVR", knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, DataKind::DenseFp32};
+    Scenario scenario;
+    scenario.mode = Mode::EmbList;
+    scenario.nullable_ratio = NullableRatio::R50;
+    scenario.emb_list_strategy = knowhere::meta::EMB_LIST_STRATEGY_TOKENANN;
+
+    auto artifact = BuildArtifactForScenario(row, scenario);
+    CAPTURE(artifact->json.dump());
+    REQUIRE(artifact->create_ok);
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+
+    std::vector<int64_t> ids(artifact->data.query_ids.begin(), artifact->data.query_ids.end());
+    auto retrieve = artifact->index.GetEmbListByIds(
+        knowhere::GenIdsDataSet(static_cast<int64_t>(ids.size()), ids.data()), "MAX_SIM_L2");
+    REQUIRE_FALSE(retrieve.has_value());
+    REQUIRE(retrieve.error() == knowhere::Status::not_implemented);
+}
+
+#ifdef KNOWHERE_WITH_CARDINAL
+TEST_CASE("Nullable raw-data vector APIs map compact serialized ids after reload", "[nullable][id_map][api]") {
+    IndexRow row{"HNSW current", knowhere::IndexEnum::INDEX_HNSW, DataKind::DenseFp32, Capabilities{}, false, true};
+    Scenario scenario;
+    scenario.mode = Mode::Vector;
+    scenario.nullable_ratio = NullableRatio::R50;
+    scenario.force_raw_data = true;
+
+    auto artifact = BuildArtifactForScenario(row, scenario);
+    REQUIRE(artifact->create_ok);
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+
+    RequireVectorIdMapCompacted(artifact->index, artifact->data.total_count);
+    RequireDenseVectorPublicApisUseOutIds(artifact->index, artifact->data, artifact->json, false);
+
+    REQUIRE(EnsureBinaryLoaded(*artifact) == knowhere::Status::success);
+    RequireVectorIdMapCompacted(artifact->binary_loaded, artifact->data.total_count);
+    RequireDenseVectorPublicApisUseOutIds(artifact->binary_loaded, artifact->data, artifact->json, false);
+
+    REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
+    RequireVectorIdMapCompacted(artifact->file_loaded, artifact->data.total_count);
+    RequireDenseVectorPublicApisUseOutIds(artifact->file_loaded, artifact->data, artifact->json, false);
+}
+
+TEST_CASE("Nullable TokenANN keeps only required list id map state", "[nullable][id_map][emblist][memory]") {
+    IndexRow row{"HNSW current", knowhere::IndexEnum::INDEX_HNSW, DataKind::DenseFp32, Capabilities{}, false, true};
+    Scenario scenario;
+    scenario.mode = Mode::EmbList;
+    scenario.nullable_ratio = NullableRatio::R50;
+    scenario.emb_list_strategy = knowhere::meta::EMB_LIST_STRATEGY_TOKENANN;
+    scenario.force_raw_data = true;
+
+    auto artifact = BuildArtifactForScenario(row, scenario);
+    CAPTURE(artifact->json.dump());
+    REQUIRE(artifact->create_ok);
+    REQUIRE(artifact->build_status == knowhere::Status::success);
+
+    RequireEmbListIdMapCompacted(artifact->index, artifact->data.valid_ids, artifact->data.total_count);
+    RequireEmbListRetrieveUsesOutIds(artifact->index, artifact->data);
+
+    REQUIRE(EnsureBinaryLoaded(*artifact) == knowhere::Status::success);
+    RequireEmbListIdMapCompacted(artifact->binary_loaded, artifact->data.valid_ids, artifact->data.total_count);
+    RequireEmbListRetrieveUsesOutIds(artifact->binary_loaded, artifact->data);
+
+    REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
+    RequireEmbListIdMapCompacted(artifact->file_loaded, artifact->data.valid_ids, artifact->data.total_count);
+    RequireEmbListRetrieveUsesOutIds(artifact->file_loaded, artifact->data);
+}
+#endif
+
+TEST_CASE("Nullable IVF_FLAT MUVERA/LEMUR emb-list APIs rebuild list ids after reload",
+          "[nullable][ivf][emblist][api]") {
+    IndexRow row{"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32};
+    for (const auto& strategy : {knowhere::meta::EMB_LIST_STRATEGY_MUVERA, knowhere::meta::EMB_LIST_STRATEGY_LEMUR}) {
+        CAPTURE(strategy);
+        Scenario scenario;
+        scenario.mode = Mode::EmbList;
+        scenario.nullable_ratio = NullableRatio::R50;
+        scenario.emb_list_strategy = strategy;
+
+        auto artifact = BuildArtifactForScenario(row, scenario);
+        CAPTURE(artifact->json.dump());
+        REQUIRE(artifact->create_ok);
+        REQUIRE(artifact->build_status == knowhere::Status::success);
+
+        RequireIdMapContent(artifact->index, artifact->data.valid_ids, artifact->data.total_count);
+        RequireEmbListApisUseOutIds(artifact->index, artifact->data, artifact->json);
+
+        REQUIRE(EnsureBinaryLoaded(*artifact) == knowhere::Status::success);
+        RequireIdMapContent(artifact->binary_loaded, artifact->data.valid_ids, artifact->data.total_count);
+        RequireEmbListApisUseOutIds(artifact->binary_loaded, artifact->data, artifact->json);
+
+        REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
+        RequireIdMapContent(artifact->file_loaded, artifact->data.valid_ids, artifact->data.total_count);
+        RequireEmbListApisUseOutIds(artifact->file_loaded, artifact->data, artifact->json);
+    }
+}
+
+TEST_CASE("Nullable mmap file load preserves large non-identity mapping", "[nullable][mmap][api]") {
+    IndexRow row{"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32};
+    Scenario scenario;
+    scenario.mode = Mode::Vector;
+    scenario.nullable_ratio = NullableRatio::R50;
+
+    BuiltArtifact artifact;
+    artifact.row = row;
+    artifact.scenario = scenario;
+    artifact.work_dir = NullableIdMapWorkDir("ivf_mmap_large_mapping");
+    RemoveAllNoThrow(artifact.work_dir);
+    fs::create_directories(artifact.work_dir);
+    artifact.main_file = artifact.work_dir / "main.index";
+    artifact.data.total_count = 160;
+    artifact.data.dim = kDenseDim;
+    artifact.data.valid_ids = EvenIds(artifact.data.total_count);
+    artifact.data.query_ids = FirstQueryIds(artifact.data.valid_ids, artifact.data.total_count);
+    artifact.data.train_ds =
+        GenNullableDenseDataSet(artifact.data.total_count, artifact.data.valid_ids, artifact.data.dim);
+    artifact.data.query_ds = GenDenseQueryDataSet(artifact.data.query_ids, artifact.data.dim);
+    artifact.json = DenseConfigFor(row, Mode::Vector);
+
+    auto created = CreateIndex(row, artifact.data);
+    REQUIRE(created.ok);
+    artifact.index = std::move(created.index);
+    REQUIRE(BuildRuntimeIdMap(artifact.data.valid_ids, artifact.data.total_count, artifact.index.GetIdMap()) ==
+            Status::success);
+    artifact.build_status = artifact.index.Build(artifact.data.train_ds, artifact.json);
+    REQUIRE(artifact.build_status == knowhere::Status::success);
+    REQUIRE(EnsureFileSerialized(artifact) == knowhere::Status::success);
+
+    auto load_json = FileLoadJson(artifact);
+    load_json["enable_mmap"] = true;
+    auto loaded = CreateIndex(row, artifact.data);
+    REQUIRE(loaded.ok);
+    REQUIRE(SetRuntimeValidBitmap(loaded.index, artifact.data) == knowhere::Status::success);
+    REQUIRE(loaded.index.DeserializeFromFile(artifact.main_file.string(), load_json) == knowhere::Status::success);
+    RequireDenseVectorApisUseOutIds(loaded.index, artifact.data, artifact.json);
+}
+
+TEST_CASE("Nullable cuVS search materializes mapped filters to internal bitmap", "[nullable][cuvs][gpu]") {
+#ifndef KNOWHERE_WITH_CUVS
+    SUCCEED("cuVS is not enabled in this build");
+#else
+    IndexRow row{"GPU_CUVS_BRUTE_FORCE",
+                 knowhere::IndexEnum::INDEX_CUVS_BRUTEFORCE,
+                 DataKind::GpuFp32,
+                 Capabilities{},
+                 true,
+                 false,
+                 false,
+                 true};
+    Scenario scenario;
+    scenario.mode = Mode::Vector;
+    scenario.nullable_ratio = NullableRatio::R50;
+
+    auto artifact = BuildArtifactForScenario(row, scenario);
+    if (!artifact->create_ok || artifact->build_status != knowhere::Status::success) {
+        SUCCEED("cuVS is unavailable in this test environment");
+        return;
+    }
+    REQUIRE(artifact->data.query_ids.size() >= 2);
+
+    std::vector<uint8_t> missing_filter_bits;
+    auto missing_id = FirstMissingOutId(artifact->data.valid_ids, artifact->data.total_count);
+    auto missing_filter =
+        BitsetViewFrom(missing_filter_bits, artifact->data.total_count, {static_cast<int32_t>(missing_id)});
+    auto missing_filter_result = artifact->index.Search(artifact->data.query_ds, artifact->json, missing_filter);
+    if (!missing_filter_result.has_value()) {
+        SUCCEED("cuVS search is unavailable in this test environment");
+        return;
+    }
+    RequireExactFirstHits(*missing_filter_result.value(), artifact->data.query_ids, artifact->data.valid_ids);
+
+    std::vector<uint8_t> valid_filter_bits;
+    auto valid_filter = BitsetViewFrom(valid_filter_bits, artifact->data.total_count, {artifact->data.query_ids[0]});
+    auto valid_filter_result = artifact->index.Search(artifact->data.query_ds, artifact->json, valid_filter);
+    REQUIRE(valid_filter_result.has_value());
+    RequireExpectedVectorResult(valid_filter_result, artifact->data.valid_ids, {artifact->data.query_ids[0]}, false);
+    REQUIRE(valid_filter_result.value()->GetIds()[0] != artifact->data.query_ids[0]);
+    REQUIRE(valid_filter_result.value()->GetIds()[kTopK] == artifact->data.query_ids[1]);
+#endif
+}
+
+TEST_CASE("Nullable matrix has 43 index rows and 220 scenarios per row", "[nullable][matrix][count]") {
+    const auto rows = IndexRows();
+    const auto scenarios = BuildScenarios();
+    REQUIRE(rows.size() == 43);
+    REQUIRE(scenarios.size() == 220);
+    REQUIRE(rows.size() * scenarios.size() == 9460);
+
+    const std::vector<RequiredIndexRow> required_rows = {
+        {"FLAT", knowhere::IndexEnum::INDEX_FAISS_IDMAP, DataKind::DenseFp32},
+        {"BIN_FLAT / BINFLAT", knowhere::IndexEnum::INDEX_FAISS_BIN_IDMAP, DataKind::DenseBin},
+        {"FAISS (fp32)", knowhere::IndexEnum::INDEX_FAISS, DataKind::DenseFp32},
+        {"FAISS (bin1)", knowhere::IndexEnum::INDEX_FAISS, DataKind::DenseBin},
+        {"BIN_IVF_FLAT / IVFBIN", knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT, DataKind::DenseBin},
+        {"IVF_FLAT / IVFFLAT", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, DataKind::DenseFp32},
+        {"IVF_FLAT_CC / IVFFLATCC", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, DataKind::DenseFp32},
+        {"IVF_PQ / IVFPQ", knowhere::IndexEnum::INDEX_FAISS_IVFPQ, DataKind::DenseFp32},
+        {"IVF_SQ8", knowhere::IndexEnum::INDEX_FAISS_IVFSQ8, DataKind::DenseFp32},
+        {"IVF_SQ / IVFSQ", "IVF_SQ", DataKind::DenseFp32},
+        {"IVF_SQ_CC", knowhere::IndexEnum::INDEX_FAISS_IVFSQ_CC, DataKind::DenseFp32},
+        {"IVF_RABITQ / IVFRABITQ", knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ, DataKind::DenseFp32},
+        {"IVF_RABITQ_FASTSCAN", knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ_FASTSCAN, DataKind::DenseFp32},
+        {"SCANN", knowhere::IndexEnum::INDEX_FAISS_SCANN, DataKind::DenseFp32},
+        {"SCANN_DVR", knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, DataKind::DenseFp32},
+        {"HNSW (Knowhere/Faiss)", knowhere::IndexEnum::INDEX_HNSW, DataKind::DenseFp32},
+        {"HNSW_SQ", knowhere::IndexEnum::INDEX_HNSW_SQ, DataKind::DenseFp32},
+        {"HNSW_PQ", knowhere::IndexEnum::INDEX_HNSW_PQ, DataKind::DenseFp32},
+        {"HNSW_PRQ", knowhere::IndexEnum::INDEX_HNSW_PRQ, DataKind::DenseFp32},
+        {"HNSWLIB_DEPRECATED", "HNSWLIB_DEPRECATED", DataKind::DenseFp32},
+        {"DISKANN (Knowhere native)", knowhere::IndexEnum::INDEX_DISKANN, DataKind::DiskAnn},
+        {"AISAQ", knowhere::IndexEnum::INDEX_AISAQ, DataKind::Aisaq},
+        {"SPARSE_INVERTED_INDEX (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX, DataKind::Sparse},
+        {"SPARSE_WAND (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_WAND, DataKind::Sparse},
+        {"SPARSE_INVERTED_INDEX_CC (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC,
+         DataKind::Sparse},
+        {"SPARSE_WAND_CC (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_WAND_CC, DataKind::Sparse},
+        {"MINHASH_LSH", knowhere::IndexEnum::INDEX_MINHASH_LSH, DataKind::MinHash},
+        {"GPU_CUVS_BRUTE_FORCE", knowhere::IndexEnum::INDEX_CUVS_BRUTEFORCE, DataKind::GpuFp32},
+        {"GPU_BRUTE_FORCE", knowhere::IndexEnum::INDEX_GPU_BRUTEFORCE, DataKind::GpuFp32},
+        {"GPU_CUVS_IVF_FLAT", knowhere::IndexEnum::INDEX_CUVS_IVFFLAT, DataKind::GpuFp32},
+        {"GPU_IVF_FLAT", knowhere::IndexEnum::INDEX_GPU_IVFFLAT, DataKind::GpuFp32},
+        {"GPU_CUVS_IVF_PQ", knowhere::IndexEnum::INDEX_CUVS_IVFPQ, DataKind::GpuFp32},
+        {"GPU_IVF_PQ", knowhere::IndexEnum::INDEX_GPU_IVFPQ, DataKind::GpuFp32},
+        {"GPU_CUVS_CAGRA", knowhere::IndexEnum::INDEX_CUVS_CAGRA, DataKind::GpuFp32},
+        {"GPU_CAGRA", knowhere::IndexEnum::INDEX_GPU_CAGRA, DataKind::GpuFp32},
+        {"GPU_FAISS_FLAT", knowhere::IndexEnum::INDEX_FAISS_GPU_IDMAP, DataKind::GpuFp32},
+        {"GPU_FAISS_IVF_FLAT", knowhere::IndexEnum::INDEX_FAISS_GPU_IVFFLAT, DataKind::GpuFp32},
+        {"GPU_FAISS_IVF_PQ", knowhere::IndexEnum::INDEX_FAISS_GPU_IVFPQ, DataKind::GpuFp32},
+        {"GPU_FAISS_IVF_SQ8", knowhere::IndexEnum::INDEX_FAISS_GPU_IVFSQ8, DataKind::GpuFp32},
+        {"SVS_FLAT", knowhere::IndexEnum::INDEX_SVS_FLAT, DataKind::DenseFp32},
+        {"SVS_VAMANA", knowhere::IndexEnum::INDEX_SVS_VAMANA, DataKind::DenseFp32},
+        {"SVS_VAMANA_LVQ", knowhere::IndexEnum::INDEX_SVS_VAMANA_LVQ, DataKind::DenseFp32},
+        {"SVS_VAMANA_LEANVEC", knowhere::IndexEnum::INDEX_SVS_VAMANA_LEANVEC, DataKind::DenseFp32},
+    };
+    REQUIRE(required_rows.size() == rows.size());
+    for (const auto& required : required_rows) {
+        CAPTURE(required.label, required.index_type);
+        REQUIRE(HasIndexRow(rows, required));
+    }
+}
+
+TEST_CASE("Nullable native matrix covers every IndexNode operation", "[nullable][matrix]") {
+    const auto rows = IndexRows();
+    const auto scenarios = BuildScenarios();
+
+    for (const auto& row : rows) {
+        SECTION(row.label) {
+            for (const auto& scenario : scenarios) {
+                SECTION(scenario.name) {
+                    ExecuteScenario(row, scenario);
+                }
+            }
+        }
+    }
+}

--- a/tests/ut/test_nullable_id_map.cc
+++ b/tests/ut/test_nullable_id_map.cc
@@ -544,6 +544,9 @@ knowhere::Status
 BuildRuntimeIdMap(const std::vector<int32_t>& valid_ids, int64_t total_count, knowhere::IdMap& id_map);
 
 knowhere::Status
+AttachRuntimeIdMapData(const knowhere::DataSetPtr& dataset, const std::vector<int32_t>& valid_ids, int64_t total_count);
+
+knowhere::Status
 BuildRuntimeValidBitmap(const std::vector<int32_t>& valid_ids, int64_t total_count, knowhere::IdMap& id_map);
 
 int32_t
@@ -843,6 +846,31 @@ GenNullableEmbListDataSet(int64_t total_docs, const std::vector<int32_t>& valid_
     auto offset_data = std::make_unique<size_t[]>(offsets.size());
     std::copy(offsets.begin(), offsets.end(), offset_data.get());
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(offset_data.release()));
+    ds->Set(knowhere::meta::NQ, static_cast<int64_t>(valid_doc_ids.size()));
+    return ds;
+}
+
+knowhere::DataSetPtr
+GenEmbListBatchDataSet(const std::vector<int32_t>& public_doc_ids, const std::vector<size_t>& absolute_offsets,
+                       int64_t dim) {
+    REQUIRE(absolute_offsets.size() == public_doc_ids.size() + 1);
+    REQUIRE(!absolute_offsets.empty());
+    REQUIRE(absolute_offsets.back() >= absolute_offsets.front());
+    const auto vector_begin = absolute_offsets.front();
+    const auto rows = static_cast<int64_t>(absolute_offsets.back() - vector_begin);
+    auto data = std::make_unique<float[]>(std::max<int64_t>(rows * dim, 1));
+    for (size_t doc = 0; doc < public_doc_ids.size(); ++doc) {
+        REQUIRE(absolute_offsets[doc + 1] >= absolute_offsets[doc]);
+        for (size_t vector_id = absolute_offsets[doc]; vector_id < absolute_offsets[doc + 1]; ++vector_id) {
+            FillDenseVector(data.get(), static_cast<int64_t>(vector_id - vector_begin), dim, public_doc_ids[doc]);
+        }
+    }
+    auto ds = knowhere::GenDataSet(rows, dim, rows == 0 ? nullptr : data.release());
+    ds->SetIsOwner(rows != 0);
+    auto offset_data = std::make_unique<size_t[]>(absolute_offsets.size());
+    std::copy(absolute_offsets.begin(), absolute_offsets.end(), offset_data.get());
+    ds->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(offset_data.release()));
+    ds->Set(knowhere::meta::NQ, static_cast<int64_t>(public_doc_ids.size()));
     return ds;
 }
 
@@ -854,6 +882,7 @@ GenEmbListQueryDataSet(const std::vector<int32_t>& logical_doc_ids, int64_t dim)
         offsets[i] = i;
     }
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(offsets.release()));
+    ds->Set(knowhere::meta::NQ, static_cast<int64_t>(logical_doc_ids.size()));
     return ds;
 }
 
@@ -1702,6 +1731,27 @@ RequireIdArrayEquals(const knowhere::IdArray& view, const std::vector<int32_t>& 
     }
 }
 
+int64_t
+RequireCompactOutToIn(const knowhere::IdMap& map, int64_t out_id, size_t compact_count) {
+    auto compact_id = map.CompactOutToIn(out_id, compact_count);
+    REQUIRE(compact_id.has_value());
+    return compact_id.value();
+}
+
+int64_t
+RequireCompactOutToIn(const knowhere::IndexNode& index_node, int64_t out_id, size_t compact_count) {
+    auto compact_id = index_node.CompactOutToIn(out_id, compact_count);
+    REQUIRE(compact_id.has_value());
+    return compact_id.value();
+}
+
+void
+RequireInvalidCompactOutToIn(const knowhere::IdMap& map, int64_t out_id, size_t compact_count) {
+    auto compact_id = map.CompactOutToIn(out_id, compact_count);
+    REQUIRE_FALSE(compact_id.has_value());
+    REQUIRE(compact_id.error() == knowhere::Status::invalid_args);
+}
+
 knowhere::IdArray
 RequireIdMapArrayContent(const knowhere::Index<knowhere::IndexNode>& index, const std::vector<int32_t>& valid_ids,
                          int64_t count) {
@@ -1724,7 +1774,7 @@ RequireIdMapContent(const knowhere::Index<knowhere::IndexNode>& index, const std
     for (size_t i = 0; i < valid_ids.size(); ++i) {
         CAPTURE(i, valid_ids[i]);
         REQUIRE(map.MapInToOut(static_cast<int64_t>(i)) == valid_ids[i]);
-        REQUIRE(index.Node()->MapOutToIn(valid_ids[i]) == static_cast<int64_t>(i));
+        REQUIRE(RequireCompactOutToIn(*index.Node(), valid_ids[i], valid_ids.size()) == static_cast<int64_t>(i));
     }
 }
 
@@ -1763,8 +1813,9 @@ RequireEmbListIdMapCompacted(const knowhere::Index<knowhere::IndexNode>& index, 
     REQUIRE(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST).empty());
     for (size_t i = 0; i < valid_ids.size(); ++i) {
         CAPTURE(i, valid_ids[i]);
-        REQUIRE(index.Node()->GetIdMap().MapOutToIn(valid_ids[i]) == static_cast<int64_t>(i));
-        REQUIRE(index.Node()->MapOutToIn(valid_ids[i]) == static_cast<int64_t>(i));
+        REQUIRE(RequireCompactOutToIn(index.Node()->GetIdMap(), valid_ids[i], valid_ids.size()) ==
+                static_cast<int64_t>(i));
+        REQUIRE(RequireCompactOutToIn(*index.Node(), valid_ids[i], valid_ids.size()) == static_cast<int64_t>(i));
     }
 }
 
@@ -1822,6 +1873,37 @@ RequireDenseCalcDistByIds(const knowhere::Index<knowhere::IndexNode>& index, con
 }
 
 void
+RequireDenseSelectedIdsRejectMissingOutId(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
+    const auto missing_id = FirstMissingOutId(data.valid_ids, data.total_count);
+    std::vector<int64_t> rejected_ids = {-1, data.total_count};
+    if (missing_id < data.total_count) {
+        rejected_ids.push_back(missing_id);
+    }
+
+    for (auto rejected_id : rejected_ids) {
+        CAPTURE(rejected_id);
+        int64_t retrieve_id = rejected_id;
+        auto retrieve = index.GetVectorByIds(knowhere::GenIdsDataSet(1, &retrieve_id));
+        REQUIRE_FALSE(retrieve.has_value());
+        REQUIRE(retrieve.error() == knowhere::Status::invalid_args);
+
+        int64_t calc_dist_id = rejected_id;
+        auto calc_dist = index.CalcDistByIDs(data.query_ds, knowhere::BitsetView{}, &calc_dist_id, 1, false);
+        REQUIRE_FALSE(calc_dist.has_value());
+        REQUIRE(calc_dist.error() == knowhere::Status::invalid_args);
+    }
+
+    auto null_retrieve = index.GetVectorByIds(knowhere::GenIdsDataSet(1, static_cast<const int64_t*>(nullptr)));
+    REQUIRE_FALSE(null_retrieve.has_value());
+    REQUIRE(null_retrieve.error() == knowhere::Status::invalid_args);
+
+    auto null_calc_dist =
+        index.CalcDistByIDs(data.query_ds, knowhere::BitsetView{}, static_cast<const int64_t*>(nullptr), 1, false);
+    REQUIRE_FALSE(null_calc_dist.has_value());
+    REQUIRE(null_calc_dist.error() == knowhere::Status::invalid_args);
+}
+
+void
 RequireDenseVectorPublicApisUseOutIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data,
                                       const knowhere::Json& json, bool require_exact_first_hit) {
     auto search = index.Search(data.query_ds, json, knowhere::BitsetView{});
@@ -1838,6 +1920,7 @@ RequireDenseVectorPublicApisUseOutIds(const knowhere::Index<knowhere::IndexNode>
     RequireDenseVectorsMatchLogicalIds(*retrieve.value(), data.query_ids, data.dim);
 
     RequireDenseCalcDistByIds(index, data);
+    RequireDenseSelectedIdsRejectMissingOutId(index, data);
 }
 
 void
@@ -1869,6 +1952,9 @@ RequireEmbListVectorsMatchLogicalIds(const knowhere::DataSet& vectors, const std
 }
 
 void
+RequireEmbListRetrieveRejectsMissingOutId(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data);
+
+void
 RequireEmbListApisUseOutIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data,
                             const knowhere::Json& json) {
     RequireIdMapContent(index, data.valid_ids, data.total_count);
@@ -1893,6 +1979,29 @@ RequireEmbListRetrieveUsesOutIds(const knowhere::Index<knowhere::IndexNode>& ind
         index.GetEmbListByIds(knowhere::GenIdsDataSet(static_cast<int64_t>(ids.size()), ids.data()), "MAX_SIM_L2");
     REQUIRE(retrieve.has_value());
     RequireEmbListVectorsMatchLogicalIds(*retrieve.value(), logical_ids, data.dim, kEmbVectorsPerDoc);
+    RequireEmbListRetrieveRejectsMissingOutId(index, data);
+}
+
+void
+RequireEmbListRetrieveRejectsMissingOutId(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
+    const auto missing_id = FirstMissingOutId(data.valid_ids, data.total_count);
+    std::vector<int64_t> rejected_ids = {-1, data.total_count};
+    if (missing_id < data.total_count) {
+        rejected_ids.push_back(missing_id);
+    }
+
+    for (auto rejected_id : rejected_ids) {
+        CAPTURE(rejected_id);
+        int64_t id = rejected_id;
+        auto retrieve = index.GetEmbListByIds(knowhere::GenIdsDataSet(1, &id), "MAX_SIM_L2");
+        REQUIRE_FALSE(retrieve.has_value());
+        REQUIRE(retrieve.error() == knowhere::Status::invalid_args);
+    }
+
+    auto null_retrieve =
+        index.GetEmbListByIds(knowhere::GenIdsDataSet(1, static_cast<const int64_t*>(nullptr)), "MAX_SIM_L2");
+    REQUIRE_FALSE(null_retrieve.has_value());
+    REQUIRE(null_retrieve.error() == knowhere::Status::invalid_args);
 }
 
 std::vector<std::vector<float>>
@@ -2221,8 +2330,9 @@ BuildArtifactForScenario(const IndexRow& row, const Scenario& scenario) {
     }
 
     artifact->index = std::move(created.index);
+    artifact->index.SetIdMapType(knowhere::IdMap::Type::SEALED);
     artifact->build_status =
-        BuildRuntimeIdMap(artifact->data.valid_ids, artifact->data.total_count, artifact->index.GetIdMap());
+        AttachRuntimeIdMapData(artifact->data.train_ds, artifact->data.valid_ids, artifact->data.total_count);
     if (artifact->build_status == knowhere::Status::success) {
         artifact->build_status = artifact->index.Build(artifact->data.train_ds, artifact->json);
     }
@@ -2245,11 +2355,31 @@ EnsureSerialized(BuiltArtifact& artifact) {
 }
 
 knowhere::Status
+AttachRuntimeIdMapData(const knowhere::DataSetPtr& dataset, const std::vector<int32_t>& valid_ids,
+                       int64_t total_count) {
+    if (dataset == nullptr || total_count < 0 || static_cast<int64_t>(valid_ids.size()) > total_count) {
+        return knowhere::Status::invalid_args;
+    }
+    if (total_count > std::numeric_limits<int32_t>::max()) {
+        return knowhere::Status::invalid_args;
+    }
+    for (auto id : valid_ids) {
+        if (id < 0 || id >= total_count) {
+            return knowhere::Status::invalid_args;
+        }
+    }
+    dataset->SetIdMapData(knowhere::IdMapData::FromIds(valid_ids.empty() ? nullptr : valid_ids.data(), valid_ids.size(),
+                                                       static_cast<size_t>(total_count)));
+    return knowhere::Status::success;
+}
+
+knowhere::Status
 BuildRuntimeIdMap(const std::vector<int32_t>& valid_ids, int64_t total_count, knowhere::IdMap& id_map) {
     if (total_count < 0 || static_cast<int64_t>(valid_ids.size()) > total_count) {
         return knowhere::Status::invalid_args;
     }
     try {
+        id_map.SetType(knowhere::IdMap::Type::SEALED);
         if (total_count > std::numeric_limits<int32_t>::max()) {
             return knowhere::Status::invalid_args;
         }
@@ -2272,6 +2402,7 @@ BuildRuntimeValidBitmap(const std::vector<int32_t>& valid_ids, int64_t total_cou
         return knowhere::Status::invalid_args;
     }
     try {
+        id_map.SetType(knowhere::IdMap::Type::SEALED);
         auto valid_data = std::make_unique<bool[]>(static_cast<size_t>(total_count));
         std::fill_n(valid_data.get(), static_cast<size_t>(total_count), false);
         for (auto id : valid_ids) {
@@ -2669,6 +2800,7 @@ MakeValidData(size_t total_count, const std::vector<int32_t>& valid_ids) {
 
 void
 SetIdMapIds(knowhere::IdMap& map, const std::vector<int32_t>& ids, int64_t count) {
+    map.SetType(knowhere::IdMap::Type::SEALED);
     map.AddFromData(
         knowhere::IdMapData::FromIds(ids.empty() ? nullptr : ids.data(), ids.size(), static_cast<size_t>(count)));
 }
@@ -2676,6 +2808,7 @@ SetIdMapIds(knowhere::IdMap& map, const std::vector<int32_t>& ids, int64_t count
 void
 RequireIdMapForwarding(knowhere::IndexNode& node) {
     knowhere::IdMap map;
+    map.SetType(knowhere::IdMap::Type::SEALED);
     const std::vector<int32_t> ids = {1, 3};
     map.AddFromData(knowhere::IdMapData::FromIds(ids.data(), ids.size(), 4));
     node.GetIdMap() = std::move(map);
@@ -2736,6 +2869,128 @@ HasIndexRow(const std::vector<IndexRow>& rows, const RequiredIndexRow& required)
     });
 }
 
+void
+RequireIdMapVectorState(const knowhere::IdMap& map, size_t out_count, const std::vector<int32_t>& in_to_out_ids) {
+    REQUIRE(map.OutCount() == out_count);
+    REQUIRE(map.InCount() == in_to_out_ids.size());
+    RequireIdArrayEquals(map.InToOutIds(), in_to_out_ids);
+    for (size_t in_id = 0; in_id < in_to_out_ids.size(); ++in_id) {
+        CAPTURE(in_id);
+        REQUIRE(map.MapInToOut(static_cast<int64_t>(in_id)) == in_to_out_ids[in_id]);
+        REQUIRE(RequireCompactOutToIn(map, in_to_out_ids[in_id], in_to_out_ids.size()) == static_cast<int64_t>(in_id));
+    }
+}
+
+void
+RequireIdMapVectorStateOnly(const knowhere::IdMap& map, size_t out_count, const std::vector<int32_t>& in_to_out_ids) {
+    RequireIdMapVectorState(map, out_count, in_to_out_ids);
+    REQUIRE(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST).empty());
+}
+
+void
+RequireDatasetsEqual(const knowhere::DataSet& lhs, const knowhere::DataSet& rhs) {
+    REQUIRE(lhs.GetRows() == rhs.GetRows());
+    REQUIRE(lhs.GetDim() == rhs.GetDim());
+    const auto rows = lhs.GetRows();
+    const auto dim = lhs.GetDim();
+
+    const auto* lhs_lims = lhs.GetLims();
+    const auto* rhs_lims = rhs.GetLims();
+    size_t value_count = dim == 0 && lhs_lims != nullptr ? lhs_lims[rows] : static_cast<size_t>(rows * dim);
+    if (lhs_lims != nullptr || rhs_lims != nullptr) {
+        REQUIRE(lhs_lims != nullptr);
+        REQUIRE(rhs_lims != nullptr);
+        for (int64_t i = 0; i <= rows; ++i) {
+            REQUIRE(lhs_lims[i] == rhs_lims[i]);
+        }
+    }
+
+    const auto* lhs_ids = lhs.GetIds();
+    const auto* rhs_ids = rhs.GetIds();
+    if (lhs_ids != nullptr || rhs_ids != nullptr) {
+        REQUIRE(lhs_ids != nullptr);
+        REQUIRE(rhs_ids != nullptr);
+        for (size_t i = 0; i < value_count; ++i) {
+            CAPTURE(i);
+            REQUIRE(lhs_ids[i] == rhs_ids[i]);
+        }
+    }
+
+    const auto* lhs_distances = lhs.GetDistance();
+    const auto* rhs_distances = rhs.GetDistance();
+    if (lhs_distances != nullptr || rhs_distances != nullptr) {
+        REQUIRE(lhs_distances != nullptr);
+        REQUIRE(rhs_distances != nullptr);
+        for (size_t i = 0; i < value_count; ++i) {
+            CAPTURE(i);
+            REQUIRE(lhs_distances[i] == Catch::Approx(rhs_distances[i]).epsilon(0.0001f));
+        }
+    }
+}
+
+void
+RequireIteratorFirstResultsEqual(const knowhere::Index<knowhere::IndexNode>& lhs,
+                                 const knowhere::Index<knowhere::IndexNode>& rhs, const knowhere::DataSetPtr& query_ds,
+                                 const knowhere::Json& json, const knowhere::BitsetView& bitset) {
+    auto lhs_iterators = lhs.AnnIterator(query_ds, json, bitset);
+    auto rhs_iterators = rhs.AnnIterator(query_ds, json, bitset);
+    REQUIRE(lhs_iterators.has_value());
+    REQUIRE(rhs_iterators.has_value());
+    REQUIRE(lhs_iterators.value().size() == rhs_iterators.value().size());
+
+    for (size_t i = 0; i < lhs_iterators.value().size(); ++i) {
+        auto lhs_has_next = lhs_iterators.value()[i]->HasNext();
+        auto rhs_has_next = rhs_iterators.value()[i]->HasNext();
+        REQUIRE(lhs_has_next.has_value());
+        REQUIRE(rhs_has_next.has_value());
+        REQUIRE(lhs_has_next.value() == rhs_has_next.value());
+        if (!lhs_has_next.value()) {
+            continue;
+        }
+
+        auto lhs_next = lhs_iterators.value()[i]->Next();
+        auto rhs_next = rhs_iterators.value()[i]->Next();
+        REQUIRE(lhs_next.has_value());
+        REQUIRE(rhs_next.has_value());
+        REQUIRE(lhs_next.value().first == rhs_next.value().first);
+        REQUIRE(lhs_next.value().second == Catch::Approx(rhs_next.value().second).epsilon(0.0001f));
+    }
+}
+
+void
+RequireEmbListRetrieveMatches(const knowhere::DataSet& result, const std::vector<int32_t>& public_ids,
+                              const std::vector<size_t>& vector_counts, int64_t dim) {
+    REQUIRE(public_ids.size() == vector_counts.size());
+    REQUIRE(result.GetRows() == static_cast<int64_t>(public_ids.size()));
+    REQUIRE(result.GetDim() == dim);
+
+    const auto* offsets = result.Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+    REQUIRE(offsets != nullptr);
+    size_t total_vectors = 0;
+    for (size_t i = 0; i < vector_counts.size(); ++i) {
+        REQUIRE(offsets[i] == total_vectors);
+        total_vectors += vector_counts[i];
+        REQUIRE(offsets[i + 1] == total_vectors);
+    }
+
+    if (total_vectors == 0) {
+        return;
+    }
+    const auto* tensor = static_cast<const float*>(result.GetTensor());
+    REQUIRE(tensor != nullptr);
+    size_t vector_offset = 0;
+    for (size_t i = 0; i < public_ids.size(); ++i) {
+        auto expected = DenseVectorForLogicalId(public_ids[i], dim);
+        for (size_t v = 0; v < vector_counts[i]; ++v) {
+            for (int64_t j = 0; j < dim; ++j) {
+                CAPTURE(i, v, j, public_ids[i]);
+                REQUIRE(tensor[(vector_offset + v) * dim + j] == Catch::Approx(expected[j]));
+            }
+        }
+        vector_offset += vector_counts[i];
+    }
+}
+
 }  // namespace
 
 TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
@@ -2747,17 +3002,107 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         REQUIRE(map.OutCount() == 8);
         REQUIRE(map.MapInToOut(2) == 4);
         REQUIRE(map.MapInToOut(static_cast<int64_t>(ids.size())) == -1);
-        REQUIRE(map.MapOutToIn(4) == 2);
-        REQUIRE(map.MapOutToIn(5) == -1);
+        REQUIRE(RequireCompactOutToIn(map, 4, map.InCount()) == 2);
+        RequireInvalidCompactOutToIn(map, 5, map.InCount());
 
         std::vector<int64_t> result_ids = {0, 1, 2, 3, 4, -1};
         map.MapInToOut(result_ids.data(), result_ids.size());
         REQUIRE(result_ids == std::vector<int64_t>{0, 2, 4, 6, -1, -1});
     }
 
+    SECTION("IdMap requires an enabled storage mode before nullable input") {
+        knowhere::IdMap map;
+        const int32_t ids[] = {0};
+        REQUIRE_THROWS(map.AddFromData(knowhere::IdMapData::FromIds(ids, 1, 1)));
+        REQUIRE_FALSE(map.IsEnabled());
+        REQUIRE_FALSE(map.HasVectorMap());
+    }
+
+    SECTION("IdMap rejects malformed ids before publishing state") {
+        auto require_rejected_on_empty_map = [](knowhere::IdMapData data) {
+            knowhere::IdMap map;
+            map.SetType(knowhere::IdMap::Type::SEALED);
+            REQUIRE_THROWS(map.AddFromData(data));
+            REQUIRE(map.OutCount() == 0);
+            REQUIRE(map.InCount() == 0);
+            REQUIRE(map.ValidBitmap().empty());
+            REQUIRE(map.InToOutIds().empty());
+        };
+        auto require_rejected_on_growing_map = [](knowhere::IdMapData data) {
+            knowhere::IdMap map;
+            map.SetType(knowhere::IdMap::Type::GROWING);
+            const int32_t base_ids[] = {1, 3};
+            map.AddFromData(knowhere::IdMapData::FromIds(base_ids, 2, 4));
+
+            REQUIRE_THROWS(map.AddFromData(data));
+            RequireIdMapVectorStateOnly(map, 4, {1, 3});
+            RequireInvalidCompactOutToIn(map, 0, map.InCount());
+            RequireInvalidCompactOutToIn(map, 2, map.InCount());
+            RequireInvalidCompactOutToIn(map, 4, map.InCount());
+        };
+
+        int32_t negative_ids[] = {0, -1};
+        require_rejected_on_empty_map(knowhere::IdMapData::FromIds(negative_ids, 2, 4));
+        require_rejected_on_growing_map(knowhere::IdMapData::FromIds(negative_ids, 2, 4));
+
+        int32_t out_of_range_ids[] = {0, 4};
+        require_rejected_on_empty_map(knowhere::IdMapData::FromIds(out_of_range_ids, 2, 4));
+        require_rejected_on_growing_map(knowhere::IdMapData::FromIds(out_of_range_ids, 2, 4));
+
+        int32_t duplicate_ids[] = {1, 1};
+        require_rejected_on_empty_map(knowhere::IdMapData::FromIds(duplicate_ids, 2, 4));
+        require_rejected_on_growing_map(knowhere::IdMapData::FromIds(duplicate_ids, 2, 4));
+
+        require_rejected_on_empty_map(knowhere::IdMapData::FromIds(nullptr, 1, 4));
+        require_rejected_on_growing_map(knowhere::IdMapData::FromIds(nullptr, 1, 4));
+
+        int32_t id_with_empty_domain[] = {0};
+        require_rejected_on_empty_map(knowhere::IdMapData::FromIds(id_with_empty_domain, 1, 0));
+        require_rejected_on_growing_map(knowhere::IdMapData::FromIds(id_with_empty_domain, 1, 0));
+    }
+
+    SECTION("IdMap rejects malformed validity inputs") {
+        knowhere::IdMap map;
+        map.SetType(knowhere::IdMap::Type::SEALED);
+        REQUIRE_THROWS(map.AddFromData(knowhere::IdMapData::FromValidData(nullptr, 4)));
+        REQUIRE_THROWS(map.AddFromData(knowhere::IdMapData::FromValidBitmap(nullptr, 4)));
+        REQUIRE(map.OutCount() == 0);
+        REQUIRE(map.InCount() == 0);
+        REQUIRE(map.ValidBitmap().empty());
+        REQUIRE(map.InToOutIds().empty());
+    }
+
+    SECTION("IdMap type is fixed after data is published") {
+        knowhere::IdMap map;
+        map.SetType(knowhere::IdMap::Type::GROWING);
+        const int32_t ids[] = {0, 2};
+        map.AddFromData(knowhere::IdMapData::FromIds(ids, 2, 4));
+        REQUIRE_THROWS(map.SetType(knowhere::IdMap::Type::SEALED));
+        REQUIRE(map.type() == knowhere::IdMap::Type::GROWING);
+        REQUIRE(map.OutCount() == 4);
+        RequireIdArrayEquals(map.InToOutIds(), {0, 2});
+    }
+
+    SECTION("IdMap rejects malformed emb-list offsets") {
+        knowhere::IdMap map;
+        map.SetType(knowhere::IdMap::Type::GROWING);
+        const int32_t ids[] = {1, 4};
+        map.AddFromData(knowhere::IdMapData::FromIds(ids, 2, 6));
+
+        const size_t decreasing_offsets[] = {0, 3, 2};
+        REQUIRE_THROWS(map.AppendEmbListIds(0, decreasing_offsets, 2));
+
+        const size_t out_of_map_offsets[] = {0, 1};
+        REQUIRE_THROWS(map.AppendEmbListIds(2, out_of_map_offsets, 1));
+
+        REQUIRE(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST).empty());
+        RequireIdArrayEquals(map.InToOutIds(), {1, 4});
+    }
+
     SECTION("IdMap can be built directly from valid data") {
         auto valid_data = MakeValidData(10, {1, 4, 9});
         knowhere::IdMap map;
+        map.SetType(knowhere::IdMap::Type::SEALED);
         map.AddFromData(knowhere::IdMapData::FromValidData(valid_data.get(), 10));
         REQUIRE(map.OutCount() == 10);
         RequireIdArrayEquals(map.InToOutIds(), {});
@@ -2765,10 +3110,10 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         map.FinalizeVectorIds();
         REQUIRE(!map.InToOutIds().empty());
         RequireIdArrayEquals(map.InToOutIds(), {1, 4, 9});
-        REQUIRE(map.MapOutToIn(1) == 0);
-        REQUIRE(map.MapOutToIn(4) == 1);
-        REQUIRE(map.MapOutToIn(9) == 2);
-        REQUIRE(map.MapOutToIn(8) == -1);
+        REQUIRE(RequireCompactOutToIn(map, 1, map.InCount()) == 0);
+        REQUIRE(RequireCompactOutToIn(map, 4, map.InCount()) == 1);
+        REQUIRE(RequireCompactOutToIn(map, 9, map.InCount()) == 2);
+        RequireInvalidCompactOutToIn(map, 8, map.InCount());
     }
 
     SECTION("IdMap views keep array buffers alive") {
@@ -2777,6 +3122,7 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         knowhere::BitmapArray valid_array;
         {
             knowhere::IdMap map;
+            map.SetType(knowhere::IdMap::Type::SEALED);
             map.AddFromData(knowhere::IdMapData::FromValidBitmap(bitmap.data(), 10));
             REQUIRE(map.InToOutIds().empty());
             map.FinalizeVectorIds();
@@ -2799,8 +3145,8 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         map.AddFromData(knowhere::IdMapData::FromIds(ids, 2, 4));
         REQUIRE(map.OutCount() == 4);
         REQUIRE(map.MapInToOut(1) == 2);
-        REQUIRE(map.MapOutToIn(2) == 1);
-        REQUIRE(map.MapOutToIn(1) == -1);
+        REQUIRE(RequireCompactOutToIn(map, 2, map.InCount()) == 1);
+        RequireInvalidCompactOutToIn(map, 1, map.InCount());
 
         std::vector<int64_t> result_ids = {0, 1, -1};
         map.MapInToOut(result_ids.data(), result_ids.size());
@@ -2887,22 +3233,23 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         REQUIRE(map.OutCount() == 12);
         REQUIRE(map.InCount() == 6);
         RequireIdArrayEquals(map.InToOutIds(), {0, 2, 3, 5, 8, 11});
-        REQUIRE(map.MapOutToIn(11) == 5);
+        REQUIRE(RequireCompactOutToIn(map, 11, map.InCount()) == 5);
     }
 
     SECTION("Sealed IdMap uses array storage") {
         const bool base_valid[] = {true, true, true, true};
         knowhere::IdMap map;
+        map.SetType(knowhere::IdMap::Type::SEALED);
         map.AddFromData(knowhere::IdMapData::FromValidData(base_valid, 4));
         map.FinalizeVectorIds();
         RequireIdArrayEquals(map.InToOutIds(), {0, 1, 2, 3});
-        REQUIRE(map.MapOutToIn(3) == 3);
+        REQUIRE(RequireCompactOutToIn(map, 3, map.InCount()) == 3);
 
         const int32_t append_ids[] = {0, 2};
         map.AddFromData(knowhere::IdMapData::FromIds(append_ids, 2, 4));
         REQUIRE(map.OutCount() == 4);
         RequireIdArrayEquals(map.InToOutIds(), {0, 2});
-        REQUIRE(map.MapOutToIn(2) == 1);
+        REQUIRE(RequireCompactOutToIn(map, 2, map.InCount()) == 1);
         REQUIRE(map.InToOutIds().is_array());
     }
 
@@ -2928,9 +3275,29 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         RequireIdArrayEquals(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {0, 0, 1, 1, 1, 2, 2});
     }
 
+    SECTION("IdMap appends emb-list ids from the list-domain public map") {
+        knowhere::IdMap map;
+        map.SetType(knowhere::IdMap::Type::GROWING);
+
+        const int32_t base_list_ids[] = {1, 4};
+        map.AddFromData(knowhere::IdMapData::FromIds(base_list_ids, 2, 6));
+        const size_t base_offsets[] = {0, 2, 5};
+        map.AppendEmbListIds(0, base_offsets, 2);
+        RequireIdArrayEquals(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {1, 1, 4, 4, 4});
+
+        const int32_t append_list_ids[] = {1, 3};
+        map.AddFromData(knowhere::IdMapData::FromIds(append_list_ids, 2, 4));
+        const size_t append_offsets[] = {0, 0, 2};
+        map.AppendEmbListIds(2, append_offsets, 2);
+
+        RequireIdArrayEquals(map.InToOutIds(), {1, 4, 7, 9});
+        RequireIdArrayEquals(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {1, 1, 4, 4, 4, 9, 9});
+    }
+
     SECTION("IdMap builds derived emb-list ids without changing bitmap") {
         auto bitmap = MakeValidBitmap(10, {1, 4, 9});
         knowhere::IdMap map;
+        map.SetType(knowhere::IdMap::Type::SEALED);
         map.AddFromData(knowhere::IdMapData::FromValidBitmap(bitmap.data(), 10));
         map.FinalizeVectorIds();
 
@@ -2938,7 +3305,7 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         map.FinalizeEmbListIds(offsets, 3);
         RequireIdArrayEquals(map.InToOutIds(), {1, 4, 9});
         RequireIdArrayEquals(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {1, 1, 4, 9, 9, 9});
-        REQUIRE(map.MapOutToIn(4) == 1);
+        REQUIRE(RequireCompactOutToIn(map, 4, map.InCount()) == 1);
 
         auto valid_before_noop = map.ValidBitmap();
         REQUIRE(valid_before_noop.size() == 10);
@@ -2949,7 +3316,7 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         map.FinalizeEmbListIds(nullptr, 0);
         RequireIdArrayEquals(map.InToOutIds(), {1, 4, 9});
         RequireIdArrayEquals(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {1, 1, 4, 9, 9, 9});
-        REQUIRE(map.MapOutToIn(4) == 1);
+        REQUIRE(RequireCompactOutToIn(map, 4, map.InCount()) == 1);
 
         auto valid_after_noop = map.ValidBitmap();
         REQUIRE(valid_after_noop.size() == 10);
@@ -2973,6 +3340,7 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         {
             auto valid_data = MakeValidData(10, {1, 4, 6, 9});
             knowhere::IdMap map;
+            map.SetType(knowhere::IdMap::Type::SEALED);
             map.ConfigureMmap(mmap_options);
             map.AddFromData(knowhere::IdMapData::FromValidData(valid_data.get(), 10));
             map.FinalizeVectorIds();
@@ -2985,8 +3353,8 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
             valid_array = map.ValidBitmap();
             RequireIdArrayEquals(ids_array, {1, 4, 6, 9});
             RequireIdArrayEquals(ebl_ids_array, {1, 4, 4, 9});
-            REQUIRE(map.MapOutToIn(6) == 2);
-            REQUIRE(map.MapOutToIn(5) == -1);
+            REQUIRE(RequireCompactOutToIn(map, 6, map.InCount()) == 2);
+            RequireInvalidCompactOutToIn(map, 5, map.InCount());
             REQUIRE(valid_array.size() == 10);
 
             size_t mmap_file_count = 0;
@@ -3027,6 +3395,7 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
 
         auto valid_data = MakeValidData(10, {});
         knowhere::IdMap map;
+        map.SetType(knowhere::IdMap::Type::SEALED);
         map.ConfigureMmap(mmap_options);
         map.AddFromData(knowhere::IdMapData::FromValidData(valid_data.get(), 10));
         map.FinalizeVectorIds();
@@ -3034,7 +3403,7 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         REQUIRE(map.OutCount() == 10);
         REQUIRE(map.InCount() == 0);
         REQUIRE(map.InToOutIds().empty());
-        REQUIRE(map.MapOutToIn(0) == -1);
+        RequireInvalidCompactOutToIn(map, 0, map.InCount());
         REQUIRE_FALSE(map.IsValidOutId(0));
 
         size_t mmap_file_count = 0;
@@ -3392,6 +3761,343 @@ TEST_CASE("Nullable Flat Add adds out id map", "[nullable][flat][add]") {
     REQUIRE(retrieved_data[kDenseDim] == 601.0f);
 }
 
+TEST_CASE("Nullable IVF_FLAT_CC emb-list Add preserves append public list ids", "[nullable][ivf][emblist][add]") {
+    auto json = BaseDenseConfig("MAX_SIM_L2", kDenseDim, 1);
+    json[knowhere::meta::INDEX_TYPE] = knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC;
+    json[knowhere::indexparam::NLIST] = 1;
+    json[knowhere::indexparam::NPROBE] = 1;
+    ApplyEmbListStrategyConfig(json, knowhere::meta::EMB_LIST_STRATEGY_TOKENANN);
+
+    auto first_batch = GenEmbListBatchDataSet({1, 4}, {0, 2, 5}, kDenseDim);
+    const int32_t first_ids[] = {1, 4};
+    first_batch->SetIdMapData(knowhere::IdMapData::FromIds(first_ids, 2, 6));
+
+    auto append_batch = GenEmbListBatchDataSet({7, 9, 10}, {5, 5, 7, 7}, kDenseDim);
+    const int32_t append_ids[] = {1, 3, 4};
+    append_batch->SetIdMapData(knowhere::IdMapData::FromIds(append_ids, 3, 5));
+
+    auto version = knowhere::Version::GetCurrentVersion().VersionNumber();
+    auto index = knowhere::IndexFactory::Instance()
+                     .Create<knowhere::fp32>(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, version)
+                     .value();
+    index.SetIdMapType(knowhere::IdMap::Type::GROWING);
+    REQUIRE(index.Build(first_batch, json, false) == Status::success);
+    REQUIRE(index.Add(append_batch, json, false) == Status::success);
+
+    RequireIdArrayEquals(index.GetIdMap().InToOutIds(), {1, 4, 7, 9, 10});
+    RequireIdArrayEquals(index.GetIdMap().InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {1, 1, 4, 4, 4, 9, 9});
+
+    auto query = GenEmbListQueryDataSet({9}, kDenseDim);
+    auto search = index.Search(query, json, knowhere::BitsetView{});
+    REQUIRE(search.has_value());
+    RequireExactFirstHits(*search.value(), {9}, {1, 4, 9});
+
+    auto filter_bits = MakeBitmap(11, {9});
+    auto prepared = index.Node()->PrepareBitset(knowhere::BitsetView(filter_bits.data(), 11));
+    REQUIRE(prepared.has_value());
+    REQUIRE(prepared.value().bitset.has_out_ids());
+    REQUIRE(prepared.value().bitset.size() == 7);
+    REQUIRE(prepared.value().bitset.count() == 2);
+    REQUIRE(prepared.value().bitset.test(5));
+    REQUIRE(prepared.value().bitset.test(6));
+    REQUIRE_FALSE(prepared.value().bitset.test(0));
+
+    auto filtered_search = index.Search(query, json, knowhere::BitsetView(filter_bits.data(), 11));
+    REQUIRE(filtered_search.has_value());
+    RequireExpectedVectorResult(filtered_search, {1, 4}, {9}, false);
+
+    auto tail_empty_filter_bits = MakeBitmap(11, {10});
+    auto tail_empty_prepared = index.Node()->PrepareBitset(knowhere::BitsetView(tail_empty_filter_bits.data(), 11));
+    REQUIRE(tail_empty_prepared.has_value());
+    REQUIRE(tail_empty_prepared.value().bitset.has_out_ids());
+    REQUIRE(tail_empty_prepared.value().bitset.count() == 0);
+
+    int64_t retrieve_ids[] = {1, 7, 9, 10};
+    auto retrieved = index.GetEmbListByIds(knowhere::GenIdsDataSet(4, retrieve_ids), "MAX_SIM_L2");
+    REQUIRE(retrieved.has_value());
+    RequireEmbListRetrieveMatches(*retrieved.value(), {1, 7, 9, 10}, {2, 0, 2, 0}, kDenseDim);
+
+    int64_t missing_id = 3;
+    auto missing = index.GetEmbListByIds(knowhere::GenIdsDataSet(1, &missing_id), "MAX_SIM_L2");
+    REQUIRE_FALSE(missing.has_value());
+    REQUIRE(missing.error() == knowhere::Status::invalid_args);
+}
+
+TEST_CASE("Nullable Index rejects plain and mapped Add mixing", "[nullable][id_map][add]") {
+    auto json = BaseDenseConfig(knowhere::metric::L2, kDenseDim, 1);
+    auto version = knowhere::Version::GetCurrentVersion().VersionNumber();
+    const int32_t batch_ids[] = {0, 2};
+    auto create_flat_index = [&] {
+        return knowhere::IndexFactory::Instance()
+            .Create<knowhere::fp32>(knowhere::IndexEnum::INDEX_FAISS_IDMAP, version)
+            .value();
+    };
+
+    SECTION("DISABLED rejects IdMapData") {
+        auto batch = GenNullableDenseDataSet(4, {0, 2}, kDenseDim);
+        batch->SetIdMapData(knowhere::IdMapData::FromIds(batch_ids, 2, 4));
+
+        auto created = create_flat_index();
+        REQUIRE(created.Build(batch, json) == Status::invalid_args);
+
+        auto add_index = create_flat_index();
+        REQUIRE(add_index.Train(batch, json) == Status::success);
+        REQUIRE(add_index.Add(batch, json) == Status::invalid_args);
+    }
+
+    SECTION("enabled IdMap requires IdMapData") {
+        auto plain_batch = GenNullableDenseDataSet(4, {0, 1, 2, 3}, kDenseDim);
+        for (auto type : {knowhere::IdMap::Type::SEALED, knowhere::IdMap::Type::GROWING}) {
+            CAPTURE(static_cast<int>(type));
+            auto build_index = create_flat_index();
+            build_index.SetIdMapType(type);
+            REQUIRE(build_index.Build(plain_batch, json) == Status::invalid_args);
+        }
+
+        auto add_index = create_flat_index();
+        add_index.SetIdMapType(knowhere::IdMap::Type::GROWING);
+        REQUIRE(add_index.Train(plain_batch, json) == Status::success);
+        REQUIRE(add_index.Add(plain_batch, json) == Status::invalid_args);
+    }
+
+    SECTION("mapped index rejects a plain append batch") {
+        auto first_batch = GenNullableDenseDataSet(4, {0, 2}, kDenseDim);
+        first_batch->SetIdMapData(knowhere::IdMapData::FromIds(batch_ids, 2, 4));
+        auto plain_second_batch = GenNullableDenseDataSet(4, {4, 6}, kDenseDim);
+
+        auto index = create_flat_index();
+        index.SetIdMapType(knowhere::IdMap::Type::GROWING);
+        REQUIRE(index.Train(first_batch, json) == Status::success);
+        REQUIRE(index.Add(first_batch, json) == Status::success);
+        REQUIRE(index.Add(plain_second_batch, json) == Status::invalid_args);
+    }
+
+    SECTION("all-valid nullable append still requires IdMapData") {
+        const int32_t all_valid_ids[] = {0, 1};
+        auto first_batch = GenNullableDenseDataSet(2, {0, 1}, kDenseDim);
+        first_batch->SetIdMapData(knowhere::IdMapData::FromIds(all_valid_ids, 2, 2));
+        auto all_valid_plain_append = GenNullableDenseDataSet(2, {2, 3}, kDenseDim);
+
+        auto index = create_flat_index();
+        index.SetIdMapType(knowhere::IdMap::Type::GROWING);
+        REQUIRE(index.Train(first_batch, json) == Status::success);
+        REQUIRE(index.Add(first_batch, json) == Status::success);
+        REQUIRE(index.Add(all_valid_plain_append, json) == Status::invalid_args);
+        RequireIdMapVectorStateOnly(index.GetIdMap(), 2, {0, 1});
+    }
+
+    SECTION("plain index rejects a mapped append batch") {
+        auto plain_first_batch = GenNullableDenseDataSet(4, {0, 2}, kDenseDim);
+        auto second_batch = GenNullableDenseDataSet(4, {4, 6}, kDenseDim);
+        second_batch->SetIdMapData(knowhere::IdMapData::FromIds(batch_ids, 2, 4));
+
+        auto index = create_flat_index();
+        REQUIRE(index.Train(plain_first_batch, json) == Status::success);
+        REQUIRE(index.Add(plain_first_batch, json) == Status::success);
+        index.SetIdMapType(knowhere::IdMap::Type::GROWING);
+        REQUIRE(index.Add(second_batch, json) == Status::invalid_args);
+    }
+}
+
+TEST_CASE("Nullable vector Build plus Add matches full Build", "[nullable][ivf][add]") {
+    auto json = BaseDenseConfig(knowhere::metric::L2, kDenseDim, 2);
+    json[knowhere::meta::INDEX_TYPE] = knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC;
+    json[knowhere::indexparam::NLIST] = 1;
+    json[knowhere::indexparam::NPROBE] = 1;
+
+    const std::vector<int32_t> full_ids = {1, 4, 7, 9};
+    const int32_t first_ids[] = {1, 4};
+    const int32_t append_ids[] = {1, 3};
+
+    auto full_ds = GenNullableDenseDataSet(11, full_ids, kDenseDim);
+    full_ds->SetIdMapData(knowhere::IdMapData::FromIds(full_ids.data(), full_ids.size(), 11));
+
+    auto first_ds = GenNullableDenseDataSet(6, {1, 4}, kDenseDim);
+    first_ds->SetIdMapData(knowhere::IdMapData::FromIds(first_ids, 2, 6));
+    auto append_ds = GenNullableDenseDataSet(5, {7, 9}, kDenseDim);
+    append_ds->SetIdMapData(knowhere::IdMapData::FromIds(append_ids, 2, 5));
+
+    auto version = knowhere::Version::GetCurrentVersion().VersionNumber();
+    auto full_index = knowhere::IndexFactory::Instance()
+                          .Create<knowhere::fp32>(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, version)
+                          .value();
+    full_index.SetIdMapType(knowhere::IdMap::Type::SEALED);
+    REQUIRE(full_index.Build(full_ds, json, false) == Status::success);
+
+    auto split_index = knowhere::IndexFactory::Instance()
+                           .Create<knowhere::fp32>(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, version)
+                           .value();
+    split_index.SetIdMapType(knowhere::IdMap::Type::GROWING);
+    REQUIRE(split_index.Build(first_ds, json, false) == Status::success);
+    REQUIRE(split_index.Add(append_ds, json, false) == Status::success);
+
+    RequireIdMapVectorStateOnly(full_index.GetIdMap(), 11, full_ids);
+    RequireIdMapVectorStateOnly(split_index.GetIdMap(), 11, full_ids);
+
+    auto query = GenDenseQueryDataSet({1, 9}, kDenseDim);
+    auto filter_bits = MakeBitmap(11, {4});
+    knowhere::BitsetView bitset(filter_bits.data(), 11);
+
+    auto full_search = full_index.Search(query, json, bitset);
+    auto split_search = split_index.Search(query, json, bitset);
+    REQUIRE(full_search.has_value());
+    REQUIRE(split_search.has_value());
+    RequireDatasetsEqual(*full_search.value(), *split_search.value());
+
+    auto range_json = json;
+    range_json[knowhere::meta::RADIUS] = 100000000.0f;
+    auto full_range = full_index.RangeSearch(query, range_json, bitset);
+    auto split_range = split_index.RangeSearch(query, range_json, bitset);
+    REQUIRE(full_range.has_value());
+    REQUIRE(split_range.has_value());
+    RequireDatasetsEqual(*full_range.value(), *split_range.value());
+
+    RequireIteratorFirstResultsEqual(full_index, split_index, query, json, bitset);
+
+    int64_t selected_ids[] = {1, 9};
+    auto full_vectors = full_index.GetVectorByIds(knowhere::GenIdsDataSet(2, selected_ids));
+    auto split_vectors = split_index.GetVectorByIds(knowhere::GenIdsDataSet(2, selected_ids));
+    REQUIRE(full_vectors.has_value());
+    REQUIRE(split_vectors.has_value());
+    RequireDenseVectorsMatchLogicalIds(*full_vectors.value(), {1, 9}, kDenseDim);
+    RequireDenseVectorsMatchLogicalIds(*split_vectors.value(), {1, 9}, kDenseDim);
+
+    auto full_dist = full_index.CalcDistByIDs(query, knowhere::BitsetView{}, selected_ids, 2, false);
+    auto split_dist = split_index.CalcDistByIDs(query, knowhere::BitsetView{}, selected_ids, 2, false);
+    REQUIRE(full_dist.has_value());
+    REQUIRE(split_dist.has_value());
+    RequireDatasetsEqual(*full_dist.value(), *split_dist.value());
+}
+
+TEST_CASE("Nullable emb-list Build plus Add matches full Build with empty lists", "[nullable][ivf][emblist][add]") {
+    auto json = BaseDenseConfig("MAX_SIM_L2", kDenseDim, 2);
+    json[knowhere::meta::INDEX_TYPE] = knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC;
+    json[knowhere::indexparam::NLIST] = 1;
+    json[knowhere::indexparam::NPROBE] = 1;
+    ApplyEmbListStrategyConfig(json, knowhere::meta::EMB_LIST_STRATEGY_TOKENANN);
+
+    const int32_t full_ids[] = {1, 4, 7, 9, 10};
+    const int32_t first_ids[] = {1, 4};
+    const int32_t append_ids[] = {1, 3, 4};
+
+    auto full_ds = GenEmbListBatchDataSet({1, 4, 7, 9, 10}, {0, 2, 5, 5, 7, 7}, kDenseDim);
+    full_ds->SetIdMapData(knowhere::IdMapData::FromIds(full_ids, 5, 11));
+    auto first_ds = GenEmbListBatchDataSet({1, 4}, {0, 2, 5}, kDenseDim);
+    first_ds->SetIdMapData(knowhere::IdMapData::FromIds(first_ids, 2, 6));
+    auto append_ds = GenEmbListBatchDataSet({7, 9, 10}, {5, 5, 7, 7}, kDenseDim);
+    append_ds->SetIdMapData(knowhere::IdMapData::FromIds(append_ids, 3, 5));
+
+    auto version = knowhere::Version::GetCurrentVersion().VersionNumber();
+    auto full_index = knowhere::IndexFactory::Instance()
+                          .Create<knowhere::fp32>(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, version)
+                          .value();
+    full_index.SetIdMapType(knowhere::IdMap::Type::SEALED);
+    REQUIRE(full_index.Build(full_ds, json, false) == Status::success);
+
+    auto split_index = knowhere::IndexFactory::Instance()
+                           .Create<knowhere::fp32>(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, version)
+                           .value();
+    split_index.SetIdMapType(knowhere::IdMap::Type::GROWING);
+    REQUIRE(split_index.Build(first_ds, json, false) == Status::success);
+    REQUIRE(split_index.Add(append_ds, json, false) == Status::success);
+
+    RequireIdMapVectorState(full_index.GetIdMap(), 11, {1, 4, 7, 9, 10});
+    RequireIdMapVectorState(split_index.GetIdMap(), 11, {1, 4, 7, 9, 10});
+    RequireIdArrayEquals(full_index.GetIdMap().InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {1, 1, 4, 4, 4, 9, 9});
+    RequireIdArrayEquals(split_index.GetIdMap().InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {1, 1, 4, 4, 4, 9, 9});
+
+    auto query = GenEmbListQueryDataSet({9, 1}, kDenseDim);
+    auto filter_bits = MakeBitmap(11, {9});
+    knowhere::BitsetView bitset(filter_bits.data(), 11);
+    auto full_search = full_index.Search(query, json, bitset);
+    auto split_search = split_index.Search(query, json, bitset);
+    REQUIRE(full_search.has_value());
+    REQUIRE(split_search.has_value());
+    RequireDatasetsEqual(*full_search.value(), *split_search.value());
+    RequireExpectedVectorResult(split_search, {1, 4}, {9}, false);
+
+    int64_t retrieve_ids[] = {1, 7, 9, 10};
+    auto full_retrieve = full_index.GetEmbListByIds(knowhere::GenIdsDataSet(4, retrieve_ids), "MAX_SIM_L2");
+    auto split_retrieve = split_index.GetEmbListByIds(knowhere::GenIdsDataSet(4, retrieve_ids), "MAX_SIM_L2");
+    REQUIRE(full_retrieve.has_value());
+    REQUIRE(split_retrieve.has_value());
+    RequireEmbListRetrieveMatches(*full_retrieve.value(), {1, 7, 9, 10}, {2, 0, 2, 0}, kDenseDim);
+    RequireEmbListRetrieveMatches(*split_retrieve.value(), {1, 7, 9, 10}, {2, 0, 2, 0}, kDenseDim);
+}
+
+TEST_CASE("Nullable selected-id APIs reject missing public ids", "[nullable][id_map][api]") {
+    struct SelectedIdCase {
+        std::string label;
+        IndexRow row;
+        bool check_calc_dist = false;
+        bool maybe_unavailable = false;
+    };
+
+    auto diskann = NativeDiskAnnRow();
+    diskann.maybe_unavailable = true;
+
+    std::vector<SelectedIdCase> cases = {
+        {"FLAT", {"FLAT", knowhere::IndexEnum::INDEX_FAISS_IDMAP, DataKind::DenseFp32}, false, false},
+        {"IVF_FLAT_CC",
+         {"IVF_FLAT_CC / IVFFLATCC", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, DataKind::DenseFp32},
+         true,
+         false},
+        {"HNSW", NativeFaissHnswRow(), true, true},
+        {"DISKANN", diskann, true, true},
+        {"SPARSE_CC",
+         {"SPARSE_INVERTED_INDEX_CC (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC,
+          DataKind::Sparse},
+         false,
+         false},
+    };
+
+    for (const auto& test_case : cases) {
+        CAPTURE(test_case.label);
+        Scenario scenario;
+        scenario.mode = Mode::Vector;
+        scenario.nullable_ratio = NullableRatio::R50;
+
+        auto artifact = BuildArtifactForScenario(test_case.row, scenario);
+        if (!artifact->create_ok || artifact->build_status != Status::success) {
+            const bool allowed_unavailable = test_case.maybe_unavailable || test_case.row.maybe_unavailable;
+            REQUIRE(allowed_unavailable);
+            continue;
+        }
+
+        const auto missing_id = FirstMissingOutId(artifact->data.valid_ids, artifact->data.total_count);
+        std::vector<int64_t> rejected_ids = {-1, artifact->data.total_count};
+        if (missing_id < artifact->data.total_count) {
+            rejected_ids.push_back(missing_id);
+        }
+
+        for (auto rejected_id : rejected_ids) {
+            CAPTURE(rejected_id);
+            auto get_vector = artifact->index.GetVectorByIds(knowhere::GenIdsDataSet(1, &rejected_id));
+            REQUIRE_FALSE(get_vector.has_value());
+            REQUIRE(get_vector.error() == Status::invalid_args);
+
+            if (test_case.check_calc_dist) {
+                auto calc_dist = artifact->index.CalcDistByIDs(artifact->data.query_ds, knowhere::BitsetView{},
+                                                               &rejected_id, 1, false);
+                REQUIRE_FALSE(calc_dist.has_value());
+                REQUIRE(calc_dist.error() == Status::invalid_args);
+            }
+        }
+
+        auto null_get_vector =
+            artifact->index.GetVectorByIds(knowhere::GenIdsDataSet(1, static_cast<const int64_t*>(nullptr)));
+        REQUIRE_FALSE(null_get_vector.has_value());
+        REQUIRE(null_get_vector.error() == Status::invalid_args);
+
+        if (test_case.check_calc_dist) {
+            auto null_calc_dist = artifact->index.CalcDistByIDs(artifact->data.query_ds, knowhere::BitsetView{},
+                                                                static_cast<const int64_t*>(nullptr), 1, false);
+            REQUIRE_FALSE(null_calc_dist.has_value());
+            REQUIRE(null_calc_dist.error() == Status::invalid_args);
+        }
+    }
+}
+
 TEST_CASE("Nullable Index Add keeps id map append when backend add fails", "[nullable][id_map][add]") {
     auto concrete_index = knowhere::Index<FailingAddFakeIndexNode>::Create();
     auto* node = concrete_index.Node();
@@ -3411,10 +4117,10 @@ TEST_CASE("Nullable Index Add keeps id map append when backend add fails", "[nul
 
     REQUIRE(index.GetIdMap().OutCount() == 8);
     RequireIdArrayEquals(index.GetIdMap().InToOutIds(), {1, 3, 4, 6});
-    REQUIRE(index.GetIdMap().MapOutToIn(1) == 0);
-    REQUIRE(index.GetIdMap().MapOutToIn(3) == 1);
-    REQUIRE(index.GetIdMap().MapOutToIn(4) == 2);
-    REQUIRE(index.GetIdMap().MapOutToIn(6) == 3);
+    REQUIRE(RequireCompactOutToIn(index.GetIdMap(), 1, index.GetIdMap().InCount()) == 0);
+    REQUIRE(RequireCompactOutToIn(index.GetIdMap(), 3, index.GetIdMap().InCount()) == 1);
+    REQUIRE(RequireCompactOutToIn(index.GetIdMap(), 4, index.GetIdMap().InCount()) == 2);
+    REQUIRE(RequireCompactOutToIn(index.GetIdMap(), 6, index.GetIdMap().InCount()) == 3);
 }
 
 TEST_CASE("Nullable DataView full-scan uses internal source ids", "[nullable][data_view][api]") {
@@ -3626,7 +4332,8 @@ TEST_CASE("Nullable SCANN_DVR emb-list cosine rerank maps calc-dist ids", "[null
 
     auto created = CreateIndex(row, data);
     REQUIRE(created.ok);
-    REQUIRE(BuildRuntimeIdMap(data.valid_ids, data.total_count, created.index.GetIdMap()) == Status::success);
+    created.index.SetIdMapType(knowhere::IdMap::Type::SEALED);
+    REQUIRE(AttachRuntimeIdMapData(data.train_ds, data.valid_ids, data.total_count) == Status::success);
     REQUIRE(created.index.Build(data.train_ds, json) == Status::success);
 
     auto result = created.index.Search(data.query_ds, json, knowhere::BitsetView{});
@@ -3721,6 +4428,7 @@ TEST_CASE("Nullable FAISS HNSW vector APIs use restored logical-id map after rel
         RequireDenseVectorsMatchLogicalIds(*retrieve.value(), artifact->data.query_ids, artifact->data.dim);
 
         RequireDenseCalcDistByIds(index, artifact->data);
+        RequireDenseSelectedIdsRejectMissingOutId(index, artifact->data);
     };
 
     require_vector_apis(artifact->index, true);
@@ -3961,7 +4669,8 @@ TEST_CASE("Nullable HNSW emb-list multi-index filters use external doc ids", "[n
     auto created = CreateIndex(row, data);
     REQUIRE(created.ok);
 
-    REQUIRE(BuildRuntimeIdMap(data.valid_ids, data.total_count, created.index.GetIdMap()) == knowhere::Status::success);
+    created.index.SetIdMapType(knowhere::IdMap::Type::SEALED);
+    REQUIRE(AttachRuntimeIdMapData(data.train_ds, data.valid_ids, data.total_count) == knowhere::Status::success);
     REQUIRE(created.index.Build(data.train_ds, json) == knowhere::Status::success);
     RequireIdMapContent(created.index, data.valid_ids, data.total_count);
     {
@@ -4169,7 +4878,8 @@ TEST_CASE("Nullable mmap file load preserves large non-identity mapping", "[null
     auto created = CreateIndex(row, artifact.data);
     REQUIRE(created.ok);
     artifact.index = std::move(created.index);
-    REQUIRE(BuildRuntimeIdMap(artifact.data.valid_ids, artifact.data.total_count, artifact.index.GetIdMap()) ==
+    artifact.index.SetIdMapType(knowhere::IdMap::Type::SEALED);
+    REQUIRE(AttachRuntimeIdMapData(artifact.data.train_ds, artifact.data.valid_ids, artifact.data.total_count) ==
             Status::success);
     artifact.build_status = artifact.index.Build(artifact.data.train_ds, artifact.json);
     REQUIRE(artifact.build_status == knowhere::Status::success);

--- a/tests/ut/utils.h
+++ b/tests/ut/utils.h
@@ -545,6 +545,7 @@ GenEmbListDataSet(int rows, int dim, const uint64_t seed = 42, int each_el_len =
     ptr[i] = (size_t)rows;
     const size_t* ptr_const = ptr.release();
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, ptr_const);
+    ds->Set(knowhere::meta::NQ, static_cast<int64_t>(i));
     ds->SetIsOwner(true);
     return ds;
 }
@@ -570,6 +571,7 @@ GenChunkDataSet(int rows, int dim, const uint64_t seed = 42, int each_el_len = 1
     auto ds = knowhere::GenDataSet(rows, dim, chunk_ts);
     ds->SetNumChunk(num_chunk);
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, (const size_t*)lims);
+    ds->Set(knowhere::meta::NQ, static_cast<int64_t>(num_chunk));
     ds->SetIsChunk(true);
     ds->SetIsOwner(true);
     return ds;
@@ -597,6 +599,7 @@ GenChunkBinDataSet(int rows, int dim, const uint64_t seed = 42, int each_el_len 
     auto ds = knowhere::GenDataSet(rows, dim, chunk_ts);
     ds->SetNumChunk(num_chunk);
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, (const size_t*)lims);
+    ds->Set(knowhere::meta::NQ, static_cast<int64_t>(num_chunk));
     ds->SetIsChunk(true);
     ds->SetIsOwner(true);
     return ds;
@@ -625,6 +628,7 @@ GenEmbListDataSetWithSomeEmpty(int rows, int dim, const uint64_t seed = 42, int 
     ptr[i] = (size_t)rows;
     const size_t* ptr_const = ptr.release();
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, ptr_const);
+    ds->Set(knowhere::meta::NQ, static_cast<int64_t>(i));
     ds->SetIsOwner(true);
     return ds;
 }
@@ -650,6 +654,7 @@ SplitEmbListDataSet(const knowhere::DataSetPtr ds, size_t partition_num, int eac
         auto ds = knowhere::GenDataSet(cur_rows, dim, (const DataType*)data + start_el * each_el_len * dim);
         const size_t* ptr_const = ptr + start_el;
         ds->Set(knowhere::meta::EMB_LIST_OFFSET, ptr_const);
+        ds->Set(knowhere::meta::NQ, static_cast<int64_t>(end_el - start_el));
         ds->SetIsOwner(false);
         res[i] = std::move(ds);
     }
@@ -673,6 +678,7 @@ GenEmbListBinDataSet(int rows, int dim, int seed = 42, int each_el_len = 10) {
     ptr[i] = (size_t)rows;
     const size_t* ptr_const = ptr.release();
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, ptr_const);
+    ds->Set(knowhere::meta::NQ, static_cast<int64_t>(i));
     ds->SetIsOwner(true);
     return ds;
 }
@@ -699,6 +705,7 @@ GenQueryEmbListDataSet(int rows, int dim, const uint64_t seed = 42) {
     ptr[i] = (size_t)rows;
     const size_t* ptr_const = ptr.release();
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, ptr_const);
+    ds->Set(knowhere::meta::NQ, static_cast<int64_t>(i));
     ds->SetIsOwner(true);
     return ds;
 }
@@ -727,6 +734,7 @@ GenQueryEmbListBinDataSet(int rows, int dim, const uint64_t seed = 42) {
     ptr[i] = (size_t)rows;
     const size_t* ptr_const = ptr.release();
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, ptr_const);
+    ds->Set(knowhere::meta::NQ, static_cast<int64_t>(i));
     ds->SetIsOwner(true);
     return ds;
 }


### PR DESCRIPTION
issue: #1687

related: zilliztech/cardinal#859
related: zilliztech/cardinal#860
related: milvus-io/milvus#50524

## Summary
- Move nullable id mapping into Knowhere's index layer. Public row/list ids remain the API, bitset, selected-id, and result boundary; backend storage can use compact internal ids.
- Add `DataSet::IdMapData` so `Build` and `Add` consume nullable mapping input together with the vector payload.
- Split id-map storage by lifecycle: sealed maps publish complete contiguous arrays with optional mmap, while growing maps append ranges and preserve existing backend-id labels.
- Use adaptive public-to-internal lookup so sparse public-id domains do not force dense heap storage unless mmap or growing storage requires it.
- Project public bitsets into backend/local id domains and map backend results back to public ids across search, range search, iterators, retrieval, data-view refinement, HNSW multi-index, DiskANN/AiSAQ, SVS, sparse, cuVS, and EmbList paths.
- Let brute-force paths use `BitsetView::out_ids` so compact raw buffers filter on public ids and return public ids without building a Knowhere `IdMap`.
- Add a design doc and nullable id-map coverage for build/add/reload/mmap/search/range/iterator/retrieve/brute-force/EmbList cases.

## Verification
- [x] `git diff --check upstream/main..HEAD`
- [x] `cmake --build build/Release --target knowhere_tests -j 8` after rebasing onto `upstream/main` `3b78cba8`
- [x] Full local CPU UT coverage was triaged for this final diff shape. The only non-passing signature was the known OpenBLAS HNSW_PRQ/EmbList allocator issue; with `OPENBLAS_NUM_THREADS=16`, the focused nullable HNSW_PRQ matrix and remaining non-redundant cases passed.
- [x] Milvus dependency-overlay validation against the nullable id-map branch: full `make test-cpp jobs="$(nproc)"` passed; `all_tests` 8212 passed / 10 skipped, cwrapper/json-stats 79 passed.
