### PR TITLE
enhance: three-way status classification; own the segcore code mapping

### DIFF
--- a/include/knowhere/expected.h
+++ b/include/knowhere/expected.h
@@ -69,8 +69,17 @@ enum class Status {
 
 enum class StatusCategory {
     success = 0,
+    // the request itself is at fault (caller must fix it; retry is useless)
     input_error = 1,
-    inner_error = 2,
+    // server-side and permanent: retrying cannot help (capability missing,
+    // data corrupt, engine bug)
+    permanent_error = 2,
+    // server-side and transient: a retry / replica-reroute may succeed
+    // (OOM pressure, disk IO hiccup)
+    transient_error = 3,
+    // deprecated alias for the pre-three-way name; == permanent_error so
+    // existing comparisons keep compiling with unchanged semantics
+    inner_error = permanent_error,
 };
 
 // Classify every knowhere::Status into a closed 3-value category. This is a
@@ -97,22 +106,33 @@ StatusCategoryOf(knowhere::Status status) {
         case knowhere::Status::type_conflict_in_json:
         case knowhere::Status::invalid_metric_type:
         case knowhere::Status::empty_index:
-        case knowhere::Status::not_implemented:
         case knowhere::Status::index_not_trained:
         case knowhere::Status::index_already_trained:
         case knowhere::Status::invalid_value_in_json:
         case knowhere::Status::arithmetic_overflow:
         case knowhere::Status::invalid_binary_set:
-        case knowhere::Status::invalid_instruction_set:
         case knowhere::Status::invalid_index_error:
         case knowhere::Status::invalid_cluster_error:
-        case knowhere::Status::invalid_serialized_index_type:
             return StatusCategory::input_error;
+        // capability errors: the request is fine, this build/CPU simply cannot
+        // serve it -- the server side owns that, so it is NOT an input error
+        // (moved out of input_error to align with the reviewed fine-grained
+        // mapping: Unsupported). Same for a corrupt serialized index: data
+        // corruption is a permanent system error, not the caller's fault.
+        case knowhere::Status::not_implemented:
+        case knowhere::Status::invalid_instruction_set:
+        case knowhere::Status::invalid_serialized_index_type:
+            return StatusCategory::permanent_error;
+        // transient: a retry or replica-reroute may succeed
+        case knowhere::Status::malloc_error:
+        case knowhere::Status::disk_file_error:
+            return StatusCategory::transient_error;
+        // timeout stays permanent for now: it is Cardinal-only
+        // (BuildAsync cancel-or-build-timeout) and conflates cancel with
+        // timeout; revisit once those are separated.
         case knowhere::Status::faiss_inner_error:
         case knowhere::Status::hnsw_inner_error:
-        case knowhere::Status::malloc_error:
         case knowhere::Status::diskann_inner_error:
-        case knowhere::Status::disk_file_error:
         case knowhere::Status::cuvs_inner_error:
         case knowhere::Status::cardinal_inner_error:
         case knowhere::Status::cuda_runtime_error:
@@ -124,9 +144,9 @@ StatusCategoryOf(knowhere::Status status) {
         case knowhere::Status::emb_list_inner_error:
         case knowhere::Status::aisaq_error:
         case knowhere::Status::knowhere_inner_error:
-            return StatusCategory::inner_error;
+            return StatusCategory::permanent_error;
     }
-    return StatusCategory::inner_error;
+    return StatusCategory::permanent_error;
 }
 #pragma GCC diagnostic pop
 
@@ -135,9 +155,17 @@ IsInputError(knowhere::Status status) {
     return StatusCategoryOf(status) == StatusCategory::input_error;
 }
 
+// "inner" keeps its historical meaning: any server-side error, i.e. NOT the
+// caller's fault -- both transient and permanent qualify.
 inline constexpr bool
 IsInnerError(knowhere::Status status) {
-    return StatusCategoryOf(status) == StatusCategory::inner_error;
+    auto category = StatusCategoryOf(status);
+    return category == StatusCategory::permanent_error || category == StatusCategory::transient_error;
+}
+
+inline constexpr bool
+IsTransientError(knowhere::Status status) {
+    return StatusCategoryOf(status) == StatusCategory::transient_error;
 }
 
 inline std::string

--- a/include/knowhere/expected.h
+++ b/include/knowhere/expected.h
@@ -155,12 +155,11 @@ IsInputError(knowhere::Status status) {
     return StatusCategoryOf(status) == StatusCategory::input_error;
 }
 
-// "inner" keeps its historical meaning: any server-side error, i.e. NOT the
-// caller's fault -- both transient and permanent qualify.
+// matches the deprecated alias `inner_error = permanent_error`: transient
+// errors are NOT "inner" -- use IsTransientError() for those.
 inline constexpr bool
 IsInnerError(knowhere::Status status) {
-    auto category = StatusCategoryOf(status);
-    return category == StatusCategory::permanent_error || category == StatusCategory::transient_error;
+    return StatusCategoryOf(status) == StatusCategory::permanent_error;
 }
 
 inline constexpr bool

--- a/include/knowhere/segcore_error_code.h
+++ b/include/knowhere/segcore_error_code.h
@@ -1,0 +1,101 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#ifndef SEGCORE_ERROR_CODE_H
+#define SEGCORE_ERROR_CODE_H
+
+#include "common/EasyAssert.h"  // milvus-common: shared milvus::ErrorCode registry
+#include "knowhere/expected.h"
+
+namespace knowhere {
+
+// Map a knowhere::Status to the shared milvus::ErrorCode that the segcore
+// boundary (and ultimately the Go retry policy) consumes.
+//
+// "Producer owns classification": knowhere knows best whether its own status
+// is the caller's fault, a transient failure, or a permanent one -- so this
+// mapping lives here, next to the Status enum, instead of a hand-maintained
+// copy on the milvus side (which this migrates and retires). Same convention
+// as milvus_storage::ToSegcoreError.
+//
+// It is deliberately a switch with NO `default:` plus a post-switch fallback:
+// a `default:` would suppress -Wswitch, letting a newly added Status fall
+// through silently; the pragma turns the warning into an error so adding a
+// Status without classifying it here breaks the build.
+//
+// Invariant (locked by tests): this mapping and StatusCategoryOf must agree --
+//   input_error      <=> InvalidParameter
+//   transient_error  <=> a code the Go-side table marks retriable
+//   permanent_error  <=> a non-retriable, non-input code
+#pragma GCC diagnostic push
+#pragma GCC diagnostic error "-Wswitch"
+inline constexpr milvus::ErrorCode
+ToSegcoreErrorCode(knowhere::Status status) {
+    switch (status) {
+        case knowhere::Status::success:
+            return milvus::ErrorCode::Success;
+        // the request content itself is at fault
+        case knowhere::Status::invalid_args:
+        case knowhere::Status::invalid_param_in_json:
+        case knowhere::Status::out_of_range_in_json:
+        case knowhere::Status::type_conflict_in_json:
+        case knowhere::Status::invalid_metric_type:
+        case knowhere::Status::empty_index:
+        case knowhere::Status::index_not_trained:
+        case knowhere::Status::index_already_trained:
+        case knowhere::Status::invalid_value_in_json:
+        case knowhere::Status::arithmetic_overflow:
+        case knowhere::Status::invalid_binary_set:
+        case knowhere::Status::invalid_index_error:
+        case knowhere::Status::invalid_cluster_error:
+            return milvus::ErrorCode::InvalidParameter;
+        // capability errors: the request is fine, this build/CPU cannot serve
+        // it (e.g. SCANN needing AVX2) -- Unsupported, not malformed input
+        case knowhere::Status::not_implemented:
+        case knowhere::Status::invalid_instruction_set:
+            return milvus::ErrorCode::Unsupported;
+        // a serialized index that cannot be recognized is corrupt data
+        case knowhere::Status::invalid_serialized_index_type:
+            return milvus::ErrorCode::DataFormatBroken;
+        // transient failures: retry / replica-reroute may succeed
+        case knowhere::Status::malloc_error:
+            return milvus::ErrorCode::MemAllocateFailed;
+        case knowhere::Status::disk_file_error:
+            return milvus::ErrorCode::FileReadFailed;
+        // permanent server-side inner errors -> generic KnowhereError.
+        // timeout stays here: it is Cardinal-only (BuildAsync
+        // cancel-or-build-timeout) and conflates cancel with timeout, so it
+        // must not map to a retriable code until those are separated.
+        case knowhere::Status::faiss_inner_error:
+        case knowhere::Status::hnsw_inner_error:
+        case knowhere::Status::diskann_inner_error:
+        case knowhere::Status::cuvs_inner_error:
+        case knowhere::Status::cardinal_inner_error:
+        case knowhere::Status::cuda_runtime_error:
+        case knowhere::Status::cluster_inner_error:
+        case knowhere::Status::timeout:
+        case knowhere::Status::internal_error:
+        case knowhere::Status::sparse_inner_error:
+        case knowhere::Status::brute_force_inner_error:
+        case knowhere::Status::emb_list_inner_error:
+        case knowhere::Status::aisaq_error:
+        case knowhere::Status::knowhere_inner_error:
+            return milvus::ErrorCode::KnowhereError;
+    }
+    // out-of-range value: safe non-retriable fallback (does not suppress
+    // -Wswitch above)
+    return milvus::ErrorCode::KnowhereError;
+}
+#pragma GCC diagnostic pop
+
+}  // namespace knowhere
+
+#endif /* SEGCORE_ERROR_CODE_H */

--- a/tests/ut/test_error_code.cc
+++ b/tests/ut/test_error_code.cc
@@ -13,6 +13,7 @@
 #include "knowhere/comp/brute_force.h"
 #include "knowhere/index/index.h"
 #include "knowhere/index/index_static.h"
+#include "knowhere/segcore_error_code.h"
 
 namespace {
 
@@ -111,21 +112,119 @@ class ThrowingStaticIndexNode {
 
 }  // namespace
 
-TEST_CASE("Status category separates input and inner errors", "[error_code]") {
+TEST_CASE("Status category separates input, transient and permanent errors", "[error_code]") {
     STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::invalid_args) == knowhere::StatusCategory::input_error);
     STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::invalid_param_in_json) ==
                    knowhere::StatusCategory::input_error);
     STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::faiss_inner_error) ==
-                   knowhere::StatusCategory::inner_error);
+                   knowhere::StatusCategory::permanent_error);
     STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::internal_error) ==
-                   knowhere::StatusCategory::inner_error);
+                   knowhere::StatusCategory::permanent_error);
     STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::knowhere_inner_error) ==
-                   knowhere::StatusCategory::inner_error);
+                   knowhere::StatusCategory::permanent_error);
+    // the two transients: retry / replica-reroute may succeed
+    STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::malloc_error) ==
+                   knowhere::StatusCategory::transient_error);
+    STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::disk_file_error) ==
+                   knowhere::StatusCategory::transient_error);
+    // capability / corrupt-data statuses are the server's problem, not the
+    // caller's: moved out of input_error to agree with the fine mapping
+    STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::not_implemented) ==
+                   knowhere::StatusCategory::permanent_error);
+    STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::invalid_instruction_set) ==
+                   knowhere::StatusCategory::permanent_error);
+    STATIC_REQUIRE(knowhere::StatusCategoryOf(knowhere::Status::invalid_serialized_index_type) ==
+                   knowhere::StatusCategory::permanent_error);
+    // the deprecated alias keeps compiling and keeps its meaning
+    STATIC_REQUIRE(knowhere::StatusCategory::inner_error == knowhere::StatusCategory::permanent_error);
 
     REQUIRE(knowhere::IsInputError(knowhere::Status::invalid_metric_type));
     REQUIRE_FALSE(knowhere::IsInputError(knowhere::Status::faiss_inner_error));
+    // IsInnerError keeps its historical meaning: any server-side error,
+    // transient included
     REQUIRE(knowhere::IsInnerError(knowhere::Status::brute_force_inner_error));
+    REQUIRE(knowhere::IsInnerError(knowhere::Status::malloc_error));
     REQUIRE_FALSE(knowhere::IsInnerError(knowhere::Status::invalid_value_in_json));
+    REQUIRE(knowhere::IsTransientError(knowhere::Status::disk_file_error));
+    REQUIRE_FALSE(knowhere::IsTransientError(knowhere::Status::timeout));
+}
+
+namespace {
+// every Status value, for exhaustive category<->code consistency checks
+constexpr knowhere::Status kAllStatuses[] = {
+    knowhere::Status::success,
+    knowhere::Status::invalid_args,
+    knowhere::Status::invalid_param_in_json,
+    knowhere::Status::out_of_range_in_json,
+    knowhere::Status::type_conflict_in_json,
+    knowhere::Status::invalid_metric_type,
+    knowhere::Status::empty_index,
+    knowhere::Status::not_implemented,
+    knowhere::Status::index_not_trained,
+    knowhere::Status::index_already_trained,
+    knowhere::Status::faiss_inner_error,
+    knowhere::Status::hnsw_inner_error,
+    knowhere::Status::malloc_error,
+    knowhere::Status::diskann_inner_error,
+    knowhere::Status::disk_file_error,
+    knowhere::Status::invalid_value_in_json,
+    knowhere::Status::arithmetic_overflow,
+    knowhere::Status::cuvs_inner_error,
+    knowhere::Status::invalid_binary_set,
+    knowhere::Status::invalid_instruction_set,
+    knowhere::Status::cardinal_inner_error,
+    knowhere::Status::cuda_runtime_error,
+    knowhere::Status::invalid_index_error,
+    knowhere::Status::invalid_cluster_error,
+    knowhere::Status::cluster_inner_error,
+    knowhere::Status::timeout,
+    knowhere::Status::internal_error,
+    knowhere::Status::invalid_serialized_index_type,
+    knowhere::Status::sparse_inner_error,
+    knowhere::Status::brute_force_inner_error,
+    knowhere::Status::emb_list_inner_error,
+    knowhere::Status::aisaq_error,
+    knowhere::Status::knowhere_inner_error,
+};
+}  // namespace
+
+TEST_CASE("ToSegcoreErrorCode agrees with StatusCategoryOf for every status", "[error_code]") {
+    for (auto status : kAllStatuses) {
+        const auto category = knowhere::StatusCategoryOf(status);
+        const auto code = knowhere::ToSegcoreErrorCode(status);
+        CAPTURE(static_cast<int>(status), static_cast<int>(category), static_cast<int>(code));
+        switch (category) {
+            case knowhere::StatusCategory::success:
+                REQUIRE(code == milvus::ErrorCode::Success);
+                break;
+            case knowhere::StatusCategory::input_error:
+                REQUIRE(code == milvus::ErrorCode::InvalidParameter);
+                break;
+            case knowhere::StatusCategory::transient_error:
+                // must land on a code the Go-side table marks retriable
+                REQUIRE((code == milvus::ErrorCode::MemAllocateFailed ||
+                         code == milvus::ErrorCode::FileReadFailed));
+                break;
+            case knowhere::StatusCategory::permanent_error:
+                REQUIRE((code == milvus::ErrorCode::Unsupported || code == milvus::ErrorCode::DataFormatBroken ||
+                         code == milvus::ErrorCode::KnowhereError));
+                break;
+        }
+    }
+}
+
+TEST_CASE("ToSegcoreErrorCode fine mapping spot checks", "[error_code]") {
+    STATIC_REQUIRE(knowhere::ToSegcoreErrorCode(knowhere::Status::malloc_error) ==
+                   milvus::ErrorCode::MemAllocateFailed);
+    STATIC_REQUIRE(knowhere::ToSegcoreErrorCode(knowhere::Status::disk_file_error) ==
+                   milvus::ErrorCode::FileReadFailed);
+    STATIC_REQUIRE(knowhere::ToSegcoreErrorCode(knowhere::Status::not_implemented) == milvus::ErrorCode::Unsupported);
+    STATIC_REQUIRE(knowhere::ToSegcoreErrorCode(knowhere::Status::invalid_serialized_index_type) ==
+                   milvus::ErrorCode::DataFormatBroken);
+    STATIC_REQUIRE(knowhere::ToSegcoreErrorCode(knowhere::Status::invalid_args) ==
+                   milvus::ErrorCode::InvalidParameter);
+    STATIC_REQUIRE(knowhere::ToSegcoreErrorCode(knowhere::Status::timeout) == milvus::ErrorCode::KnowhereError);
+    STATIC_REQUIRE(knowhere::ToSegcoreErrorCode(knowhere::Status::success) == milvus::ErrorCode::Success);
 }
 
 TEST_CASE("Index facade APIs are noexcept and convert exceptions to error codes", "[error_code]") {
@@ -185,29 +284,48 @@ TEST_CASE("StatusCategoryOf classifies every status without a silent default", "
         Status::type_conflict_in_json,
         Status::invalid_metric_type,
         Status::empty_index,
-        Status::not_implemented,
         Status::index_not_trained,
         Status::index_already_trained,
         Status::invalid_value_in_json,
         Status::arithmetic_overflow,
         Status::invalid_binary_set,
-        Status::invalid_instruction_set,
         Status::invalid_index_error,
         Status::invalid_cluster_error,
-        Status::invalid_serialized_index_type,
     };
     for (auto s : input_errors) {
         REQUIRE(knowhere::StatusCategoryOf(s) == StatusCategory::input_error);
         REQUIRE(knowhere::IsInputError(s));
     }
 
-    // server-side inner errors
+    // capability / corrupt-data statuses: server-side permanent, not the
+    // caller's fault (aligned with the fine mapping: Unsupported /
+    // DataFormatBroken)
+    const Status capability_and_data_errors[] = {
+        Status::not_implemented,
+        Status::invalid_instruction_set,
+        Status::invalid_serialized_index_type,
+    };
+    for (auto s : capability_and_data_errors) {
+        REQUIRE(knowhere::StatusCategoryOf(s) == StatusCategory::permanent_error);
+        REQUIRE_FALSE(knowhere::IsInputError(s));
+    }
+
+    // transient failures: retry / replica-reroute may succeed
+    const Status transient_errors[] = {
+        Status::malloc_error,
+        Status::disk_file_error,
+    };
+    for (auto s : transient_errors) {
+        REQUIRE(knowhere::StatusCategoryOf(s) == StatusCategory::transient_error);
+        REQUIRE(knowhere::IsTransientError(s));
+        REQUIRE(knowhere::IsInnerError(s));  // still a server-side error
+    }
+
+    // server-side permanent inner errors
     const Status inner_errors[] = {
         Status::faiss_inner_error,
         Status::hnsw_inner_error,
-        Status::malloc_error,
         Status::diskann_inner_error,
-        Status::disk_file_error,
         Status::cuvs_inner_error,
         Status::cardinal_inner_error,
         Status::cuda_runtime_error,
@@ -221,11 +339,12 @@ TEST_CASE("StatusCategoryOf classifies every status without a silent default", "
         Status::knowhere_inner_error,
     };
     for (auto s : inner_errors) {
-        REQUIRE(knowhere::StatusCategoryOf(s) == StatusCategory::inner_error);
+        REQUIRE(knowhere::StatusCategoryOf(s) == StatusCategory::permanent_error);
         REQUIRE(knowhere::IsInnerError(s));
+        REQUIRE_FALSE(knowhere::IsTransientError(s));
     }
 
     // Regression: cardinal_inner_error used to be caught only by the removed
-    // `default:` branch; it must now be classified explicitly as an inner error.
-    REQUIRE(knowhere::StatusCategoryOf(Status::cardinal_inner_error) == StatusCategory::inner_error);
+    // `default:` branch; it must stay explicitly classified.
+    REQUIRE(knowhere::StatusCategoryOf(Status::cardinal_inner_error) == StatusCategory::permanent_error);
 }

--- a/tests/ut/test_error_code.cc
+++ b/tests/ut/test_error_code.cc
@@ -140,10 +140,10 @@ TEST_CASE("Status category separates input, transient and permanent errors", "[e
 
     REQUIRE(knowhere::IsInputError(knowhere::Status::invalid_metric_type));
     REQUIRE_FALSE(knowhere::IsInputError(knowhere::Status::faiss_inner_error));
-    // IsInnerError keeps its historical meaning: any server-side error,
-    // transient included
+    // IsInnerError matches the deprecated alias inner_error = permanent_error:
+    // transient errors are not "inner"
     REQUIRE(knowhere::IsInnerError(knowhere::Status::brute_force_inner_error));
-    REQUIRE(knowhere::IsInnerError(knowhere::Status::malloc_error));
+    REQUIRE_FALSE(knowhere::IsInnerError(knowhere::Status::malloc_error));
     REQUIRE_FALSE(knowhere::IsInnerError(knowhere::Status::invalid_value_in_json));
     REQUIRE(knowhere::IsTransientError(knowhere::Status::disk_file_error));
     REQUIRE_FALSE(knowhere::IsTransientError(knowhere::Status::timeout));
@@ -275,13 +275,23 @@ TEST_CASE("StatusCategoryOf classifies every status without a silent default", "
     REQUIRE(knowhere::StatusCategoryOf(Status::success) == StatusCategory::success);
 
     // caller-input errors
+    // clang-format off
     const Status input_errors[] = {
-        Status::invalid_args,          Status::invalid_param_in_json, Status::out_of_range_in_json,
-        Status::type_conflict_in_json, Status::invalid_metric_type,   Status::empty_index,
-        Status::index_not_trained,     Status::index_already_trained, Status::invalid_value_in_json,
-        Status::arithmetic_overflow,   Status::invalid_binary_set,    Status::invalid_index_error,
+        Status::invalid_args,
+        Status::invalid_param_in_json,
+        Status::out_of_range_in_json,
+        Status::type_conflict_in_json,
+        Status::invalid_metric_type,
+        Status::empty_index,
+        Status::index_not_trained,
+        Status::index_already_trained,
+        Status::invalid_value_in_json,
+        Status::arithmetic_overflow,
+        Status::invalid_binary_set,
+        Status::invalid_index_error,
         Status::invalid_cluster_error,
     };
+    // clang-format on
     for (auto s : input_errors) {
         REQUIRE(knowhere::StatusCategoryOf(s) == StatusCategory::input_error);
         REQUIRE(knowhere::IsInputError(s));
@@ -308,7 +318,7 @@ TEST_CASE("StatusCategoryOf classifies every status without a silent default", "
     for (auto s : transient_errors) {
         REQUIRE(knowhere::StatusCategoryOf(s) == StatusCategory::transient_error);
         REQUIRE(knowhere::IsTransientError(s));
-        REQUIRE(knowhere::IsInnerError(s));  // still a server-side error
+        REQUIRE_FALSE(knowhere::IsInnerError(s));  // "inner" == permanent only
     }
 
     // server-side permanent inner errors

--- a/tests/ut/test_error_code.cc
+++ b/tests/ut/test_error_code.cc
@@ -202,8 +202,7 @@ TEST_CASE("ToSegcoreErrorCode agrees with StatusCategoryOf for every status", "[
                 break;
             case knowhere::StatusCategory::transient_error:
                 // must land on a code the Go-side table marks retriable
-                REQUIRE((code == milvus::ErrorCode::MemAllocateFailed ||
-                         code == milvus::ErrorCode::FileReadFailed));
+                REQUIRE((code == milvus::ErrorCode::MemAllocateFailed || code == milvus::ErrorCode::FileReadFailed));
                 break;
             case knowhere::StatusCategory::permanent_error:
                 REQUIRE((code == milvus::ErrorCode::Unsupported || code == milvus::ErrorCode::DataFormatBroken ||
@@ -221,8 +220,7 @@ TEST_CASE("ToSegcoreErrorCode fine mapping spot checks", "[error_code]") {
     STATIC_REQUIRE(knowhere::ToSegcoreErrorCode(knowhere::Status::not_implemented) == milvus::ErrorCode::Unsupported);
     STATIC_REQUIRE(knowhere::ToSegcoreErrorCode(knowhere::Status::invalid_serialized_index_type) ==
                    milvus::ErrorCode::DataFormatBroken);
-    STATIC_REQUIRE(knowhere::ToSegcoreErrorCode(knowhere::Status::invalid_args) ==
-                   milvus::ErrorCode::InvalidParameter);
+    STATIC_REQUIRE(knowhere::ToSegcoreErrorCode(knowhere::Status::invalid_args) == milvus::ErrorCode::InvalidParameter);
     STATIC_REQUIRE(knowhere::ToSegcoreErrorCode(knowhere::Status::timeout) == milvus::ErrorCode::KnowhereError);
     STATIC_REQUIRE(knowhere::ToSegcoreErrorCode(knowhere::Status::success) == milvus::ErrorCode::Success);
 }
@@ -278,18 +276,10 @@ TEST_CASE("StatusCategoryOf classifies every status without a silent default", "
 
     // caller-input errors
     const Status input_errors[] = {
-        Status::invalid_args,
-        Status::invalid_param_in_json,
-        Status::out_of_range_in_json,
-        Status::type_conflict_in_json,
-        Status::invalid_metric_type,
-        Status::empty_index,
-        Status::index_not_trained,
-        Status::index_already_trained,
-        Status::invalid_value_in_json,
-        Status::arithmetic_overflow,
-        Status::invalid_binary_set,
-        Status::invalid_index_error,
+        Status::invalid_args,          Status::invalid_param_in_json, Status::out_of_range_in_json,
+        Status::type_conflict_in_json, Status::invalid_metric_type,   Status::empty_index,
+        Status::index_not_trained,     Status::index_already_trained, Status::invalid_value_in_json,
+        Status::arithmetic_overflow,   Status::invalid_binary_set,    Status::invalid_index_error,
         Status::invalid_cluster_error,
     };
     for (auto s : input_errors) {


### PR DESCRIPTION
issue: #1703

Two coupled changes that share one classification truth:

## 1. StatusCategory: {input, inner} → {input, transient, permanent}

Two-way classification cannot carry a retry verdict. `transient_error` (currently `malloc_error`, `disk_file_error` — a retry or replica reroute may succeed) is now distinct from `permanent_error`; new `IsTransientError()`. `inner_error` stays as a deprecated alias of `permanent_error`, and `IsInnerError()` matches that alias: true only for permanent errors (it has no in-tree callers, so nothing depended on a wider meaning) — existing code keeps compiling.

Three statuses move out of `input_error` to agree with the reviewed fine-grained mapping: `not_implemented` / `invalid_instruction_set` are **capability** errors (the request is fine, this build/CPU cannot serve it) and `invalid_serialized_index_type` is **data corruption** — all server-side permanent, not the caller's fault. `timeout` deliberately stays permanent: it is Cardinal-only (BuildAsync cancel-or-build-timeout) and conflates cancel with timeout; revisit once separated.

## 2. ToSegcoreErrorCode moves into knowhere

New `knowhere/segcore_error_code.h`: `ToSegcoreErrorCode(Status) -> milvus::ErrorCode`, migrated verbatim from the milvus-side `KnowhereStatusToErrorCode` — producer owns classification, same convention as `milvus_storage::ToSegcoreError`. No-default switch + `-Werror=switch`: adding a Status without classifying it breaks the build. The milvus-side copy becomes a thin delegate in a follow-up once this ships.

## Consistency lock

A test iterates every Status value and pins the two views together:
input ⟺ InvalidParameter · transient ⟺ a retriable code (MemAllocateFailed/FileReadFailed) · permanent ⟺ a non-retriable one · success ⟺ Success.

## Verification

- `[error_code]` suites: 6 cases / 156 assertions, all pass.
- Full knowhere_tests build clean on current main (milvus-common `ae43d5c`).

Part of the error-handling hardening tracked in milvus-io/milvus#50903.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
