### PR TITLE
[WIP] ci: refactor 2.6 cache strategy

### DIFF
--- a/.github/actions/cache-restore/action.yaml
+++ b/.github/actions/cache-restore/action.yaml
@@ -1,10 +1,6 @@
 name: 'Knowhere Cache'
 description: 'Restore branch-aware Conan and hosted-runner CCache snapshots'
 inputs:
-  os:
-    description: 'OS name used only to restore legacy cache keys during migration'
-    required: true
-    default: 'ubuntu22.04'
   runner-class:
     description: 'Stable runner class such as selfhosted-linux, github-linux, or github-macos'
     required: true
@@ -52,7 +48,4 @@ runs:
         # share it. Runner class and branch prevent incompatible environments
         # and maintained branches from contaminating dependency snapshots.
         key: knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-conan1-${{ hashFiles('conanfile.py') }}
-        # Keep the old OS/job prefix temporarily so existing caches seed the new layout.
-        restore-keys: |
-          knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-conan1-
-          knowhere-${{ inputs.os }}-${{ github.job }}-conan-
+        restore-keys: knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-conan1-

--- a/.github/actions/cache-restore/action.yaml
+++ b/.github/actions/cache-restore/action.yaml
@@ -1,23 +1,58 @@
 name: 'Knowhere Cache'
-description: ''
+description: 'Restore branch-aware Conan and hosted-runner CCache snapshots'
 inputs:
   os:
-    description: 'OS name'
+    description: 'OS name used only to restore legacy cache keys during migration'
     required: true
     default: 'ubuntu22.04'
+  runner-class:
+    description: 'Stable runner class such as selfhosted-linux, github-linux, or github-macos'
+    required: true
+  cache-branch:
+    description: 'Target branch used to isolate caches between maintained branches'
+    required: true
+  cache-ccache:
+    description: 'Whether to transfer CCache through GitHub Actions cache storage'
+    required: false
+    default: 'true'
+  ccache-max-size:
+    description: 'Maximum CCache size uploaded by ephemeral runners'
+    required: false
+    default: '1G'
 
 runs:
   using: 'composite'
   steps:
-    - name: Cache CCache Volumes
+    # GitHub-hosted runners are ephemeral, so persist their compiler cache.
+    # Query CCache itself because its default path differs by platform/version.
+    - name: Resolve CCache Directory
+      if: ${{ inputs.cache-ccache == 'true' }}
+      id: ccache
+      shell: bash
+      run: |
+        set -euo pipefail
+        ccache --max-size="${{ inputs.ccache-max-size }}"
+        echo "dir=$(ccache --get-config cache_dir)" >> "${GITHUB_OUTPUT}"
+
+    - name: Restore CCache
+      if: ${{ inputs.cache-ccache == 'true' }}
       uses: actions/cache/restore@v4
       with:
-        path: ~/.cache/ccache
-        key: knowhere-${{ inputs.os }}-${{ github.job }}-ccache-${{ hashFiles( '**/*.cpp', '**/*.cc', '**/*.c', '**/*.h', '**/*.hpp', '**/CMakeLists.txt') }}
-        restore-keys: knowhere-${{ inputs.os }}-${{ github.job }}-ccache-
-    - name: Cache Conan Packages
+        path: ${{ steps.ccache.outputs.dir }}
+        # Keep build jobs separate because their compiler flags differ. Source
+        # hashing rolls immutable snapshots while the prefix restores the latest.
+        key: knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-${{ github.job }}-ccache-${{ hashFiles('src/**/*.cpp', 'src/**/*.cc', 'src/**/*.c', 'src/**/*.h', 'src/**/*.hpp', 'include/**/*.h', 'include/**/*.hpp', 'tests/**/*.cpp', 'tests/**/*.cc', 'tests/**/*.h', 'benchmark/**/*.cpp', 'benchmark/**/*.cc', 'benchmark/**/*.h', 'cmake/**', 'CMakeLists.txt', 'Makefile', 'conanfile.py') }}
+        restore-keys: knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-${{ github.job }}-ccache-
+
+    - name: Restore Conan Packages
       uses: actions/cache/restore@v4
       with:
         path: ~/.conan
-        key: knowhere-${{ inputs.os }}-${{ github.job }}-conan-${{ hashFiles('conanfile.py') }}
-        restore-keys: knowhere-${{ inputs.os }}-${{ github.job }}-conan-
+        # Conan stores multiple package IDs/settings in one cache, so jobs can
+        # share it. Runner class and branch prevent incompatible environments
+        # and maintained branches from contaminating dependency snapshots.
+        key: knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-conan1-${{ hashFiles('conanfile.py') }}
+        # Keep the old OS/job prefix temporarily so existing caches seed the new layout.
+        restore-keys: |
+          knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-conan1-
+          knowhere-${{ inputs.os }}-${{ github.job }}-conan-

--- a/.github/actions/cache-save/action.yaml
+++ b/.github/actions/cache-save/action.yaml
@@ -1,21 +1,52 @@
 name: 'Knowhere Cache'
-description: ''
+description: 'Save branch-aware Conan and bounded hosted-runner CCache snapshots'
 inputs:
   os:
-    description: 'OS name'
+    description: 'OS name retained for a consistent restore/save interface'
     required: true
     default: 'ubuntu22.04'
+  runner-class:
+    description: 'Stable runner class such as selfhosted-linux, github-linux, or github-macos'
+    required: true
+  cache-branch:
+    description: 'Target branch used to isolate caches between maintained branches'
+    required: true
+  cache-ccache:
+    description: 'Whether to transfer CCache through GitHub Actions cache storage'
+    required: false
+    default: 'true'
+  ccache-max-size:
+    description: 'Maximum CCache size uploaded by ephemeral runners'
+    required: false
+    default: '1G'
 
 runs:
   using: 'composite'
   steps:
-    - name: Cache CCache Volumes
+    # Cap hosted-runner archives at 1G by default before upload. Conan archives
+    # already use most of the repository cache allowance, so an unbounded
+    # compiler cache would cause useful dependency caches to churn out.
+    - name: Prepare CCache for Upload
+      if: ${{ inputs.cache-ccache == 'true' }}
+      id: ccache
+      shell: bash
+      run: |
+        set -euo pipefail
+        ccache --max-size="${{ inputs.ccache-max-size }}"
+        ccache --cleanup
+        echo "dir=$(ccache --get-config cache_dir)" >> "${GITHUB_OUTPUT}"
+
+    - name: Save CCache
+      if: ${{ inputs.cache-ccache == 'true' }}
       uses: actions/cache/save@v4
       with:
-        path: ~/.cache/ccache
-        key: knowhere-${{ inputs.os }}-${{ github.job }}-ccache-${{ hashFiles( '**/*.cpp', '**/*.cc', '**/*.c', '**/*.h', '**/*.hpp', '**/CMakeLists.txt') }}
-    - name: Cache Conan Packages
+        path: ${{ steps.ccache.outputs.dir }}
+        # Must match cache-restore/action.yaml exactly for exact-key hits.
+        key: knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-${{ github.job }}-ccache-${{ hashFiles('src/**/*.cpp', 'src/**/*.cc', 'src/**/*.c', 'src/**/*.h', 'src/**/*.hpp', 'include/**/*.h', 'include/**/*.hpp', 'tests/**/*.cpp', 'tests/**/*.cc', 'tests/**/*.h', 'benchmark/**/*.cpp', 'benchmark/**/*.cc', 'benchmark/**/*.h', 'cmake/**', 'CMakeLists.txt', 'Makefile', 'conanfile.py') }}
+
+    - name: Save Conan Packages
       uses: actions/cache/save@v4
       with:
         path: ~/.conan
-        key: knowhere-${{ inputs.os }}-${{ github.job }}-conan-${{ hashFiles('conanfile.py') }}
+        # Must match cache-restore/action.yaml exactly for exact-key hits.
+        key: knowhere-${{ inputs.runner-class }}-${{ inputs.cache-branch }}-conan1-${{ hashFiles('conanfile.py') }}

--- a/.github/actions/cache-save/action.yaml
+++ b/.github/actions/cache-save/action.yaml
@@ -1,10 +1,6 @@
 name: 'Knowhere Cache'
 description: 'Save branch-aware Conan and bounded hosted-runner CCache snapshots'
 inputs:
-  os:
-    description: 'OS name retained for a consistent restore/save interface'
-    required: true
-    default: 'ubuntu22.04'
   runner-class:
     description: 'Stable runner class such as selfhosted-linux, github-linux, or github-macos'
     required: true

--- a/.github/workflows/analyzer.yaml
+++ b/.github/workflows/analyzer.yaml
@@ -3,7 +3,7 @@ name: Analyzer
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: ['2.6']
 
 jobs:
   analyzer:
@@ -17,14 +17,17 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: 'none'
-      - name: Restore Cache
-        uses: ./.github/actions/cache-restore
-        with:
-          os: ubuntu-22.04
       - name: Install Dependency
         run: |
           sudo apt update && sudo apt install -y cmake g++ gcc libopenblas-openmp-dev libaio-dev libcurl4-openssl-dev libevent-dev clang-tidy-14 python3-pip libomp-dev ccache && \
           pip3 install conan==1.61.0 && (conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local || true)
+      # Resolve CCache only after the dependency step installs its binary.
+      - name: Restore Cache
+        uses: ./.github/actions/cache-restore
+        with:
+          os: ubuntu-22.04
+          runner-class: github-linux
+          cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build & Analyzer
         run: |
           mkdir build && cd build && conan install .. --build=missing -o with_ut=True -o with_diskann=True -s compiler.libcxx=libstdc++11 && conan build .. \
@@ -33,3 +36,5 @@ jobs:
         uses: ./.github/actions/cache-save
         with:
           os: ubuntu-22.04
+          runner-class: github-linux
+          cache-branch: ${{ github.base_ref || github.ref_name }}

--- a/.github/workflows/analyzer.yaml
+++ b/.github/workflows/analyzer.yaml
@@ -25,7 +25,6 @@ jobs:
       - name: Restore Cache
         uses: ./.github/actions/cache-restore
         with:
-          os: ubuntu-22.04
           runner-class: github-linux
           cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build & Analyzer
@@ -35,6 +34,5 @@ jobs:
       - name: Save Cache
         uses: ./.github/actions/cache-save
         with:
-          os: ubuntu-22.04
           runner-class: github-linux
           cache-branch: ${{ github.base_ref || github.ref_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,6 @@ jobs:
       - name: Restore Cache
         uses: ./.github/actions/cache-restore
         with:
-          os: ubuntu-22.04
           runner-class: github-linux
           # Manual releases use the selected ref's maintained-branch cache.
           cache-branch: ${{ github.base_ref || github.ref_name }}
@@ -50,7 +49,6 @@ jobs:
       - name: Save Cache
         uses: ./.github/actions/cache-save
         with:
-          os: ubuntu-22.04
           runner-class: github-linux
           cache-branch: ${{ github.base_ref || github.ref_name }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,9 @@ jobs:
         uses: ./.github/actions/cache-restore
         with:
           os: ubuntu-22.04
+          runner-class: github-linux
+          # Manual releases use the selected ref's maintained-branch cache.
+          cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build
         env:
           ARTIFACT_NAME: ${{ env.RELEASE_NAME }}-${{ matrix.os }}
@@ -48,6 +51,8 @@ jobs:
         uses: ./.github/actions/cache-save
         with:
           os: ubuntu-22.04
+          runner-class: github-linux
+          cache-branch: ${{ github.base_ref || github.ref_name }}
 
   Release:
     needs: Build

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -45,7 +45,6 @@ jobs:
       - name: Restore Cache
         uses: ./.github/actions/cache-restore
         with:
-          os: ubuntu-22.04
           runner-class: github-linux
           # PRs and direct pushes use the same maintained-branch cache namespace.
           cache-branch: ${{ github.base_ref || github.ref_name }}
@@ -58,7 +57,6 @@ jobs:
       - name: Save Cache
         uses: ./.github/actions/cache-save
         with:
-          os: ubuntu-22.04
           runner-class: github-linux
           cache-branch: ${{ github.base_ref || github.ref_name }}
 
@@ -85,7 +83,6 @@ jobs:
       - name: Restore Cache
         uses: ./.github/actions/cache-restore
         with:
-          os: ubuntu-22.04
           runner-class: github-linux
           # Keep hosted builds branch-scoped while sharing Conan within the branch.
           cache-branch: ${{ github.base_ref || github.ref_name }}
@@ -98,7 +95,6 @@ jobs:
       - name: Save Cache
         uses: ./.github/actions/cache-save
         with:
-          os: ubuntu-22.04
           runner-class: github-linux
           cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build Portable Wheel

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -4,7 +4,7 @@ name: Unit Test
 on:
   push:
     branches:
-      - main
+      - '2.6'
   pull_request:
     # File paths to consider in the event. Optional; defaults to all.
     paths:
@@ -16,7 +16,11 @@ on:
       - "cmake/**"
       - "!cmake/libs/libcardinal.cmake"
       - ".github/workflows/ut.yaml"
+      - ".github/actions/**"
       - "CMakeLists.txt"
+      - "Makefile"
+      - "conanfile.py"
+      - "scripts/**"
       - "!**.md"
       - "tests/**"
 
@@ -42,6 +46,9 @@ jobs:
         uses: ./.github/actions/cache-restore
         with:
           os: ubuntu-22.04
+          runner-class: github-linux
+          # PRs and direct pushes use the same maintained-branch cache namespace.
+          cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build
         run: |
           mkdir build && cd build \
@@ -52,6 +59,8 @@ jobs:
         uses: ./.github/actions/cache-save
         with:
           os: ubuntu-22.04
+          runner-class: github-linux
+          cache-branch: ${{ github.base_ref || github.ref_name }}
 
   swig-build:
     name: python3 wheel
@@ -77,6 +86,9 @@ jobs:
         uses: ./.github/actions/cache-restore
         with:
           os: ubuntu-22.04
+          runner-class: github-linux
+          # Keep hosted builds branch-scoped while sharing Conan within the branch.
+          cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build
         run: |
           mkdir build \
@@ -87,6 +99,8 @@ jobs:
         uses: ./.github/actions/cache-save
         with:
           os: ubuntu-22.04
+          runner-class: github-linux
+          cache-branch: ${{ github.base_ref || github.ref_name }}
       - name: Build Portable Wheel
         run: |
           cd python && ./build_portable_wheel.sh


### PR DESCRIPTION
## Question

How can Knowhere `2.6` warm reusable release-branch caches while matching the cache behavior and code style introduced for `main`?

The `2.6` Unit Test and Analyzer workflows currently warm on pushes to `main`, so direct pushes to `2.6` produce neither branch runs nor `refs/heads/2.6` caches. Existing cache keys are also split by job and assume a fixed CCache directory.

## Solution

- Warm Unit Test and Analyzer caches on direct pushes to `2.6`.
- Preserve all existing GitHub-hosted runner assignments.
- Detect CCache's configured directory, keep compiler caches job-specific, and cap uploaded CCache at 1 GB.
- Scope CCache and Conan 1 keys by stable runner class and target branch.
- Share Conan across jobs and remove job fragmentation from new keys.
- Start the new `2.6` cache namespace cold instead of retaining a migration-only OS/job fallback; successful `2.6` runs seed caches reusable by later PRs.
- Update every cache caller, including UT, wheel, Analyzer, and Release.
- Install CCache before Analyzer resolves its cache directory.
- Document the rationale beside branch scoping, cold-start behavior, dynamic path detection, and size limiting.

Knowhere PR https://github.com/zilliztech/knowhere/pull/1717 introduces the equivalent policy on `main` and is the direct behavior/style baseline for this PR. Cardinal PR https://github.com/zilliztech/cardinal/pull/889 applies the independently implemented and verifier-compared `2.6` counterpart; Cardinal PR https://github.com/zilliztech/cardinal/pull/887 provides the related Cardinal `master` change.

## Known tradeoff

The shared Conan cache is immutable after the first producer saves it. On a cold branch cache, a non-UT job may save before UT/Analyzer and omit Catch2. Builds remain correct and common dependencies remain reusable, but Catch2 may be downloaded again until the Conan key changes. This matches the accepted policy in PR #1717; selecting one dependency-superset Conan producer is a possible follow-up.

## Verification

- Independent worker implementation followed by a separate cross-repository verifier agent
- Verifier confirmed semantic and style parity with Cardinal `2.6` and Knowhere `main`
- Restore/save key symmetry checked programmatically
- All composite callers provide required inputs
- No legacy OS/job restore references remain
- All modified YAML parses successfully
- Scoped Actionlint reports no cache-refactor errors
- `git diff --check`
- DCO sign-off verified exactly
