### PR TITLE
optimize bm25 scoring in WAND/BLOCK_WAND/BLOCK_MAXSCORE

### DIFF
--- a/src/index/sparse/scorer.h
+++ b/src/index/sparse/scorer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <cstdint>
 #include <functional>
 #include <vector>
@@ -29,8 +30,8 @@ struct IndexScorerConfig {
 using DimScorer = std::function<float(uint32_t, float)>;
 
 [[nodiscard]] inline float
-bm25_score_with_document_component(float qval_p1, float tf, float p2, float document_component) noexcept {
-    return qval_p1 * tf / ((tf + p2) + document_component);
+bm25_score_with_doc_norm(float qval_p1, float tf, float p2, float doc_norm) noexcept {
+    return qval_p1 * tf / ((tf + p2) + doc_norm);
 }
 
 /** Index scorer construct scorers for dimensions in the index. */
@@ -127,5 +128,44 @@ struct BM25IndexScorer : public IndexScorer {
     const float p2_;
     const float p3_;
     const std::vector<float>& row_sums_;
+};
+
+class BM25ScoringContext {
+ public:
+    explicit BM25ScoringContext(const std::vector<float>& row_sums, const IndexScorer& scorer) : row_sums_(row_sums) {
+        if (scorer.config().scorer_type == IndexScorerType::BM25) {
+            const auto* bm25_scorer = dynamic_cast<const BM25IndexScorer*>(&scorer);
+            assert(bm25_scorer != nullptr);
+            p1_ = bm25_scorer->p1();
+            p2_ = bm25_scorer->p2();
+            p3_ = bm25_scorer->p3();
+        }
+    }
+
+    [[nodiscard]] float
+    query_component(float query_value) const noexcept {
+        return query_value * p1_;
+    }
+
+    [[nodiscard]] float
+    doc_norm(uint32_t vec_id) const noexcept {
+        return p3_ * row_sums_[vec_id];
+    }
+
+    [[nodiscard]] float
+    score(float qval_p1, float tf, float doc_norm) const noexcept {
+        return bm25_score_with_doc_norm(qval_p1, tf, p2_, doc_norm);
+    }
+
+    void
+    prefetch_document(uint32_t vec_id) const noexcept {
+        __builtin_prefetch(&row_sums_[vec_id], 0, 3);
+    }
+
+ private:
+    const std::vector<float>& row_sums_;
+    float p1_{1.0F};
+    float p2_{0.0F};
+    float p3_{0.0F};
 };
 }  // namespace knowhere::sparse::inverted

--- a/src/index/sparse/scorer.h
+++ b/src/index/sparse/scorer.h
@@ -28,6 +28,11 @@ struct IndexScorerConfig {
  */
 using DimScorer = std::function<float(uint32_t, float)>;
 
+[[nodiscard]] inline float
+bm25_score_with_document_component(float qval_p1, float tf, float p2, float document_component) noexcept {
+    return qval_p1 * tf / ((tf + p2) + document_component);
+}
+
 /** Index scorer construct scorers for dimensions in the index. */
 class IndexScorer {
  public:

--- a/src/index/sparse/searcher/block_max_maxscore.h
+++ b/src/index/sparse/searcher/block_max_maxscore.h
@@ -78,21 +78,16 @@ class BlockMaxMaxScoreSearcher : public RankedSearcher {
                                       const uint32_t max_vec_id, const BitsetView& bitset, float dim_max_score_ratio)
         : RankedSearcher(k),
           filter_bounds_(GetFilterBounds(bitset, max_vec_id)),
+          bm25_context_(index.get_row_sums(), *search_scorer),
           cursors_([&]() {
               std::sort(query.begin(), query.end(), [&](auto& a, auto& b) {
                   return index.get_dim_max_score(a.first, a.second) > index.get_dim_max_score(b.first, b.second);
               });
-              return make_cursors(index, query, search_scorer, bitset, dim_max_score_ratio, filter_bounds_);
+              return make_cursors(index, query, search_scorer, bm25_context_, bitset, dim_max_score_ratio,
+                                  filter_bounds_);
           }()),
           max_vec_id_(filter_bounds_.upper_bound),
-          row_sums_(index.get_row_sums()),
           scorer_type_(search_scorer->config().scorer_type) {
-        if (scorer_type_ == IndexScorerType::BM25) {
-            const auto* bm25_scorer = dynamic_cast<const BM25IndexScorer*>(search_scorer.get());
-            assert(bm25_scorer != nullptr);
-            bm25_p2_ = bm25_scorer->p2();
-            bm25_p3_ = bm25_scorer->p3();
-        }
     }
 
     void
@@ -130,15 +125,15 @@ class BlockMaxMaxScoreSearcher : public RankedSearcher {
         while (ne_start_cursor_id > 0 && curr_cand_vec_id < max_vec_id_) {
             float score = 0;
             uint32_t next_cand_vec_id = max_vec_id_;
-            float document_component = 0.0F;
+            float doc_norm = 0.0F;
             if constexpr (ScorerType == IndexScorerType::BM25) {
-                document_component = bm25_p3_ * row_sums_[curr_cand_vec_id];
+                doc_norm = bm25_context_.doc_norm(curr_cand_vec_id);
             }
 
             auto score_term = [&](Cursor& cursor) -> float {
                 if constexpr (ScorerType == IndexScorerType::BM25) {
                     const float tf = static_cast<float>(cursor.index_cursor.val());
-                    return bm25_score_with_document_component(cursor.qval_p1, tf, bm25_p2_, document_component);
+                    return bm25_context_.score(cursor.qval_p1, tf, doc_norm);
                 } else {
                     return cursor.score();
                 }
@@ -197,30 +192,23 @@ class BlockMaxMaxScoreSearcher : public RankedSearcher {
 
     static std::vector<Cursor>
     make_cursors(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
-                 const std::shared_ptr<IndexScorer>& index_scorer, const BitsetView& bitset, float dim_max_score_ratio,
-                 const FilterBounds& filter_bounds) {
+                 const std::shared_ptr<IndexScorer>& index_scorer, const BM25ScoringContext& bm25_context,
+                 const BitsetView& bitset, float dim_max_score_ratio, const FilterBounds& filter_bounds) {
         std::vector<Cursor> cursors;
         cursors.reserve(query.size());
-        const BM25IndexScorer* bm25_scorer = nullptr;
-        if (index_scorer->config().scorer_type == IndexScorerType::BM25) {
-            bm25_scorer = dynamic_cast<const BM25IndexScorer*>(index_scorer.get());
-            assert(bm25_scorer != nullptr);
-        }
         for (const auto& [dim_id, dim_val] : query) {
             cursors.push_back(Cursor{
                 GetFilteredPostingListCursor(index, dim_id, bitset, filter_bounds), index_scorer->dim_scorer(dim_val),
                 dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val), index.get_block_max_data_cursor(dim_id),
-                dim_val, bm25_scorer != nullptr ? dim_val * bm25_scorer->p1() : 0.0F});
+                dim_val, bm25_context.query_component(dim_val)});
         }
         return cursors;
     }
 
     FilterBounds filter_bounds_;
+    BM25ScoringContext bm25_context_;
     std::vector<Cursor> cursors_;
     uint32_t max_vec_id_;
-    const std::vector<float>& row_sums_;
     IndexScorerType scorer_type_;
-    float bm25_p2_{0.0F};
-    float bm25_p3_{0.0F};
 };
 }  // namespace knowhere::sparse::inverted

--- a/src/index/sparse/searcher/block_max_maxscore.h
+++ b/src/index/sparse/searcher/block_max_maxscore.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cassert>
 #include <utility>
 #include <vector>
 
@@ -29,6 +30,7 @@ class BlockMaxMaxScoreSearcher : public RankedSearcher {
         float max_score;
         BlockMaxDataCursor block_max_data_cursor;
         float weight;
+        float qval_p1;
 
         [[nodiscard]] uint32_t
         vec_id() const noexcept {
@@ -82,11 +84,34 @@ class BlockMaxMaxScoreSearcher : public RankedSearcher {
               });
               return make_cursors(index, query, search_scorer, bitset, dim_max_score_ratio, filter_bounds_);
           }()),
-          max_vec_id_(filter_bounds_.upper_bound) {
+          max_vec_id_(filter_bounds_.upper_bound),
+          row_sums_(index.get_row_sums()),
+          scorer_type_(search_scorer->config().scorer_type) {
+        if (scorer_type_ == IndexScorerType::BM25) {
+            const auto* bm25_scorer = dynamic_cast<const BM25IndexScorer*>(search_scorer.get());
+            assert(bm25_scorer != nullptr);
+            bm25_p2_ = bm25_scorer->p2();
+            bm25_p3_ = bm25_scorer->p3();
+        }
     }
 
     void
     search() override {
+        if (cursors_.empty()) {
+            return;
+        }
+
+        if (scorer_type_ == IndexScorerType::BM25) {
+            run<IndexScorerType::BM25>();
+        } else {
+            run<IndexScorerType::IP>();
+        }
+    }
+
+ private:
+    template <IndexScorerType ScorerType>
+    void
+    run() {
         std::vector<float> upper_bounds(cursors_.size() + 1, 0.0f);
         float bound_sum = 0.0f;
         for (size_t i = cursors_.size() - 1; i + 1 > 0; --i) {
@@ -105,11 +130,24 @@ class BlockMaxMaxScoreSearcher : public RankedSearcher {
         while (ne_start_cursor_id > 0 && curr_cand_vec_id < max_vec_id_) {
             float score = 0;
             uint32_t next_cand_vec_id = max_vec_id_;
+            float document_component = 0.0F;
+            if constexpr (ScorerType == IndexScorerType::BM25) {
+                document_component = bm25_p3_ * row_sums_[curr_cand_vec_id];
+            }
+
+            auto score_term = [&](Cursor& cursor) -> float {
+                if constexpr (ScorerType == IndexScorerType::BM25) {
+                    const float tf = static_cast<float>(cursor.index_cursor.val());
+                    return bm25_score_with_document_component(cursor.qval_p1, tf, bm25_p2_, document_component);
+                } else {
+                    return cursor.score();
+                }
+            };
 
             // score essential list and find next
             for (size_t i = 0; i < ne_start_cursor_id; ++i) {
                 if (cursors_[i].vec_id() == curr_cand_vec_id) {
-                    score += cursors_[i].score();
+                    score += score_term(cursors_[i]);
                     cursors_[i].next();
                 }
                 if (cursors_[i].vec_id() < next_cand_vec_id) {
@@ -134,7 +172,7 @@ class BlockMaxMaxScoreSearcher : public RankedSearcher {
                     for (size_t i = ne_start_cursor_id; i < cursors_.size(); ++i) {
                         cursors_[i].next_geq(curr_cand_vec_id);
                         if (cursors_[i].vec_id() == curr_cand_vec_id) {
-                            new_score += cursors_[i].score();
+                            new_score += score_term(cursors_[i]);
                         }
                         new_score -= cursors_[i].block_max_score();
 
@@ -157,18 +195,22 @@ class BlockMaxMaxScoreSearcher : public RankedSearcher {
         }
     }
 
- private:
     static std::vector<Cursor>
     make_cursors(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
                  const std::shared_ptr<IndexScorer>& index_scorer, const BitsetView& bitset, float dim_max_score_ratio,
                  const FilterBounds& filter_bounds) {
         std::vector<Cursor> cursors;
         cursors.reserve(query.size());
+        const BM25IndexScorer* bm25_scorer = nullptr;
+        if (index_scorer->config().scorer_type == IndexScorerType::BM25) {
+            bm25_scorer = dynamic_cast<const BM25IndexScorer*>(index_scorer.get());
+            assert(bm25_scorer != nullptr);
+        }
         for (const auto& [dim_id, dim_val] : query) {
-            cursors.push_back(Cursor{GetFilteredPostingListCursor(index, dim_id, bitset, filter_bounds),
-                                     index_scorer->dim_scorer(dim_val),
-                                     dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val),
-                                     index.get_block_max_data_cursor(dim_id), dim_val});
+            cursors.push_back(Cursor{
+                GetFilteredPostingListCursor(index, dim_id, bitset, filter_bounds), index_scorer->dim_scorer(dim_val),
+                dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val), index.get_block_max_data_cursor(dim_id),
+                dim_val, bm25_scorer != nullptr ? dim_val * bm25_scorer->p1() : 0.0F});
         }
         return cursors;
     }
@@ -176,5 +218,9 @@ class BlockMaxMaxScoreSearcher : public RankedSearcher {
     FilterBounds filter_bounds_;
     std::vector<Cursor> cursors_;
     uint32_t max_vec_id_;
+    const std::vector<float>& row_sums_;
+    IndexScorerType scorer_type_;
+    float bm25_p2_{0.0F};
+    float bm25_p3_{0.0F};
 };
 }  // namespace knowhere::sparse::inverted

--- a/src/index/sparse/searcher/block_max_wand.h
+++ b/src/index/sparse/searcher/block_max_wand.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cassert>
 #include <utility>
 #include <vector>
 
@@ -27,6 +28,7 @@ class BlockMaxWandSearcher : public RankedSearcher {
         float max_score;
         BlockMaxDataCursor block_max_data_cursor;
         float weight;
+        float qval_p1;
 
         [[nodiscard]] uint32_t
         vec_id() const noexcept {
@@ -75,11 +77,30 @@ class BlockMaxWandSearcher : public RankedSearcher {
         : RankedSearcher(k),
           filter_bounds_(GetFilterBounds(bitset, max_vec_id)),
           cursors_(make_cursors(index, query, search_scorer, bitset, dim_max_score_ratio, filter_bounds_)),
-          max_vec_id_(filter_bounds_.upper_bound) {
+          max_vec_id_(filter_bounds_.upper_bound),
+          row_sums_(index.get_row_sums()),
+          scorer_type_(search_scorer->config().scorer_type) {
+        if (scorer_type_ == IndexScorerType::BM25) {
+            const auto* bm25_scorer = dynamic_cast<const BM25IndexScorer*>(search_scorer.get());
+            assert(bm25_scorer != nullptr);
+            bm25_p2_ = bm25_scorer->p2();
+            bm25_p3_ = bm25_scorer->p3();
+        }
     }
 
     void
     search() override {
+        if (scorer_type_ == IndexScorerType::BM25) {
+            run<IndexScorerType::BM25>();
+        } else {
+            run<IndexScorerType::IP>();
+        }
+    }
+
+ private:
+    template <IndexScorerType ScorerType>
+    void
+    run() {
         std::vector<Cursor*> ordered_cursors;
         ordered_cursors.reserve(cursors_.size());
         for (auto& en : cursors_) {
@@ -136,11 +157,22 @@ class BlockMaxWandSearcher : public RankedSearcher {
                 // check if pivot is a possible match
                 if (pivot_id == ordered_cursors[0]->vec_id()) {
                     float score = 0;
+                    float document_component = 0.0F;
+                    if constexpr (ScorerType == IndexScorerType::BM25) {
+                        document_component = bm25_p3_ * row_sums_[pivot_id];
+                    }
                     for (Cursor* en : ordered_cursors) {
                         if (en->vec_id() != pivot_id) {
                             break;
                         }
-                        float part_score = en->score();
+                        float part_score;
+                        if constexpr (ScorerType == IndexScorerType::BM25) {
+                            const float tf = static_cast<float>(en->index_cursor.val());
+                            part_score =
+                                bm25_score_with_document_component(en->qval_p1, tf, bm25_p2_, document_component);
+                        } else {
+                            part_score = en->score();
+                        }
                         score += part_score;
                         block_upper_bound -= en->block_max_score() - part_score;
                         if (!topk_.WouldEnter(block_upper_bound)) {
@@ -218,18 +250,22 @@ class BlockMaxWandSearcher : public RankedSearcher {
         }
     }
 
- private:
     static std::vector<Cursor>
     make_cursors(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
                  const std::shared_ptr<IndexScorer>& index_scorer, const BitsetView& bitset, float dim_max_score_ratio,
                  const FilterBounds& filter_bounds) {
         std::vector<Cursor> cursors;
         cursors.reserve(query.size());
+        const BM25IndexScorer* bm25_scorer = nullptr;
+        if (index_scorer->config().scorer_type == IndexScorerType::BM25) {
+            bm25_scorer = dynamic_cast<const BM25IndexScorer*>(index_scorer.get());
+            assert(bm25_scorer != nullptr);
+        }
         for (const auto& [dim_id, dim_val] : query) {
-            cursors.push_back(Cursor{GetFilteredPostingListCursor(index, dim_id, bitset, filter_bounds),
-                                     index_scorer->dim_scorer(dim_val),
-                                     dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val),
-                                     index.get_block_max_data_cursor(dim_id), dim_val});
+            cursors.push_back(Cursor{
+                GetFilteredPostingListCursor(index, dim_id, bitset, filter_bounds), index_scorer->dim_scorer(dim_val),
+                dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val), index.get_block_max_data_cursor(dim_id),
+                dim_val, bm25_scorer != nullptr ? dim_val * bm25_scorer->p1() : 0.0F});
         }
         return cursors;
     }
@@ -237,6 +273,10 @@ class BlockMaxWandSearcher : public RankedSearcher {
     FilterBounds filter_bounds_;
     std::vector<Cursor> cursors_;
     uint32_t max_vec_id_;
+    const std::vector<float>& row_sums_;
+    IndexScorerType scorer_type_;
+    float bm25_p2_{0.0F};
+    float bm25_p3_{0.0F};
 };
 
 }  // namespace knowhere::sparse::inverted

--- a/src/index/sparse/searcher/block_max_wand.h
+++ b/src/index/sparse/searcher/block_max_wand.h
@@ -76,16 +76,11 @@ class BlockMaxWandSearcher : public RankedSearcher {
                                   const uint32_t max_vec_id, const BitsetView& bitset, float dim_max_score_ratio)
         : RankedSearcher(k),
           filter_bounds_(GetFilterBounds(bitset, max_vec_id)),
-          cursors_(make_cursors(index, query, search_scorer, bitset, dim_max_score_ratio, filter_bounds_)),
+          bm25_context_(index.get_row_sums(), *search_scorer),
+          cursors_(
+              make_cursors(index, query, search_scorer, bm25_context_, bitset, dim_max_score_ratio, filter_bounds_)),
           max_vec_id_(filter_bounds_.upper_bound),
-          row_sums_(index.get_row_sums()),
           scorer_type_(search_scorer->config().scorer_type) {
-        if (scorer_type_ == IndexScorerType::BM25) {
-            const auto* bm25_scorer = dynamic_cast<const BM25IndexScorer*>(search_scorer.get());
-            assert(bm25_scorer != nullptr);
-            bm25_p2_ = bm25_scorer->p2();
-            bm25_p3_ = bm25_scorer->p3();
-        }
     }
 
     void
@@ -157,9 +152,9 @@ class BlockMaxWandSearcher : public RankedSearcher {
                 // check if pivot is a possible match
                 if (pivot_id == ordered_cursors[0]->vec_id()) {
                     float score = 0;
-                    float document_component = 0.0F;
+                    float doc_norm = 0.0F;
                     if constexpr (ScorerType == IndexScorerType::BM25) {
-                        document_component = bm25_p3_ * row_sums_[pivot_id];
+                        doc_norm = bm25_context_.doc_norm(pivot_id);
                     }
                     for (Cursor* en : ordered_cursors) {
                         if (en->vec_id() != pivot_id) {
@@ -168,8 +163,7 @@ class BlockMaxWandSearcher : public RankedSearcher {
                         float part_score;
                         if constexpr (ScorerType == IndexScorerType::BM25) {
                             const float tf = static_cast<float>(en->index_cursor.val());
-                            part_score =
-                                bm25_score_with_document_component(en->qval_p1, tf, bm25_p2_, document_component);
+                            part_score = bm25_context_.score(en->qval_p1, tf, doc_norm);
                         } else {
                             part_score = en->score();
                         }
@@ -252,31 +246,24 @@ class BlockMaxWandSearcher : public RankedSearcher {
 
     static std::vector<Cursor>
     make_cursors(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
-                 const std::shared_ptr<IndexScorer>& index_scorer, const BitsetView& bitset, float dim_max_score_ratio,
-                 const FilterBounds& filter_bounds) {
+                 const std::shared_ptr<IndexScorer>& index_scorer, const BM25ScoringContext& bm25_context,
+                 const BitsetView& bitset, float dim_max_score_ratio, const FilterBounds& filter_bounds) {
         std::vector<Cursor> cursors;
         cursors.reserve(query.size());
-        const BM25IndexScorer* bm25_scorer = nullptr;
-        if (index_scorer->config().scorer_type == IndexScorerType::BM25) {
-            bm25_scorer = dynamic_cast<const BM25IndexScorer*>(index_scorer.get());
-            assert(bm25_scorer != nullptr);
-        }
         for (const auto& [dim_id, dim_val] : query) {
             cursors.push_back(Cursor{
                 GetFilteredPostingListCursor(index, dim_id, bitset, filter_bounds), index_scorer->dim_scorer(dim_val),
                 dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val), index.get_block_max_data_cursor(dim_id),
-                dim_val, bm25_scorer != nullptr ? dim_val * bm25_scorer->p1() : 0.0F});
+                dim_val, bm25_context.query_component(dim_val)});
         }
         return cursors;
     }
 
     FilterBounds filter_bounds_;
+    BM25ScoringContext bm25_context_;
     std::vector<Cursor> cursors_;
     uint32_t max_vec_id_;
-    const std::vector<float>& row_sums_;
     IndexScorerType scorer_type_;
-    float bm25_p2_{0.0F};
-    float bm25_p3_{0.0F};
 };
 
 }  // namespace knowhere::sparse::inverted

--- a/src/index/sparse/searcher/daat_maxscore.h
+++ b/src/index/sparse/searcher/daat_maxscore.h
@@ -49,16 +49,11 @@ class DaatMaxScoreSearcher : public RankedSearcher {
                                   const uint32_t max_vec_id, const BitsetView& bitset, float dim_max_score_ratio)
         : RankedSearcher(k),
           filter_bounds_(GetFilterBounds(bitset, max_vec_id)),
-          cursors_(make_cursors(index, query, search_scorer, bitset, dim_max_score_ratio, filter_bounds_)),
+          bm25_context_(index.get_row_sums(), *search_scorer),
+          cursors_(
+              make_cursors(index, query, search_scorer, bm25_context_, bitset, dim_max_score_ratio, filter_bounds_)),
           max_vec_id_(filter_bounds_.upper_bound),
-          row_sums_(index.get_row_sums()),
           scorer_type_(search_scorer->config().scorer_type) {
-        if (scorer_type_ == IndexScorerType::BM25) {
-            const auto* bm25_scorer = dynamic_cast<const BM25IndexScorer*>(search_scorer.get());
-            assert(bm25_scorer != nullptr);
-            bm25_p2_ = bm25_scorer->p2();
-            bm25_p3_ = bm25_scorer->p3();
-        }
     }
 
     [[nodiscard]] auto
@@ -139,14 +134,14 @@ class DaatMaxScoreSearcher : public RankedSearcher {
                 if constexpr (ScorerType == IndexScorerType::BM25) {
                     // Prefetch row_sums_ for next iterations that will be used by the BM25 scorer
                     // Experiments show this prefetch pattern is optimal vs only prefetching next_vec_id
-                    __builtin_prefetch(&row_sums_[current_vec_id], 0, 3);
-                    doc_norm = bm25_p2_ + bm25_p3_ * row_sums_[current_vec_id];
+                    bm25_context_.prefetch_document(current_vec_id);
+                    doc_norm = bm25_context_.doc_norm(current_vec_id);
                 }
 
                 auto score_term = [&](auto& cursor) -> float {
                     if constexpr (ScorerType == IndexScorerType::BM25) {
                         const float tf = static_cast<float>(cursor.index_cursor.val());
-                        return cursor.qval_p1 * tf / (tf + doc_norm);
+                        return bm25_context_.score(cursor.qval_p1, tf, doc_norm);
                     } else {
                         return cursor.qval_p1 * static_cast<float>(cursor.index_cursor.val());
                     }
@@ -159,7 +154,7 @@ class DaatMaxScoreSearcher : public RankedSearcher {
                         if constexpr (ScorerType == IndexScorerType::BM25) {
                             // Prefetch row_sums_ for next iterations that will be used by the BM25 scorer
                             // Experiments show this prefetch pattern is optimal vs only prefetching next_vec_id
-                            __builtin_prefetch(&row_sums_[cursor.vec_id()], 0, 3);
+                            bm25_context_.prefetch_document(cursor.vec_id());
                         }
                     }
                     if (auto vec_id = cursor.vec_id(); vec_id < next_vec_id) {
@@ -205,31 +200,23 @@ class DaatMaxScoreSearcher : public RankedSearcher {
  private:
     static std::vector<Cursor>
     make_cursors(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
-                 const std::shared_ptr<IndexScorer>& index_scorer, const BitsetView& bitset, float dim_max_score_ratio,
-                 const FilterBounds& filter_bounds) {
+                 const std::shared_ptr<IndexScorer>& index_scorer, const BM25ScoringContext& bm25_context,
+                 const BitsetView& bitset, float dim_max_score_ratio, const FilterBounds& filter_bounds) {
         std::vector<Cursor> cursors;
         cursors.reserve(query.size());
-        const BM25IndexScorer* bm25_scorer = nullptr;
-        if (index_scorer->config().scorer_type == IndexScorerType::BM25) {
-            bm25_scorer = dynamic_cast<const BM25IndexScorer*>(index_scorer.get());
-            assert(bm25_scorer != nullptr);
-        }
         for (const auto& [dim_id, dim_val] : query) {
             cursors.push_back(Cursor{GetFilteredPostingListCursor(index, dim_id, bitset, filter_bounds),
                                      dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val),
-                                     bm25_scorer != nullptr ? dim_val * bm25_scorer->p1() : dim_val});
+                                     bm25_context.query_component(dim_val)});
         }
         return cursors;
     }
 
     FilterBounds filter_bounds_;
+    BM25ScoringContext bm25_context_;
     std::vector<Cursor> cursors_;
     uint32_t max_vec_id_;
-    // row_sums_ is only used for BM25 scorer
-    const std::vector<float>& row_sums_;
     IndexScorerType scorer_type_;
-    float bm25_p2_{0.0f};
-    float bm25_p3_{0.0f};
 };
 
 }  // namespace knowhere::sparse::inverted

--- a/src/index/sparse/searcher/daat_wand.h
+++ b/src/index/sparse/searcher/daat_wand.h
@@ -58,16 +58,11 @@ class DaatWandSearcher : public RankedSearcher {
                               const uint32_t max_vec_id, const BitsetView& bitset, float dim_max_score_ratio)
         : RankedSearcher(k),
           filter_bounds_(GetFilterBounds(bitset, max_vec_id)),
-          cursors_(make_cursors(index, query, search_scorer, bitset, dim_max_score_ratio, filter_bounds_)),
+          bm25_context_(index.get_row_sums(), *search_scorer),
+          cursors_(
+              make_cursors(index, query, search_scorer, bm25_context_, bitset, dim_max_score_ratio, filter_bounds_)),
           max_vec_id_(filter_bounds_.upper_bound),
-          row_sums_(index.get_row_sums()),
           scorer_type_(search_scorer->config().scorer_type) {
-        if (scorer_type_ == IndexScorerType::BM25) {
-            const auto* bm25_scorer = dynamic_cast<const BM25IndexScorer*>(search_scorer.get());
-            assert(bm25_scorer != nullptr);
-            bm25_p2_ = bm25_scorer->p2();
-            bm25_p3_ = bm25_scorer->p3();
-        }
     }
 
     void
@@ -125,9 +120,9 @@ class DaatWandSearcher : public RankedSearcher {
             uint64_t pivot_id = ordered_cursors[pivot]->vec_id();
             if (pivot_id == ordered_cursors[0]->vec_id()) {
                 float score = 0;
-                float document_component = 0.0F;
+                float doc_norm = 0.0F;
                 if constexpr (ScorerType == IndexScorerType::BM25) {
-                    document_component = bm25_p3_ * row_sums_[pivot_id];
+                    doc_norm = bm25_context_.doc_norm(pivot_id);
                 }
                 for (Cursor* en : ordered_cursors) {
                     if (en->vec_id() != pivot_id) {
@@ -135,7 +130,7 @@ class DaatWandSearcher : public RankedSearcher {
                     }
                     if constexpr (ScorerType == IndexScorerType::BM25) {
                         const float tf = static_cast<float>(en->index_cursor.val());
-                        score += bm25_score_with_document_component(en->qval_p1, tf, bm25_p2_, document_component);
+                        score += bm25_context_.score(en->qval_p1, tf, doc_norm);
                     } else {
                         score += en->score();
                     }
@@ -163,30 +158,22 @@ class DaatWandSearcher : public RankedSearcher {
 
     static std::vector<Cursor>
     make_cursors(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
-                 const std::shared_ptr<IndexScorer>& index_scorer, const BitsetView& bitset, float dim_max_score_ratio,
-                 const FilterBounds& filter_bounds) {
+                 const std::shared_ptr<IndexScorer>& index_scorer, const BM25ScoringContext& bm25_context,
+                 const BitsetView& bitset, float dim_max_score_ratio, const FilterBounds& filter_bounds) {
         std::vector<Cursor> cursors;
         cursors.reserve(query.size());
-        const BM25IndexScorer* bm25_scorer = nullptr;
-        if (index_scorer->config().scorer_type == IndexScorerType::BM25) {
-            bm25_scorer = dynamic_cast<const BM25IndexScorer*>(index_scorer.get());
-            assert(bm25_scorer != nullptr);
-        }
         for (const auto& [dim_id, dim_val] : query) {
-            cursors.push_back(Cursor{GetFilteredPostingListCursor(index, dim_id, bitset, filter_bounds),
-                                     index_scorer->dim_scorer(dim_val),
-                                     dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val),
-                                     bm25_scorer != nullptr ? dim_val * bm25_scorer->p1() : 0.0F});
+            cursors.push_back(Cursor{
+                GetFilteredPostingListCursor(index, dim_id, bitset, filter_bounds), index_scorer->dim_scorer(dim_val),
+                dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val), bm25_context.query_component(dim_val)});
         }
         return cursors;
     }
 
     FilterBounds filter_bounds_;
+    BM25ScoringContext bm25_context_;
     std::vector<Cursor> cursors_;
     uint32_t max_vec_id_;
-    const std::vector<float>& row_sums_;
     IndexScorerType scorer_type_;
-    float bm25_p2_{0.0F};
-    float bm25_p3_{0.0F};
 };
 }  // namespace knowhere::sparse::inverted

--- a/src/index/sparse/searcher/daat_wand.h
+++ b/src/index/sparse/searcher/daat_wand.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cassert>
 #include <utility>
 #include <vector>
 
@@ -24,6 +25,7 @@ class DaatWandSearcher : public RankedSearcher {
         typename IndexType::posting_list_iterator index_cursor;
         DimScorer scorer;
         float max_score;
+        float qval_p1;
 
         [[nodiscard]] uint32_t
         vec_id() const noexcept {
@@ -57,7 +59,15 @@ class DaatWandSearcher : public RankedSearcher {
         : RankedSearcher(k),
           filter_bounds_(GetFilterBounds(bitset, max_vec_id)),
           cursors_(make_cursors(index, query, search_scorer, bitset, dim_max_score_ratio, filter_bounds_)),
-          max_vec_id_(filter_bounds_.upper_bound) {
+          max_vec_id_(filter_bounds_.upper_bound),
+          row_sums_(index.get_row_sums()),
+          scorer_type_(search_scorer->config().scorer_type) {
+        if (scorer_type_ == IndexScorerType::BM25) {
+            const auto* bm25_scorer = dynamic_cast<const BM25IndexScorer*>(search_scorer.get());
+            assert(bm25_scorer != nullptr);
+            bm25_p2_ = bm25_scorer->p2();
+            bm25_p3_ = bm25_scorer->p3();
+        }
     }
 
     void
@@ -66,6 +76,17 @@ class DaatWandSearcher : public RankedSearcher {
             return;
         }
 
+        if (scorer_type_ == IndexScorerType::BM25) {
+            run<IndexScorerType::BM25>();
+        } else {
+            run<IndexScorerType::IP>();
+        }
+    }
+
+ private:
+    template <IndexScorerType ScorerType>
+    void
+    run() {
         std::vector<Cursor*> ordered_cursors;
         ordered_cursors.reserve(cursors_.size());
         for (auto& en : cursors_) {
@@ -104,11 +125,20 @@ class DaatWandSearcher : public RankedSearcher {
             uint64_t pivot_id = ordered_cursors[pivot]->vec_id();
             if (pivot_id == ordered_cursors[0]->vec_id()) {
                 float score = 0;
+                float document_component = 0.0F;
+                if constexpr (ScorerType == IndexScorerType::BM25) {
+                    document_component = bm25_p3_ * row_sums_[pivot_id];
+                }
                 for (Cursor* en : ordered_cursors) {
                     if (en->vec_id() != pivot_id) {
                         break;
                     }
-                    score += en->score();
+                    if constexpr (ScorerType == IndexScorerType::BM25) {
+                        const float tf = static_cast<float>(en->index_cursor.val());
+                        score += bm25_score_with_document_component(en->qval_p1, tf, bm25_p2_, document_component);
+                    } else {
+                        score += en->score();
+                    }
                     en->next();
                 }
                 this->topk_.Push(score, pivot_id);  // Access base class topk_
@@ -131,17 +161,22 @@ class DaatWandSearcher : public RankedSearcher {
         }
     }
 
- private:
     static std::vector<Cursor>
     make_cursors(const IndexType& index, const std::vector<std::pair<uint32_t, float>>& query,
                  const std::shared_ptr<IndexScorer>& index_scorer, const BitsetView& bitset, float dim_max_score_ratio,
                  const FilterBounds& filter_bounds) {
         std::vector<Cursor> cursors;
         cursors.reserve(query.size());
+        const BM25IndexScorer* bm25_scorer = nullptr;
+        if (index_scorer->config().scorer_type == IndexScorerType::BM25) {
+            bm25_scorer = dynamic_cast<const BM25IndexScorer*>(index_scorer.get());
+            assert(bm25_scorer != nullptr);
+        }
         for (const auto& [dim_id, dim_val] : query) {
             cursors.push_back(Cursor{GetFilteredPostingListCursor(index, dim_id, bitset, filter_bounds),
                                      index_scorer->dim_scorer(dim_val),
-                                     dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val)});
+                                     dim_max_score_ratio * index.get_dim_max_score(dim_id, dim_val),
+                                     bm25_scorer != nullptr ? dim_val * bm25_scorer->p1() : 0.0F});
         }
         return cursors;
     }
@@ -149,5 +184,9 @@ class DaatWandSearcher : public RankedSearcher {
     FilterBounds filter_bounds_;
     std::vector<Cursor> cursors_;
     uint32_t max_vec_id_;
+    const std::vector<float>& row_sums_;
+    IndexScorerType scorer_type_;
+    float bm25_p2_{0.0F};
+    float bm25_p3_{0.0F};
 };
 }  // namespace knowhere::sparse::inverted


### PR DESCRIPTION
issue: #1730 

  - Introduced BM25ScoringContext to centralize BM25 parameters and document-length information.
  - Precomputes reusable BM25 components:
      - qval * (k1 + 1) once per query term.
      - The document normalization component once per candidate document.

Intel(R) Xeon(R) Gold 6338 CPU @ 2.00GHz search threads=32

| Dataset | Algorithm | Baseline QPS | Patched QPS | QPS change |
|---|---|---:|---:|---:|
| msmarco | `DAAT_WAND` | 1,184.7 | 2,005.9 | **+69.32%** |
| msmarco | `BLOCK_MAX_WAND` | 1,398.7 | 2,417.6 | **+72.84%** |
| msmarco | `BLOCK_MAX_MAXSCORE` | 1,767.1 | 2,924.9 | **+65.52%** |
| nq | `DAAT_WAND` | 2,163.9 | 2,169.1 | +0.24% |
| nq | `BLOCK_MAX_WAND` | 1,333.3 | 1,938.9 | **+45.43%** |
| nq | `BLOCK_MAX_MAXSCORE` | 2,157.8 | 2,945.2 | **+36.49%** |
| fever | `DAAT_WAND` | 1,786.8 | 1,867.9 | +4.54% |
| fever | `BLOCK_MAX_WAND` | 1,916.4 | 1,843.2 | **-1.82%** |
| fever | `BLOCK_MAX_MAXSCORE` | 2,989.6 | 3,054.9 | +2.18% |
| hotpotqa | `DAAT_WAND` | 578.4 | 633.3 | +9.50% |
| hotpotqa | `BLOCK_MAX_WAND` | 574.9 | 607.8 | +5.73% |
| hotpotqa | `BLOCK_MAX_MAXSCORE` | 925.2 | 1,109.3 | **+19.89%** |