### PR TITLE
enhance: keep knowhere sparse with cardinal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,8 +191,6 @@ if(WITH_CARDINAL)
   list(APPEND CARDINAL_LIBS cardinalv1)
   add_subdirectory(cmake/libs/cardinal/v2)
   list(APPEND CARDINAL_LIBS cardinalv2)
-  knowhere_file_glob(GLOB_RECURSE KNOWHERE_SPARSE_NODE_SRCS src/index/sparse/sparse_index_node.cc)
-  list(REMOVE_ITEM KNOWHERE_SRCS ${KNOWHERE_SPARSE_NODE_SRCS})
 endif()
 
 # Sparse codec C files (not captured by *.cc globs)
@@ -288,6 +286,9 @@ target_link_libraries(knowhere PUBLIC ${KNOWHERE_LINKER_LIBS})
 target_link_libraries(knowhere PUBLIC Boost::boost nlohmann_json::nlohmann_json glog::glog Folly::folly prometheus-cpp::core opentelemetry-cpp::opentelemetry_trace)
 
 if (WITH_CARDINAL)
+  target_compile_definitions(knowhere PRIVATE
+    SPARSE_INDEX_VERSION_USE_RAW_DATA_THRESHOLD=7
+    SPARSE_INDEX_VERSION_SUPPORT_FP16_QUANT_FOR_IP=0)
   target_link_libraries(knowhere PRIVATE "-Wl,--no-as-needed" ${CARDINAL_LIBS} "-Wl,--as-needed")
 endif()
 


### PR DESCRIPTION
- Stop removing Knowhere sparse index node when building with Cardinal.
- Compile Knowhere sparse with Cardinalv1-compatible sparse version thresholds under WITH_CARDINAL.

related: #1671