### PR TITLE
enhance: optimize SINDI window result insertion

### DIFF
--- a/src/index/sparse/sindi_inverted_index.h
+++ b/src/index/sparse/sindi_inverted_index.h
@@ -843,7 +843,9 @@ class SindiInvertedIndex : public DimMapInvertedIndex<DataType, AllowIncremental
                     }
                 }
 
-                batch_insert_fn(wscores_final, docid_start, curr_window_size, topk_q, threshold, bitset);
+                if (curr_max_score > threshold) {
+                    batch_insert_fn(wscores_final, docid_start, curr_window_size, topk_q, threshold, bitset);
+                }
             }
         } else {
             const auto accumulate_fn = sindi::get_bm25_kernels().accumulate;
@@ -890,7 +892,9 @@ class SindiInvertedIndex : public DimMapInvertedIndex<DataType, AllowIncremental
                     }
                 }
 
-                batch_insert_fn(wscores_final, docid_start, curr_window_size, topk_q, threshold, bitset);
+                if (curr_max_score > threshold) {
+                    batch_insert_fn(wscores_final, docid_start, curr_window_size, topk_q, threshold, bitset);
+                }
             }
         }
 


### PR DESCRIPTION
issue: #1555

- Skip window result insertion when the window max score is not above the current top-k threshold.
- Apply the guard to both IP and BM25 SINDI top-k paths.

This delivers the biggest performance gains for small Top-K workloads running on ARM SVE (the improvement on x86 is negligible). On such workloads, the heap threshold stabilizes sooner, allowing more windows to bypass the full batch_insert scan. While we still observe positive performance benefits at Top-100, the margin shrinks: the heap threshold takes longer to fill, so fewer windows get filtered out.

  ARM SVE / MS MARCO BM25, SINDI top-k batch-insert gate

  Compared with always calling batch_insert_fn for every window:

  top10:
    QPS:        +70.6%   (1818.26 -> 3101.18)
    Seq latency:-40.4%   (4138.02us -> 2465.94us)
    P90:        -30.2%   (5468us -> 3816us)
    P99:        -22.5%   (7562us -> 5864us)

  top100:
    QPS:        +18.9%   (1662.90 -> 1977.19)
    Seq latency:-16.1%   (4553.84us -> 3820.95us)
    P90:        -11.8%   (6136us -> 5409us)
    P99:        -9.2%    (8642us -> 7851us)