### PR TITLE
Update milvus-common package

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -116,7 +116,7 @@ class KnowhereConan(ConanFile):
     def requirements(self):
         self.requires("abseil/20250127.0#481edcc75deb0efb16500f511f0f0a1c")
         self.requires("boost/1.83.0#4e8a94ac1b88312af95eded83cd81ca8")
-        self.requires("milvus-common/1.0.0-ae43d5c@milvus/dev#fe24230e26e129f6bf303a8342ba8980")
+        self.requires("milvus-common/1.0.0-a3299ca@milvus/dev#eea0e22b8d5e36ff6f0a5ffbed14703e")
         self.requires("gflags/2.2.2#7671803f1dc19354cc90bd32874dcfda")
         self.requires("glog/0.7.1#a306e61d7b8311db8cb148ad62c48030")
         self.requires("nlohmann_json/3.11.3#ffb9e9236619f1c883e36662f944345d", force=True)


### PR DESCRIPTION
## Summary
- bump `milvus-common` from `1.0.0-ae43d5c` to `1.0.0-a3299ca`
- use the published Conan recipe revision `eea0e22b8d5e36ff6f0a5ffbed14703e`
- keep Knowhere aligned with the Cardinal and Milvus tracing dependency chain

## Dependency context
Cardinal PR https://github.com/zilliztech/cardinal/pull/865 now pins `milvus-common/1.0.0-a3299ca@milvus/dev` for its tracing branch. Milvus PR https://github.com/milvus-io/milvus/pull/50932 also uses the same `milvus-common` package to pick up the OpenTelemetry span ABI namespace fix.

milvus-common PR https://github.com/zilliztech/milvus-common/pull/103 adds the later trace-helper overloads included in this package, and conanfiles PR https://github.com/milvus-io/conanfiles/pull/155 publishes `milvus-common/1.0.0-a3299ca@milvus/dev` for downstream Conan consumers.

## Tests / verification
- `git diff --check`
- `python3 -m py_compile conanfile.py`

Fixes #1705