### PR TITLE
[WIP] ci: refactor main branch cache strategy

### DIFF
--- a/.github/actions/cache-restore/action.yaml
+++ b/.github/actions/cache-restore/action.yaml
@@ -1,10 +1,6 @@
 name: 'Knowhere Cache'
 description: 'Restore branch-aware Conan and hosted-runner CCache snapshots'
 inputs:
-  os:
-    description: 'OS name used only to restore legacy cache keys during migration'
-    required: true
-    default: 'ubuntu22.04'
   runner-class:
     description: 'Stable runner class such as selfhosted-linux, github-linux, or github-macos'
     required: true
@@ -23,43 +19,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    # New Conan keys no longer depend on CPU features. Keep this detection only
-    # while the legacy restore prefix is needed to seed the new cache layout.
-    - name: Detect Legacy CPU Feature Bucket
-      id: cpu_feature
-      shell: bash
-      run: |
-        set -euo pipefail
-
-        flags=""
-        if command -v lscpu >/dev/null 2>&1; then
-          flags="$(LC_ALL=C lscpu | awk -F: '/^(Flags|Features):/ {gsub(/^[[:space:]]+/, "", $2); print $2; exit}' | tr '[:upper:]' '[:lower:]')"
-        fi
-
-        if [ -z "${flags}" ] && command -v sysctl >/dev/null 2>&1; then
-          flags="$(sysctl -a machdep.cpu.features machdep.cpu.leaf7_features 2>/dev/null | tr '[:upper:]' '[:lower:]' || true)"
-        fi
-
-        if [ -z "${flags}" ] && [ -r /proc/cpuinfo ]; then
-          flags="$(awk -F: '/^(flags|Features)[[:space:]]*:/ {gsub(/^[[:space:]]+/, "", $2); print $2; exit}' /proc/cpuinfo | tr '[:upper:]' '[:lower:]')"
-        fi
-
-        features=()
-        for feature in avx512f avx512bw avx512vl avx512dq avx512cd avx512vnni avx512vbmi2 avx512vpopcntdq avx512_bf16 avx512_fp16 avx2 fma sse4_2 sve asimd; do
-          if grep -qw "${feature}" <<< "${flags}"; then
-            features+=("${feature}")
-          fi
-        done
-
-        if [ ${#features[@]} -eq 0 ]; then
-          bucket="cpu-generic"
-        else
-          bucket="cpu-$(IFS=_; echo "${features[*]}")"
-        fi
-
-        echo "bucket=${bucket}" >> "${GITHUB_OUTPUT}"
-        echo "Using legacy cache CPU feature bucket: ${bucket}"
-
     # GitHub-hosted runners are ephemeral, so persist their compiler cache.
     # Query CCache itself because its default path differs by platform/version.
     - name: Resolve CCache Directory
@@ -89,11 +48,8 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ~/.conan2
-        # Conan stores multiple package IDs/settings in one cache, so jobs and
-        # CPU feature buckets can share it. Runner class and branch prevent
-        # incompatible environments and maintained branches from contaminating
-        # each other's dependency snapshots.
+        # Conan stores multiple package IDs/settings in one cache, so jobs can
+        # share it. Runner class and branch prevent incompatible environments
+        # and maintained branches from contaminating dependency snapshots.
         key: knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-conan2-${{ hashFiles('conanfile.py') }}
-        restore-keys: |
-          knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-conan2-
-          knowhere-${{ inputs.os }}-${{ github.job }}-${{ steps.cpu_feature.outputs.bucket }}-conan2-
+        restore-keys: knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-conan2-

--- a/.github/actions/cache-restore/action.yaml
+++ b/.github/actions/cache-restore/action.yaml
@@ -1,15 +1,31 @@
 name: 'Knowhere Cache'
-description: ''
+description: 'Restore branch-aware Conan and hosted-runner CCache snapshots'
 inputs:
   os:
-    description: 'OS name'
+    description: 'OS name used only to restore legacy cache keys during migration'
     required: true
     default: 'ubuntu22.04'
+  runner-class:
+    description: 'Stable runner class such as selfhosted-linux, github-linux, or github-macos'
+    required: true
+  cache-branch:
+    description: 'Target branch used to isolate caches between maintained branches'
+    required: true
+  cache-ccache:
+    description: 'Whether to transfer CCache through GitHub Actions cache storage'
+    required: false
+    default: 'true'
+  ccache-max-size:
+    description: 'Maximum CCache size uploaded by ephemeral runners'
+    required: false
+    default: '1G'
 
 runs:
   using: 'composite'
   steps:
-    - name: Detect CPU Feature Bucket
+    # New Conan keys no longer depend on CPU features. Keep this detection only
+    # while the legacy restore prefix is needed to seed the new cache layout.
+    - name: Detect Legacy CPU Feature Bucket
       id: cpu_feature
       shell: bash
       run: |
@@ -42,24 +58,42 @@ runs:
         fi
 
         echo "bucket=${bucket}" >> "${GITHUB_OUTPUT}"
-        echo "Using cache CPU feature bucket: ${bucket}"
-    - name: Cache CCache Volumes
+        echo "Using legacy cache CPU feature bucket: ${bucket}"
+
+    # GitHub-hosted runners are ephemeral, so persist their compiler cache.
+    # Query CCache itself because its default path differs by platform/version.
+    - name: Resolve CCache Directory
+      if: ${{ inputs.cache-ccache == 'true' }}
+      id: ccache
+      shell: bash
+      run: |
+        set -euo pipefail
+        ccache --max-size="${{ inputs.ccache-max-size }}"
+        echo "dir=$(ccache --get-config cache_dir)" >> "${GITHUB_OUTPUT}"
+
+    - name: Restore CCache
+      if: ${{ inputs.cache-ccache == 'true' }}
       uses: actions/cache/restore@v4
       with:
-        path: ~/.ccache
-        # hashFiles intentionally omits thirdparty/** — thirdparty changes (e.g.
-        # faiss submodule bumps) would otherwise roll the key on every bump and
-        # spawn orphan tarballs that burn GitHub's 10 GB cache quota. ccache
-        # inside the restored tarball still detects thirdparty source changes
-        # via its own content hashing, so compilation correctness is unaffected.
-        # Key must match cache-save/action.yaml exactly for exact-key hits.
-        key: knowhere-${{ inputs.os }}-${{ github.job }}-${{ steps.cpu_feature.outputs.bucket }}-ccache-${{ hashFiles('src/**/*.cpp', 'src/**/*.cc', 'src/**/*.c', 'src/**/*.h', 'src/**/*.hpp', 'include/**/*.h', 'include/**/*.hpp', 'tests/**/*.cpp', 'tests/**/*.cc', 'tests/**/*.h', 'benchmark/**/*.cpp', 'benchmark/**/*.cc', 'benchmark/**/*.h', 'cmake/**', 'CMakeLists.txt', 'Makefile', 'conanfile.py') }}
-        restore-keys: knowhere-${{ inputs.os }}-${{ github.job }}-${{ steps.cpu_feature.outputs.bucket }}-ccache-
+        path: ${{ steps.ccache.outputs.dir }}
+        # Keep build jobs separate because their compiler flags differ. Source
+        # hashing rolls immutable snapshots while the prefix restores the latest.
+        key: knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-${{ github.job }}-ccache-${{ hashFiles('src/**/*.cpp', 'src/**/*.cc', 'src/**/*.c', 'src/**/*.h', 'src/**/*.hpp', 'include/**/*.h', 'include/**/*.hpp', 'tests/**/*.cpp', 'tests/**/*.cc', 'tests/**/*.h', 'benchmark/**/*.cpp', 'benchmark/**/*.cc', 'benchmark/**/*.h', 'cmake/**', 'CMakeLists.txt', 'Makefile', 'conanfile.py') }}
+        restore-keys: knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-${{ github.job }}-ccache-
+
     - name: Reset Conan package cache
       shell: bash
       run: rm -rf ~/.conan2/p
-    - name: Cache Conan Packages
+
+    - name: Restore Conan Packages
       uses: actions/cache/restore@v4
       with:
         path: ~/.conan2
-        key: knowhere-${{ inputs.os }}-${{ github.job }}-${{ steps.cpu_feature.outputs.bucket }}-conan2-${{ hashFiles('conanfile.py') }}
+        # Conan stores multiple package IDs/settings in one cache, so jobs and
+        # CPU feature buckets can share it. Runner class and branch prevent
+        # incompatible environments and maintained branches from contaminating
+        # each other's dependency snapshots.
+        key: knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-conan2-${{ hashFiles('conanfile.py') }}
+        restore-keys: |
+          knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-conan2-
+          knowhere-${{ inputs.os }}-${{ github.job }}-${{ steps.cpu_feature.outputs.bucket }}-conan2-

--- a/.github/actions/cache-save/action.yaml
+++ b/.github/actions/cache-save/action.yaml
@@ -1,61 +1,52 @@
 name: 'Knowhere Cache'
-description: ''
+description: 'Save branch-aware Conan and bounded hosted-runner CCache snapshots'
 inputs:
   os:
-    description: 'OS name'
+    description: 'OS name retained for a consistent restore/save interface'
     required: true
     default: 'ubuntu22.04'
+  runner-class:
+    description: 'Stable runner class such as selfhosted-linux, github-linux, or github-macos'
+    required: true
+  cache-branch:
+    description: 'Target branch used to isolate caches between maintained branches'
+    required: true
+  cache-ccache:
+    description: 'Whether to transfer CCache through GitHub Actions cache storage'
+    required: false
+    default: 'true'
+  ccache-max-size:
+    description: 'Maximum CCache size uploaded by ephemeral runners'
+    required: false
+    default: '1G'
 
 runs:
   using: 'composite'
   steps:
-    - name: Detect CPU Feature Bucket
-      id: cpu_feature
+    # Bound the hosted-runner archive before upload. Conan archives already use
+    # most of the repository cache allowance, so an unbounded compiler cache
+    # would cause useful dependency caches to churn out.
+    - name: Prepare CCache for Upload
+      if: ${{ inputs.cache-ccache == 'true' }}
+      id: ccache
       shell: bash
       run: |
         set -euo pipefail
+        ccache --max-size="${{ inputs.ccache-max-size }}"
+        ccache --cleanup
+        echo "dir=$(ccache --get-config cache_dir)" >> "${GITHUB_OUTPUT}"
 
-        flags=""
-        if command -v lscpu >/dev/null 2>&1; then
-          flags="$(LC_ALL=C lscpu | awk -F: '/^(Flags|Features):/ {gsub(/^[[:space:]]+/, "", $2); print $2; exit}' | tr '[:upper:]' '[:lower:]')"
-        fi
-
-        if [ -z "${flags}" ] && command -v sysctl >/dev/null 2>&1; then
-          flags="$(sysctl -a machdep.cpu.features machdep.cpu.leaf7_features 2>/dev/null | tr '[:upper:]' '[:lower:]' || true)"
-        fi
-
-        if [ -z "${flags}" ] && [ -r /proc/cpuinfo ]; then
-          flags="$(awk -F: '/^(flags|Features)[[:space:]]*:/ {gsub(/^[[:space:]]+/, "", $2); print $2; exit}' /proc/cpuinfo | tr '[:upper:]' '[:lower:]')"
-        fi
-
-        features=()
-        for feature in avx512f avx512bw avx512vl avx512dq avx512cd avx512vnni avx512vbmi2 avx512vpopcntdq avx512_bf16 avx512_fp16 avx2 fma sse4_2 sve asimd; do
-          if grep -qw "${feature}" <<< "${flags}"; then
-            features+=("${feature}")
-          fi
-        done
-
-        if [ ${#features[@]} -eq 0 ]; then
-          bucket="cpu-generic"
-        else
-          bucket="cpu-$(IFS=_; echo "${features[*]}")"
-        fi
-
-        echo "bucket=${bucket}" >> "${GITHUB_OUTPUT}"
-        echo "Using cache CPU feature bucket: ${bucket}"
-    - name: Cache CCache Volumes
+    - name: Save CCache
+      if: ${{ inputs.cache-ccache == 'true' }}
       uses: actions/cache/save@v4
       with:
-        path: ~/.ccache
-        # hashFiles intentionally omits thirdparty/** — thirdparty changes (e.g.
-        # faiss submodule bumps) would otherwise roll the key on every bump and
-        # spawn orphan tarballs that burn GitHub's 10 GB cache quota. ccache
-        # inside the restored tarball still detects thirdparty source changes
-        # via its own content hashing, so compilation correctness is unaffected.
-        # Key must match cache-restore/action.yaml exactly for exact-key hits.
-        key: knowhere-${{ inputs.os }}-${{ github.job }}-${{ steps.cpu_feature.outputs.bucket }}-ccache-${{ hashFiles('src/**/*.cpp', 'src/**/*.cc', 'src/**/*.c', 'src/**/*.h', 'src/**/*.hpp', 'include/**/*.h', 'include/**/*.hpp', 'tests/**/*.cpp', 'tests/**/*.cc', 'tests/**/*.h', 'benchmark/**/*.cpp', 'benchmark/**/*.cc', 'benchmark/**/*.h', 'cmake/**', 'CMakeLists.txt', 'Makefile', 'conanfile.py') }}
-    - name: Cache Conan Packages
+        path: ${{ steps.ccache.outputs.dir }}
+        # Must match cache-restore/action.yaml exactly for exact-key hits.
+        key: knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-${{ github.job }}-ccache-${{ hashFiles('src/**/*.cpp', 'src/**/*.cc', 'src/**/*.c', 'src/**/*.h', 'src/**/*.hpp', 'include/**/*.h', 'include/**/*.hpp', 'tests/**/*.cpp', 'tests/**/*.cc', 'tests/**/*.h', 'benchmark/**/*.cpp', 'benchmark/**/*.cc', 'benchmark/**/*.h', 'cmake/**', 'CMakeLists.txt', 'Makefile', 'conanfile.py') }}
+
+    - name: Save Conan Packages
       uses: actions/cache/save@v4
       with:
         path: ~/.conan2
-        key: knowhere-${{ inputs.os }}-${{ github.job }}-${{ steps.cpu_feature.outputs.bucket }}-conan2-${{ hashFiles('conanfile.py') }}
+        # Must match cache-restore/action.yaml exactly for exact-key hits.
+        key: knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-conan2-${{ hashFiles('conanfile.py') }}

--- a/.github/actions/cache-save/action.yaml
+++ b/.github/actions/cache-save/action.yaml
@@ -1,10 +1,6 @@
 name: 'Knowhere Cache'
 description: 'Save branch-aware Conan and bounded hosted-runner CCache snapshots'
 inputs:
-  os:
-    description: 'OS name retained for a consistent restore/save interface'
-    required: true
-    default: 'ubuntu22.04'
   runner-class:
     description: 'Stable runner class such as selfhosted-linux, github-linux, or github-macos'
     required: true

--- a/.github/workflows/analyzer.yaml
+++ b/.github/workflows/analyzer.yaml
@@ -21,10 +21,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'none'
-      - name: Restore Cache
-        uses: ./.github/actions/cache-restore
-        with:
-          os: ubuntu-22.04
       - name: Install GCC 12
         # GCC 11 (ubuntu-22.04 default) has incomplete C++20 support:
         # std::partial_ordering, std::strong_ordering, std::weak_ordering
@@ -36,6 +32,14 @@ jobs:
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 120
       - name: Install Dependency
         run: bash scripts/install_deps.sh
+      # Resolve CCache only after install_deps provides a consistent ccache
+      # binary across hosted runner images.
+      - name: Restore Cache
+        uses: ./.github/actions/cache-restore
+        with:
+          os: ubuntu-22.04
+          runner-class: github-linux
+          cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build & Analyzer
         run: |
           make WITH_UT=True \
@@ -44,3 +48,5 @@ jobs:
         uses: ./.github/actions/cache-save
         with:
           os: ubuntu-22.04
+          runner-class: github-linux
+          cache-branch: ${{ github.base_ref || github.ref_name }}

--- a/.github/workflows/analyzer.yaml
+++ b/.github/workflows/analyzer.yaml
@@ -37,7 +37,6 @@ jobs:
       - name: Restore Cache
         uses: ./.github/actions/cache-restore
         with:
-          os: ubuntu-22.04
           runner-class: github-linux
           cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build & Analyzer
@@ -47,6 +46,5 @@ jobs:
       - name: Save Cache
         uses: ./.github/actions/cache-save
         with:
-          os: ubuntu-22.04
           runner-class: github-linux
           cache-branch: ${{ github.base_ref || github.ref_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,6 @@ jobs:
       - name: Restore Cache
         uses: ./.github/actions/cache-restore
         with:
-          os: ubuntu-22.04
           runner-class: github-linux
           cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build
@@ -46,7 +45,6 @@ jobs:
       - name: Save Cache
         uses: ./.github/actions/cache-save
         with:
-          os: ubuntu-22.04
           runner-class: github-linux
           cache-branch: ${{ github.base_ref || github.ref_name }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,8 @@ jobs:
         uses: ./.github/actions/cache-restore
         with:
           os: ubuntu-22.04
+          runner-class: github-linux
+          cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build
         env:
           ARTIFACT_NAME: ${{ env.RELEASE_NAME }}-${{ matrix.os }}
@@ -45,6 +47,8 @@ jobs:
         uses: ./.github/actions/cache-save
         with:
           os: ubuntu-22.04
+          runner-class: github-linux
+          cache-branch: ${{ github.base_ref || github.ref_name }}
 
   Release:
     needs: Build

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -47,7 +47,6 @@ jobs:
       - name: Restore Cache
         uses: ./.github/actions/cache-restore
         with:
-          os: ubuntu-22.04
           runner-class: selfhosted-linux
           cache-branch: ${{ github.base_ref || github.ref_name }}
           # This runner keeps a persistent multi-GB local CCache with a high hit
@@ -60,7 +59,6 @@ jobs:
       - name: Save Cache
         uses: ./.github/actions/cache-save
         with:
-          os: ubuntu-22.04
           runner-class: selfhosted-linux
           cache-branch: ${{ github.base_ref || github.ref_name }}
           cache-ccache: 'false'
@@ -84,7 +82,6 @@ jobs:
       - name: Restore Cache
         uses: ./.github/actions/cache-restore
         with:
-          os: ${{ matrix.os }}
           runner-class: github-macos
           cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build
@@ -99,7 +96,6 @@ jobs:
       - name: Save Cache
         uses: ./.github/actions/cache-save
         with:
-          os: ${{ matrix.os }}
           runner-class: github-macos
           cache-branch: ${{ github.base_ref || github.ref_name }}
 
@@ -133,7 +129,6 @@ jobs:
       - name: Restore Cache
         uses: ./.github/actions/cache-restore
         with:
-          os: ubuntu-22.04
           runner-class: github-linux
           cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build
@@ -142,7 +137,6 @@ jobs:
       - name: Save Cache
         uses: ./.github/actions/cache-save
         with:
-          os: ubuntu-22.04
           runner-class: github-linux
           cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build Portable Wheel

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -44,24 +44,12 @@ jobs:
         run: |
           bash scripts/install_deps.sh
           sudo pip3 install cmake==3.28.1
-      - name: Restore Cache
-        uses: ./.github/actions/cache-restore
-        with:
-          runner-class: selfhosted-linux
-          cache-branch: ${{ github.base_ref || github.ref_name }}
-          # This runner keeps a persistent multi-GB local CCache with a high hit
-          # rate. Uploading it would add transfer time and consume repo quota.
-          cache-ccache: 'false'
+      # This runner keeps CCache and Conan on persistent local storage. Avoid
+      # duplicating those caches in GitHub storage and consuming repository quota.
       - name: Build
         run: |
           make WITH_UT=True WITH_ASAN=True
           make test
-      - name: Save Cache
-        uses: ./.github/actions/cache-save
-        with:
-          runner-class: selfhosted-linux
-          cache-branch: ${{ github.base_ref || github.ref_name }}
-          cache-ccache: 'false'
 
   ut-macos:
     name: ut on ${{ matrix.os }}

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -48,6 +48,11 @@ jobs:
         uses: ./.github/actions/cache-restore
         with:
           os: ubuntu-22.04
+          runner-class: selfhosted-linux
+          cache-branch: ${{ github.base_ref || github.ref_name }}
+          # This runner keeps a persistent multi-GB local CCache with a high hit
+          # rate. Uploading it would add transfer time and consume repo quota.
+          cache-ccache: 'false'
       - name: Build
         run: |
           make WITH_UT=True WITH_ASAN=True
@@ -56,6 +61,9 @@ jobs:
         uses: ./.github/actions/cache-save
         with:
           os: ubuntu-22.04
+          runner-class: selfhosted-linux
+          cache-branch: ${{ github.base_ref || github.ref_name }}
+          cache-ccache: 'false'
 
   ut-macos:
     name: ut on ${{ matrix.os }}
@@ -77,6 +85,8 @@ jobs:
         uses: ./.github/actions/cache-restore
         with:
           os: ${{ matrix.os }}
+          runner-class: github-macos
+          cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build
         run: |
           # CMake 4.x (Homebrew) removed compat with cmake_minimum_required < 3.5;
@@ -90,6 +100,8 @@ jobs:
         uses: ./.github/actions/cache-save
         with:
           os: ${{ matrix.os }}
+          runner-class: github-macos
+          cache-branch: ${{ github.base_ref || github.ref_name }}
 
   swig-build:
     name: python3 wheel
@@ -122,6 +134,8 @@ jobs:
         uses: ./.github/actions/cache-restore
         with:
           os: ubuntu-22.04
+          runner-class: github-linux
+          cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build
         run: |
           make
@@ -129,6 +143,8 @@ jobs:
         uses: ./.github/actions/cache-save
         with:
           os: ubuntu-22.04
+          runner-class: github-linux
+          cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build Portable Wheel
         run: |
           cd python && ./build_portable_wheel.sh


### PR DESCRIPTION
## Question

How can Knowhere keep fast compilation without uploading persistent self-hosted runner caches, while still giving ephemeral GitHub-hosted jobs useful and reusable caches?

The current workflow hard-codes `~/.ccache`. On `Github-Action-Runner-Knowhere-2`, the Actions service runs as `ubuntu` and CCache reports `/home/ubuntu/.cache/ccache`; its CCache and Conan homes are both persistent and multi-GB. Transferring those local caches through GitHub adds latency and consumes repository cache quota without providing persistence.

Conan cache keys also include the job and CPU feature bucket. That duplicates large dependency archives across hosted jobs and prevents maintained branches from having explicit cache identities.

## Solution

- Keep both CCache and Conan entirely local for the self-hosted Linux UT; remove GitHub cache restore/save from that job.
- Ask CCache for its configured directory on ephemeral runners instead of assuming a platform-specific path.
- Limit hosted-runner CCache archives to 1 GB before upload to control repository cache pressure.
- Scope hosted cache keys by stable runner class and target branch.
- Keep hosted CCache job-specific because build flags differ, while sharing hosted Conan across jobs within one runner class and branch.
- Start the new hosted cache namespaces cold instead of retaining migration-only legacy restore prefixes; successful `main` runs seed caches reusable by later PRs.
- Install dependencies before Analyzer cache resolution so the CCache CLI is consistently available.
- Document each non-obvious decision next to the relevant workflow/action logic.

Cardinal PR https://github.com/zilliztech/cardinal/pull/887 introduces the related runner-class and target-branch cache strategy for Cardinal. Cardinal PR https://github.com/zilliztech/cardinal/pull/889 applies the same persistent-local-cache policy to its self-hosted `2.6` compatibility job.

## Verification

- Ruby YAML parser on all modified workflow and composite-action files
- `git diff --check`
- Programmatic audit confirms the self-hosted UT invokes no GitHub cache action
- Verified all hosted cache action callers provide `runner-class` and `cache-branch`
- Verified restore/save cache-key symmetry for hosted jobs
- Verified no legacy CPU/OS restore references remain
- Verified directly that the runner service uses `ubuntu` with persistent 6.4 GB Conan and 5.2 GB CCache directories
- DCO sign-off verified exactly
