### PR TITLE
fix: wait for a free AiSAQ scratch slot before searching

### DIFF
--- a/thirdparty/DiskANN/src/pq_flash_aisaq_index.cpp
+++ b/thirdparty/DiskANN/src/pq_flash_aisaq_index.cpp
@@ -1312,7 +1312,14 @@ void PQFlashAisaqIndex<T>::aisaq_cached_beam_search(
         return;
     }
     float query_norm = query_norm_opt.value();
-    AisaqThreadData aisaq_data = aisaq_thread_data.pop();
+    /* aisaq_thread_data.pop() returns a default constructed object when the
+     * pool is empty, wait for a slot to be released instead of running the
+     * search with an uninitialized scratch */
+    AisaqThreadData<T> aisaq_data = aisaq_thread_data.pop();
+    while (aisaq_data.aisaq_scratch_mem_offset.empty()) {
+        aisaq_thread_data.wait_for_push_notify();
+        aisaq_data = aisaq_thread_data.pop();
+    }
     auto ctx = this->reader->get_ctx();
     if(aisaq_data.aisaq_pq_reader_ctx) {
         _aisaq_pq_vectors_reader->set_io_ctx(*aisaq_data.aisaq_pq_reader_ctx, ctx);
@@ -1321,10 +1328,12 @@ void PQFlashAisaqIndex<T>::aisaq_cached_beam_search(
         if(aisaq_data.aisaq_pq_reader_ctx){
             _aisaq_pq_vectors_reader->set_io_ctx(*aisaq_data.aisaq_pq_reader_ctx, nullptr);
         }
-        this->thread_data.push(data);
-        this->thread_data.push_notify_all();
+        /* release the aisaq scratch first, a thread woken up by the
+         * thread_data notification below acquires it right after */
         this->aisaq_thread_data.push(aisaq_data);
         this->aisaq_thread_data.push_notify_all();
+        this->thread_data.push(data);
+        this->thread_data.push_notify_all();
         this->reader->put_ctx(ctx);
     };
     auto ctx_pool = AioContextPool::GetGlobalAioPool();


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/1739

## Summary

- `aisaq_cached_beam_search()` popped the per-thread AiSAQ scratch without checking whether the pool was empty. `diskann::ConcurrentQueue::pop()` returns a default constructed object in that case, so the search ran with an empty `aisaq_scratch_mem_offset` and a null `aisaq_pq_reader_ctx`, and threw `No free nodes, increase defaults::MAX_N_SECTOR_READS` on the first frontier node that needed a disk read. Now it waits for a free slot, exactly like the base `ThreadData` acquisition right above it.
- `release_data()` returned the base `ThreadData` before the AiSAQ scratch, which left a window where a thread woken up by the `thread_data` notification found the AiSAQ pool empty. The two pushes are swapped so the AiSAQ scratch goes back first.

Without the wait, the failure was also sticky: `release_data` captures `aisaq_data` by value, so the failing search pushed the invalid object back into the pool and every later search that popped it failed the same way. If a query touched only cached nodes, the null `aisaq_pq_reader_ctx` was dereferenced in `compute_dists()` / `hibernate()` instead.

This is what makes `Test DiskANN Search Cancellation / Test Search without cancellation should succeed` fail intermittently on the `ut on ubuntu-22.04` job: that runner reports 8 search threads, the test issues 10 queries right after `Deserialize()`, and the async cache generation task is still running its own searches at that point.

## Verification

- Reproduced the pre-fix failure locally with a temporary stress harness (search with more queries than search threads immediately after `Deserialize()` on an AiSAQ index), which hit the exact same exception at `pq_flash_aisaq_index.cpp:1557`.
- `knowhere_tests "[diskann]"` passes with the fix (11 test cases, 2192445 assertions).
