### PR TITLE
[2.6] fix: default ef in GPU_CAGRA CheckAndAdjust

### DIFF
--- a/src/index/gpu_cuvs/gpu_cuvs_cagra_config.h
+++ b/src/index/gpu_cuvs/gpu_cuvs_cagra_config.h
@@ -27,6 +27,7 @@ namespace {
 constexpr const CFG_INT::value_type kSearchWidth = 1;
 constexpr const CFG_INT::value_type kAlignFactor = 32;
 constexpr const CFG_INT::value_type kItopkSize = 64;
+constexpr const CFG_INT::value_type kCagraEfMinValue = 16;
 }  // namespace
 
 struct GpuCuvsCagraConfig : public BaseConfig {
@@ -150,6 +151,15 @@ struct GpuCuvsCagraConfig : public BaseConfig {
                 }
             } else {
                 search_width = std::max((k.value() - 1) / kAlignFactor + 1, kSearchWidth);
+            }
+
+            // Default ef for adapt_for_cpu HNSW search path
+            if (!ef.has_value()) {
+                ef = std::max(k.value(), kCagraEfMinValue);
+            } else if (k.value() > ef.value()) {
+                std::string msg =
+                    "ef(" + std::to_string(ef.value()) + ") should be larger than k(" + std::to_string(k.value()) + ")";
+                return HandleError(err_msg, msg, Status::out_of_range_in_json);
             }
         }
         return Status::success;

--- a/tests/ut/test_gpu_search.cc
+++ b/tests/ut/test_gpu_search.cc
@@ -310,6 +310,36 @@ TEST_CASE("Test All GPU Index", "[search]") {
         }
     }
 
+    SECTION("Test Gpu Index Cagra Adapt For Cpu Without Ef") {
+        using std::make_tuple;
+        auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
+            make_tuple(knowhere::IndexEnum::INDEX_CUVS_CAGRA, cagra_gen),
+        }));
+        auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version).value();
+        auto cfg_json = gen().dump();
+        CAPTURE(name, cfg_json);
+        knowhere::Json json = knowhere::Json::parse(cfg_json);
+        auto train_ds = GenDataSet(nb, dim, seed);
+        auto query_ds = GenDataSet(nq, dim, seed);
+        REQUIRE(idx.Type() == name);
+        auto res = idx.Build(train_ds, json);
+        REQUIRE(res == knowhere::Status::success);
+        knowhere::BinarySet bs;
+        idx.Serialize(bs);
+        auto idx_ = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version).value();
+        knowhere::Json deser_json = json;
+        deser_json[knowhere::indexparam::ADAPT_FOR_CPU] = true;
+        // Intentionally NOT setting ef — this is the bug scenario
+        idx_.Deserialize(bs, deser_json);
+        // Search without ef in params — should not crash
+        auto results = idx_.Search(query_ds, json, nullptr);
+        REQUIRE(results.has_value());
+        auto ids = results.value()->GetIds();
+        for (int i = 1; i < nq; ++i) {
+            CHECK(ids[i] == i);
+        }
+    }
+
     SECTION("Test Gpu Index Search Simple Bitset") {
         using std::make_tuple;
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>(


### PR DESCRIPTION
## Summary
- Cherrypick #1511 to the 2.6 branch.
- Fix `GPU_CAGRA` with `adapt_for_cpu=true` when search params omit `ef`.
- Default `ef` to `max(k, 16)` for the adapt-for-cpu HNSW search path and keep explicit `ef < k` validation.
- Add regression coverage for searching a deserialized adapt-for-cpu CAGRA index without `ef`.

pr: #1511
issue: #1510

## Test plan
- [x] `git diff --check origin/2.6..HEAD`
- [x] Source-level verification that #1511 applies cleanly on `origin/2.6`
