### PR TITLE
Cherrypick expose CAGRA num_random_samplings to 2.6

### DIFF
--- a/include/knowhere/comp/index_param.h
+++ b/include/knowhere/comp/index_param.h
@@ -162,6 +162,7 @@ constexpr const char* BUILD_ALGO = "build_algo";
 constexpr const char* SEARCH_ALGO = "search_algo";
 constexpr const char* TEAM_SIZE = "team_size";
 constexpr const char* SEARCH_WIDTH = "search_width";
+constexpr const char* NUM_RANDOM_SAMPLINGS = "num_random_samplings";
 constexpr const char* MIN_ITERATIONS = "min_iterations";
 constexpr const char* MAX_ITERATIONS = "max_iterations";
 constexpr const char* THREAD_BLOCK_SIZE = "thread_block_size";

--- a/src/common/cuvs/integration/cuvs_knowhere_config.hpp
+++ b/src/common/cuvs/integration/cuvs_knowhere_config.hpp
@@ -63,6 +63,7 @@ struct cuvs_knowhere_config {
     std::optional<std::string> search_algo = std::nullopt;
     std::optional<int> team_size = std::nullopt;
     std::optional<int> search_width = std::nullopt;
+    std::optional<int> num_random_samplings = std::nullopt;
     std::optional<int> min_iterations = std::nullopt;
     std::optional<int> max_iterations = std::nullopt;
     std::optional<int> thread_block_size = std::nullopt;
@@ -112,6 +113,7 @@ validate_cuvs_knowhere_config(cuvs_knowhere_config config) {
         config.search_algo = config.search_algo.value_or("AUTO");
         config.team_size = config.team_size.value_or(0);
         config.search_width = config.search_width.value_or(1);
+        config.num_random_samplings = config.num_random_samplings.value_or(1);
         config.min_iterations = config.min_iterations.value_or(0);
         config.max_iterations = config.max_iterations.value_or(0);
         config.thread_block_size = config.thread_block_size.value_or(0);

--- a/src/common/cuvs/integration/cuvs_knowhere_index.cuh
+++ b/src/common/cuvs/integration/cuvs_knowhere_index.cuh
@@ -340,6 +340,7 @@ config_to_search_params(cuvs_knowhere_config const& raw_config) {
         result.algo = search_algo_string_to_cagra_search_algo(*(config.search_algo));
         result.team_size = *(config.team_size);
         result.search_width = *(config.search_width);
+        result.num_random_samplings = *(config.num_random_samplings);
         result.min_iterations = *(config.min_iterations);
         result.thread_block_size = *(config.thread_block_size);
         result.hashmap_mode = hashmap_mode_string_to_cagra_hashmap_mode(*(config.hashmap_mode));

--- a/src/index/gpu_cuvs/gpu_cuvs_cagra_config.h
+++ b/src/index/gpu_cuvs/gpu_cuvs_cagra_config.h
@@ -41,6 +41,7 @@ struct GpuCuvsCagraConfig : public BaseConfig {
     CFG_STRING search_algo;
     CFG_INT team_size;
     CFG_INT search_width;
+    CFG_INT num_random_samplings;
     CFG_INT min_iterations;
     CFG_INT max_iterations;
     CFG_INT thread_block_size;
@@ -87,6 +88,11 @@ struct GpuCuvsCagraConfig : public BaseConfig {
         KNOWHERE_CONFIG_DECLARE_FIELD(search_width)
             .description("nodes to select as starting point in each iteration")
             .allow_empty_without_default()
+            .for_search();
+        KNOWHERE_CONFIG_DECLARE_FIELD(num_random_samplings)
+            .description("number of random seed samplings")
+            .set_default(1)
+            .set_range(1, std::numeric_limits<CFG_INT::value_type>::max())
             .for_search();
         KNOWHERE_CONFIG_DECLARE_FIELD(min_iterations)
             .description("minimum number of search iterations")
@@ -183,6 +189,7 @@ to_cuvs_knowhere_config(GpuCuvsCagraConfig const& cfg) {
     result.search_algo = cfg.search_algo;
     result.team_size = cfg.team_size;
     result.search_width = cfg.search_width;
+    result.num_random_samplings = cfg.num_random_samplings;
     result.min_iterations = cfg.min_iterations;
     result.max_iterations = cfg.max_iterations;
     result.thread_block_size = cfg.thread_block_size;

--- a/tests/ut/test_config.cc
+++ b/tests/ut/test_config.cc
@@ -648,6 +648,24 @@ TEST_CASE("Test config json parse", "[config]") {
             s = knowhere::Config::Load(cagra_config, tmp_json, knowhere::SEARCH);
             CHECK(s == knowhere::Status::success);
         }
+
+        {
+            // search with legal num_random_samplings
+            knowhere::GpuCuvsCagraConfig cagra_config;
+            auto tmp_json = json;
+            tmp_json["num_random_samplings"] = 32;
+            s = knowhere::Config::Load(cagra_config, tmp_json, knowhere::SEARCH);
+            CHECK(s == knowhere::Status::success);
+        }
+
+        {
+            // search with illegal num_random_samplings
+            knowhere::GpuCuvsCagraConfig cagra_config;
+            auto tmp_json = json;
+            tmp_json["num_random_samplings"] = 0;
+            s = knowhere::Config::Load(cagra_config, tmp_json, knowhere::SEARCH);
+            CHECK(s == knowhere::Status::out_of_range_in_json);
+        }
     }
 
 #endif


### PR DESCRIPTION
## Summary
- Cherrypick #1713 to 2.6.
- Expose GPU_CAGRA search JSON parameter `num_random_samplings`.
- Validate it as a search parameter with default `1` and range `>= 1`.
- Forward the value to `cuvs::neighbors::cagra::search_params`.

pr: #1713
issue: #1692

## Test plan
- [x] `env UV_CACHE_DIR=/tmp/uv-cache CONAN_USER_HOME=/tmp/conan1-home uv tool run --from conan==1.61.0 conan install . -if /tmp/knowhere_issue_1692_2_6_build --build=missing -o with_ut=True -s compiler.libcxx=libstdc++11 -s build_type=Release`
- [x] `env UV_CACHE_DIR=/tmp/uv-cache CONAN_USER_HOME=/tmp/conan1-home uv tool run --from conan==1.61.0 conan build . -if /tmp/knowhere_issue_1692_2_6_build`
- [x] `build/Release/tests/ut/knowhere_tests "[config]"`
- [x] Direct compile `tests/ut/test_config.cc` with `-DKNOWHERE_WITH_CUVS`
- [ ] Full local `WITH_CUVS`/GPU source build was not completed: this machine does not have a consistent 2.6-compatible RAPIDS/cuVS/RAFT/RMM header set available. The regular 2.6 build and CUVS config conditional compile passed.
