### PR TITLE
update: bump cardinal (v2 ref) to v3.0.3

### DIFF
--- a/cmake/libs/cardinal/v2/CMakeLists.txt
+++ b/cmake/libs/cardinal/v2/CMakeLists.txt
@@ -3,7 +3,7 @@ project(knowhere CXX C)
 
 # Use short SHA1 as version
 # currenly checkout a commit for cardinal v2. TODO: need a tag here
-set(CARDINAL_VERSION v3.0.2)
+set(CARDINAL_VERSION v3.0.3)
 set(CARDINAL_REPO_URL "https://github.com/zilliztech/cardinal.git")
 
 set(CARDINAL_ROOT  "${KNOWHERE_THRID_ROOT}/cardinalv2")


### PR DESCRIPTION
Bump the cardinal v2 reference (`cmake/libs/cardinal/v2/CMakeLists.txt`) from `v3.0.2` to `v3.0.3`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)