### PR TITLE
test: run version matrix against max version only

### DIFF
--- a/.github/actions/cache-restore/action.yaml
+++ b/.github/actions/cache-restore/action.yaml
@@ -9,6 +9,40 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Detect CPU Feature Bucket
+      id: cpu_feature
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        flags=""
+        if command -v lscpu >/dev/null 2>&1; then
+          flags="$(LC_ALL=C lscpu | awk -F: '/^(Flags|Features):/ {gsub(/^[[:space:]]+/, "", $2); print $2; exit}' | tr '[:upper:]' '[:lower:]')"
+        fi
+
+        if [ -z "${flags}" ] && command -v sysctl >/dev/null 2>&1; then
+          flags="$(sysctl -a machdep.cpu.features machdep.cpu.leaf7_features 2>/dev/null | tr '[:upper:]' '[:lower:]' || true)"
+        fi
+
+        if [ -z "${flags}" ] && [ -r /proc/cpuinfo ]; then
+          flags="$(awk -F: '/^(flags|Features)[[:space:]]*:/ {gsub(/^[[:space:]]+/, "", $2); print $2; exit}' /proc/cpuinfo | tr '[:upper:]' '[:lower:]')"
+        fi
+
+        features=()
+        for feature in avx512f avx512bw avx512vl avx512dq avx512cd avx512vnni avx512vbmi2 avx512vpopcntdq avx512_bf16 avx512_fp16 avx2 fma sse4_2 sve asimd; do
+          if grep -qw "${feature}" <<< "${flags}"; then
+            features+=("${feature}")
+          fi
+        done
+
+        if [ ${#features[@]} -eq 0 ]; then
+          bucket="cpu-generic"
+        else
+          bucket="cpu-$(IFS=_; echo "${features[*]}")"
+        fi
+
+        echo "bucket=${bucket}" >> "${GITHUB_OUTPUT}"
+        echo "Using cache CPU feature bucket: ${bucket}"
     - name: Cache CCache Volumes
       uses: actions/cache/restore@v4
       with:
@@ -19,8 +53,8 @@ runs:
         # inside the restored tarball still detects thirdparty source changes
         # via its own content hashing, so compilation correctness is unaffected.
         # Key must match cache-save/action.yaml exactly for exact-key hits.
-        key: knowhere-${{ inputs.os }}-${{ github.job }}-ccache-${{ hashFiles('src/**/*.cpp', 'src/**/*.cc', 'src/**/*.c', 'src/**/*.h', 'src/**/*.hpp', 'include/**/*.h', 'include/**/*.hpp', 'tests/**/*.cpp', 'tests/**/*.cc', 'tests/**/*.h', 'benchmark/**/*.cpp', 'benchmark/**/*.cc', 'benchmark/**/*.h', 'cmake/**', 'CMakeLists.txt', 'Makefile', 'conanfile.py') }}
-        restore-keys: knowhere-${{ inputs.os }}-${{ github.job }}-ccache-
+        key: knowhere-${{ inputs.os }}-${{ github.job }}-${{ steps.cpu_feature.outputs.bucket }}-ccache-${{ hashFiles('src/**/*.cpp', 'src/**/*.cc', 'src/**/*.c', 'src/**/*.h', 'src/**/*.hpp', 'include/**/*.h', 'include/**/*.hpp', 'tests/**/*.cpp', 'tests/**/*.cc', 'tests/**/*.h', 'benchmark/**/*.cpp', 'benchmark/**/*.cc', 'benchmark/**/*.h', 'cmake/**', 'CMakeLists.txt', 'Makefile', 'conanfile.py') }}
+        restore-keys: knowhere-${{ inputs.os }}-${{ github.job }}-${{ steps.cpu_feature.outputs.bucket }}-ccache-
     - name: Reset Conan package cache
       shell: bash
       run: rm -rf ~/.conan2/p
@@ -28,4 +62,4 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ~/.conan2
-        key: knowhere-${{ inputs.os }}-${{ github.job }}-conan2-${{ hashFiles('conanfile.py') }}
+        key: knowhere-${{ inputs.os }}-${{ github.job }}-${{ steps.cpu_feature.outputs.bucket }}-conan2-${{ hashFiles('conanfile.py') }}

--- a/.github/actions/cache-save/action.yaml
+++ b/.github/actions/cache-save/action.yaml
@@ -9,6 +9,40 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Detect CPU Feature Bucket
+      id: cpu_feature
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        flags=""
+        if command -v lscpu >/dev/null 2>&1; then
+          flags="$(LC_ALL=C lscpu | awk -F: '/^(Flags|Features):/ {gsub(/^[[:space:]]+/, "", $2); print $2; exit}' | tr '[:upper:]' '[:lower:]')"
+        fi
+
+        if [ -z "${flags}" ] && command -v sysctl >/dev/null 2>&1; then
+          flags="$(sysctl -a machdep.cpu.features machdep.cpu.leaf7_features 2>/dev/null | tr '[:upper:]' '[:lower:]' || true)"
+        fi
+
+        if [ -z "${flags}" ] && [ -r /proc/cpuinfo ]; then
+          flags="$(awk -F: '/^(flags|Features)[[:space:]]*:/ {gsub(/^[[:space:]]+/, "", $2); print $2; exit}' /proc/cpuinfo | tr '[:upper:]' '[:lower:]')"
+        fi
+
+        features=()
+        for feature in avx512f avx512bw avx512vl avx512dq avx512cd avx512vnni avx512vbmi2 avx512vpopcntdq avx512_bf16 avx512_fp16 avx2 fma sse4_2 sve asimd; do
+          if grep -qw "${feature}" <<< "${flags}"; then
+            features+=("${feature}")
+          fi
+        done
+
+        if [ ${#features[@]} -eq 0 ]; then
+          bucket="cpu-generic"
+        else
+          bucket="cpu-$(IFS=_; echo "${features[*]}")"
+        fi
+
+        echo "bucket=${bucket}" >> "${GITHUB_OUTPUT}"
+        echo "Using cache CPU feature bucket: ${bucket}"
     - name: Cache CCache Volumes
       uses: actions/cache/save@v4
       with:
@@ -19,9 +53,9 @@ runs:
         # inside the restored tarball still detects thirdparty source changes
         # via its own content hashing, so compilation correctness is unaffected.
         # Key must match cache-restore/action.yaml exactly for exact-key hits.
-        key: knowhere-${{ inputs.os }}-${{ github.job }}-ccache-${{ hashFiles('src/**/*.cpp', 'src/**/*.cc', 'src/**/*.c', 'src/**/*.h', 'src/**/*.hpp', 'include/**/*.h', 'include/**/*.hpp', 'tests/**/*.cpp', 'tests/**/*.cc', 'tests/**/*.h', 'benchmark/**/*.cpp', 'benchmark/**/*.cc', 'benchmark/**/*.h', 'cmake/**', 'CMakeLists.txt', 'Makefile', 'conanfile.py') }}
+        key: knowhere-${{ inputs.os }}-${{ github.job }}-${{ steps.cpu_feature.outputs.bucket }}-ccache-${{ hashFiles('src/**/*.cpp', 'src/**/*.cc', 'src/**/*.c', 'src/**/*.h', 'src/**/*.hpp', 'include/**/*.h', 'include/**/*.hpp', 'tests/**/*.cpp', 'tests/**/*.cc', 'tests/**/*.h', 'benchmark/**/*.cpp', 'benchmark/**/*.cc', 'benchmark/**/*.h', 'cmake/**', 'CMakeLists.txt', 'Makefile', 'conanfile.py') }}
     - name: Cache Conan Packages
       uses: actions/cache/save@v4
       with:
         path: ~/.conan2
-        key: knowhere-${{ inputs.os }}-${{ github.job }}-conan2-${{ hashFiles('conanfile.py') }}
+        key: knowhere-${{ inputs.os }}-${{ github.job }}-${{ steps.cpu_feature.outputs.bucket }}-conan2-${{ hashFiles('conanfile.py') }}

--- a/tests/ut/utils.h
+++ b/tests/ut/utils.h
@@ -23,7 +23,6 @@
 #include <vector>
 
 #include "catch2/generators/catch_generators.hpp"
-#include "catch2/generators/catch_generators_range.hpp"
 #include "knowhere/binaryset.h"
 #include "knowhere/dataset.h"
 #include "knowhere/object.h"
@@ -420,24 +419,12 @@ GenerateRandomDistanceIdPair(size_t n) {
 
 inline auto
 GenTestVersionList() {
-    static const auto versions = [] {
-        std::vector<int32_t> res = {knowhere::Version::GetCurrentVersion().VersionNumber()};
-        const auto maximum_version = knowhere::Version::GetMaximumVersion().VersionNumber();
-        if (maximum_version != res.front()) {
-            res.push_back(maximum_version);
-        }
-        return res;
-    }();
-    return GENERATE_COPY(from_range(versions));
+    return GENERATE(as<int32_t>{}, knowhere::Version::GetMaximumVersion().VersionNumber());
 }
 
 inline auto
 GenTestEmbListVersionList() {
-#ifdef KNOWHERE_WITH_CARDINAL
-    return GENERATE(as<int32_t>{}, std::max(knowhere::Version::GetCurrentVersion().VersionNumber(), 9));
-#else
-    return GENERATE(as<int32_t>{}, knowhere::Version::GetCurrentVersion().VersionNumber());
-#endif
+    return GENERATE(as<int32_t>{}, knowhere::Version::GetMaximumVersion().VersionNumber());
 }
 
 inline knowhere::DataSetPtr


### PR DESCRIPTION
## What changed

- Update `GenTestVersionList()` and `GenTestEmbListVersionList()` to generate only `knowhere::Version::GetMaximumVersion()`.
- Remove the now-unused Catch2 range generator include.
- Bucket GitHub Actions ccache and Conan caches by detected CPU features, following the same pattern as Cardinal commit https://github.com/zilliztech/cardinal/commit/592d5838d4ce6301281c58e567b9074bd690d24f.

## Why

PR https://github.com/zilliztech/knowhere/pull/1683 expanded the general version helper from current-version-only to current plus maximum version. That doubled version-aware UT matrices, including expensive DiskANN/AiSAQ cases. The EmbList helper also still generated the current version, so this PR keeps both helpers focused on the max supported version instead of running version 8 and version 11 paths for these callers.

While validating this PR, the GitHub-hosted `python3 wheel` job also reproduced a separate cache portability issue: a Conan cache produced on one CPU-feature set can be restored on another GitHub-hosted runner and fail at runtime with `Illegal instruction`. The cache bucket avoids reusing CPU-specific Conan/ccache artifacts across incompatible runners.

## Verification

- `grep -n 'return GENERATE(as<int32_t>{}, knowhere::Version::GetMaximumVersion().VersionNumber());' tests/ut/utils.h`
  - Shows both `GenTestVersionList()` and `GenTestEmbListVersionList()` returning max version.
- `rg -n 'from_range|catch_generators_range|GetCurrentVersion\(\)\.VersionNumber\(\)' tests/ut/utils.h`
  - No matches.
- `clang-format --dry-run --Werror tests/ut/utils.h`
- `git diff --check`
- `python3 -c 'import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]' .github/actions/cache-restore/action.yaml .github/actions/cache-save/action.yaml`

Attempted `make WITH_UT=True BUILD_DIR=/tmp/knowhere-max-version-helper-build`, but local verification stopped before compilation because this machine has Conan 1.64.1 while the repo requires Conan >= 2.0.

## Related issue

- https://github.com/zilliztech/knowhere/issues/1691 tracks the runner storage/AiSAQ timeout behavior observed while validating this PR.