### PR TITLE
Update mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,7 +3,7 @@ pull_request_rules:
     conditions:
       - or:
           - base=main
-          - base~=^2(\.\d+){1,2}$
+          - base~=^\d+(\.\d+){1,2}$
       - -status-success=DCO
     actions:
       label:
@@ -16,7 +16,7 @@ pull_request_rules:
     conditions:
       - or:
           - base=main
-          - base~=^2(\.\d+){1,2}$
+          - base~=^\d+(\.\d+){1,2}$
       - status-success=DCO
     actions:
       label:
@@ -25,12 +25,11 @@ pull_request_rules:
         add:
           - dco-passed
 
-
   - name: Blocking PR if missing a related issue or PR doesn't have kind/improvement label
     conditions:
       - or:
           - base=main
-          - base~=^2(\.\d+){1,2}$
+          - base~=^\d+(\.\d+){1,2}$
       - title!=\[automated\]
       - label!=kind/improvement
       - and:
@@ -55,12 +54,11 @@ pull_request_rules:
 
           Thanks for your efforts and contribution to the community!.
 
-
   - name: Dismiss block label if related issue be added into PR
     conditions:
       - or:
           - base=main
-          - base~=^2(\.\d+){1,2}$
+          - base~=^\d+(\.\d+){1,2}$
       - label!=kind/improvement
       - and:
         - or:
@@ -79,7 +77,7 @@ pull_request_rules:
     conditions:
       - or:
           - base=main
-          - base~=^2(\.\d+){1,2}$
+          - base~=^\d+(\.\d+){1,2}$
       - or:
         - and:
           - label=kind/improvement
@@ -113,12 +111,11 @@ pull_request_rules:
         message: |
           @{{author}} Please remove redundant `kind/xxx` labels and make sure that there is only one `kind/xxx` label  of your Pull Request.  (eg. “/remove-kind improvement”)
 
-
   - name: Dismiss block PR if have not multiple 'kind' type labels
     conditions:
       - or:
           - base=main
-          - base~=^2(\.\d+){1,2}$
+          - base~=^\d+(\.\d+){1,2}$
       - or:
         - and:
           - label=kind/improvement
@@ -150,12 +147,11 @@ pull_request_rules:
         remove:
           - do-not-merge/description-tag-conflict
 
-
-  - name: Test passed for code changed for main
+  - name: Test passed for code changed
     conditions:
       - or:
           - base=main
-          - base~=^2(\.\d+){1,2}$
+          - base~=^\d+(\.\d+){1,2}$
       - "status-success=ut on ubuntu-22.04"
       - "status-success=ut on macos-15"
       - 'status-success=pre-commit'
@@ -170,11 +166,11 @@ pull_request_rules:
         add:
           - ci-passed
 
-  - name: Test passed for cpu code changed only for main
+  - name: Test passed for cpu code changed only
     conditions:
       - or:
           - base=main
-          - base~=^2(\.\d+){1,2}$
+          - base~=^\d+(\.\d+){1,2}$
       - -files~=^(?=src/index/ivf_raft/)
       - files~=^(?=.*((\.(h|cpp)|CMakeLists.txt))).*$
       - "status-success=ut on ubuntu-22.04"
@@ -189,11 +185,11 @@ pull_request_rules:
         add:
           - ci-passed
 
-  - name: Test passed for non c++ or go code changed for main
+  - name: Test passed for non c++ or go code changed
     conditions:
       - or:
           - base=main
-          - base~=^2(\.\d+){1,2}$
+          - base~=^\d+(\.\d+){1,2}$
       - -files~=^(?=.*((\.(h|cpp)|CMakeLists.txt))).*$
       - 'status-success=pre-commit'
       - 'status-success=analyzer'
@@ -208,7 +204,7 @@ pull_request_rules:
     conditions:
       - or:
           - base=main
-          - base~=^2(\.\d+){1,2}$
+          - base~=^\d+(\.\d+){1,2}$
       - title~=\[skip e2e\]
       - -files~=^(?=.*((\.(h|cpp)|CMakeLists.txt))).*$
     actions:
@@ -220,7 +216,7 @@ pull_request_rules:
     conditions:
       - or:
           - base=main
-          - base~=^2(\.\d+){1,2}$
+          - base~=^\d+(\.\d+){1,2}$
       - 'check-failure=e2e'
     actions:
       comment:
@@ -231,18 +227,18 @@ pull_request_rules:
     conditions:
       - or:
           - base=main
-          - base~=^2(\.\d+){1,2}$
+          - base~=^\d+(\.\d+){1,2}$
       - 'check-failure=e2e-sse'
     actions:
       comment:
         message: |
           @{{author}} e2e jenkins job failed, comment `/run-e2e-sse` can trigger the job again.
 
-  - name: Remove ci-passed label when ut failed for main
+  - name: Remove ci-passed label when ut failed
     conditions:
       - or:
           - base=main
-          - base~=^2(\.\d+){1,2}$
+          - base~=^\d+(\.\d+){1,2}$
       - or:
         - "status-success!=ut on ubuntu-22.04"
         - "status-success!=ut on macos-15"
@@ -257,11 +253,11 @@ pull_request_rules:
         remove:
           - ci-passed
 
-  - name: Remove ci-passed label when gpu ut failed for main
+  - name: Remove ci-passed label when gpu ut failed
     conditions:
       - or:
           - base=main
-          - base~=^2(\.\d+){1,2}$
+          - base~=^\d+(\.\d+){1,2}$
       - or:
         - "status-success!=ut on ubuntu-22.04"
         - "status-success!=ut on macos-15"


### PR DESCRIPTION
Mergify reads its configuration from the repository default branch, so PRs targeting release branches are still evaluated using the Mergify rules defined on main. Because of that, release-branch PRs can be blocked by checks that are only present on some branches.

This change makes the Mergify CI rules branch-aware:
  - main and 3.x branches require the full check set, including ut on macos-15
  - 2.x branches do not require ut on macos-15, because that workflow is not present there

The rules for adding ci-passed and removing ci-passed were updated consistently so Mergify applies the correct expectations for each branch family.