### PR TITLE
fix: guard facade APIs from exceptions

### DIFF
--- a/include/knowhere/cluster/cluster.h
+++ b/include/knowhere/cluster/cluster.h
@@ -117,16 +117,16 @@ class Cluster {
     }
 
     expected<DataSetPtr>
-    Train(const DataSet& dataset, const Json& json);
+    Train(const DataSet& dataset, const Json& json) noexcept;
 
     expected<DataSetPtr>
-    Assign(const DataSet& dataset);
+    Assign(const DataSet& dataset) noexcept;
 
     expected<DataSetPtr>
-    GetCentroids() const;
+    GetCentroids() const noexcept;
 
     std::string
-    Type() const;
+    Type() const noexcept;
 
     ~Cluster() {
         if (node == nullptr)

--- a/include/knowhere/cluster/cluster_factory.h
+++ b/include/knowhere/cluster/cluster_factory.h
@@ -24,12 +24,12 @@ class ClusterFactory {
  public:
     template <typename DataType>
     expected<Cluster<ClusterNode>>
-    Create(const std::string& name, const Object& object = nullptr);
+    Create(const std::string& name, const Object& object = nullptr) noexcept;
     template <typename DataType>
     const ClusterFactory&
     Register(const std::string& name, std::function<Cluster<ClusterNode>(const Object&)> func);
     static ClusterFactory&
-    Instance();
+    Instance() noexcept;
 
  private:
     struct FunMapValueBase {

--- a/include/knowhere/comp/brute_force.h
+++ b/include/knowhere/comp/brute_force.h
@@ -28,43 +28,44 @@ class BruteForce {
     template <typename DataType>
     static expected<DataSetPtr>
     Search(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config, const BitsetView& bitset,
-           milvus::OpContext* op_context = nullptr);
+           milvus::OpContext* op_context = nullptr) noexcept;
 
     template <typename DataType>
     static Status
     SearchWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_dataset, int64_t* ids, float* dis,
-                  const Json& config, const BitsetView& bitset, milvus::OpContext* op_context = nullptr);
+                  const Json& config, const BitsetView& bitset, milvus::OpContext* op_context = nullptr) noexcept;
 
     template <typename DataType>
     static Status
     SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_dataset, int64_t* ids, float* dis,
-                         const Json& config, const BitsetView& bitset, milvus::OpContext* op_context = nullptr);
+                         const Json& config, const BitsetView& bitset,
+                         milvus::OpContext* op_context = nullptr) noexcept;
 
     template <typename DataType>
     static expected<DataSetPtr>
     RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
-                const BitsetView& bitset, milvus::OpContext* op_context = nullptr);
+                const BitsetView& bitset, milvus::OpContext* op_context = nullptr) noexcept;
 
     // Perform row oriented sparse vector brute force search.
     static expected<DataSetPtr>
     SearchSparse(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
-                 const BitsetView& bitset, milvus::OpContext* op_context = nullptr);
+                 const BitsetView& bitset, milvus::OpContext* op_context = nullptr) noexcept;
 
     static Status
     SearchSparseWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_dataset, sparse::label_t* ids, float* dis,
-                        const Json& config, const BitsetView& bitset, milvus::OpContext* op_context = nullptr);
+                        const Json& config, const BitsetView& bitset, milvus::OpContext* op_context = nullptr) noexcept;
 
     template <typename DataType>
     static expected<std::vector<IndexNode::IteratorPtr>>
     AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
                 const BitsetView& bitset, bool use_knowhere_search_pool = true,
-                milvus::OpContext* op_context = nullptr);
+                milvus::OpContext* op_context = nullptr) noexcept;
 
     template <typename DataType>
     static expected<std::vector<IndexNode::IteratorPtr>>
     AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
                        const BitsetView& bitset, bool use_knowhere_search_pool = true,
-                       milvus::OpContext* op_context = nullptr);
+                       milvus::OpContext* op_context = nullptr) noexcept;
 };
 
 }  // namespace knowhere

--- a/include/knowhere/expected.h
+++ b/include/knowhere/expected.h
@@ -13,9 +13,21 @@
 #define EXPECTED_H
 
 #include <cassert>
+#include <functional>
 #include <iostream>
+#include <memory>
+#include <new>
 #include <optional>
+#include <stdexcept>
 #include <string>
+#include <type_traits>
+#include <utility>
+
+#if defined(SWIG)
+#define KNOWHERE_NODISCARD
+#else
+#define KNOWHERE_NODISCARD [[nodiscard]]
+#endif
 
 namespace knowhere {
 
@@ -52,7 +64,66 @@ enum class Status {
     brute_force_inner_error = 30,
     emb_list_inner_error = 31,
     aisaq_error = 32,
+    knowhere_inner_error = 33,
 };
+
+enum class StatusCategory {
+    success = 0,
+    input_error = 1,
+    inner_error = 2,
+};
+
+inline constexpr StatusCategory
+StatusCategoryOf(knowhere::Status status) {
+    switch (status) {
+        case knowhere::Status::success:
+            return StatusCategory::success;
+        case knowhere::Status::invalid_args:
+        case knowhere::Status::invalid_param_in_json:
+        case knowhere::Status::out_of_range_in_json:
+        case knowhere::Status::type_conflict_in_json:
+        case knowhere::Status::invalid_metric_type:
+        case knowhere::Status::empty_index:
+        case knowhere::Status::not_implemented:
+        case knowhere::Status::index_not_trained:
+        case knowhere::Status::index_already_trained:
+        case knowhere::Status::invalid_value_in_json:
+        case knowhere::Status::arithmetic_overflow:
+        case knowhere::Status::invalid_binary_set:
+        case knowhere::Status::invalid_instruction_set:
+        case knowhere::Status::invalid_index_error:
+        case knowhere::Status::invalid_cluster_error:
+        case knowhere::Status::invalid_serialized_index_type:
+            return StatusCategory::input_error;
+        case knowhere::Status::faiss_inner_error:
+        case knowhere::Status::hnsw_inner_error:
+        case knowhere::Status::malloc_error:
+        case knowhere::Status::diskann_inner_error:
+        case knowhere::Status::disk_file_error:
+        case knowhere::Status::cuvs_inner_error:
+        case knowhere::Status::cuda_runtime_error:
+        case knowhere::Status::cluster_inner_error:
+        case knowhere::Status::timeout:
+        case knowhere::Status::internal_error:
+        case knowhere::Status::sparse_inner_error:
+        case knowhere::Status::brute_force_inner_error:
+        case knowhere::Status::emb_list_inner_error:
+        case knowhere::Status::aisaq_error:
+        case knowhere::Status::knowhere_inner_error:
+        default:
+            return StatusCategory::inner_error;
+    }
+}
+
+inline constexpr bool
+IsInputError(knowhere::Status status) {
+    return StatusCategoryOf(status) == StatusCategory::input_error;
+}
+
+inline constexpr bool
+IsInnerError(knowhere::Status status) {
+    return StatusCategoryOf(status) == StatusCategory::inner_error;
+}
 
 inline std::string
 Status2String(knowhere::Status status) {
@@ -113,13 +184,15 @@ Status2String(knowhere::Status status) {
             return "emb_list inner error";
         case knowhere::Status::aisaq_error:
             return "internal AiSAQ error";
+        case knowhere::Status::knowhere_inner_error:
+            return "knowhere inner error";
         default:
             return "unexpected status";
     }
 }
 
 template <typename T>
-class expected {
+class KNOWHERE_NODISCARD expected {
  public:
     template <typename... Args>
     expected(Args&&... args) : val(std::make_optional<T>(std::forward<Args>(args)...)), err(Status::success) {
@@ -201,6 +274,94 @@ class expected {
     Status err;
     std::string msg;
 };
+
+#if !defined(SWIG)
+
+namespace detail {
+
+template <typename T>
+struct is_expected : std::false_type {};
+
+template <typename T>
+struct is_expected<expected<T>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_expected_v = is_expected<std::decay_t<T>>::value;
+
+template <typename T>
+struct expected_value;
+
+template <typename T>
+struct expected_value<expected<T>> {
+    using type = T;
+};
+
+inline std::string
+ExceptionMessage(const char* prefix, const std::string& what) {
+    if (what.empty()) {
+        return prefix;
+    }
+    return std::string(prefix) + ": " + what;
+}
+
+template <typename R>
+std::decay_t<R>
+GuardedFailure(Status status, std::string msg) noexcept {
+    using Result = std::decay_t<R>;
+    if constexpr (std::is_same_v<Result, Status>) {
+        return status;
+    } else if constexpr (is_expected_v<Result>) {
+        using Value = typename expected_value<Result>::type;
+        return expected<Value>::Err(status, std::move(msg));
+    } else if constexpr (std::is_same_v<Result, bool>) {
+        return false;
+    } else if constexpr (std::is_integral_v<Result> || std::is_floating_point_v<Result>) {
+        return Result{};
+    } else if constexpr (std::is_same_v<Result, std::string>) {
+        return {};
+    } else if constexpr (std::is_default_constructible_v<Result>) {
+        return Result{};
+    } else {
+        static_assert(std::is_default_constructible_v<Result>,
+                      "GuardedCall requires Status, expected<T>, or a default-constructible return type");
+    }
+}
+
+template <typename R>
+std::decay_t<R>
+GuardedCallFailure(Status status, std::string msg) noexcept {
+    if constexpr (std::is_void_v<R>) {
+        return;
+    } else {
+        return GuardedFailure<R>(status, std::move(msg));
+    }
+}
+
+}  // namespace detail
+
+template <typename Func, typename... Args>
+std::decay_t<std::invoke_result_t<Func, Args...>>
+GuardedCall(Func&& func, Args&&... args) noexcept {
+    using Result = std::invoke_result_t<Func, Args...>;
+    try {
+        if constexpr (std::is_void_v<Result>) {
+            std::invoke(std::forward<Func>(func), std::forward<Args>(args)...);
+            return;
+        } else {
+            return std::invoke(std::forward<Func>(func), std::forward<Args>(args)...);
+        }
+    } catch (const std::bad_alloc& e) {
+        return detail::GuardedCallFailure<Result>(Status::malloc_error,
+                                                  detail::ExceptionMessage("bad alloc", e.what()));
+    } catch (const std::exception& e) {
+        return detail::GuardedCallFailure<Result>(Status::knowhere_inner_error,
+                                                  detail::ExceptionMessage("unhandled exception", e.what()));
+    } catch (...) {
+        return detail::GuardedCallFailure<Result>(Status::knowhere_inner_error, "unknown exception");
+    }
+}
+
+#endif
 
 // Evaluates expr that returns a Status. Does nothing if the returned Status is
 // a Status::success, otherwise returns the Status from the current function.

--- a/include/knowhere/index/index.h
+++ b/include/knowhere/index/index.h
@@ -140,81 +140,81 @@ class Index {
     }
 
     Status
-    Build(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool = true);
+    Build(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool = true) noexcept;
 
 #ifdef KNOWHERE_WITH_CARDINAL
     const std::shared_ptr<Interrupt>
     BuildAsync(const DataSetPtr dataset, const Json& json,
-               const std::chrono::seconds timeout = std::chrono::seconds::max());
+               const std::chrono::seconds timeout = std::chrono::seconds::max()) noexcept;
 #else
     const std::shared_ptr<Interrupt>
-    BuildAsync(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool = true);
+    BuildAsync(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool = true) noexcept;
 #endif
 
     Status
-    Train(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool = true);
+    Train(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool = true) noexcept;
 
     Status
-    Add(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool = true);
+    Add(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool = true) noexcept;
 
     expected<DataSetPtr>
     Search(const DataSetPtr dataset, const Json& json, const BitsetView& bitset,
-           milvus::OpContext* op_context = nullptr) const;
+           milvus::OpContext* op_context = nullptr) const noexcept;
 
     expected<std::vector<IndexNode::IteratorPtr>>
     AnnIterator(const DataSetPtr dataset, const Json& json, const BitsetView& bitset,
-                bool use_knowhere_search_pool = true, milvus::OpContext* op_context = nullptr) const;
+                bool use_knowhere_search_pool = true, milvus::OpContext* op_context = nullptr) const noexcept;
 
     expected<DataSetPtr>
     RangeSearch(const DataSetPtr dataset, const Json& json, const BitsetView& bitset,
-                milvus::OpContext* op_context = nullptr) const;
+                milvus::OpContext* op_context = nullptr) const noexcept;
 
     expected<DataSetPtr>
-    GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context = nullptr) const;
+    GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context = nullptr) const noexcept;
 
     expected<DataSetPtr>
     GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_type,
-                    milvus::OpContext* op_context = nullptr) const;
+                    milvus::OpContext* op_context = nullptr) const noexcept;
 
     expected<DataSetPtr>
     CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
-                  const bool is_cosine, milvus::OpContext* op_context = nullptr) const;
+                  const bool is_cosine, milvus::OpContext* op_context = nullptr) const noexcept;
 
     bool
-    HasRawData(const std::string& metric_type) const;
+    HasRawData(const std::string& metric_type) const noexcept;
 
     bool
-    IsAdditionalScalarSupported(bool is_mv_only) const;
+    IsAdditionalScalarSupported(bool is_mv_only) const noexcept;
 
     bool
-    IsIndexRefineEnabled() const;
+    IsIndexRefineEnabled() const noexcept;
 
     expected<DataSetPtr>
-    GetIndexMeta(const Json& json) const;
+    GetIndexMeta(const Json& json) const noexcept;
 
     Status
-    Serialize(BinarySet& binset) const;
+    Serialize(BinarySet& binset) const noexcept;
 
     Status
-    Deserialize(const BinarySet& binset, const Json& json = {});
+    Deserialize(const BinarySet& binset, const Json& json = {}) noexcept;
 
     Status
-    DeserializeFromFile(const std::string& filename, const Json& json = {});
+    DeserializeFromFile(const std::string& filename, const Json& json = {}) noexcept;
 
     int64_t
-    Dim() const;
+    Dim() const noexcept;
 
     int64_t
-    Size() const;
+    Size() const noexcept;
 
     int64_t
-    Count() const;
+    Count() const noexcept;
 
     std::string
-    Type() const;
+    Type() const noexcept;
 
     [[nodiscard]] bool
-    LoadIndexWithStream() const;
+    LoadIndexWithStream() const noexcept;
 
     ~Index() {
         if (node == nullptr)

--- a/include/knowhere/index/index_factory.h
+++ b/include/knowhere/index/index_factory.h
@@ -28,7 +28,7 @@ class IndexFactory {
  public:
     template <typename DataType>
     expected<Index<IndexNode>>
-    Create(const std::string& name, const int32_t& version, const Object& object = nullptr);
+    Create(const std::string& name, const int32_t& version, const Object& object = nullptr) noexcept;
 
     template <typename DataType>
     const IndexFactory&
@@ -36,18 +36,18 @@ class IndexFactory {
              const uint64_t features);
 
     static IndexFactory&
-    Instance();
+    Instance() noexcept;
     typedef std::tuple<std::set<std::pair<std::string, VecType>>, std::set<std::string>, std::set<std::string>>
         GlobalIndexTable;
 
     bool
-    FeatureCheck(const std::string& name, uint64_t feature) const;
+    FeatureCheck(const std::string& name, uint64_t feature) const noexcept;
 
     static const std::map<std::string, uint64_t>&
-    GetIndexFeatures();
+    GetIndexFeatures() noexcept;
 
     static GlobalIndexTable&
-    StaticIndexTableInstance();
+    StaticIndexTableInstance() noexcept;
 
  private:
     struct FunMapValueBase {

--- a/include/knowhere/index/index_static.h
+++ b/include/knowhere/index/index_static.h
@@ -60,11 +60,11 @@ class IndexStaticFaced {
      * @return generate the config binding with the corresponding vector index
      */
     static std::unique_ptr<BaseConfig>
-    CreateConfig(const knowhere::IndexType& indexType, const knowhere::IndexVersion& version);
+    CreateConfig(const knowhere::IndexType& indexType, const knowhere::IndexVersion& version) noexcept;
 
     static knowhere::Status
     ConfigCheck(const knowhere::IndexType& indexType, const knowhere::IndexVersion& version,
-                const knowhere::Json& params, std::string& msg);
+                const knowhere::Json& params, std::string& msg) noexcept;
 
     /**
      * @brief estimate the memory and disk resource usage before index loading by index params
@@ -79,7 +79,7 @@ class IndexStaticFaced {
     static expected<Resource>
     EstimateLoadResource(const knowhere::IndexType& indexType, const knowhere::IndexVersion& version,
                          const uint64_t file_size_in_bytes, const int64_t num_rows, const int64_t dim,
-                         const knowhere::Json& params);
+                         const knowhere::Json& params) noexcept;
 
     /**
      * @brief determine whether the index contains the raw data before loading the index by index params
@@ -90,7 +90,7 @@ class IndexStaticFaced {
      */
     static bool
     HasRawData(const knowhere::IndexType& indexType, const knowhere::IndexVersion& version,
-               const knowhere::Json& params);
+               const knowhere::Json& params) noexcept;
 
     template <typename VecIndexNode>
     IndexStaticFaced&

--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -35,32 +35,34 @@ LoadConfig(Config* cfg, const Json& json, knowhere::PARAM_TYPE param_type, const
 
 template <typename T>
 inline expected<DataSetPtr>
-Cluster<T>::Train(const DataSet& dataset, const Json& json) {
-    auto cfg = this->node->CreateConfig();
-    std::string msg;
-    auto status = LoadConfig(cfg.get(), json, knowhere::CLUSTER, "Train", &msg);
-    if (status != Status::success) {
-        return expected<DataSetPtr>::Err(status, msg);
-    }
-    return this->node->Train(dataset, *cfg);
+Cluster<T>::Train(const DataSet& dataset, const Json& json) noexcept {
+    return GuardedCall([&]() -> expected<DataSetPtr> {
+        auto cfg = this->node->CreateConfig();
+        std::string msg;
+        auto status = LoadConfig(cfg.get(), json, knowhere::CLUSTER, "Train", &msg);
+        if (status != Status::success) {
+            return expected<DataSetPtr>::Err(status, msg);
+        }
+        return this->node->Train(dataset, *cfg);
+    });
 }
 
 template <typename T>
 inline expected<DataSetPtr>
-Cluster<T>::Assign(const DataSet& dataset) {
-    return this->node->Assign(dataset);
+Cluster<T>::Assign(const DataSet& dataset) noexcept {
+    return GuardedCall([&]() { return this->node->Assign(dataset); });
 }
 
 template <typename T>
 inline expected<DataSetPtr>
-Cluster<T>::GetCentroids() const {
-    return this->node->GetCentroids();
+Cluster<T>::GetCentroids() const noexcept {
+    return GuardedCall([&]() { return this->node->GetCentroids(); });
 }
 
 template <typename T>
 inline std::string
-Cluster<T>::Type() const {
-    return this->node->Type();
+Cluster<T>::Type() const noexcept {
+    return GuardedCall([&]() { return this->node->Type(); });
 }
 
 template class Cluster<ClusterNode>;

--- a/src/cluster/cluster_factory.cc
+++ b/src/cluster/cluster_factory.cc
@@ -17,18 +17,20 @@ namespace knowhere {
 
 template <typename DataType>
 expected<Cluster<ClusterNode>>
-ClusterFactory::Create(const std::string& name, const Object& object) {
-    static_assert(KnowhereDataTypeCheck<DataType>::value == true);
-    auto& func_mapping_ = MapInstance();
-    auto key = GetKey<DataType>(name);
-    if (func_mapping_.find(key) == func_mapping_.end()) {
-        LOG_KNOWHERE_ERROR_ << "failed to find cluster type " << key << " in factory";
-        return expected<Cluster<ClusterNode>>::Err(Status::invalid_cluster_error, "cluster type not supported");
-    }
-    LOG_KNOWHERE_INFO_ << "use key " << key << " to create knowhere cluster worker " << name;
-    auto fun_map_v = static_cast<FunMapValue<Cluster<ClusterNode>>*>(func_mapping_[key].get());
+ClusterFactory::Create(const std::string& name, const Object& object) noexcept {
+    return GuardedCall([&]() -> expected<Cluster<ClusterNode>> {
+        static_assert(KnowhereDataTypeCheck<DataType>::value == true);
+        auto& func_mapping_ = MapInstance();
+        auto key = GetKey<DataType>(name);
+        if (func_mapping_.find(key) == func_mapping_.end()) {
+            LOG_KNOWHERE_ERROR_ << "failed to find cluster type " << key << " in factory";
+            return expected<Cluster<ClusterNode>>::Err(Status::invalid_cluster_error, "cluster type not supported");
+        }
+        LOG_KNOWHERE_INFO_ << "use key " << key << " to create knowhere cluster worker " << name;
+        auto fun_map_v = static_cast<FunMapValue<Cluster<ClusterNode>>*>(func_mapping_[key].get());
 
-    return fun_map_v->fun_value(object);
+        return fun_map_v->fun_value(object);
+    });
 }
 
 template <typename DataType>
@@ -43,7 +45,7 @@ ClusterFactory::Register(const std::string& name, std::function<Cluster<ClusterN
 }
 
 ClusterFactory&
-ClusterFactory::Instance() {
+ClusterFactory::Instance() noexcept {
     static ClusterFactory factory;
     return factory;
 }

--- a/src/common/comp/brute_force.cc
+++ b/src/common/comp/brute_force.cc
@@ -143,9 +143,26 @@ GetInverseVecNorms(const DataSetPtr& base) {
 }  // namespace
 
 template <typename DataType>
+Status
+BruteForceSearchWithBufImpl(const DataSetPtr base_dataset, const DataSetPtr query_dataset, int64_t* ids, float* dis,
+                            const Json& config, const BitsetView& bitset, milvus::OpContext* op_context);
+
+template <typename DataType>
+Status
+BruteForceSearchOnChunkWithBufImpl(const DataSetPtr base_dataset, const DataSetPtr query_dataset, int64_t* ids,
+                                   float* dis, const Json& config, const BitsetView& bitset,
+                                   milvus::OpContext* op_context);
+
+template <typename DataType>
+expected<std::vector<IndexNode::IteratorPtr>>
+BruteForceAnnIteratorOnChunkImpl(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
+                                 const BitsetView& bitset, bool use_knowhere_search_pool,
+                                 milvus::OpContext* op_context);
+
+template <typename DataType>
 expected<DataSetPtr>
-BruteForce::Search(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
-                   const BitsetView& bitset_, milvus::OpContext* op_context) {
+BruteForceSearchImpl(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
+                     const BitsetView& bitset_, milvus::OpContext* op_context) {
     BruteForceConfig cfg;
     std::string msg;
     auto status = Config::Load(cfg, config, knowhere::SEARCH, &msg);
@@ -172,11 +189,11 @@ BruteForce::Search(const DataSetPtr base_dataset, const DataSetPtr query_dataset
     Status search_status;
     bool base_is_chunk = base_dataset->GetIsChunk();
     if (base_is_chunk) {
-        search_status = SearchOnChunkWithBuf<DataType>(base_dataset, query_dataset, labels.get(), distances.get(),
-                                                       config, bitset_, op_context);
+        search_status = BruteForceSearchOnChunkWithBufImpl<DataType>(base_dataset, query_dataset, labels.get(),
+                                                                     distances.get(), config, bitset_, op_context);
     } else {
-        search_status = SearchWithBuf<DataType>(base_dataset, query_dataset, labels.get(), distances.get(), config,
-                                                bitset_, op_context);
+        search_status = BruteForceSearchWithBufImpl<DataType>(base_dataset, query_dataset, labels.get(),
+                                                              distances.get(), config, bitset_, op_context);
     }
     if (search_status != Status::success) {
         return expected<DataSetPtr>::Err(search_status, "search failed");
@@ -468,11 +485,12 @@ brute_force_emb_list_impl(const void* xq, size_t query_el_idx, const void* xb, i
 
 template <typename DataType>
 Status
-BruteForce::SearchWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_dataset, int64_t* ids, float* dis,
-                          const Json& config, const BitsetView& bitset_, milvus::OpContext* op_context) {
+BruteForceSearchWithBufImpl(const DataSetPtr base_dataset, const DataSetPtr query_dataset, int64_t* ids, float* dis,
+                            const Json& config, const BitsetView& bitset_, milvus::OpContext* op_context) {
     auto base_is_chunk = base_dataset->GetIsChunk();
     if (base_is_chunk) {
-        return SearchOnChunkWithBuf<DataType>(base_dataset, query_dataset, ids, dis, config, bitset_, op_context);
+        return BruteForceSearchOnChunkWithBufImpl<DataType>(base_dataset, query_dataset, ids, dis, config, bitset_,
+                                                            op_context);
     }
     auto xb = base_dataset->GetTensor();
     auto nb = base_dataset->GetRows();
@@ -612,9 +630,9 @@ BruteForce::SearchWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_
 
 template <typename DataType>
 Status
-BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_dataset, int64_t* ids,
-                                 float* dis, const Json& config, const BitsetView& bitset_,
-                                 milvus::OpContext* op_context) {
+BruteForceSearchOnChunkWithBufImpl(const DataSetPtr base_dataset, const DataSetPtr query_dataset, int64_t* ids,
+                                   float* dis, const Json& config, const BitsetView& bitset_,
+                                   milvus::OpContext* op_context) {
     auto base_is_chunk = base_dataset->GetIsChunk();
     if (!base_is_chunk) {
         LOG_KNOWHERE_ERROR_ << "Base dataset is not chunk, should NOT use it.";
@@ -912,8 +930,8 @@ BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr
  */
 template <typename DataType>
 expected<DataSetPtr>
-BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
-                        const BitsetView& bitset_, milvus::OpContext* op_context) {
+BruteForceRangeSearchImpl(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
+                          const BitsetView& bitset_, milvus::OpContext* op_context) {
     DataSetPtr query(query_dataset);
     auto xb = base_dataset->GetTensor();
     auto nb = base_dataset->GetRows();
@@ -1132,9 +1150,9 @@ BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_da
 }
 
 Status
-BruteForce::SearchSparseWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_dataset, sparse::label_t* labels,
-                                float* distances, const Json& config, const BitsetView& bitset,
-                                milvus::OpContext* op_context) {
+BruteForceSearchSparseWithBufImpl(const DataSetPtr base_dataset, const DataSetPtr query_dataset,
+                                  sparse::label_t* labels, float* distances, const Json& config,
+                                  const BitsetView& bitset, milvus::OpContext* op_context) {
     auto base = static_cast<const sparse::SparseRow<float>*>(base_dataset->GetTensor());
     auto rows = base_dataset->GetRows();
     auto xb_id_offset = base_dataset->GetTensorBeginId();
@@ -1235,8 +1253,8 @@ BruteForce::SearchSparseWithBuf(const DataSetPtr base_dataset, const DataSetPtr 
 }
 
 expected<DataSetPtr>
-BruteForce::SearchSparse(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
-                         const BitsetView& bitset, milvus::OpContext* op_context) {
+BruteForceSearchSparseImpl(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
+                           const BitsetView& bitset, milvus::OpContext* op_context) {
     auto nq = query_dataset->GetRows();
     BruteForceConfig cfg;
     std::string msg;
@@ -1249,18 +1267,22 @@ BruteForce::SearchSparse(const DataSetPtr base_dataset, const DataSetPtr query_d
     auto labels = std::make_unique<sparse::label_t[]>(nq * topk);
     auto distances = std::make_unique<float[]>(nq * topk);
 
-    SearchSparseWithBuf(base_dataset, query_dataset, labels.get(), distances.get(), config, bitset, op_context);
+    auto search_status = BruteForceSearchSparseWithBufImpl(base_dataset, query_dataset, labels.get(), distances.get(),
+                                                           config, bitset, op_context);
+    if (search_status != Status::success) {
+        return expected<DataSetPtr>::Err(search_status, "sparse search failed");
+    }
     return GenResultDataSet(nq, topk, std::move(labels), std::move(distances));
 }
 
 template <typename DataType>
 expected<std::vector<IndexNode::IteratorPtr>>
-BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
-                        const BitsetView& bitset_, bool use_knowhere_search_pool, milvus::OpContext* op_context) {
+BruteForceAnnIteratorImpl(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
+                          const BitsetView& bitset_, bool use_knowhere_search_pool, milvus::OpContext* op_context) {
     auto base_is_chunk = base_dataset->GetIsChunk();
     if (base_is_chunk) {
-        return AnnIteratorOnChunk<DataType>(base_dataset, query_dataset, config, bitset_, use_knowhere_search_pool,
-                                            op_context);
+        return BruteForceAnnIteratorOnChunkImpl<DataType>(base_dataset, query_dataset, config, bitset_,
+                                                          use_knowhere_search_pool, op_context);
     }
     auto nb = base_dataset->GetRows();
     auto dim = base_dataset->GetDim();
@@ -1450,9 +1472,9 @@ BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_da
 
 template <typename DataType>
 expected<std::vector<IndexNode::IteratorPtr>>
-BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
-                               const BitsetView& bitset_, bool use_knowhere_search_pool,
-                               milvus::OpContext* op_context) {
+BruteForceAnnIteratorOnChunkImpl(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
+                                 const BitsetView& bitset_, bool use_knowhere_search_pool,
+                                 milvus::OpContext* op_context) {
     auto base_is_chunk = base_dataset->GetIsChunk();
     if (!base_is_chunk) {
         LOG_KNOWHERE_ERROR_ << "Base dataset is not chunk, should NOT use it.";
@@ -1705,10 +1727,10 @@ BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr q
 
 template <>
 expected<std::vector<IndexNode::IteratorPtr>>
-BruteForce::AnnIterator<knowhere::sparse::SparseRow<float>>(const DataSetPtr base_dataset,
-                                                            const DataSetPtr query_dataset, const Json& config,
-                                                            const BitsetView& bitset, bool use_knowhere_search_pool,
-                                                            milvus::OpContext* op_context) {
+BruteForceAnnIteratorImpl<knowhere::sparse::SparseRow<float>>(const DataSetPtr base_dataset,
+                                                              const DataSetPtr query_dataset, const Json& config,
+                                                              const BitsetView& bitset, bool use_knowhere_search_pool,
+                                                              milvus::OpContext* op_context) {
     auto rows = base_dataset->GetRows();
     auto xb_id_offset = base_dataset->GetTensorBeginId();
     auto nq = query_dataset->GetRows();
@@ -1797,6 +1819,84 @@ BruteForce::AnnIterator<knowhere::sparse::SparseRow<float>>(const DataSetPtr bas
 #endif
 
     return vec;
+}
+
+template <typename DataType>
+expected<DataSetPtr>
+BruteForce::Search(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
+                   const BitsetView& bitset, milvus::OpContext* op_context) noexcept {
+    return GuardedCall([&]() -> expected<DataSetPtr> {
+        return BruteForceSearchImpl<DataType>(base_dataset, query_dataset, config, bitset, op_context);
+    });
+}
+
+template <typename DataType>
+Status
+BruteForce::SearchWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_dataset, int64_t* ids, float* dis,
+                          const Json& config, const BitsetView& bitset, milvus::OpContext* op_context) noexcept {
+    return GuardedCall([&]() -> Status {
+        return BruteForceSearchWithBufImpl<DataType>(base_dataset, query_dataset, ids, dis, config, bitset, op_context);
+    });
+}
+
+template <typename DataType>
+Status
+BruteForce::SearchOnChunkWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_dataset, int64_t* ids,
+                                 float* dis, const Json& config, const BitsetView& bitset,
+                                 milvus::OpContext* op_context) noexcept {
+    return GuardedCall([&]() -> Status {
+        return BruteForceSearchOnChunkWithBufImpl<DataType>(base_dataset, query_dataset, ids, dis, config, bitset,
+                                                            op_context);
+    });
+}
+
+template <typename DataType>
+expected<DataSetPtr>
+BruteForce::RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
+                        const BitsetView& bitset, milvus::OpContext* op_context) noexcept {
+    return GuardedCall([&]() -> expected<DataSetPtr> {
+        return BruteForceRangeSearchImpl<DataType>(base_dataset, query_dataset, config, bitset, op_context);
+    });
+}
+
+Status
+BruteForce::SearchSparseWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_dataset, sparse::label_t* labels,
+                                float* distances, const Json& config, const BitsetView& bitset,
+                                milvus::OpContext* op_context) noexcept {
+    return GuardedCall([&]() -> Status {
+        return BruteForceSearchSparseWithBufImpl(base_dataset, query_dataset, labels, distances, config, bitset,
+                                                 op_context);
+    });
+}
+
+expected<DataSetPtr>
+BruteForce::SearchSparse(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
+                         const BitsetView& bitset, milvus::OpContext* op_context) noexcept {
+    return GuardedCall([&]() -> expected<DataSetPtr> {
+        return BruteForceSearchSparseImpl(base_dataset, query_dataset, config, bitset, op_context);
+    });
+}
+
+template <typename DataType>
+expected<std::vector<IndexNode::IteratorPtr>>
+BruteForce::AnnIterator(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
+                        const BitsetView& bitset, bool use_knowhere_search_pool,
+                        milvus::OpContext* op_context) noexcept {
+    return GuardedCall([&]() -> expected<std::vector<IndexNode::IteratorPtr>> {
+        return BruteForceAnnIteratorImpl<DataType>(base_dataset, query_dataset, config, bitset,
+                                                   use_knowhere_search_pool, op_context);
+    });
+}
+
+template <typename DataType>
+expected<std::vector<IndexNode::IteratorPtr>>
+BruteForce::AnnIteratorOnChunk(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
+                               const BitsetView& bitset, bool use_knowhere_search_pool,
+                               milvus::OpContext* op_context) noexcept {
+    return GuardedCall([&]() -> expected<std::vector<IndexNode::IteratorPtr>> {
+        return BruteForceAnnIteratorOnChunkImpl<DataType>(base_dataset, query_dataset, config, bitset,
+                                                          use_knowhere_search_pool, op_context);
+    });
 }
 
 template knowhere::expected<knowhere::DataSetPtr>
@@ -1903,5 +2003,9 @@ knowhere::BruteForce::AnnIterator<knowhere::bin1>(const knowhere::DataSetPtr bas
                                                   const knowhere::DataSetPtr query_dataset,
                                                   const knowhere::Json& config, const knowhere::BitsetView& bitset,
                                                   bool use_knowhere_search_pool, milvus::OpContext* op_context);
+template knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
+knowhere::BruteForce::AnnIterator<knowhere::sparse::SparseRow<float>>(
+    const knowhere::DataSetPtr base_dataset, const knowhere::DataSetPtr query_dataset, const knowhere::Json& config,
+    const knowhere::BitsetView& bitset, bool use_knowhere_search_pool, milvus::OpContext* op_context);
 
 }  // namespace knowhere

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -40,392 +40,419 @@ LoadConfig(BaseConfig* cfg, const Json& json, knowhere::PARAM_TYPE param_type, c
 #ifdef KNOWHERE_WITH_CARDINAL
 template <typename T>
 inline const std::shared_ptr<Interrupt>
-Index<T>::BuildAsync(const DataSetPtr dataset, const Json& json, const std::chrono::seconds timeout) {
-    auto pool = ThreadPool::GetGlobalBuildThreadPool();
-    auto interrupt = std::make_shared<Interrupt>(timeout);
-    interrupt->Set(pool->push([this, dataset, json, interrupt]() {
-        auto cfg = this->node->CreateConfig();
-        RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Build"));
+Index<T>::BuildAsync(const DataSetPtr dataset, const Json& json, const std::chrono::seconds timeout) noexcept {
+    return GuardedCall([&]() -> std::shared_ptr<Interrupt> {
+        auto pool = ThreadPool::GetGlobalBuildThreadPool();
+        auto interrupt = std::make_shared<Interrupt>(timeout);
+        interrupt->Set(pool->push([this, dataset, json, interrupt]() {
+            return GuardedCall([&]() -> Status {
+                auto cfg = this->node->CreateConfig();
+                RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Build"));
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
-        TimeRecorder rc("BuildAsync index ", 2);
-        auto res = this->node->BulidAsyncEmbListIfNeed(dataset, std::move(cfg), interrupt.get());
-        auto time = rc.ElapseFromBegin("done");
-        time *= 0.000001;  // convert to s
-        this->node->GetBuildLatencyMetric().Observe(time);
+                TimeRecorder rc("BuildAsync index ", 2);
+                auto res = this->node->BulidAsyncEmbListIfNeed(dataset, std::move(cfg), interrupt.get());
+                auto time = rc.ElapseFromBegin("done");
+                time *= 0.000001;  // convert to s
+                this->node->GetBuildLatencyMetric().Observe(time);
 #else
-        auto res = this->node->BulidAsyncEmbListIfNeed(dataset, std::move(cfg), Interrupt.get());
+                auto res = this->node->BulidAsyncEmbListIfNeed(dataset, std::move(cfg), Interrupt.get());
 #endif
-        return res;
-    }));
-    return interrupt;
+                return res;
+            });
+        }));
+        return interrupt;
+    });
 }
 #else
 template <typename T>
 inline const std::shared_ptr<Interrupt>
-Index<T>::BuildAsync(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool) {
-    auto pool = ThreadPool::GetGlobalBuildThreadPool();
-    auto interrupt = std::make_shared<Interrupt>();
-    interrupt->Set(pool->push([this, dataset, json]() { return this->Build(dataset, json); }));
-    return interrupt;
+Index<T>::BuildAsync(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool) noexcept {
+    return GuardedCall([&]() -> std::shared_ptr<Interrupt> {
+        auto pool = ThreadPool::GetGlobalBuildThreadPool();
+        auto interrupt = std::make_shared<Interrupt>();
+        interrupt->Set(pool->push([this, dataset, json, use_knowhere_build_pool]() {
+            return this->Build(dataset, json, use_knowhere_build_pool);
+        }));
+        return interrupt;
+    });
 }
 #endif
 
 template <typename T>
 inline Status
-Index<T>::Build(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool) {
-    auto cfg = this->node->CreateConfig();
-    RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Build"));
+Index<T>::Build(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool) noexcept {
+    return GuardedCall([&]() -> Status {
+        auto cfg = this->node->CreateConfig();
+        RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Build"));
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
-    TimeRecorder rc("Build index", 2);
-    auto res = this->node->BuildEmbListIfNeed(dataset, std::move(cfg), use_knowhere_build_pool);
-    auto time = rc.ElapseFromBegin("done");
-    time *= 0.000001;  // convert to s
-    this->node->GetBuildLatencyMetric().Observe(time);
+        TimeRecorder rc("Build index", 2);
+        auto res = this->node->BuildEmbListIfNeed(dataset, std::move(cfg), use_knowhere_build_pool);
+        auto time = rc.ElapseFromBegin("done");
+        time *= 0.000001;  // convert to s
+        this->node->GetBuildLatencyMetric().Observe(time);
 #else
-    auto res = this->node->BuildEmbListIfNeed(dataset, std::move(cfg), use_knowhere_build_pool);
+        auto res = this->node->BuildEmbListIfNeed(dataset, std::move(cfg), use_knowhere_build_pool);
 #endif
-    return res;
+        return res;
+    });
 }
 
 template <typename T>
 inline Status
-Index<T>::Train(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool) {
-    bool is_emb_list = dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET) != nullptr;
-    if (is_emb_list) {
-        // should use Index::Build instead.
-        LOG_KNOWHERE_WARNING_ << "EmbList should use Index::Build instead.";
-        return Status::emb_list_inner_error;
-    }
-    auto cfg = this->node->CreateConfig();
-    std::string msg;
-    RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Train", &msg));
-    return this->node->Train(dataset, std::move(cfg), use_knowhere_build_pool);
+Index<T>::Train(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool) noexcept {
+    return GuardedCall([&]() -> Status {
+        bool is_emb_list = dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET) != nullptr;
+        if (is_emb_list) {
+            // should use Index::Build instead.
+            LOG_KNOWHERE_WARNING_ << "EmbList should use Index::Build instead.";
+            return Status::emb_list_inner_error;
+        }
+        auto cfg = this->node->CreateConfig();
+        std::string msg;
+        RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Train", &msg));
+        return this->node->Train(dataset, std::move(cfg), use_knowhere_build_pool);
+    });
 }
 
 template <typename T>
 inline Status
-Index<T>::Add(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool) {
-    auto cfg = this->node->CreateConfig();
-    std::string msg;
-    RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Add", &msg));
-    return this->node->AddEmbListIfNeed(dataset, std::move(cfg), use_knowhere_build_pool);
+Index<T>::Add(const DataSetPtr dataset, const Json& json, bool use_knowhere_build_pool) noexcept {
+    return GuardedCall([&]() -> Status {
+        auto cfg = this->node->CreateConfig();
+        std::string msg;
+        RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Add", &msg));
+        return this->node->AddEmbListIfNeed(dataset, std::move(cfg), use_knowhere_build_pool);
+    });
 }
 
 template <typename T>
 inline expected<DataSetPtr>
 Index<T>::Search(const DataSetPtr dataset, const Json& json, const BitsetView& bitset_,
-                 milvus::OpContext* op_context) const {
-    auto cfg = this->node->CreateConfig();
-    std::string msg;
-    const Status load_status = LoadConfig(cfg.get(), json, knowhere::SEARCH, "Search", &msg);
-    if (load_status != Status::success) {
-        return expected<DataSetPtr>::Err(load_status, msg);
-    }
-    // when index is immutable, bitset size should always equal to data count in index
-    // when index is mutable, it could happen that data count larger than bitset size, see
-    // https://github.com/zilliztech/knowhere/issues/70
-    // so something must be wrong at caller side when passed bitset size larger than data count
-    if (bitset_.size() > static_cast<size_t>(this->Count())) {
-        msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
-                          bitset_.size(), this->Count());
-        LOG_KNOWHERE_ERROR_ << msg;
-        return expected<DataSetPtr>::Err(Status::invalid_args, msg);
-    }
+                 milvus::OpContext* op_context) const noexcept {
+    return GuardedCall([&]() -> expected<DataSetPtr> {
+        auto cfg = this->node->CreateConfig();
+        std::string msg;
+        const Status load_status = LoadConfig(cfg.get(), json, knowhere::SEARCH, "Search", &msg);
+        if (load_status != Status::success) {
+            return expected<DataSetPtr>::Err(load_status, msg);
+        }
+        // when index is immutable, bitset size should always equal to data count in index
+        // when index is mutable, it could happen that data count larger than bitset size, see
+        // https://github.com/zilliztech/knowhere/issues/70
+        // so something must be wrong at caller side when passed bitset size larger than data count
+        if (bitset_.size() > static_cast<size_t>(this->Count())) {
+            msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
+                              bitset_.size(), this->Count());
+            LOG_KNOWHERE_ERROR_ << msg;
+            return expected<DataSetPtr>::Err(Status::invalid_args, msg);
+        }
 
-    BitsetView bitset;
-    if (bitset_.count() == 0) {
-        // traverse bitset to get the filtered out num
-        auto filtered_out_num = bitset_.get_filtered_out_num_();
-        bitset = BitsetView(bitset_.data(), bitset_.size(), filtered_out_num);
-    } else {
-        // if bitset has filtered out num, use it
-        bitset = bitset_;
-    }
+        BitsetView bitset;
+        if (bitset_.count() == 0) {
+            // traverse bitset to get the filtered out num
+            auto filtered_out_num = bitset_.get_filtered_out_num_();
+            bitset = BitsetView(bitset_.data(), bitset_.size(), filtered_out_num);
+        } else {
+            // if bitset has filtered out num, use it
+            bitset = bitset_;
+        }
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
-    const BaseConfig& b_cfg = static_cast<const BaseConfig&>(*cfg);
-    // LCOV_EXCL_START
-    std::shared_ptr<tracer::trace::Span> span = nullptr;
-    if (b_cfg.trace_id.has_value()) {
-        auto trace_id_str = tracer::GetIDFromHexStr(b_cfg.trace_id.value());
-        auto span_id_str = tracer::GetIDFromHexStr(b_cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()),
-                                        .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
-                                        .traceFlags = static_cast<uint8_t>(b_cfg.trace_flags.value())};
-        span = tracer::StartSpan("knowhere search", &ctx);
-        span->SetAttribute(meta::METRIC_TYPE, b_cfg.metric_type.value());
-        span->SetAttribute(meta::TOPK, b_cfg.k.value());
-        span->SetAttribute(meta::ROWS, Count());
-        span->SetAttribute(meta::DIM, Dim());
-        span->SetAttribute(meta::NQ, dataset->GetRows());
-    }
-    // LCOV_EXCL_STOP
+        const BaseConfig& b_cfg = static_cast<const BaseConfig&>(*cfg);
+        // LCOV_EXCL_START
+        std::shared_ptr<tracer::trace::Span> span = nullptr;
+        if (b_cfg.trace_id.has_value()) {
+            auto trace_id_str = tracer::GetIDFromHexStr(b_cfg.trace_id.value());
+            auto span_id_str = tracer::GetIDFromHexStr(b_cfg.span_id.value());
+            auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()),
+                                            .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
+                                            .traceFlags = static_cast<uint8_t>(b_cfg.trace_flags.value())};
+            span = tracer::StartSpan("knowhere search", &ctx);
+            span->SetAttribute(meta::METRIC_TYPE, b_cfg.metric_type.value());
+            span->SetAttribute(meta::TOPK, b_cfg.k.value());
+            span->SetAttribute(meta::ROWS, Count());
+            span->SetAttribute(meta::DIM, Dim());
+            span->SetAttribute(meta::NQ, dataset->GetRows());
+        }
+        // LCOV_EXCL_STOP
 
-    TimeRecorder rc("Search");
-    bool has_trace_id = b_cfg.trace_id.has_value();
-    auto k = cfg->k.value();
-    auto res = this->node->SearchEmbListIfNeed(dataset, std::move(cfg), bitset, op_context);
-    auto time = rc.ElapseFromBegin("done");
-    time *= 0.001;  // convert to ms
-    this->node->GetSearchLatencyMetric().Observe(time);
-    knowhere_search_topk.Observe(k);
+        TimeRecorder rc("Search");
+        bool has_trace_id = b_cfg.trace_id.has_value();
+        auto k = cfg->k.value();
+        auto res = this->node->SearchEmbListIfNeed(dataset, std::move(cfg), bitset, op_context);
+        auto time = rc.ElapseFromBegin("done");
+        time *= 0.001;  // convert to ms
+        this->node->GetSearchLatencyMetric().Observe(time);
+        knowhere_search_topk.Observe(k);
 
-    // LCOV_EXCL_START
-    if (has_trace_id) {
-        span->End();
-    }
-    // LCOV_EXCL_STOP
+        // LCOV_EXCL_START
+        if (has_trace_id) {
+            span->End();
+        }
+        // LCOV_EXCL_STOP
 #else
-    auto res = this->node->SearchEmbListIfNeed(dataset, std::move(cfg), bitset, op_context);
+        auto res = this->node->SearchEmbListIfNeed(dataset, std::move(cfg), bitset, op_context);
 #endif
-    return res;
+        return res;
+    });
 }
 
 template <typename T>
 inline expected<std::vector<std::shared_ptr<IndexNode::iterator>>>
 Index<T>::AnnIterator(const DataSetPtr dataset, const Json& json, const BitsetView& bitset_,
-                      bool use_knowhere_search_pool, milvus::OpContext* op_context) const {
-    auto cfg = this->node->CreateConfig();
-    std::string msg;
-    Status status = LoadConfig(cfg.get(), json, knowhere::ITERATOR, "Iterator", &msg);
-    if (status != Status::success) {
-        return expected<std::vector<std::shared_ptr<IndexNode::iterator>>>::Err(status, msg);
-    }
-    // when index is immutable, bitset size should always equal to data count in index
-    // when index is mutable, it could happen that data count larger than bitset size, see
-    // https://github.com/zilliztech/knowhere/issues/70
-    // so something must be wrong at caller side when passed bitset size larger than data count
-    if (bitset_.size() > static_cast<size_t>(this->Count())) {
-        msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
-                          bitset_.size(), this->Count());
-        LOG_KNOWHERE_ERROR_ << msg;
-        return expected<std::vector<std::shared_ptr<IndexNode::iterator>>>::Err(Status::invalid_args, msg);
-    }
+                      bool use_knowhere_search_pool, milvus::OpContext* op_context) const noexcept {
+    return GuardedCall([&]() -> expected<std::vector<std::shared_ptr<IndexNode::iterator>>> {
+        auto cfg = this->node->CreateConfig();
+        std::string msg;
+        Status status = LoadConfig(cfg.get(), json, knowhere::ITERATOR, "Iterator", &msg);
+        if (status != Status::success) {
+            return expected<std::vector<std::shared_ptr<IndexNode::iterator>>>::Err(status, msg);
+        }
+        // when index is immutable, bitset size should always equal to data count in index
+        // when index is mutable, it could happen that data count larger than bitset size, see
+        // https://github.com/zilliztech/knowhere/issues/70
+        // so something must be wrong at caller side when passed bitset size larger than data count
+        if (bitset_.size() > static_cast<size_t>(this->Count())) {
+            msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
+                              bitset_.size(), this->Count());
+            LOG_KNOWHERE_ERROR_ << msg;
+            return expected<std::vector<std::shared_ptr<IndexNode::iterator>>>::Err(Status::invalid_args, msg);
+        }
 
-    const auto bitset = BitsetView(bitset_.data(), bitset_.size(), bitset_.get_filtered_out_num_());
+        const auto bitset = BitsetView(bitset_.data(), bitset_.size(), bitset_.get_filtered_out_num_());
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
-    // note that this time includes only the initial search phase of iterator.
-    TimeRecorder rc("AnnIterator");
-    auto res =
-        this->node->AnnIteratorEmbListIfNeed(dataset, std::move(cfg), bitset, use_knowhere_search_pool, op_context);
-    auto time = rc.ElapseFromBegin("done");
-    time *= 0.001;  // convert to ms
-    this->node->GetSearchLatencyMetric().Observe(time);
+        // note that this time includes only the initial search phase of iterator.
+        TimeRecorder rc("AnnIterator");
+        auto res =
+            this->node->AnnIteratorEmbListIfNeed(dataset, std::move(cfg), bitset, use_knowhere_search_pool, op_context);
+        auto time = rc.ElapseFromBegin("done");
+        time *= 0.001;  // convert to ms
+        this->node->GetSearchLatencyMetric().Observe(time);
 #else
-    auto res =
-        this->node->AnnIteratorEmbListIfNeed(dataset, std::move(cfg), bitset, use_knowhere_search_pool, op_context);
+        auto res =
+            this->node->AnnIteratorEmbListIfNeed(dataset, std::move(cfg), bitset, use_knowhere_search_pool, op_context);
 #endif
-    return res;
+        return res;
+    });
 }
 
 template <typename T>
 inline expected<DataSetPtr>
 Index<T>::RangeSearch(const DataSetPtr dataset, const Json& json, const BitsetView& bitset_,
-                      milvus::OpContext* op_context) const {
-    auto cfg = this->node->CreateConfig();
-    std::string msg;
-    auto status = LoadConfig(cfg.get(), json, knowhere::RANGE_SEARCH, "RangeSearch", &msg);
-    if (status != Status::success) {
-        return expected<DataSetPtr>::Err(status, std::move(msg));
-    }
-    // when index is immutable, bitset size should always equal to data count in index
-    // when index is mutable, it could happen that data count larger than bitset size, see
-    // https://github.com/zilliztech/knowhere/issues/70
-    // so something must be wrong at caller side when passed bitset size larger than data count
-    if (bitset_.size() > static_cast<size_t>(this->Count())) {
-        msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
-                          bitset_.size(), this->Count());
-        LOG_KNOWHERE_ERROR_ << msg;
-        return expected<DataSetPtr>::Err(Status::invalid_args, msg);
-    }
+                      milvus::OpContext* op_context) const noexcept {
+    return GuardedCall([&]() -> expected<DataSetPtr> {
+        auto cfg = this->node->CreateConfig();
+        std::string msg;
+        auto status = LoadConfig(cfg.get(), json, knowhere::RANGE_SEARCH, "RangeSearch", &msg);
+        if (status != Status::success) {
+            return expected<DataSetPtr>::Err(status, std::move(msg));
+        }
+        // when index is immutable, bitset size should always equal to data count in index
+        // when index is mutable, it could happen that data count larger than bitset size, see
+        // https://github.com/zilliztech/knowhere/issues/70
+        // so something must be wrong at caller side when passed bitset size larger than data count
+        if (bitset_.size() > static_cast<size_t>(this->Count())) {
+            msg = fmt::format("bitset size should be <= data count, but we get bitset size: {}, data count: {}",
+                              bitset_.size(), this->Count());
+            LOG_KNOWHERE_ERROR_ << msg;
+            return expected<DataSetPtr>::Err(Status::invalid_args, msg);
+        }
 
-    const auto bitset = BitsetView(bitset_.data(), bitset_.size(), bitset_.get_filtered_out_num_());
+        const auto bitset = BitsetView(bitset_.data(), bitset_.size(), bitset_.get_filtered_out_num_());
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
-    const BaseConfig& b_cfg = static_cast<const BaseConfig&>(*cfg);
-    // LCOV_EXCL_START
-    std::shared_ptr<tracer::trace::Span> span = nullptr;
-    if (b_cfg.trace_id.has_value()) {
-        auto trace_id_str = tracer::GetIDFromHexStr(b_cfg.trace_id.value());
-        auto span_id_str = tracer::GetIDFromHexStr(b_cfg.span_id.value());
-        auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()),
-                                        .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
-                                        .traceFlags = static_cast<uint8_t>(b_cfg.trace_flags.value())};
-        span = tracer::StartSpan("knowhere range search", &ctx);
-        span->SetAttribute(meta::METRIC_TYPE, b_cfg.metric_type.value());
-        span->SetAttribute(meta::RADIUS, b_cfg.radius.value());
-        if (b_cfg.range_filter.value() != defaultRangeFilter) {
-            span->SetAttribute(meta::RANGE_FILTER, b_cfg.range_filter.value());
+        const BaseConfig& b_cfg = static_cast<const BaseConfig&>(*cfg);
+        // LCOV_EXCL_START
+        std::shared_ptr<tracer::trace::Span> span = nullptr;
+        if (b_cfg.trace_id.has_value()) {
+            auto trace_id_str = tracer::GetIDFromHexStr(b_cfg.trace_id.value());
+            auto span_id_str = tracer::GetIDFromHexStr(b_cfg.span_id.value());
+            auto ctx = tracer::TraceContext{.traceID = reinterpret_cast<const uint8_t*>(trace_id_str.c_str()),
+                                            .spanID = reinterpret_cast<const uint8_t*>(span_id_str.c_str()),
+                                            .traceFlags = static_cast<uint8_t>(b_cfg.trace_flags.value())};
+            span = tracer::StartSpan("knowhere range search", &ctx);
+            span->SetAttribute(meta::METRIC_TYPE, b_cfg.metric_type.value());
+            span->SetAttribute(meta::RADIUS, b_cfg.radius.value());
+            if (b_cfg.range_filter.value() != defaultRangeFilter) {
+                span->SetAttribute(meta::RANGE_FILTER, b_cfg.range_filter.value());
+            }
+            span->SetAttribute(meta::ROWS, Count());
+            span->SetAttribute(meta::DIM, Dim());
+            span->SetAttribute(meta::NQ, dataset->GetRows());
         }
-        span->SetAttribute(meta::ROWS, Count());
-        span->SetAttribute(meta::DIM, Dim());
-        span->SetAttribute(meta::NQ, dataset->GetRows());
-    }
-    // LCOV_EXCL_STOP
+        // LCOV_EXCL_STOP
 
-    TimeRecorder rc("Range Search");
-    bool has_trace_id = b_cfg.trace_id.has_value();
-    auto res = this->node->RangeSearchEmbListIfNeed(dataset, std::move(cfg), bitset, op_context);
-    auto time = rc.ElapseFromBegin("done");
-    time *= 0.001;  // convert to ms
-    this->node->GetRangeSearchLatencyMetric().Observe(time);
+        TimeRecorder rc("Range Search");
+        bool has_trace_id = b_cfg.trace_id.has_value();
+        auto res = this->node->RangeSearchEmbListIfNeed(dataset, std::move(cfg), bitset, op_context);
+        auto time = rc.ElapseFromBegin("done");
+        time *= 0.001;  // convert to ms
+        this->node->GetRangeSearchLatencyMetric().Observe(time);
 
-    // LCOV_EXCL_START
-    if (has_trace_id) {
-        span->End();
-    }
-    // LCOV_EXCL_STOP
+        // LCOV_EXCL_START
+        if (has_trace_id) {
+            span->End();
+        }
+        // LCOV_EXCL_STOP
 #else
-    auto res = this->node->RangeSearchEmbListIfNeed(dataset, std::move(cfg), bitset, op_context);
+        auto res = this->node->RangeSearchEmbListIfNeed(dataset, std::move(cfg), bitset, op_context);
 #endif
-    return res;
+        return res;
+    });
 }
 
 template <typename T>
 inline expected<DataSetPtr>
-Index<T>::GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context) const {
-    return this->node->GetVectorByIds(dataset, op_context);
+Index<T>::GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context) const noexcept {
+    return GuardedCall([&]() { return this->node->GetVectorByIds(dataset, op_context); });
 }
 
 template <typename T>
 inline expected<DataSetPtr>
 Index<T>::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_type,
-                          milvus::OpContext* op_context) const {
-    return this->node->GetEmbListByIds(dataset, metric_type, op_context);
+                          milvus::OpContext* op_context) const noexcept {
+    return GuardedCall([&]() { return this->node->GetEmbListByIds(dataset, metric_type, op_context); });
 }
 
 template <typename T>
 inline expected<DataSetPtr>
 Index<T>::CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels,
-                        const size_t labels_len, const bool is_cosine, milvus::OpContext* op_context) const {
-    return this->node->CalcDistByIDs(dataset, bitset, labels, labels_len, is_cosine, op_context);
+                        const size_t labels_len, const bool is_cosine, milvus::OpContext* op_context) const noexcept {
+    return GuardedCall(
+        [&]() { return this->node->CalcDistByIDs(dataset, bitset, labels, labels_len, is_cosine, op_context); });
 }
 
 template <typename T>
 inline bool
-Index<T>::HasRawData(const std::string& metric_type) const {
-    return this->node->HasRawData(metric_type);
+Index<T>::HasRawData(const std::string& metric_type) const noexcept {
+    return GuardedCall([&]() { return this->node->HasRawData(metric_type); });
 }
 
 template <typename T>
 inline bool
-Index<T>::IsAdditionalScalarSupported(bool is_mv_only) const {
-    return this->node->IsAdditionalScalarSupported(is_mv_only);
+Index<T>::IsAdditionalScalarSupported(bool is_mv_only) const noexcept {
+    return GuardedCall([&]() { return this->node->IsAdditionalScalarSupported(is_mv_only); });
 }
 
 template <typename T>
 inline bool
-Index<T>::IsIndexRefineEnabled() const {
-    return this->node->IsIndexRefineEnabled();
+Index<T>::IsIndexRefineEnabled() const noexcept {
+    return GuardedCall([&]() { return this->node->IsIndexRefineEnabled(); });
 }
 
 template <typename T>
 inline expected<DataSetPtr>
-Index<T>::GetIndexMeta(const Json& json) const {
-    auto cfg = this->node->CreateConfig();
-    std::string msg;
-    auto status = LoadConfig(cfg.get(), json, knowhere::FEDER, "GetIndexMeta", &msg);
-    if (status != Status::success) {
-        return expected<DataSetPtr>::Err(status, msg);
-    }
-    return this->node->GetIndexMeta(std::move(cfg));
+Index<T>::GetIndexMeta(const Json& json) const noexcept {
+    return GuardedCall([&]() -> expected<DataSetPtr> {
+        auto cfg = this->node->CreateConfig();
+        std::string msg;
+        auto status = LoadConfig(cfg.get(), json, knowhere::FEDER, "GetIndexMeta", &msg);
+        if (status != Status::success) {
+            return expected<DataSetPtr>::Err(status, msg);
+        }
+        return this->node->GetIndexMeta(std::move(cfg));
+    });
 }
 
 template <typename T>
 inline Status
-Index<T>::Serialize(BinarySet& binset) const {
-    return this->node->SerializeEmbListIfNeed(binset);
+Index<T>::Serialize(BinarySet& binset) const noexcept {
+    return GuardedCall([&]() { return this->node->SerializeEmbListIfNeed(binset); });
 }
 
 template <typename T>
 inline Status
-Index<T>::Deserialize(const BinarySet& binset, const Json& json) {
-    Json json_(json);
-    auto cfg = this->node->CreateConfig();
-    {
-        auto res = Config::FormatAndCheck(*cfg, json_);
-        LOG_KNOWHERE_DEBUG_ << "Deserialize config dump: " << json_.dump();
+Index<T>::Deserialize(const BinarySet& binset, const Json& json) noexcept {
+    return GuardedCall([&]() -> Status {
+        Json json_(json);
+        auto cfg = this->node->CreateConfig();
+        {
+            auto res = Config::FormatAndCheck(*cfg, json_);
+            LOG_KNOWHERE_DEBUG_ << "Deserialize config dump: " << json_.dump();
+            if (res != Status::success) {
+                return res;
+            }
+        }
+        auto res = Config::Load(*cfg, json_, knowhere::DESERIALIZE);
         if (res != Status::success) {
             return res;
         }
-    }
-    auto res = Config::Load(*cfg, json_, knowhere::DESERIALIZE);
-    if (res != Status::success) {
-        return res;
-    }
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
-    TimeRecorder rc("Load index", 2);
-    res = this->node->DeserializeEmbListIfNeed(binset, std::move(cfg));
-    auto time = rc.ElapseFromBegin("done");
-    time *= 0.001;  // convert to ms
-    this->node->GetLoadLatencyMetric().Observe(time);
+        TimeRecorder rc("Load index", 2);
+        res = this->node->DeserializeEmbListIfNeed(binset, std::move(cfg));
+        auto time = rc.ElapseFromBegin("done");
+        time *= 0.001;  // convert to ms
+        this->node->GetLoadLatencyMetric().Observe(time);
 #else
-    res = this->node->DeserializeEmbListIfNeed(binset, std::move(cfg));
+        res = this->node->DeserializeEmbListIfNeed(binset, std::move(cfg));
 #endif
-    return res;
+        return res;
+    });
 }
 
 template <typename T>
 inline Status
-Index<T>::DeserializeFromFile(const std::string& filename, const Json& json) {
-    Json json_(json);
-    auto cfg = this->node->CreateConfig();
-    {
-        auto res = Config::FormatAndCheck(*cfg, json_);
-        LOG_KNOWHERE_DEBUG_ << "DeserializeFromFile config dump: " << json_.dump();
+Index<T>::DeserializeFromFile(const std::string& filename, const Json& json) noexcept {
+    return GuardedCall([&]() -> Status {
+        Json json_(json);
+        auto cfg = this->node->CreateConfig();
+        {
+            auto res = Config::FormatAndCheck(*cfg, json_);
+            LOG_KNOWHERE_DEBUG_ << "DeserializeFromFile config dump: " << json_.dump();
+            if (res != Status::success) {
+                return res;
+            }
+        }
+        auto res = Config::Load(*cfg, json_, knowhere::DESERIALIZE_FROM_FILE);
         if (res != Status::success) {
             return res;
         }
-    }
-    auto res = Config::Load(*cfg, json_, knowhere::DESERIALIZE_FROM_FILE);
-    if (res != Status::success) {
-        return res;
-    }
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
-    TimeRecorder rc("Load index from file", 2);
-    res = this->node->DeserializeFromFileIfNeed(filename, std::move(cfg));
-    auto time = rc.ElapseFromBegin("done");
-    time *= 0.001;  // convert to ms
-    this->node->GetLoadLatencyMetric().Observe(time);
+        TimeRecorder rc("Load index from file", 2);
+        res = this->node->DeserializeFromFileIfNeed(filename, std::move(cfg));
+        auto time = rc.ElapseFromBegin("done");
+        time *= 0.001;  // convert to ms
+        this->node->GetLoadLatencyMetric().Observe(time);
 #else
-    res = this->node->DeserializeFromFileIfNeed(filename, std::move(cfg));
+        res = this->node->DeserializeFromFileIfNeed(filename, std::move(cfg));
 #endif
-    return res;
+        return res;
+    });
 }
 
 template <typename T>
 inline int64_t
-Index<T>::Dim() const {
-    return this->node->Dim();
+Index<T>::Dim() const noexcept {
+    return GuardedCall([&]() { return this->node->Dim(); });
 }
 
 template <typename T>
 inline int64_t
-Index<T>::Size() const {
-    return this->node->Size();
+Index<T>::Size() const noexcept {
+    return GuardedCall([&]() { return this->node->Size(); });
 }
 
 template <typename T>
 inline int64_t
-Index<T>::Count() const {
-    return this->node->Count();
+Index<T>::Count() const noexcept {
+    return GuardedCall([&]() { return this->node->Count(); });
 }
 
 template <typename T>
 inline std::string
-Index<T>::Type() const {
-    return this->node->Type();
+Index<T>::Type() const noexcept {
+    return GuardedCall([&]() { return this->node->Type(); });
 }
 
 template <typename T>
 inline bool
-Index<T>::LoadIndexWithStream() const {
-    return this->node->LoadIndexWithStream();
+Index<T>::LoadIndexWithStream() const noexcept {
+    return GuardedCall([&]() { return this->node->LoadIndexWithStream(); });
 }
 
 template class Index<IndexNode>;

--- a/src/index/index_factory.cc
+++ b/src/index/index_factory.cc
@@ -47,38 +47,41 @@ checkGpuAvailable(const std::string& name) {
 
 template <typename DataType>
 expected<Index<IndexNode>>
-IndexFactory::Create(const std::string& name, const int32_t& version, const Object& object) {
-    static_assert(KnowhereDataTypeCheck<DataType>::value == true);
-    auto& func_mapping_ = MapInstance();
-    auto key = GetKey<DataType>(name);
-    if (func_mapping_.find(key) == func_mapping_.end()) {
-        LOG_KNOWHERE_ERROR_ << "failed to find index " << key << " in factory";
-        return expected<Index<IndexNode>>::Err(Status::invalid_index_error, "index not supported");
-    }
-    LOG_KNOWHERE_INFO_ << "use key " << key << " to create knowhere index " << name << " with version " << version;
-    auto fun_map_v = static_cast<FunMapValue<Index<IndexNode>>*>(func_mapping_[key].get());
+IndexFactory::Create(const std::string& name, const int32_t& version, const Object& object) noexcept {
+    return GuardedCall([&]() -> expected<Index<IndexNode>> {
+        static_assert(KnowhereDataTypeCheck<DataType>::value == true);
+        auto& func_mapping_ = MapInstance();
+        auto key = GetKey<DataType>(name);
+        if (func_mapping_.find(key) == func_mapping_.end()) {
+            LOG_KNOWHERE_ERROR_ << "failed to find index " << key << " in factory";
+            return expected<Index<IndexNode>>::Err(Status::invalid_index_error, "index not supported");
+        }
+        LOG_KNOWHERE_INFO_ << "use key " << key << " to create knowhere index " << name << " with version " << version;
+        auto fun_map_v = static_cast<FunMapValue<Index<IndexNode>>*>(func_mapping_[key].get());
 
 #ifdef KNOWHERE_WITH_CUVS
-    if (!checkGpuAvailable(name)) {
-        return expected<Index<IndexNode>>::Err(Status::cuda_runtime_error, "gpu not available");
-    }
+        if (!checkGpuAvailable(name)) {
+            return expected<Index<IndexNode>>::Err(Status::cuda_runtime_error, "gpu not available");
+        }
 #endif
-    if (name == knowhere::IndexEnum::INDEX_FAISS_SCANN && !faiss::cppcontrib::knowhere::support_pq_fast_scan) {
-        LOG_KNOWHERE_ERROR_ << "SCANN index is not supported on the current CPU model";
-        return expected<Index<IndexNode>>::Err(Status::invalid_index_error,
-                                               "SCANN index is not supported on the current CPU model");
-    }
+        if (name == knowhere::IndexEnum::INDEX_FAISS_SCANN && !faiss::cppcontrib::knowhere::support_pq_fast_scan) {
+            LOG_KNOWHERE_ERROR_ << "SCANN index is not supported on the current CPU model";
+            return expected<Index<IndexNode>>::Err(Status::invalid_index_error,
+                                                   "SCANN index is not supported on the current CPU model");
+        }
 
 #ifdef KNOWHERE_WITH_SVS
-    if ((name == knowhere::IndexEnum::INDEX_SVS_VAMANA_LVQ || name == knowhere::IndexEnum::INDEX_SVS_VAMANA_LEANVEC) &&
-        !faiss::IndexSVSVamana::is_lvq_leanvec_enabled()) {
-        LOG_KNOWHERE_ERROR_ << "SVS LVQ/LeanVec indices are only supported on Intel CPUs";
-        return expected<Index<IndexNode>>::Err(Status::invalid_index_error,
-                                               "SVS LVQ/LeanVec indices are only supported on Intel CPUs");
-    }
+        if ((name == knowhere::IndexEnum::INDEX_SVS_VAMANA_LVQ ||
+             name == knowhere::IndexEnum::INDEX_SVS_VAMANA_LEANVEC) &&
+            !faiss::IndexSVSVamana::is_lvq_leanvec_enabled()) {
+            LOG_KNOWHERE_ERROR_ << "SVS LVQ/LeanVec indices are only supported on Intel CPUs";
+            return expected<Index<IndexNode>>::Err(Status::invalid_index_error,
+                                                   "SVS LVQ/LeanVec indices are only supported on Intel CPUs");
+        }
 #endif
 
-    return fun_map_v->fun_value(version, object);
+        return fun_map_v->fun_value(version, object);
+    });
 }
 
 template <typename DataType>
@@ -102,7 +105,7 @@ IndexFactory::Register(const std::string& name, std::function<Index<IndexNode>(c
 }
 
 IndexFactory&
-IndexFactory::Instance() {
+IndexFactory::Instance() noexcept {
     static IndexFactory factory;
     return factory;
 }
@@ -122,20 +125,22 @@ IndexFactory::FeatureMapInstance() {
 }
 
 IndexFactory::GlobalIndexTable&
-IndexFactory::StaticIndexTableInstance() {
+IndexFactory::StaticIndexTableInstance() noexcept {
     static GlobalIndexTable static_index_table;
     return static_index_table;
 }
 
 bool
-IndexFactory::FeatureCheck(const std::string& name, uint64_t feature) const {
-    auto& feature_mapping_ = IndexFactory::FeatureMapInstance();
-    assert(feature_mapping_.find(name) != feature_mapping_.end());
-    return (feature_mapping_[name] & feature) == feature;
+IndexFactory::FeatureCheck(const std::string& name, uint64_t feature) const noexcept {
+    return GuardedCall([&]() {
+        auto& feature_mapping_ = IndexFactory::FeatureMapInstance();
+        assert(feature_mapping_.find(name) != feature_mapping_.end());
+        return (feature_mapping_[name] & feature) == feature;
+    });
 }
 
 const std::map<std::string, uint64_t>&
-IndexFactory::GetIndexFeatures() {
+IndexFactory::GetIndexFeatures() noexcept {
     return FeatureMapInstance();
 }
 

--- a/src/index/index_static.cc
+++ b/src/index/index_static.cc
@@ -20,6 +20,13 @@ namespace knowhere {
 inline Status
 LoadStaticConfig(BaseConfig* cfg, const Json& json, knowhere::PARAM_TYPE param_type, const std::string& method,
                  std::string* const msg = nullptr) {
+    if (cfg == nullptr) {
+        if (msg != nullptr) {
+            *msg = "failed to create config";
+        }
+        LOG_KNOWHERE_ERROR_ << method << " failed to create config";
+        return Status::knowhere_inner_error;
+    }
     Json json_(json);
     auto res = Config::FormatAndCheck(*cfg, json_, msg);
     LOG_KNOWHERE_DEBUG_ << method << " config dump: " << json_.dump();
@@ -36,39 +43,43 @@ IndexStaticFaced<DataType>::Instance() {
 
 template <typename DataType>
 std::unique_ptr<BaseConfig>
-IndexStaticFaced<DataType>::CreateConfig(const IndexType& indexType, const IndexVersion& version) {
-    if (Instance().staticCreateConfigMap.find(indexType) != Instance().staticCreateConfigMap.end()) {
-        return Instance().staticCreateConfigMap[indexType]();
-    }
-    LOG_KNOWHERE_WARNING_ << "unhandled create config for indexType: " << indexType;
-    return std::make_unique<BaseConfig>();
+IndexStaticFaced<DataType>::CreateConfig(const IndexType& indexType, const IndexVersion& version) noexcept {
+    return GuardedCall([&]() -> std::unique_ptr<BaseConfig> {
+        if (Instance().staticCreateConfigMap.find(indexType) != Instance().staticCreateConfigMap.end()) {
+            return Instance().staticCreateConfigMap[indexType]();
+        }
+        LOG_KNOWHERE_WARNING_ << "unhandled create config for indexType: " << indexType;
+        return std::make_unique<BaseConfig>();
+    });
 }
 
 template <typename DataType>
 knowhere::Status
 IndexStaticFaced<DataType>::ConfigCheck(const IndexType& indexType, const IndexVersion& version, const Json& params,
-                                        std::string& msg) {
-    auto cfg = IndexStaticFaced<DataType>::CreateConfig(indexType, version);
+                                        std::string& msg) noexcept {
+    return GuardedCall([&]() -> Status {
+        auto cfg = IndexStaticFaced<DataType>::CreateConfig(indexType, version);
 
-    const Status status = LoadStaticConfig(cfg.get(), params, knowhere::PARAM_TYPE::TRAIN, "ConfigCheck", &msg);
-    if (status != Status::success) {
-        LOG_KNOWHERE_ERROR_ << "Load Config failed, msg = " << msg;
-        return status;
-    }
-
-    if constexpr (!std::is_same_v<DataType, knowhere::fp32>) {
-        auto strategy = cfg->emb_list_strategy.value_or("");
-        if (strategy == meta::EMB_LIST_STRATEGY_MUVERA || strategy == meta::EMB_LIST_STRATEGY_LEMUR) {
-            msg = "MUVERA/LEMUR strategies only support fp32 data type, got '" + strategy + "'";
-            return Status::invalid_args;
+        const Status status = LoadStaticConfig(cfg.get(), params, knowhere::PARAM_TYPE::TRAIN, "ConfigCheck", &msg);
+        if (status != Status::success) {
+            LOG_KNOWHERE_ERROR_ << "Load Config failed, msg = " << msg;
+            return status;
         }
-    }
 
-    if (Instance().staticConfigCheckMap.find(indexType) != Instance().staticConfigCheckMap.end()) {
-        return Instance().staticConfigCheckMap[indexType](*cfg, knowhere::PARAM_TYPE::TRAIN, msg);
-    }
+        if constexpr (!std::is_same_v<DataType, knowhere::fp32>) {
+            auto strategy = cfg->emb_list_strategy.value_or("");
+            if (strategy == meta::EMB_LIST_STRATEGY_MUVERA || strategy == meta::EMB_LIST_STRATEGY_LEMUR) {
+                msg = "MUVERA/LEMUR strategies only support fp32 data type, got '" + strategy + "'";
+                return Status::invalid_args;
+            }
+        }
 
-    return knowhere::Status::success;
+        if (Instance().staticConfigCheckMap.find(indexType) != Instance().staticConfigCheckMap.end()) {
+            return Instance().staticConfigCheckMap[indexType](*cfg, knowhere::PARAM_TYPE::TRAIN, msg);
+        }
+
+        return knowhere::Status::success;
+    });
 }
 
 template <typename DataType>
@@ -76,21 +87,25 @@ expected<Resource>
 IndexStaticFaced<DataType>::EstimateLoadResource(const knowhere::IndexType& indexType,
                                                  const knowhere::IndexVersion& version,
                                                  const uint64_t file_size_in_bytes, const int64_t num_rows,
-                                                 const int64_t dim, const knowhere::Json& params) {
-    auto cfg = IndexStaticFaced<DataType>::CreateConfig(indexType, version);
+                                                 const int64_t dim, const knowhere::Json& params) noexcept {
+    return GuardedCall([&]() -> expected<Resource> {
+        auto cfg = IndexStaticFaced<DataType>::CreateConfig(indexType, version);
 
-    std::string msg;
-    const Status status = LoadStaticConfig(cfg.get(), params, knowhere::STATIC, "EstimateLoadResource", &msg);
-    if (status != Status::success) {
-        LOG_KNOWHERE_ERROR_ << "Load Config failed, msg = " << msg;
-        return expected<Resource>::Err(status, msg);
-    }
+        std::string msg;
+        const Status status = LoadStaticConfig(cfg.get(), params, knowhere::STATIC, "EstimateLoadResource", &msg);
+        if (status != Status::success) {
+            LOG_KNOWHERE_ERROR_ << "Load Config failed, msg = " << msg;
+            return expected<Resource>::Err(status, msg);
+        }
 
-    if (Instance().staticEstimateLoadResourceMap.find(indexType) != Instance().staticEstimateLoadResourceMap.end()) {
-        return Instance().staticEstimateLoadResourceMap[indexType](file_size_in_bytes, num_rows, dim, *cfg, version);
-    }
+        if (Instance().staticEstimateLoadResourceMap.find(indexType) !=
+            Instance().staticEstimateLoadResourceMap.end()) {
+            return Instance().staticEstimateLoadResourceMap[indexType](file_size_in_bytes, num_rows, dim, *cfg,
+                                                                       version);
+        }
 
-    return InternalEstimateLoadResource(file_size_in_bytes, num_rows, dim, *cfg, version);
+        return InternalEstimateLoadResource(file_size_in_bytes, num_rows, dim, *cfg, version);
+    });
 }
 
 template <typename DataType>
@@ -111,32 +126,36 @@ IndexStaticFaced<DataType>::InternalEstimateLoadResource(const uint64_t file_siz
 
 template <typename DataType>
 bool
-IndexStaticFaced<DataType>::HasRawData(const IndexType& indexType, const IndexVersion& version, const Json& params) {
-    auto cfg = IndexStaticFaced<DataType>::CreateConfig(indexType, version);
-    std::string msg;
-    const Status status = LoadStaticConfig(cfg.get(), params, knowhere::STATIC, "HasRawData", &msg);
+IndexStaticFaced<DataType>::HasRawData(const IndexType& indexType, const IndexVersion& version,
+                                       const Json& params) noexcept {
+    return GuardedCall([&]() {
+        auto cfg = IndexStaticFaced<DataType>::CreateConfig(indexType, version);
+        std::string msg;
+        const Status status = LoadStaticConfig(cfg.get(), params, knowhere::STATIC, "HasRawData", &msg);
 
-    if (status != Status::success) {
-        LOG_KNOWHERE_ERROR_ << "Load Config failed, msg = " << msg;
-        return false;
-    }
+        if (status != Status::success) {
+            LOG_KNOWHERE_ERROR_ << "Load Config failed, msg = " << msg;
+            return false;
+        }
 
-    if (Instance().staticHasRawDataMap.find(indexType) != Instance().staticHasRawDataMap.end()) {
-        return Instance().staticHasRawDataMap[indexType](*cfg, version);
-    }
+        if (Instance().staticHasRawDataMap.find(indexType) != Instance().staticHasRawDataMap.end()) {
+            return Instance().staticHasRawDataMap[indexType](*cfg, version);
+        }
 
-    static std::set<knowhere::IndexType> has_raw_data_index_set = {
-        IndexEnum::INDEX_FAISS_BIN_IDMAP, IndexEnum::INDEX_FAISS_BIN_IVFFLAT, IndexEnum::INDEX_FAISS_IVFFLAT,
-        IndexEnum::INDEX_FAISS_IVFFLAT_CC};
+        static std::set<knowhere::IndexType> has_raw_data_index_set = {
+            IndexEnum::INDEX_FAISS_BIN_IDMAP, IndexEnum::INDEX_FAISS_BIN_IVFFLAT, IndexEnum::INDEX_FAISS_IVFFLAT,
+            IndexEnum::INDEX_FAISS_IVFFLAT_CC};
 
-    static std::set<knowhere::IndexType> has_raw_data_index_alias_set = {"IVFBIN", "BINFLAT", "IVFFLAT", "IVFFLATCC"};
+        static std::set<knowhere::IndexType> has_raw_data_index_alias_set = {"IVFBIN", "BINFLAT", "IVFFLAT",
+                                                                             "IVFFLATCC"};
 
-    if (has_raw_data_index_set.find(indexType) != has_raw_data_index_set.end() ||
-        has_raw_data_index_alias_set.find(indexType) != has_raw_data_index_alias_set.end()) {
-        return true;
-    }
+        if (has_raw_data_index_set.find(indexType) != has_raw_data_index_set.end() ||
+            has_raw_data_index_alias_set.find(indexType) != has_raw_data_index_alias_set.end()) {
+            return true;
+        }
 
-    return InternalStaticHasRawData(*cfg, version);
+        return InternalStaticHasRawData(*cfg, version);
+    });
 }
 
 template <typename DataType>

--- a/tests/ut/test_diskann.cc
+++ b/tests/ut/test_diskann.cc
@@ -838,7 +838,8 @@ TEST_CASE("Test_AiSAQ_dynamic_cache", "[diskann]") {
              read_page_cache_size += 4096) {
             knn_json["pq_read_page_cache_size"] = read_page_cache_size;
             auto start = std::chrono::high_resolution_clock::now();
-            diskann.Search(query_ds, knn_json, nullptr);
+            auto loop_results = diskann.Search(query_ds, knn_json, nullptr);
+            REQUIRE(loop_results.has_value());
             auto end = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
             std::cout << "*********************** Run time: " << duration.count() << " ms"

--- a/tests/ut/test_emb_list.cc
+++ b/tests/ut/test_emb_list.cc
@@ -2679,7 +2679,8 @@ TEST_CASE("EmbList Serialization", "Strategy and IndexNode serialization/deseria
 
         const size_t* lims = default_ds_ptr->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
         knowhere::EmbListOffset doc_offset(std::vector<size_t>(lims, lims + NB / EACH_EL_LEN + 1));
-        strategy->PrepareDataForBuild(default_ds_ptr, doc_offset, cfg);
+        auto prep_result = strategy->PrepareDataForBuild(default_ds_ptr, doc_offset, cfg);
+        REQUIRE(prep_result.has_value());
 
         std::shared_ptr<uint8_t[]> data;
         int64_t size = 0;
@@ -2702,7 +2703,8 @@ TEST_CASE("EmbList Serialization", "Strategy and IndexNode serialization/deseria
 
         const size_t* lims = default_ds_ptr->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
         knowhere::EmbListOffset doc_offset(std::vector<size_t>(lims, lims + NB / EACH_EL_LEN + 1));
-        strategy_or.value()->PrepareDataForBuild(default_ds_ptr, doc_offset, cfg);
+        auto prep_result = strategy_or.value()->PrepareDataForBuild(default_ds_ptr, doc_offset, cfg);
+        REQUIRE(prep_result.has_value());
 
         std::shared_ptr<uint8_t[]> data;
         int64_t size = 0;
@@ -2763,7 +2765,8 @@ TEST_CASE("EmbList Serialization", "Strategy and IndexNode serialization/deseria
 
         const size_t* lims = default_ds_ptr->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
         knowhere::EmbListOffset doc_offset(std::vector<size_t>(lims, lims + NB / EACH_EL_LEN + 1));
-        strategy_or.value()->PrepareDataForBuild(default_ds_ptr, doc_offset, cfg);
+        auto prep_result = strategy_or.value()->PrepareDataForBuild(default_ds_ptr, doc_offset, cfg);
+        REQUIRE(prep_result.has_value());
 
         std::shared_ptr<uint8_t[]> data;
         int64_t size = 0;
@@ -2789,7 +2792,8 @@ TEST_CASE("EmbList Serialization", "Strategy and IndexNode serialization/deseria
 
         const size_t* lims = default_ds_ptr->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
         knowhere::EmbListOffset doc_offset(std::vector<size_t>(lims, lims + NB / EACH_EL_LEN + 1));
-        strategy_or.value()->PrepareDataForBuild(default_ds_ptr, doc_offset, cfg);
+        auto prep_result = strategy_or.value()->PrepareDataForBuild(default_ds_ptr, doc_offset, cfg);
+        REQUIRE(prep_result.has_value());
 
         std::shared_ptr<uint8_t[]> data;
         int64_t size = 0;

--- a/tests/ut/test_error_code.cc
+++ b/tests/ut/test_error_code.cc
@@ -1,0 +1,171 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+// the License for the specific language governing permissions and limitations under the License.
+
+#include "catch2/catch_test_macros.hpp"
+#include "knowhere/comp/brute_force.h"
+#include "knowhere/index/index.h"
+#include "knowhere/index/index_static.h"
+
+namespace {
+
+class ThrowingIndexNode : public knowhere::IndexNode {
+ public:
+    knowhere::Status
+    Train(const knowhere::DataSetPtr, std::shared_ptr<knowhere::Config>, bool) override {
+        throw std::runtime_error("boom train");
+    }
+
+    knowhere::Status
+    Add(const knowhere::DataSetPtr, std::shared_ptr<knowhere::Config>, bool) override {
+        throw std::runtime_error("boom add");
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    Search(const knowhere::DataSetPtr, std::unique_ptr<knowhere::Config>, const knowhere::BitsetView&,
+           milvus::OpContext*) const override {
+        throw std::runtime_error("boom search");
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    RangeSearch(const knowhere::DataSetPtr, std::unique_ptr<knowhere::Config>, const knowhere::BitsetView&,
+                milvus::OpContext*) const override {
+        throw std::runtime_error("boom range search");
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    GetVectorByIds(const knowhere::DataSetPtr, milvus::OpContext*) const override {
+        throw std::runtime_error("boom get vector");
+    }
+
+    bool
+    HasRawData(const std::string&) const override {
+        throw std::runtime_error("boom raw data");
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    GetIndexMeta(std::unique_ptr<knowhere::Config>) const override {
+        throw std::runtime_error("boom meta");
+    }
+
+    knowhere::Status
+    Serialize(knowhere::BinarySet&) const override {
+        throw std::runtime_error("boom serialize");
+    }
+
+    knowhere::Status
+    Deserialize(const knowhere::BinarySet&, std::shared_ptr<knowhere::Config>) override {
+        throw std::runtime_error("boom deserialize");
+    }
+
+    knowhere::Status
+    DeserializeFromFile(const std::string&, std::shared_ptr<knowhere::Config>) override {
+        throw std::runtime_error("boom deserialize file");
+    }
+
+    std::unique_ptr<knowhere::BaseConfig>
+    CreateConfig() const override {
+        return std::make_unique<knowhere::BaseConfig>();
+    }
+
+    int64_t
+    Dim() const override {
+        throw std::runtime_error("boom dim");
+    }
+
+    int64_t
+    Size() const override {
+        throw std::runtime_error("boom size");
+    }
+
+    int64_t
+    Count() const override {
+        throw std::runtime_error("boom count");
+    }
+
+    std::string
+    Type() const override {
+        throw std::runtime_error("boom type");
+    }
+};
+
+knowhere::Index<knowhere::IndexNode>
+CreateThrowingIndex() {
+    return knowhere::Index<ThrowingIndexNode>::Create();
+}
+
+class ThrowingStaticIndexNode {
+ public:
+    static std::unique_ptr<knowhere::BaseConfig>
+    StaticCreateConfig() {
+        throw std::runtime_error("boom static create config");
+    }
+};
+
+}  // namespace
+
+TEST_CASE("Status category separates input and inner errors", "[error_code]") {
+    STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::invalid_args) == knowhere::StatusCategory::input_error);
+    STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::invalid_param_in_json) ==
+                   knowhere::StatusCategory::input_error);
+    STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::faiss_inner_error) ==
+                   knowhere::StatusCategory::inner_error);
+    STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::internal_error) ==
+                   knowhere::StatusCategory::inner_error);
+    STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::knowhere_inner_error) ==
+                   knowhere::StatusCategory::inner_error);
+
+    REQUIRE(knowhere::IsInputError(knowhere::Status::invalid_metric_type));
+    REQUIRE_FALSE(knowhere::IsInputError(knowhere::Status::faiss_inner_error));
+    REQUIRE(knowhere::IsInnerError(knowhere::Status::brute_force_inner_error));
+    REQUIRE_FALSE(knowhere::IsInnerError(knowhere::Status::invalid_value_in_json));
+}
+
+TEST_CASE("Index facade APIs are noexcept and convert exceptions to error codes", "[error_code]") {
+    auto index = CreateThrowingIndex();
+    auto ds = std::make_shared<knowhere::DataSet>();
+    knowhere::BinarySet binset;
+
+    STATIC_REQUIRE(noexcept(index.GetVectorByIds(ds)));
+    STATIC_REQUIRE(noexcept(index.Serialize(binset)));
+    STATIC_REQUIRE(noexcept(index.Count()));
+    STATIC_REQUIRE(noexcept(index.Type()));
+    STATIC_REQUIRE(
+        noexcept(knowhere::BruteForce::Search<knowhere::fp32>(ds, ds, knowhere::Json{}, knowhere::BitsetView{})));
+    STATIC_REQUIRE(noexcept(knowhere::BruteForce::SearchWithBuf<knowhere::fp32>(
+        ds, ds, static_cast<int64_t*>(nullptr), static_cast<float*>(nullptr), knowhere::Json{},
+        knowhere::BitsetView{})));
+
+    const auto get_vector_result = index.GetVectorByIds(ds);
+    REQUIRE(get_vector_result.error() == knowhere::Status::knowhere_inner_error);
+    REQUIRE(std::string(get_vector_result.what()).find("boom get vector") != std::string::npos);
+
+    REQUIRE(index.Serialize(binset) == knowhere::Status::knowhere_inner_error);
+    REQUIRE(index.Count() == 0);
+    REQUIRE(index.Type().empty());
+}
+
+TEST_CASE("Index static facade APIs handle config creation failures", "[error_code]") {
+    const knowhere::IndexType index_type = "THROWING_STATIC_CONFIG";
+    constexpr knowhere::IndexVersion version = 0;
+    knowhere::IndexStaticFaced<knowhere::fp32>::Instance().RegisterStaticFunc<ThrowingStaticIndexNode>(index_type);
+
+    std::string msg;
+    REQUIRE(knowhere::IndexStaticFaced<knowhere::fp32>::ConfigCheck(index_type, version, knowhere::Json{}, msg) ==
+            knowhere::Status::knowhere_inner_error);
+    REQUIRE(msg == "failed to create config");
+
+    auto resource = knowhere::IndexStaticFaced<knowhere::fp32>::EstimateLoadResource(index_type, version, 1024, 10, 4,
+                                                                                     knowhere::Json{});
+    REQUIRE(resource.error() == knowhere::Status::knowhere_inner_error);
+    REQUIRE(resource.what() == "failed to create config");
+
+    REQUIRE_FALSE(knowhere::IndexStaticFaced<knowhere::fp32>::HasRawData(index_type, version, knowhere::Json{}));
+}


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/1674

## Summary
- Add guarded facade calls so C++ exceptions are converted to error-code based results.
- Mark public facade APIs as `noexcept` and preserve existing returned status values.
- Add status-category helpers and unit coverage for error-code behavior.
