### PR TITLE
fix: handle empty SINDI posting lists

### DIFF
--- a/src/index/sparse/sindi_inverted_index.h
+++ b/src/index/sparse/sindi_inverted_index.h
@@ -368,9 +368,6 @@ class SindiInvertedIndex : public DimMapInvertedIndex<DataType, AllowIncremental
             section_headers[0].type = InvertedIndexSectionType::POSTING_LISTS;
             section_headers[0].size = [&, this]() -> uint64_t {
                 size_t res = sizeof(uint32_t) * 3;
-                if (nr_dims == 0 || nr_windows_ == 0) {
-                    return res;
-                }
 
                 const size_t mask_sz = (nr_dims + 7) / 8;
                 res += mask_sz * sizeof(uint8_t);
@@ -382,6 +379,10 @@ class SindiInvertedIndex : public DimMapInvertedIndex<DataType, AllowIncremental
                 }
 
                 res += sizeof(uint32_t) * (nr_dims + 1);
+
+                if (nr_windows_ == 0) {
+                    return res;
+                }
 
                 auto total_postings = plists_dim_offsets_span_[nr_dims];
                 res += total_postings * sizeof(uint16_t);

--- a/tests/ut/utils.h
+++ b/tests/ut/utils.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "catch2/generators/catch_generators.hpp"
+#include "catch2/generators/catch_generators_range.hpp"
 #include "knowhere/binaryset.h"
 #include "knowhere/dataset.h"
 #include "knowhere/object.h"
@@ -419,7 +420,15 @@ GenerateRandomDistanceIdPair(size_t n) {
 
 inline auto
 GenTestVersionList() {
-    return GENERATE(as<int32_t>{}, knowhere::Version::GetCurrentVersion().VersionNumber());
+    static const auto versions = [] {
+        std::vector<int32_t> res = {knowhere::Version::GetCurrentVersion().VersionNumber()};
+        const auto maximum_version = knowhere::Version::GetMaximumVersion().VersionNumber();
+        if (maximum_version != res.front()) {
+            res.push_back(maximum_version);
+        }
+        return res;
+    }();
+    return GENERATE_COPY(from_range(versions));
 }
 
 inline auto


### PR DESCRIPTION
issue: #1555

- Fix SINDI POSTING_LISTS section size for empty sparse data by counting metadata and dim offsets before returning.
- Run sparse unit tests against both current and maximum knowhere index versions.