### PR TITLE
fix: guard iterator APIs from exceptions

### DIFF
--- a/include/knowhere/expected.h
+++ b/include/knowhere/expected.h
@@ -292,6 +292,30 @@ class KNOWHERE_NODISCARD expected {
 
 #if !defined(SWIG)
 
+// Exception carrying a knowhere::Status, for propagating an existing error-code result
+// through a throwing code path without losing the original status. GuardedCall converts
+// it back to the carried status instead of recoding it as knowhere_inner_error.
+class StatusException : public std::exception {
+ public:
+    StatusException(Status status, std::string msg) : status_(status), msg_(std::move(msg)) {
+        assert(status_ != Status::success);
+    }
+
+    Status
+    status() const noexcept {
+        return status_;
+    }
+
+    const char*
+    what() const noexcept override {
+        return msg_.c_str();
+    }
+
+ private:
+    Status status_;
+    std::string msg_;
+};
+
 namespace detail {
 
 template <typename T>
@@ -365,6 +389,8 @@ GuardedCall(Func&& func, Args&&... args) noexcept {
         } else {
             return std::invoke(std::forward<Func>(func), std::forward<Args>(args)...);
         }
+    } catch (const StatusException& e) {
+        return detail::GuardedCallFailure<Result>(e.status(), e.what());
     } catch (const std::bad_alloc& e) {
         return detail::GuardedCallFailure<Result>(Status::malloc_error,
                                                   detail::ExceptionMessage("bad alloc", e.what()));

--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -172,12 +172,14 @@ class IndexNode : public Object {
     };
 
     // not thread safe.
+    // Next()/HasNext() must not throw: errors are reported through the returned expected<>,
+    // consistent with the error-code based contract of the facade APIs.
     class iterator {
      public:
-        virtual std::pair<int64_t, float>
-        Next() = 0;
-        [[nodiscard]] virtual bool
-        HasNext() = 0;
+        virtual expected<std::pair<int64_t, float>>
+        Next() noexcept = 0;
+        [[nodiscard]] virtual expected<bool>
+        HasNext() noexcept = 0;
         virtual ~iterator() {
         }
     };
@@ -676,14 +678,36 @@ class IndexIterator : public IndexNode::iterator {
           use_knowhere_search_pool_(use_knowhere_search_pool) {
     }
 
-    std::pair<int64_t, float>
-    Next() override {
+    expected<std::pair<int64_t, float>>
+    Next() noexcept final {
+        return GuardedCall([&]() -> expected<std::pair<int64_t, float>> { return next_impl(); });
+    }
+
+    [[nodiscard]] expected<bool>
+    HasNext() noexcept final {
+        return GuardedCall([&]() -> expected<bool> { return has_next_impl(); });
+    }
+
+    virtual void
+    initialize() {
+        if (initialized_) {
+            throw std::runtime_error("initialize should not be called twice");
+        }
+        UpdateNext();
+        initialized_ = true;
+    }
+
+ protected:
+    // The *_impl methods may throw or return an error result; exceptions are converted to
+    //   error codes by GuardedCall at the public Next()/HasNext() boundary.
+    virtual expected<std::pair<int64_t, float>>
+    next_impl() {
         if (!initialized_) {
             initialize();
         }
         auto& q = !refine_ ? res_ : refined_res_;
         if (q.empty()) {
-            throw std::runtime_error("No more elements");
+            return expected<std::pair<int64_t, float>>::Err(Status::knowhere_inner_error, "No more elements");
         }
         auto ret = q.top();
         q.pop();
@@ -691,7 +715,7 @@ class IndexIterator : public IndexNode::iterator {
         auto update_next_func = [&]() {
             UpdateNext();
             if (retain_iterator_order_) {
-                while (HasNext()) {
+                while (!res_.empty() || !refined_res_.empty()) {
                     auto& q = !refine_ ? res_ : refined_res_;
                     auto next_ret = q.top();
                     // with the help of `sign_`, both `res_` and `refine_res` are min-heap.
@@ -723,24 +747,14 @@ class IndexIterator : public IndexNode::iterator {
         return std::make_pair(ret.id, ret.val * sign_);
     }
 
-    [[nodiscard]] bool
-    HasNext() override {
+    virtual expected<bool>
+    has_next_impl() {
         if (!initialized_) {
             initialize();
         }
         return !res_.empty() || !refined_res_.empty();
     }
 
-    virtual void
-    initialize() {
-        if (initialized_) {
-            throw std::runtime_error("initialize should not be called twice");
-        }
-        UpdateNext();
-        initialized_ = true;
-    }
-
- protected:
     inline size_t
     min_refine_size() const {
         // TODO: maybe make this configurable
@@ -805,35 +819,42 @@ class PrecomputedDistanceIterator : public IndexNode::iterator {
           use_knowhere_search_pool_(use_knowhere_search_pool) {
     }
 
-    std::pair<int64_t, float>
-    Next() override {
-        if (!initialized_) {
-            initialize();
-        }
-        if (use_knowhere_search_pool_) {
+    expected<std::pair<int64_t, float>>
+    Next() noexcept override {
+        return GuardedCall([&]() -> expected<std::pair<int64_t, float>> {
+            if (!initialized_) {
+                initialize();
+            }
+            if (!has_next_unchecked()) {
+                return expected<std::pair<int64_t, float>>::Err(Status::knowhere_inner_error, "No more elements");
+            }
+            if (use_knowhere_search_pool_) {
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
-            std::vector<folly::Future<folly::Unit>> futs;
-            futs.emplace_back(ThreadPool::GetGlobalSearchThreadPool()->push([&]() {
-                ThreadPool::ScopedSearchOmpSetter setter(1);
-                sort_next();
-            }));
-            WaitAllSuccess(futs);
+                std::vector<folly::Future<folly::Unit>> futs;
+                futs.emplace_back(ThreadPool::GetGlobalSearchThreadPool()->push([&]() {
+                    ThreadPool::ScopedSearchOmpSetter setter(1);
+                    sort_next();
+                }));
+                WaitAllSuccess(futs);
 #else
-            sort_next();
+                sort_next();
 #endif
-        } else {
-            sort_next();
-        }
-        auto& result = results_[next_++];
-        return std::make_pair(result.id, result.val);
+            } else {
+                sort_next();
+            }
+            auto& result = results_[next_++];
+            return std::make_pair(result.id, result.val);
+        });
     }
 
-    [[nodiscard]] bool
-    HasNext() override {
-        if (!initialized_) {
-            initialize();
-        }
-        return next_ < results_.size() && results_[next_].id != -1;
+    [[nodiscard]] expected<bool>
+    HasNext() noexcept override {
+        return GuardedCall([&]() -> expected<bool> {
+            if (!initialized_) {
+                initialize();
+            }
+            return has_next_unchecked();
+        });
     }
 
     void
@@ -861,6 +882,11 @@ class PrecomputedDistanceIterator : public IndexNode::iterator {
     }
 
  private:
+    bool
+    has_next_unchecked() const {
+        return next_ < results_.size() && results_[next_].id != -1;
+    }
+
     static inline size_t
     get_sort_size(size_t rows) {
         return std::max((size_t)50000, rows / 10);

--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -172,14 +172,16 @@ class IndexNode : public Object {
     };
 
     // not thread safe.
-    // Next()/HasNext() must not throw: errors are reported through the returned expected<>,
-    // consistent with the error-code based contract of the facade APIs.
+    // Next()/HasNext() report errors through the returned expected<> instead of throwing,
+    // consistent with the error-code based contract of the facade APIs. Implementations
+    // should convert exceptions at this boundary (see IndexIterator/GuardedCall); the
+    // built-in implementations additionally declare their overrides noexcept.
     class iterator {
      public:
         virtual expected<std::pair<int64_t, float>>
-        Next() noexcept = 0;
+        Next() = 0;
         [[nodiscard]] virtual expected<bool>
-        HasNext() noexcept = 0;
+        HasNext() = 0;
         virtual ~iterator() {
         }
     };

--- a/python/knowhere/knowhere.i
+++ b/python/knowhere/knowhere.i
@@ -148,11 +148,19 @@ class AnnIteratorWrap {
     }
 
     bool HasNext() {
-        return it_->HasNext();
+        auto has_next = it_->HasNext();
+        if (!has_next.has_value()) {
+            throw std::runtime_error("ann iterator HasNext failed: " + has_next.what());
+        }
+        return has_next.value();
     }
 
     std::pair<int64_t, float> Next() {
-        return it_->Next();
+        auto next = it_->Next();
+        if (!next.has_value()) {
+            throw std::runtime_error("ann iterator Next failed: " + next.what());
+        }
+        return next.value();
     }
 
  private:

--- a/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
+++ b/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
@@ -218,19 +218,29 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
             refine_computer_->set_query((const float*)copied_query_.get());
         }
 
-        std::pair<int64_t, float>
-        Next() override {
+        expected<std::pair<int64_t, float>>
+        next_impl() override {
             if (!initialized_) {
                 initialize();
             }
             if (!refine_) {
                 return base_workspace_->Next();
             } else {
+                if (refined_res_.empty()) {
+                    return expected<std::pair<int64_t, float>>::Err(Status::knowhere_inner_error, "No more elements");
+                }
                 auto ret = refined_res_.top();
                 refined_res_.pop();
                 UpdateNext();
                 if (retain_iterator_order_) {
-                    while (HasNext()) {
+                    while (true) {
+                        auto has_next = has_next_impl();
+                        if (!has_next.has_value()) {
+                            return expected<std::pair<int64_t, float>>::Err(has_next.error(), has_next.what());
+                        }
+                        if (!has_next.value()) {
+                            break;
+                        }
                         auto next_ret = refined_res_.top();
                         if (next_ret.val >= ret.val) {
                             break;
@@ -243,15 +253,18 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
             }
         }
 
-        [[nodiscard]] bool
-        HasNext() override {
+        expected<bool>
+        has_next_impl() override {
             if (!initialized_) {
                 initialize();
             }
             if (!refine_) {
                 return base_workspace_->HasNext();
             } else {
-                return !refined_res_.empty() || base_workspace_->HasNext();
+                if (!refined_res_.empty()) {
+                    return true;
+                }
+                return base_workspace_->HasNext();
             }
         }
 
@@ -279,14 +292,26 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
         }
 
      private:
+        // Called from throwing contexts (initialize/next_impl); errors from the base workspace
+        //   are rethrown and converted to error codes at the public Next()/HasNext() boundary.
         void
         UpdateNext() {
-            if (!base_workspace_->HasNext() || refine_ == false) {
+            auto base_has_next = [&]() {
+                auto has_next = base_workspace_->HasNext();
+                if (!has_next.has_value()) {
+                    throw std::runtime_error(has_next.what());
+                }
+                return has_next.value();
+            };
+            if (!base_has_next() || refine_ == false) {
                 return;
             }
-            while (base_workspace_->HasNext() && (refined_res_.empty() || refined_res_.size() < min_refine_size())) {
-                auto pair = base_workspace_->Next();
-                refined_res_.emplace(pair.first, raw_distance(pair.first) * sign_);
+            while (base_has_next() && (refined_res_.empty() || refined_res_.size() < min_refine_size())) {
+                auto next = base_workspace_->Next();
+                if (!next.has_value()) {
+                    throw std::runtime_error(next.what());
+                }
+                refined_res_.emplace(next.value().first, raw_distance(next.value().first) * sign_);
             }
         }
 

--- a/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
+++ b/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
@@ -293,13 +293,14 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
 
      private:
         // Called from throwing contexts (initialize/next_impl); errors from the base workspace
-        //   are rethrown and converted to error codes at the public Next()/HasNext() boundary.
+        //   are rethrown as StatusException so GuardedCall at the public Next()/HasNext()
+        //   boundary restores the original status instead of recoding it.
         void
         UpdateNext() {
             auto base_has_next = [&]() {
                 auto has_next = base_workspace_->HasNext();
                 if (!has_next.has_value()) {
-                    throw std::runtime_error(has_next.what());
+                    throw StatusException(has_next.error(), has_next.what());
                 }
                 return has_next.value();
             };
@@ -309,7 +310,7 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
             while (base_has_next() && (refined_res_.empty() || refined_res_.size() < min_refine_size())) {
                 auto next = base_workspace_->Next();
                 if (!next.has_value()) {
-                    throw std::runtime_error(next.what());
+                    throw StatusException(next.error(), next.what());
                 }
                 refined_res_.emplace(next.value().first, raw_distance(next.value().first) * sign_);
             }

--- a/src/index/index_node.cc
+++ b/src/index/index_node.cc
@@ -81,6 +81,8 @@ IndexNode::RangeSearch(const DataSetPtr dataset, std::unique_ptr<Config> cfg, co
     const auto nq = its.size();
     std::vector<std::vector<int64_t>> result_id_array(nq);
     std::vector<std::vector<float>> result_dist_array(nq);
+    std::vector<Status> task_status(nq, Status::success);
+    std::vector<std::string> task_msg(nq);
 
     const bool retain_iterator_order = base_cfg.retain_iterator_order.value();
     LOG_KNOWHERE_DEBUG_ << "retain_iterator_order: " << retain_iterator_order;
@@ -95,11 +97,26 @@ IndexNode::RangeSearch(const DataSetPtr dataset, std::unique_ptr<Config> cfg, co
         checkCancellation(op_context);
 #endif
         auto it = its[idx];
-        while (it->HasNext()) {
+        while (true) {
 #if defined(NOT_COMPILE_FOR_SWIG)
             checkCancellation(op_context);
 #endif
-            auto [id, dist] = it->Next();
+            auto has_next = it->HasNext();
+            if (!has_next.has_value()) {
+                task_status[idx] = has_next.error();
+                task_msg[idx] = has_next.what();
+                return;
+            }
+            if (!has_next.value()) {
+                break;
+            }
+            auto next = it->Next();
+            if (!next.has_value()) {
+                task_status[idx] = next.error();
+                task_msg[idx] = next.what();
+                return;
+            }
+            auto [id, dist] = next.value();
             if (has_closer_bound && too_close(dist)) {
                 continue;
             }
@@ -136,11 +153,26 @@ IndexNode::RangeSearch(const DataSetPtr dataset, std::unique_ptr<Config> cfg, co
         auto same_or_too_far = [&is_first_closer, &tighter_further_bound](float dist) {
             return !is_first_closer(dist, tighter_further_bound);
         };
-        while (it->HasNext()) {
+        while (true) {
 #if defined(NOT_COMPILE_FOR_SWIG)
             checkCancellation(op_context);
 #endif
-            auto [id, dist] = it->Next();
+            auto has_next = it->HasNext();
+            if (!has_next.has_value()) {
+                task_status[idx] = has_next.error();
+                task_msg[idx] = has_next.what();
+                return;
+            }
+            if (!has_next.value()) {
+                break;
+            }
+            auto next = it->Next();
+            if (!next.has_value()) {
+                task_status[idx] = next.error();
+                task_msg[idx] = next.what();
+                return;
+            }
+            auto [id, dist] = next.value();
             num_next++;
             if (has_closer_bound && too_close(dist)) {
                 continue;
@@ -202,6 +234,13 @@ IndexNode::RangeSearch(const DataSetPtr dataset, std::unique_ptr<Config> cfg, co
         }
     }
 #endif
+
+    for (size_t i = 0; i < nq; i++) {
+        if (task_status[i] != Status::success) {
+            LOG_KNOWHERE_WARNING_ << "range search iterator error: " << task_msg[i];
+            return expected<DataSetPtr>::Err(task_status[i], task_msg[i]);
+        }
+    }
 
     auto range_search_result = GetRangeSearchResult(result_dist_array, result_id_array, the_larger_the_closer, nq,
                                                     further_bound, closer_bound);

--- a/tests/ut/test_emb_list.cc
+++ b/tests/ut/test_emb_list.cc
@@ -81,10 +81,10 @@ check_same_iterator(const knowhere::IndexNode::IteratorPtr& iter1, const knowher
     size_t count = 0;
     size_t number_of_imprecise_distances = 0;
     double max_abs_relative_error = 0;
-    while (iter1->HasNext()) {
-        REQUIRE(iter2->HasNext());
-        auto [id1, dist1] = iter1->Next();
-        auto [id2, dist2] = iter2->Next();
+    while (iter1->HasNext().value()) {
+        REQUIRE(iter2->HasNext().value());
+        auto [id1, dist1] = iter1->Next().value();
+        auto [id2, dist2] = iter2->Next().value();
         count++;
 
         // Perform a precise match of ids
@@ -112,7 +112,7 @@ check_same_iterator(const knowhere::IndexNode::IteratorPtr& iter1, const knowher
         printf("Total number of imprecise distances: %ld\n", number_of_imprecise_distances);
         printf("Max abs relative error exponent: %f\n", std::log10(max_abs_relative_error));
     }
-    REQUIRE(!iter2->HasNext());
+    REQUIRE(!iter2->HasNext().value());
     return true;
 }
 

--- a/tests/ut/test_error_code.cc
+++ b/tests/ut/test_error_code.cc
@@ -109,6 +109,18 @@ class ThrowingStaticIndexNode {
     }
 };
 
+class ThrowingIterator : public knowhere::IndexIterator {
+ public:
+    ThrowingIterator() : knowhere::IndexIterator(/*larger_is_closer=*/false, /*use_knowhere_search_pool=*/false) {
+    }
+
+ protected:
+    void
+    next_batch(std::function<void(const std::vector<knowhere::DistId>&)>) override {
+        throw std::runtime_error("boom next batch");
+    }
+};
+
 }  // namespace
 
 TEST_CASE("Status category separates input and inner errors", "[error_code]") {
@@ -150,6 +162,52 @@ TEST_CASE("Index facade APIs are noexcept and convert exceptions to error codes"
     REQUIRE(index.Serialize(binset) == knowhere::Status::knowhere_inner_error);
     REQUIRE(index.Count() == 0);
     REQUIRE(index.Type().empty());
+}
+
+TEST_CASE("Iterator APIs are noexcept and convert exceptions to error codes", "[error_code]") {
+    SECTION("IndexIterator converts next_batch exceptions on first access") {
+        std::shared_ptr<knowhere::IndexNode::iterator> it = std::make_shared<ThrowingIterator>();
+        STATIC_REQUIRE(noexcept(it->Next()));
+        STATIC_REQUIRE(noexcept(it->HasNext()));
+
+        const auto has_next = it->HasNext();
+        REQUIRE(!has_next.has_value());
+        REQUIRE(has_next.error() == knowhere::Status::knowhere_inner_error);
+        REQUIRE(has_next.what().find("boom next batch") != std::string::npos);
+
+        const auto next = it->Next();
+        REQUIRE(!next.has_value());
+        REQUIRE(next.error() == knowhere::Status::knowhere_inner_error);
+    }
+
+    SECTION("PrecomputedDistanceIterator converts deferred compute exceptions") {
+        auto it = std::make_shared<knowhere::PrecomputedDistanceIterator>(
+            []() -> std::vector<knowhere::DistId> { throw std::runtime_error("boom compute dist"); },
+            /*larger_is_closer=*/false, /*use_knowhere_search_pool=*/false);
+
+        const auto next = it->Next();
+        REQUIRE(!next.has_value());
+        REQUIRE(next.error() == knowhere::Status::knowhere_inner_error);
+        REQUIRE(next.what().find("boom compute dist") != std::string::npos);
+    }
+
+    SECTION("exhausted iterator reports an error instead of throwing") {
+        auto it = std::make_shared<knowhere::PrecomputedDistanceIterator>(
+            []() {
+                return std::vector<knowhere::DistId>{{0, 1.0f}};
+            },
+            /*larger_is_closer=*/false, /*use_knowhere_search_pool=*/false);
+
+        REQUIRE(it->HasNext().value());
+        const auto first = it->Next();
+        REQUIRE(first.has_value());
+        REQUIRE(first.value().first == 0);
+
+        REQUIRE(!it->HasNext().value());
+        const auto next = it->Next();
+        REQUIRE(!next.has_value());
+        REQUIRE(next.error() == knowhere::Status::knowhere_inner_error);
+    }
 }
 
 TEST_CASE("Index static facade APIs handle config creation failures", "[error_code]") {

--- a/tests/ut/test_error_code.cc
+++ b/tests/ut/test_error_code.cc
@@ -121,6 +121,18 @@ class ThrowingIterator : public knowhere::IndexIterator {
     }
 };
 
+class StatusThrowingIterator : public knowhere::IndexIterator {
+ public:
+    StatusThrowingIterator() : knowhere::IndexIterator(/*larger_is_closer=*/false, /*use_knowhere_search_pool=*/false) {
+    }
+
+ protected:
+    void
+    next_batch(std::function<void(const std::vector<knowhere::DistId>&)>) override {
+        throw knowhere::StatusException(knowhere::Status::malloc_error, "boom status alloc");
+    }
+};
+
 }  // namespace
 
 TEST_CASE("Status category separates input and inner errors", "[error_code]") {
@@ -166,7 +178,8 @@ TEST_CASE("Index facade APIs are noexcept and convert exceptions to error codes"
 
 TEST_CASE("Iterator APIs are noexcept and convert exceptions to error codes", "[error_code]") {
     SECTION("IndexIterator converts next_batch exceptions on first access") {
-        std::shared_ptr<knowhere::IndexNode::iterator> it = std::make_shared<ThrowingIterator>();
+        auto it = std::make_shared<ThrowingIterator>();
+        // the guarded built-in implementations are noexcept at the public boundary
         STATIC_REQUIRE(noexcept(it->Next()));
         STATIC_REQUIRE(noexcept(it->HasNext()));
 
@@ -178,6 +191,16 @@ TEST_CASE("Iterator APIs are noexcept and convert exceptions to error codes", "[
         const auto next = it->Next();
         REQUIRE(!next.has_value());
         REQUIRE(next.error() == knowhere::Status::knowhere_inner_error);
+    }
+
+    SECTION("GuardedCall preserves the status carried by StatusException") {
+        auto it = std::make_shared<StatusThrowingIterator>();
+
+        const auto next = it->Next();
+        REQUIRE(!next.has_value());
+        REQUIRE(next.error() == knowhere::Status::malloc_error);
+        // message must pass through unmodified (no extra prefixing)
+        REQUIRE(next.what() == "boom status alloc");
     }
 
     SECTION("PrecomputedDistanceIterator converts deferred compute exceptions") {

--- a/tests/ut/test_iterator.cc
+++ b/tests/ut/test_iterator.cc
@@ -37,8 +37,8 @@ GetIteratorKNNResult(const std::vector<std::shared_ptr<knowhere::IndexNode::iter
     for (int i = 0; i < nq; ++i) {
         auto& iter = iterators[i];
         for (int j = 0; j < k; ++j) {
-            if (iter->HasNext()) {
-                auto [id, dist] = iter->Next();
+            if (iter->HasNext().value()) {
+                auto [id, dist] = iter->Next().value();
                 // if bitset is provided, verify we don't return filtered out points.
                 REQUIRE((!bitset || !bitset->test(id)));
                 p_id[i * k + j] = id;
@@ -66,7 +66,7 @@ AssertBruteForceIteratorResultCorrect(size_t nb,
         size_t j = 0;
         while (j < nb) {
             if (gt_ids[j] == -1) {
-                REQUIRE(!iter.HasNext());
+                REQUIRE(!iter.HasNext().value());
                 break;
             }
             auto dis = gt_dist[j];
@@ -76,8 +76,8 @@ AssertBruteForceIteratorResultCorrect(size_t nb,
             }
             ++j;
             while (!ids_set.empty()) {
-                REQUIRE(iter.HasNext());
-                auto [id, dist] = iter.Next();
+                REQUIRE(iter.HasNext().value());
+                auto [id, dist] = iter.Next().value();
                 REQUIRE(ids_set.find(id) != ids_set.end());
                 REQUIRE(dist == dis);
                 ids_set.erase(id);
@@ -301,15 +301,15 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
         for (int i = 0; i < nq; ++i) {
             auto& iter = its.value()[i];
             float last_dist;
-            if (iter->HasNext()) {
-                auto [id, dist] = iter->Next();
+            if (iter->HasNext().value()) {
+                auto [id, dist] = iter->Next().value();
                 last_dist = dist;
             } else {
                 continue;
             }
 
-            while (iter->HasNext()) {
-                auto [id, dist] = iter->Next();
+            while (iter->HasNext().value()) {
+                auto [id, dist] = iter->Next().value();
                 REQUIRE(is_first_closer_or_equal(last_dist, dist));
                 last_dist = dist;
             }
@@ -406,7 +406,7 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
             auto iterator_results = GetIteratorKNNResult(its.value(), topk);
             // after get those remaining points, iterator should return false for HasNext.
             for (const auto& it : its.value()) {
-                REQUIRE(!it->HasNext());
+                REQUIRE(!it->HasNext().value());
             }
             auto search_results = idx.Search(query_ds, json, bitset);
             REQUIRE(search_results.has_value());
@@ -479,8 +479,8 @@ TEST_CASE("Test Iterator IVFFlatCC With Newly Insert Vectors", "[float metrics] 
         for (int i = 0; i < iters_old.size(); ++i) {
             auto& iter = iters_old[i];
             for (int j = 0; j < nb; ++j) {
-                REQUIRE(iter->HasNext());
-                auto [id, dist] = iter->Next();
+                REQUIRE(iter->HasNext().value());
+                auto [id, dist] = iter->Next().value();
                 REQUIRE(id < nb);
             }
         }
@@ -490,8 +490,8 @@ TEST_CASE("Test Iterator IVFFlatCC With Newly Insert Vectors", "[float metrics] 
             auto& iter = iters_new[i];
             bool id_larger_than_nb = false;
             for (int j = 0; j < nb + nb_new; ++j) {
-                REQUIRE(iter->HasNext());
-                auto [id, dist] = iter->Next();
+                REQUIRE(iter->HasNext().value());
+                auto [id, dist] = iter->Next().value();
                 id_larger_than_nb |= id >= nb;
             }
             REQUIRE(id_larger_than_nb);

--- a/tests/ut/test_sparse.cc
+++ b/tests/ut/test_sparse.cc
@@ -273,8 +273,8 @@ TEST_CASE("Test Mem Sparse Index With Float Vector", "[float metrics]") {
         for (int i = 0; i < nq; ++i) {
             auto& iter = iterators[i];
             float prev_dist = std::numeric_limits<float>::max();
-            while (iter->HasNext()) {
-                auto [id, dist] = iter->Next();
+            while (iter->HasNext().value()) {
+                auto [id, dist] = iter->Next().value();
                 REQUIRE(!bitset.test(id));
                 count++;
                 if (prev_dist < dist) {


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/1674

## Summary
- Follow-up to #1675: iterator objects returned by `AnnIterator` escape the facade guard, and their deferred heavy computations (e.g. `compute_dist_func` deferred to the first `Next()` call) can throw after creation, bypassing the error-code contract.
- Change `IndexNode::iterator::Next()`/`HasNext()` to `noexcept` APIs returning `expected<>`; exceptions are converted to error codes at the `IndexIterator`/`PrecomputedDistanceIterator` public boundary. Index implementations that only override `next_batch` need no changes.
- Propagate per-query iterator errors in the default iterator-based `RangeSearch` implementation, preserving the original status instead of collapsing it.
- Add unit coverage for iterator error-code behavior (throwing `next_batch`, throwing deferred compute, exhausted iterator).

Note: this changes the public iterator interface; downstream callers need to unwrap the returned `expected<>`.