### PR TITLE
enhance: make StatusCategoryOf exhaustive (no silent default)

### DIFF
--- a/include/knowhere/expected.h
+++ b/include/knowhere/expected.h
@@ -73,6 +73,19 @@ enum class StatusCategory {
     inner_error = 2,
 };
 
+// Classify every knowhere::Status into a closed 3-value category. This is a
+// switch with NO `default:` plus a post-switch fallback on purpose:
+//   * a `default:` inside the switch suppresses -Wswitch, so a newly added
+//     Status would silently fall into `inner_error` instead of being
+//     deliberately classified;
+//   * the post-switch `return` keeps the function total (and satisfies
+//     -Wreturn-type) without suppressing the exhaustiveness warning.
+// The surrounding pragma promotes -Wswitch to an error, so adding a
+// knowhere::Status without categorizing it here breaks the build -- forcing the
+// author to decide input vs inner. retry/ownership decisions downstream are
+// derived from this category, so a missed status must never default silently.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic error "-Wswitch"
 inline constexpr StatusCategory
 StatusCategoryOf(knowhere::Status status) {
     switch (status) {
@@ -101,6 +114,7 @@ StatusCategoryOf(knowhere::Status status) {
         case knowhere::Status::diskann_inner_error:
         case knowhere::Status::disk_file_error:
         case knowhere::Status::cuvs_inner_error:
+        case knowhere::Status::cardinal_inner_error:
         case knowhere::Status::cuda_runtime_error:
         case knowhere::Status::cluster_inner_error:
         case knowhere::Status::timeout:
@@ -110,10 +124,11 @@ StatusCategoryOf(knowhere::Status status) {
         case knowhere::Status::emb_list_inner_error:
         case knowhere::Status::aisaq_error:
         case knowhere::Status::knowhere_inner_error:
-        default:
             return StatusCategory::inner_error;
     }
+    return StatusCategory::inner_error;
 }
+#pragma GCC diagnostic pop
 
 inline constexpr bool
 IsInputError(knowhere::Status status) {

--- a/tests/ut/test_error_code.cc
+++ b/tests/ut/test_error_code.cc
@@ -169,3 +169,63 @@ TEST_CASE("Index static facade APIs handle config creation failures", "[error_co
 
     REQUIRE_FALSE(knowhere::IndexStaticFaced<knowhere::fp32>::HasRawData(index_type, version, knowhere::Json{}));
 }
+
+TEST_CASE("StatusCategoryOf classifies every status without a silent default", "[error_code]") {
+    using knowhere::Status;
+    using knowhere::StatusCategory;
+
+    // success
+    REQUIRE(knowhere::StatusCategoryOf(Status::success) == StatusCategory::success);
+
+    // caller-input errors
+    const Status input_errors[] = {
+        Status::invalid_args,
+        Status::invalid_param_in_json,
+        Status::out_of_range_in_json,
+        Status::type_conflict_in_json,
+        Status::invalid_metric_type,
+        Status::empty_index,
+        Status::not_implemented,
+        Status::index_not_trained,
+        Status::index_already_trained,
+        Status::invalid_value_in_json,
+        Status::arithmetic_overflow,
+        Status::invalid_binary_set,
+        Status::invalid_instruction_set,
+        Status::invalid_index_error,
+        Status::invalid_cluster_error,
+        Status::invalid_serialized_index_type,
+    };
+    for (auto s : input_errors) {
+        REQUIRE(knowhere::StatusCategoryOf(s) == StatusCategory::input_error);
+        REQUIRE(knowhere::IsInputError(s));
+    }
+
+    // server-side inner errors
+    const Status inner_errors[] = {
+        Status::faiss_inner_error,
+        Status::hnsw_inner_error,
+        Status::malloc_error,
+        Status::diskann_inner_error,
+        Status::disk_file_error,
+        Status::cuvs_inner_error,
+        Status::cardinal_inner_error,
+        Status::cuda_runtime_error,
+        Status::cluster_inner_error,
+        Status::timeout,
+        Status::internal_error,
+        Status::sparse_inner_error,
+        Status::brute_force_inner_error,
+        Status::emb_list_inner_error,
+        Status::aisaq_error,
+        Status::knowhere_inner_error,
+    };
+    for (auto s : inner_errors) {
+        REQUIRE(knowhere::StatusCategoryOf(s) == StatusCategory::inner_error);
+        REQUIRE(knowhere::IsInnerError(s));
+    }
+
+    // Regression: cardinal_inner_error used to be caught only by the removed
+    // `default:` branch; it must now be classified explicitly as an inner error.
+    REQUIRE(knowhere::StatusCategoryOf(Status::cardinal_inner_error) == StatusCategory::inner_error);
+}


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/1695

## What

Make `StatusCategoryOf` (`include/knowhere/expected.h`) exhaustive: drop the `default:` inside its switch, rely on a post-switch fallback plus a localized `-Werror=switch`.

## Why

`StatusCategoryOf` ended its switch with `default: return inner_error`. A `default` inside the switch suppresses `-Wswitch`, so a newly added `knowhere::Status` silently falls into `inner_error` instead of being deliberately classified — and the retry / ownership decision the host derives from this category drifts with it (this is the follow-up hardening of the category helper added in #1675).

Dropping the default makes adding a `knowhere::Status` without classifying it a build error. This surfaced `cardinal_inner_error`, which was only ever caught by the default and is now classified explicitly as an inner error (behavior preserved). Adds coverage in `test_error_code.cc`.

## Part of

The segcore error-classification effort across producers: milvus-io/milvus#50903. Follow-up to #1675.