### PR TITLE
fix: remove num_build_thread upper-bound validation

### DIFF
--- a/include/knowhere/config.h
+++ b/include/knowhere/config.h
@@ -19,7 +19,6 @@
 #include <list>
 #include <optional>
 #include <sstream>
-#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <variant>
@@ -670,7 +669,6 @@ class BaseConfig : public Config {
         KNOWHERE_CONFIG_DECLARE_FIELD(num_build_thread)
             .description("index thread limit for build.")
             .allow_empty_without_default()
-            .set_range(1, std::thread::hardware_concurrency())
             .for_train();
         KNOWHERE_CONFIG_DECLARE_FIELD(radius)
             .set_default(0.0)


### PR DESCRIPTION
issue: #1715

Backport of #1711 to 2.6.

## Issue

DISKANN sealed-index builds fail deterministically on pods where the cgroup
cpu limit exceeds the process-visible core count.

Server logs show repeated:

```
[KNOWHERE][HandleError][milvus] Out of range in json: param 'num_build_thread' (8) should be in range [1,4]
=> failed to build disk index
```

## Root cause

`BaseConfig` validates `num_build_thread` with
`set_range(1, std::thread::hardware_concurrency())`, where
`hardware_concurrency()` reports the **process-visible** cores
(`sched_getaffinity` semantics).

Milvus, however, derives `num_build_thread` from the **cgroup cpu limit**
(`GOMAXPROCS` via `automaxprocs`) × `BuildNumThreadsRatio`. When the cpu
limit (e.g. `limits.cpu: "8"`) is larger than the process-visible cores
(e.g. `4`), the two figures disagree and this range check rejects an
otherwise valid value.

- Growing / interim index paths already hardcode-bypass this parameter, so
  only DISKANN sealed builds were affected.
- The failure is deterministic, so the caller retries forever, saturating
  index scheduling.

## Fix

Remove the range check on `num_build_thread` (and the now-unused `<thread>`
include).

The value only drives `ScopedBuildOmpSetter`, which treats non-positive
values as "use default" and lets OpenMP cap effective thread usage for
values above the available cores. So the range check provided no real
safety and only produced spurious build failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)