### PR TITLE
update: bump cardinal (v1 ref) to v2.5.109

### DIFF
--- a/cmake/libs/cardinal/v1/CMakeLists.txt
+++ b/cmake/libs/cardinal/v1/CMakeLists.txt
@@ -3,7 +3,7 @@ project(knowhere CXX C)
 
 # Use short SHA1 as version
 # currently check out a commit for cardinal v1. TODO: need a tag here
-set(CARDINAL_VERSION v2.5.108)
+set(CARDINAL_VERSION v2.5.109)
 set(CARDINAL_REPO_URL "https://github.com/zilliztech/cardinal.git")
 
 set(CARDINAL_ROOT  "${KNOWHERE_THRID_ROOT}/cardinalv1")


### PR DESCRIPTION
Bump the cardinal v1 reference (`cmake/libs/cardinal/v1/CMakeLists.txt`) from `v2.5.108` to `v2.5.109`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)