### PR TITLE
Cherrypick fix int8 cosine normalization for GPU CAGRA to 2.6

### DIFF
--- a/src/common/cuvs/integration/cuvs_knowhere_index.cuh
+++ b/src/common/cuvs/integration/cuvs_knowhere_index.cuh
@@ -30,7 +30,9 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/core/resource/thrust_policy.hpp>
 #include <raft/core/serialize.hpp>
+#include <raft/linalg/matrix_vector_op.cuh>
 #include <raft/linalg/normalize.cuh>
+#include <raft/linalg/reduce.cuh>
 #include <tuple>
 #include <type_traits>
 
@@ -41,6 +43,9 @@
 
 namespace cuvs_knowhere {
 namespace detail {
+
+constexpr float kInt8CosineScale = 127.0f;
+constexpr float kInt8CosineInvScaleSqr = 1.0f / (kInt8CosineScale * kInt8CosineScale);
 
 // This helper struct maps the generic type of cuVS index to the specific
 // instantiation of that index used within knowhere.
@@ -103,6 +108,48 @@ struct check_valid_entry {
     U max_distance_;
     V max_id_;
 };
+
+struct normalize_int8_cosine_op {
+    __device__ std::int8_t
+    operator()(std::int8_t value, float norm) const {
+        if (!(norm > 0.0f)) {
+            return std::int8_t{0};
+        }
+        auto scaled = static_cast<float>(value) / norm * kInt8CosineScale;
+        scaled = fminf(kInt8CosineScale, fmaxf(-kInt8CosineScale, scaled));
+        return static_cast<std::int8_t>(roundf(scaled));
+    }
+};
+
+template <typename IdType>
+struct rescale_int8_cosine_distance_op {
+    __device__ thrust::tuple<IdType, knowhere_distance_type>
+    operator()(IdType id, knowhere_distance_type distance) const {
+        if (id < IdType{0}) {
+            return thrust::tuple<IdType, knowhere_distance_type>(id, distance);
+        }
+        auto cosine = distance * kInt8CosineInvScaleSqr;
+        return thrust::tuple<IdType, knowhere_distance_type>(
+            id, fminf(knowhere_distance_type{1.0f}, fmaxf(knowhere_distance_type{-1.0f}, cosine)));
+    }
+};
+
+template <typename DeviceMatrixView>
+void
+normalize_int8_rows_for_cosine(raft::resources const& res, DeviceMatrixView device_data_view) {
+    using index_type = std::decay_t<decltype(device_data_view.extent(0))>;
+
+    const auto row_count = device_data_view.extent(0);
+    const auto feature_count = device_data_view.extent(1);
+    auto row_norms = raft::make_device_vector<float, index_type>(res, row_count);
+    auto stream = raft::resource::get_cuda_stream(res);
+
+    raft::linalg::reduce<true, true>(row_norms.data_handle(), device_data_view.data_handle(), feature_count, row_count,
+                                     0.0f, stream, false, raft::sq_op(), raft::add_op(), raft::sqrt_op());
+    raft::linalg::matrixVectorOp<true, false>(device_data_view.data_handle(), device_data_view.data_handle(),
+                                              row_norms.data_handle(), feature_count, row_count,
+                                              normalize_int8_cosine_op{}, stream);
+}
 
 }  // namespace detail
 
@@ -431,8 +478,12 @@ struct cuvs_knowhere_index<IndexKind, DataType>::impl {
             auto device_data = raft::make_device_matrix<data_type, input_indexing_type>(res, row_count, feature_count);
             auto device_data_view = device_data.view();
             raft::copy(res, device_data_view, host_data);
-            raft::linalg::row_normalize<raft::linalg::NormType::L2Norm>(res, raft::make_const_mdspan(device_data_view),
-                                                                        device_data_view);
+            if constexpr (std::is_same_v<data_type, std::int8_t>) {
+                detail::normalize_int8_rows_for_cosine(res, device_data_view);
+            } else {
+                raft::linalg::row_normalize<raft::linalg::NormType::L2Norm>(
+                    res, raft::make_const_mdspan(device_data_view), device_data_view);
+            }
             auto host_data_view = raft::make_host_matrix_view(const_cast<data_type*>(data), row_count, feature_count);
             raft::copy(res, host_data_view, device_data_view);
             res.sync_stream();
@@ -471,8 +522,12 @@ struct cuvs_knowhere_index<IndexKind, DataType>::impl {
 
         if (config.metric_type == knowhere::metric::COSINE) {
             auto device_data_view = device_data_storage.view();
-            raft::linalg::row_normalize<raft::linalg::NormType::L2Norm>(res, raft::make_const_mdspan(device_data_view),
-                                                                        device_data_view);
+            if constexpr (std::is_same_v<data_type, std::int8_t>) {
+                detail::normalize_int8_rows_for_cosine(res, device_data_view);
+            } else {
+                raft::linalg::row_normalize<raft::linalg::NormType::L2Norm>(
+                    res, raft::make_const_mdspan(device_data_view), device_data_view);
+            }
         }
 
         auto device_bitset = std::optional<
@@ -550,6 +605,20 @@ struct cuvs_knowhere_index<IndexKind, DataType>::impl {
                 thrust::make_tuple(thrust::device_ptr<knowhere_indexing_type>(device_knowhere_ids.data_handle()),
                                    thrust::device_ptr<knowhere_distance_type>(device_distances.data_handle()))),
             device_post_process);
+
+        if (config.metric_type == knowhere::metric::COSINE) {
+            if constexpr (std::is_same_v<data_type, std::int8_t>) {
+                thrust::transform(raft::resource::get_thrust_policy(res),
+                                  thrust::device_ptr<knowhere_indexing_type>(device_knowhere_ids.data_handle()),
+                                  thrust::device_ptr<knowhere_indexing_type>(device_knowhere_ids.data_handle() +
+                                                                             device_knowhere_ids.size()),
+                                  thrust::device_ptr<knowhere_distance_type>(device_distances.data_handle()),
+                                  thrust::make_zip_iterator(thrust::make_tuple(
+                                      thrust::device_ptr<knowhere_indexing_type>(device_knowhere_ids.data_handle()),
+                                      thrust::device_ptr<knowhere_distance_type>(device_distances.data_handle()))),
+                                  detail::rescale_int8_cosine_distance_op<knowhere_indexing_type>{});
+            }
+        }
 
         raft::copy(res, host_ids, device_knowhere_ids);
         raft::copy(res, host_distances, device_distances);

--- a/tests/ut/test_gpu_search.cc
+++ b/tests/ut/test_gpu_search.cc
@@ -9,7 +9,11 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
 #include <string>
+#include <vector>
 
 #include "catch2/catch_approx.hpp"
 #include "catch2/catch_test_macros.hpp"
@@ -22,6 +26,35 @@
 #include "utils.h"
 
 #ifdef KNOWHERE_WITH_CUVS
+
+inline knowhere::DataSetPtr
+GenNormalizedInt8DataSet(int rows, int dim, int seed = 42) {
+    auto* tensor = new knowhere::int8[rows * dim];
+    std::vector<float> row(dim);
+    for (int i = 0; i < rows; ++i) {
+        double norm = 0.0;
+        for (int j = 0; j < dim; ++j) {
+            row[j] = std::sin(float((i + seed + 1) * (j + 3))) + std::cos(float((i + seed + 5) * (j + 1)));
+            norm += double(row[j]) * row[j];
+        }
+        norm = std::sqrt(norm);
+
+        auto nonzero = false;
+        for (int j = 0; j < dim; ++j) {
+            auto scaled = norm == 0.0 ? 0 : int(std::llround(double(row[j]) / norm * 127.0));
+            scaled = std::max(-127, std::min(127, scaled));
+            tensor[i * dim + j] = knowhere::int8(scaled);
+            nonzero = nonzero || scaled != 0;
+        }
+        if (!nonzero) {
+            tensor[i * dim] = knowhere::int8(127);
+        }
+    }
+
+    auto ds = knowhere::GenDataSet(rows, dim, tensor);
+    ds->SetIsOwner(true);
+    return ds;
+}
 
 template <typename T>
 void
@@ -413,6 +446,46 @@ TEST_CASE("Test All GPU Index", "[search]") {
         auto gt = knowhere::BruteForce::Search<knowhere::fp32>(train_ds, query_ds, json, nullptr);
         float recall = GetKNNRecall(*gt.value(), *results.value());
         REQUIRE(recall > 0.65f);
+    }
+
+    SECTION("Test Gpu Cagra Int8 Cosine Score Range") {
+        constexpr auto rows = 512;
+        constexpr auto query_rows = 64;
+        constexpr auto test_dim = 64;
+        constexpr auto topk = 10;
+
+        knowhere::Json json;
+        json[knowhere::meta::DIM] = test_dim;
+        json[knowhere::meta::METRIC_TYPE] = knowhere::metric::COSINE;
+        json[knowhere::meta::TOPK] = topk;
+        json[knowhere::indexparam::INTERMEDIATE_GRAPH_DEGREE] = 64;
+        json[knowhere::indexparam::GRAPH_DEGREE] = 32;
+        json[knowhere::indexparam::ITOPK_SIZE] = 64;
+        json[knowhere::indexparam::NUM_RANDOM_SAMPLINGS] = 4;
+
+        auto idx = knowhere::IndexFactory::Instance()
+                       .Create<knowhere::int8>(knowhere::IndexEnum::INDEX_CUVS_CAGRA, version)
+                       .value();
+        auto train_ds = GenNormalizedInt8DataSet(rows, test_dim, seed);
+        auto query_ds = GenNormalizedInt8DataSet(query_rows, test_dim, seed);
+
+        auto res = idx.Build(train_ds, json);
+        REQUIRE(res == knowhere::Status::success);
+        auto results = idx.Search(query_ds, json, nullptr);
+        REQUIRE(results.has_value());
+
+        auto ids = results.value()->GetIds();
+        auto distances = results.value()->GetDistance();
+        auto max_distance = -1.0f;
+        for (auto i = 0; i < query_rows * topk; ++i) {
+            if (ids[i] < 0) {
+                continue;
+            }
+            max_distance = std::max(max_distance, distances[i]);
+            CHECK(distances[i] >= -1.00001f);
+            CHECK(distances[i] <= 1.00001f);
+        }
+        CHECK(max_distance > 0.5f);
     }
 
     SECTION("Test Gpu Index Search Hamming Metric") {


### PR DESCRIPTION
## Summary
- Cherrypick #1720 to 2.6.
- Normalize INT8 COSINE rows with a float norm and a scaled int8 representation before GPU CAGRA build/search.
- Rescale valid INT8 COSINE GPU CAGRA scores by `127^2` so returned COSINE scores stay in `[-1, 1]`.
- Add GPU_CUVS_CAGRA INT8 COSINE regression coverage.

pr: #1720
issue: #1721

## Test plan
- [x] `git diff --check -- src/common/cuvs/integration/cuvs_knowhere_index.cuh tests/ut/test_gpu_search.cc`
- [x] `clang-format-15 --dry-run --Werror src/common/cuvs/integration/cuvs_knowhere_index.cuh tests/ut/test_gpu_search.cc`
- [x] `cmake --build build/Release --target knowhere_tests -- -j16`
- [x] `knowhere_tests "Test All GPU Index" -c "Test Gpu Cagra Int8 Cosine Score Range" -s`
