### PR TITLE
support block_adaptive encoding for block inverted index

### DIFF
--- a/src/index/sparse/block_inverted_index.h
+++ b/src/index/sparse/block_inverted_index.h
@@ -21,6 +21,25 @@
 
 namespace knowhere::sparse::inverted {
 
+// Empty posting lists are never materialized. Encoded count value 0 (wire byte 0x80) therefore marks the singleton
+// short form whose logical count is one. Its sole document ID occupies the posting block max-ID slot. BM25 stores
+// TF - 1 after that slot as an untagged internal varint, including an explicit zero for TF == 1; IP keeps its regular
+// raw value payload.
+inline constexpr uint32_t kSingletonShortFormSizeMarker = 0;
+
+struct PostingListSizeInfo {
+    uint32_t size;
+    bool is_singleton_short_form;
+};
+
+[[nodiscard]] inline PostingListSizeInfo
+posting_list_size_info(uint32_t encoded_size) noexcept {
+    const bool is_singleton_short_form = encoded_size == kSingletonShortFormSizeMarker;
+    return {is_singleton_short_form ? 1U : encoded_size, is_singleton_short_form};
+}
+
+// Internal little-endian base-128 varint. Unlike unsigned LEB128 or Lucene VInt, bit 7 marks the final byte: it is
+// clear on continuation bytes and set on the terminator (for example, 0 -> 0x80 and 128 -> 0x00 0x81).
 inline void
 varint_encode(uint32_t val, std::vector<uint8_t>& out) {
     while (val >= 128) {
@@ -56,16 +75,26 @@ class BlockInvertedIndexCursor {
     BlockInvertedIndexCursor(const BlockCodecPtr& block_codec, std::uint8_t const* data, std::uint32_t universe,
                              BitsetView bitset, uint32_t initial_lower_bound = 0,
                              uint32_t valid_upper_bound = std::numeric_limits<uint32_t>::max())
-        : base_(varint_decode(data, &n_, 1)),
-          nr_blocks_((n_ + block_codec->block_size() - 1) / block_codec->block_size()),
-          block_maxids_(base_),
-          block_offsets_(block_maxids_ + sizeof(int32_t) * nr_blocks_),
-          blocks_data_(block_offsets_ + sizeof(uint32_t) * (nr_blocks_ - 1)),
-          universe_(universe),
+        : universe_(universe),
           block_codec_(block_codec),
           block_size_(block_codec->block_size()),
           bitset_(bitset),
           valid_upper_bound_(std::min(universe, valid_upper_bound)) {
+        uint32_t encoded_size = 0;
+        base_ = varint_decode(data, &encoded_size, 1);
+        const auto size_info = posting_list_size_info(encoded_size);
+        n_ = size_info.size;
+        is_singleton_short_form_ = size_info.is_singleton_short_form;
+        assert(!is_singleton_short_form_ || block_codec_->supports_singleton_short_form());
+        assert(n_ > 0 && n_ <= universe_);
+        nr_blocks_ = (n_ + block_size_ - 1) / block_size_;
+
+        const size_t block_maxids_size = sizeof(uint32_t) * nr_blocks_;
+        const size_t block_offsets_size = sizeof(uint32_t) * (nr_blocks_ - 1);
+        block_maxids_ = base_;
+        block_offsets_ = block_maxids_ + block_maxids_size;
+        blocks_data_ = block_offsets_ + block_offsets_size;
+
         ids_buf_.resize(block_size_);
         vals_buf_.resize(block_size_);
         reset(initial_lower_bound);
@@ -77,13 +106,8 @@ class BlockInvertedIndexCursor {
             set_invalid();
             return;
         }
-        const auto* block_maxids = reinterpret_cast<const uint32_t*>(block_maxids_);
-        const auto* block_it = std::lower_bound(block_maxids, block_maxids + nr_blocks_, lower_bound);
-        decode_vecids_block(static_cast<uint32_t>(block_it - block_maxids));
-        while (cur_vec_id_ < lower_bound) {
-            cur_vec_id_ += ids_buf_[++pos_in_block_] + 1;
-            assert(pos_in_block_ < cur_block_size_);
-        }
+        decode_vecids_block(lower_bound_block(0, lower_bound));
+        advance_to(lower_bound);
         if (cur_vec_id_ >= valid_upper_bound_) {
             set_invalid();
             return;
@@ -101,7 +125,7 @@ class BlockInvertedIndexCursor {
             }
             decode_vecids_block(cur_block_ + 1);
         } else {
-            cur_vec_id_ += ids_buf_[pos_in_block_] + 1;
+            cur_vec_id_ = ids_buf_[pos_in_block_];
         }
         if (cur_vec_id_ >= valid_upper_bound_) {
             set_invalid();
@@ -132,17 +156,10 @@ class BlockInvertedIndexCursor {
                 cur_vec_id_ = universe_;
                 return;
             }
-            const auto* block_maxids = reinterpret_cast<const uint32_t*>(block_maxids_);
-            const auto* block_it =
-                std::lower_bound(block_maxids + cur_block_ + 1, block_maxids + nr_blocks_, lower_bound);
-            const uint32_t block = static_cast<uint32_t>(block_it - block_maxids);
-            decode_vecids_block(block);
+            decode_vecids_block(lower_bound_block(cur_block_ + 1, lower_bound));
         }
 
-        while (cur_vec_id_ < lower_bound) {
-            cur_vec_id_ += ids_buf_[++pos_in_block_] + 1;
-            assert(pos_in_block_ < cur_block_size_);
-        }
+        advance_to(lower_bound);
 
         skip_filtered_ids();
     }
@@ -158,7 +175,7 @@ class BlockInvertedIndexCursor {
             decode_vals_block();
         }
 
-        // now only uint32_t is compression supported
+        // Only the uint32_t/BM25 value path stores TF - 1 through the block codec; IP values remain verbatim.
         if constexpr (std::is_same_v<VType, uint32_t>) {
             return vals_buf_[pos_in_block_] + 1;
         } else {
@@ -173,7 +190,7 @@ class BlockInvertedIndexCursor {
 
     [[nodiscard]] uint32_t
     block_maxid(uint32_t blk_idx) const {
-        return ((uint32_t const*)block_maxids_)[blk_idx];
+        return load_u32(block_maxids_ + sizeof(uint32_t) * blk_idx);
     }
 
     void
@@ -211,6 +228,39 @@ class BlockInvertedIndexCursor {
         vals_decoded_ = false;
     }
 
+    [[nodiscard]] static uint32_t
+    load_u32(const uint8_t* data) {
+        uint32_t value = 0;
+        std::memcpy(&value, data, sizeof(value));
+        return value;
+    }
+
+    [[nodiscard]] uint32_t
+    block_offset(uint32_t blk_idx) const {
+        return load_u32(block_offsets_ + sizeof(uint32_t) * blk_idx);
+    }
+
+    [[nodiscard]] uint32_t
+    lower_bound_block(uint32_t first, uint32_t lower_bound) const {
+        uint32_t last = nr_blocks_;
+        while (first < last) {
+            const uint32_t middle = first + (last - first) / 2;
+            if (block_maxid(middle) < lower_bound) {
+                first = middle + 1;
+            } else {
+                last = middle;
+            }
+        }
+        return first;
+    }
+
+    void
+    advance_to(uint32_t lower_bound) {
+        while (cur_vec_id_ < lower_bound) {
+            cur_vec_id_ = ids_buf_[++pos_in_block_];
+        }
+    }
+
     void
     decode_vecids_block(uint32_t blkid) {
         while (blkid < nr_blocks_) {
@@ -230,17 +280,24 @@ class BlockInvertedIndexCursor {
             return;
         }
 
-        uint32_t endpoint = blkid != 0U ? ((uint32_t const*)block_offsets_)[blkid - 1] : 0;
+        const uint32_t endpoint = blkid != 0U ? block_offset(blkid - 1) : 0;
         uint8_t const* block_data = blocks_data_ + endpoint;
         cur_block_size_ = ((blkid + 1) * block_size_ <= n_) ? block_size_ : (n_ % block_size_);
-        uint32_t cur_base = (blkid != 0U ? block_maxid(blkid - 1) : uint32_t(-1)) + 1;
         cur_block_maxid_ = block_maxid(blkid);
-        vals_block_data_ = block_codec_->decode(block_data, ids_buf_.data(), cur_block_size_);
+
+        if (is_singleton_short_form_) [[unlikely]] {
+            assert(n_ == 1 && nr_blocks_ == 1 && blkid == 0 && cur_block_size_ == 1);
+            assert(cur_block_maxid_ < universe_);
+            ids_buf_[0] = cur_block_maxid_;
+            vals_block_data_ = block_data;
+        } else {
+            const uint32_t previous_vec_id = blkid == 0 ? UINT32_MAX : block_maxid(blkid - 1);
+            vals_block_data_ =
+                block_codec_->decode_doc_ids(block_data, ids_buf_.data(), cur_block_size_, previous_vec_id);
+        }
 #if defined(__GNUC__) || defined(__clang__)
         __builtin_prefetch(vals_block_data_, 0, 3);
 #endif
-
-        ids_buf_[0] += cur_base;
 
         cur_block_ = blkid;
         pos_in_block_ = 0;
@@ -251,7 +308,12 @@ class BlockInvertedIndexCursor {
     void
     decode_vals_block() {
         if constexpr (std::is_same_v<VType, uint32_t>) {
-            uint8_t const* next_block = block_codec_->decode(vals_block_data_, vals_buf_.data(), cur_block_size_);
+            uint8_t const* next_block = vals_block_data_;
+            if (is_singleton_short_form_) [[unlikely]] {
+                next_block = varint_decode(vals_block_data_, vals_buf_.data(), 1);
+            } else {
+                next_block = block_codec_->decode(vals_block_data_, vals_buf_.data(), cur_block_size_);
+            }
 #if defined(__GNUC__) || defined(__clang__)
             __builtin_prefetch(next_block, 0, 3);
 #endif
@@ -287,6 +349,7 @@ class BlockInvertedIndexCursor {
     std::vector<VType> vals_buf_;
     BlockCodecPtr block_codec_;
     std::size_t block_size_;
+    bool is_singleton_short_form_{false};
     BitsetView bitset_;
     uint32_t valid_upper_bound_{0};
     BlockFilterState cur_block_filter_state_{BlockFilterState::AllValid};
@@ -354,16 +417,16 @@ class BlockInvertedIndex : public CRTPInvertedIndex<BlockInvertedIndex<DType, QT
 
     [[nodiscard]] posting_list_iterator
     get_dim_plist_cursor(uint32_t dim_id, const BitsetView& bitset) const {
-        auto endpoint = this->posting_blocks_dim_offsets_[dim_id];
-        auto* data = this->posting_blocks_data_.data() + endpoint;
+        const auto begin = this->posting_blocks_dim_offsets_[dim_id];
+        auto* data = this->posting_blocks_data_.data() + begin;
         return posting_list_iterator(this->block_codec_, data, this->nr_rows_, bitset);
     }
 
     [[nodiscard]] posting_list_iterator
     get_dim_plist_cursor(uint32_t dim_id, const BitsetView& bitset, uint32_t initial_lower_bound,
                          uint32_t valid_upper_bound) const {
-        auto endpoint = this->posting_blocks_dim_offsets_[dim_id];
-        auto* data = this->posting_blocks_data_.data() + endpoint;
+        const auto begin = this->posting_blocks_dim_offsets_[dim_id];
+        auto* data = this->posting_blocks_data_.data() + begin;
         return posting_list_iterator(this->block_codec_, data, this->nr_rows_, bitset, initial_lower_bound,
                                      valid_upper_bound);
     }
@@ -429,15 +492,13 @@ class BlockInvertedIndex : public CRTPInvertedIndex<BlockInvertedIndex<DType, QT
      * @param enable_mmap Whether to use file backed memory mapping
      * @param backed_filename File to use for memory mapping if enabled
      *
-     * This function builds the raw index from the serialized data.
-     * It first reads the number of rows and the maximum dimension seen.
-     * Then it calculates the memory requirements for the index structures.
+     * This function starts at the serialized row payload after the caller has read the row and dimension headers. It
+     * first scans the rows to count postings per external dimension, then allocates and fills the flattened raw
+     * arrays.
      * If memory mapping is enabled, it creates a memory mapped file to store the data.
      * Otherwise, it uses heap memory.
      *
-     * The memory is allocated for:
-     * - Inverted lists storing vector IDs (inverted_index_ids_)
-     * - Inverted lists storing values (inverted_index_vals_)
+     * The memory is allocated for the flattened raw_index_ids/raw_index_vals arrays and raw_index_offsets table.
      */
     void
     build_raw_index(MemoryIOReader& reader, std::unique_ptr<BinaryContainer>& raw_index_container,
@@ -495,7 +556,7 @@ class BlockInvertedIndex : public CRTPInvertedIndex<BlockInvertedIndex<DType, QT
     // The start offset of each dimension's list is stored in posting_blocks_dim_offsets_
     std::span<size_t> posting_blocks_dim_offsets_;
 
-    // Inverted lists storing all vector blocks
+    // Posting headers and encoded document-ID/value blocks for all dimensions, followed by a decoder guard.
     std::span<uint8_t> posting_blocks_data_;
 
     // Block codec
@@ -686,22 +747,36 @@ BlockInvertedIndex<DType, QType, MetricType>::encode_posting_list(std::vector<ui
                                                                   std::span<uint32_t> vec_ids, std::span<QType> vals) {
     // Posting list layout:
     // +----------------+------------------------------------------+
-    // | list_sz       | uint32_t: total number of postings       |
+    // | encoded_count | internal varint; 0 marks a singleton     |
     // +----------------+------------------------------------------+
-    // | block_maxids  | int32_t[nr_blocks]: max vector id/block  |
+    // | block_maxids  | uint32_t[nr_blocks]: max vector ID/block |
     // +----------------+------------------------------------------+
     // | block_ends    | uint32_t[nr_blocks-1]: block end offsets |
     // +----------------+------------------------------------------+
     // | blocks        | uint8_t[]: encoded posting data          |
     // +----------------+------------------------------------------+
-    // Note: First block end offset is omitted (always 0)
-    size_t list_sz = vec_ids.size();
-    varint_encode(list_sz, out_buf);
+    // block_ends[i] is the end of block i and therefore the start of block i + 1; block 0 starts implicitly at 0.
+    // A codec with the singleton short form stores no doc-ID payload and reuses block_maxids[0] as the sole document
+    // ID.
+    // BM25 follows it with an untagged internal varint containing TF - 1, including zero for TF == 1. IP follows it
+    // with its regular raw value payload.
+    const uint32_t block_sz = block_codec_->block_size();
 
-    uint32_t block_sz = block_codec_->block_size();
+    const size_t list_sz = vec_ids.size();
+    const bool use_singleton_short_form = list_sz == 1 && block_codec_->supports_singleton_short_form();
+    uint32_t singleton_stored_value = 0;
+    uint32_t encoded_list_size = static_cast<uint32_t>(list_sz);
+    if (use_singleton_short_form) {
+        encoded_list_size = kSingletonShortFormSizeMarker;
+        if constexpr (!kIsIPMetric) {
+            singleton_stored_value = static_cast<uint32_t>(get_quant_val<DType, QType>(vals.front() - 1));
+        }
+    }
+    varint_encode(encoded_list_size, out_buf);
+
     size_t nr_blocks = (list_sz + block_sz - 1) / block_sz;
     size_t begin_block_maxids = out_buf.size();
-    size_t begin_block_endpoints = begin_block_maxids + sizeof(int32_t) * nr_blocks;
+    size_t begin_block_endpoints = begin_block_maxids + sizeof(uint32_t) * nr_blocks;
     size_t begin_blocks = begin_block_endpoints + sizeof(uint32_t) * (nr_blocks - 1);
     out_buf.resize(begin_blocks);
 
@@ -709,7 +784,7 @@ BlockInvertedIndex<DType, QType, MetricType>::encode_posting_list(std::vector<ui
     auto* vals_it = vals.data();
 
     std::vector<uint32_t> ids_buf(block_sz);
-    int32_t last_vecid(-1);
+    uint32_t last_vecid = UINT32_MAX;
     for (size_t b = 0; b < nr_blocks; ++b) {
         uint32_t cur_block_size = ((b + 1) * block_sz <= list_sz) ? block_sz : (list_sz % block_sz);
 
@@ -718,9 +793,11 @@ BlockInvertedIndex<DType, QType, MetricType>::encode_posting_list(std::vector<ui
             ids_buf[i] = vecid - last_vecid - 1;
             last_vecid = vecid;
         }
-        std::memcpy(out_buf.data() + begin_block_maxids + sizeof(int32_t) * b, &last_vecid, sizeof(last_vecid));
+        std::memcpy(out_buf.data() + begin_block_maxids + sizeof(uint32_t) * b, &last_vecid, sizeof(last_vecid));
 
-        block_codec_->encode(ids_buf.data(), cur_block_size, out_buf);
+        if (!use_singleton_short_form) {
+            block_codec_->encode_doc_ids(ids_buf.data(), cur_block_size, out_buf);
+        }
 
         if constexpr (kIsIPMetric) {
             std::vector<QType> vals_buf(cur_block_size);
@@ -729,6 +806,10 @@ BlockInvertedIndex<DType, QType, MetricType>::encode_posting_list(std::vector<ui
             }
             out_buf.insert(out_buf.end(), reinterpret_cast<uint8_t*>(vals_buf.data()),
                            reinterpret_cast<uint8_t*>(vals_buf.data() + cur_block_size));
+        } else if (use_singleton_short_form) {
+            assert(cur_block_size == 1 && b == 0);
+            varint_encode(singleton_stored_value, out_buf);
+            ++vals_it;
         } else {
             std::vector<uint32_t> vals_buf(cur_block_size);
             for (size_t i = 0; i < cur_block_size; ++i) {
@@ -738,7 +819,7 @@ BlockInvertedIndex<DType, QType, MetricType>::encode_posting_list(std::vector<ui
         }
 
         if (b != nr_blocks - 1) {
-            uint32_t endpoint = out_buf.size() - begin_blocks;
+            const uint32_t endpoint = static_cast<uint32_t>(out_buf.size() - begin_blocks);
             std::memcpy(out_buf.data() + begin_block_endpoints + sizeof(uint32_t) * b, &endpoint, sizeof(endpoint));
         }
     }
@@ -773,7 +854,8 @@ BlockInvertedIndex<DType, QType, MetricType>::build_block_index(std::span<uint32
         index_container_->write_at((i + 1) * sizeof(size_t), reinterpret_cast<uint8_t*>(&endpoint), sizeof(size_t));
     }
 
-    // This is a workaround to QMX codex having to sometimes look beyond the buffer due to some SIMD loads.
+    // The vectorized StreamVByte decoder may issue a 16-byte unaligned load from the final payload byte. Keep a
+    // 15-byte zero guard after all postings so that read stays inside the container without changing list offsets.
     std::array<uint8_t, 15> padding{};
     index_container_->append(padding.data(), padding.size());
 
@@ -909,9 +991,8 @@ BlockInvertedIndex<DType, QType, MetricType>::build_from_raw_data(MemoryIOReader
     int64_t rows = 0;
     size_t cols = 0;
 
-    // previous versions used the signness of rows to indicate whether to
-    // use wand. now we use a template parameter to control this thus simply
-    // take the absolute value of rows.
+    // Previous versions used the sign of rows to indicate whether WAND metadata was present. The current format
+    // records that in metadata, so ignore the legacy sign and use the absolute row count.
     readBinaryPOD(reader, rows);
     this->nr_rows_ = std::abs(rows);
     readBinaryPOD(reader, cols);
@@ -954,6 +1035,8 @@ BlockInvertedIndex<DType, QType, MetricType>::serialize(MemoryIOWriter& writer) 
             return static_cast<uint32_t>(InvertedIndexEncoding::BLOCK_STREAMVBYTE);
         } else if (this->block_codec_->get_name() == "block_maskedvbyte") {
             return static_cast<uint32_t>(InvertedIndexEncoding::BLOCK_MASKEDVBYTE);
+        } else if (this->block_codec_->get_name() == "block_adaptive") {
+            return static_cast<uint32_t>(InvertedIndexEncoding::BLOCK_ADAPTIVE);
         } else {
             throw std::runtime_error("Unsupported index encoding type for BlockInvertedIndex");
         }
@@ -1105,6 +1188,10 @@ BlockInvertedIndex<DType, QType, MetricType>::deserialize(MemoryIOReader& reader
                     }
                     if (index_encoding_type == static_cast<uint32_t>(InvertedIndexEncoding::BLOCK_MASKEDVBYTE) &&
                         this->block_codec_->get_name() != "block_maskedvbyte") {
+                        return Status::invalid_serialized_index_type;
+                    }
+                    if (index_encoding_type == static_cast<uint32_t>(InvertedIndexEncoding::BLOCK_ADAPTIVE) &&
+                        this->block_codec_->get_name() != "block_adaptive") {
                         return Status::invalid_serialized_index_type;
                     }
                     // construct posting blocks dim offsets

--- a/src/index/sparse/codec/adaptive.h
+++ b/src/index/sparse/codec/adaptive.h
@@ -1,0 +1,547 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+// for the specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string_view>
+#include <vector>
+
+#include "index/sparse/codec/block_codec.h"
+#include "index/sparse/codec/simd_bitpacking.h"
+#include "index/sparse/codec/streamvbyte.h"
+
+namespace knowhere::sparse::inverted {
+
+/**
+ * Adaptive compression for blocks of up to 256 unsigned integers.
+ *
+ * Document-ID gaps, in both complete and final partial blocks, choose among fixed-width bit packing, the custom
+ * StreamVByte-0124 format, and an all-equal representation. Complete term-frequency blocks use an all-equal
+ * representation when possible and otherwise use a Lucene-inspired patched-bitpacking format; this format is not
+ * wire-compatible with Lucene. A complete block that cannot reduce a 32-bit base within the exception limit uses
+ * plain 32-bit packing. Final partial term-frequency blocks choose the smallest payload among StreamVByte-0124,
+ * fixed-width bit packing, all-equal, and patched bit packing. Partial blocks encode exactly their logical value
+ * count and are never padded to 256 values.
+ *
+ * Complete 128-value chunks at widths 1..31 use vertical SIMD kernels derived from fast-pack/simdcomp; width 32 is a
+ * direct copy. Document-ID decoding uses the integrated d1 unpacker to reconstruct absolute IDs; TF decoding remains
+ * ordinary bit unpacking. A logical block still carries one outer encoding tag.
+ *
+ * Block layout:
+ *   byte 0      : encoding tag
+ *   remaining   : encoding-specific payload
+ *
+ * Tags 1..32 directly encode the bit width. Other tags are listed below.
+ */
+class AdaptiveBlockCodec final : public BlockCodec {
+ public:
+    // Maximum number of values in one logical adaptive block.
+    static constexpr size_t kBlockSize = 256;
+    static constexpr std::string_view name = "block_adaptive";
+
+    void
+    encode(uint32_t const* in, size_t n, std::vector<uint8_t>& out) const override {
+        assert(in != nullptr);
+        assert(n > 0 && n <= kBlockSize);
+
+        encode_block(in, n, out, /*doc_ids=*/false);
+    }
+
+    void
+    encode_doc_ids(uint32_t const* in, size_t n, std::vector<uint8_t>& out) const override {
+        assert(in != nullptr);
+        assert(n > 0 && n <= kBlockSize);
+
+        encode_block(in, n, out, /*doc_ids=*/true);
+    }
+
+    uint8_t const*
+    decode(uint8_t const* in, uint32_t* out, size_t n) const override {
+        assert(in != nullptr);
+        assert(out != nullptr);
+        assert(n > 0 && n <= kBlockSize);
+        return decode_block(in, out, n);
+    }
+
+    uint8_t const*
+    decode_doc_ids(uint8_t const* in, uint32_t* out, size_t n, uint32_t previous_value) const override {
+        assert(in != nullptr);
+        assert(out != nullptr);
+        assert(n > 0 && n <= kBlockSize);
+
+        const uint8_t type = *in;
+        if (is_bitpacked(type)) {
+            return simd_bitpacking::unpack_doc_ids(in + 1, out, n, type, previous_value);
+        }
+        return BlockCodec::decode_doc_ids(in, out, n, previous_value);
+    }
+
+    [[nodiscard]] auto
+    block_size() const noexcept -> size_t override {
+        return kBlockSize;
+    }
+
+    [[nodiscard]] auto
+    get_name() const noexcept -> std::string_view override {
+        return name;
+    }
+
+    [[nodiscard]] bool
+    supports_singleton_short_form() const noexcept override {
+        return true;
+    }
+
+ private:
+    void
+    encode_block(uint32_t const* in, size_t n, std::vector<uint8_t>& out, bool doc_ids) const {
+        assert(n > 0 && n <= kBlockSize);
+
+        const Selection selection = select_encoding(in, n, doc_ids);
+        out.push_back(selection.type);
+
+        if (selection.type == kAllZero) {
+            return;
+        }
+        if (is_bitpacked(selection.type)) {
+            const size_t begin = out.size();
+            out.resize(begin + selection.payload_size);
+            pack_bits(in, n, selection.type, out.data() + begin);
+            return;
+        }
+
+        switch (selection.type) {
+            case kAllEqual8:
+                out.push_back(static_cast<uint8_t>(in[0]));
+                return;
+            case kAllEqual16:
+                append_u16(in[0], out);
+                return;
+            case kAllEqual32:
+                append_u32(in[0], out);
+                return;
+            case kStreamVByte: {
+                alignas(16) thread_local std::array<uint8_t, kMaxStreamVByteBytes> buffer{};
+                const size_t encoded_size = streamvbyte_encode_0124(in, static_cast<uint32_t>(n), buffer.data());
+                assert(encoded_size == selection.payload_size);
+                out.insert(out.end(), buffer.data(), buffer.data() + encoded_size);
+                return;
+            }
+            case kPatchedBitpack: {
+                const size_t begin = out.size();
+                encode_patched_bitpack(in, n, selection, out);
+                assert(out.size() - begin == selection.payload_size);
+                static_cast<void>(begin);
+                return;
+            }
+            default:
+                assert(false && "invalid adaptive block encoding");
+                return;
+        }
+    }
+
+    uint8_t const*
+    decode_block(uint8_t const* in, uint32_t* out, size_t n) const {
+        assert(n > 0 && n <= kBlockSize);
+
+        const uint8_t type = *in++;
+        if (type == kAllZero) {
+            std::fill_n(out, n, 0U);
+            return in;
+        }
+        if (is_bitpacked(type)) {
+            return unpack_bits(in, out, n, type);
+        }
+
+        switch (type) {
+            case kAllEqual8:
+                std::fill_n(out, n, static_cast<uint32_t>(*in));
+                return in + 1;
+            case kAllEqual16: {
+                const uint32_t value = read_u16(in);
+                std::fill_n(out, n, value);
+                return in + sizeof(uint16_t);
+            }
+            case kAllEqual32: {
+                const uint32_t value = read_u32(in);
+                std::fill_n(out, n, value);
+                return in + sizeof(uint32_t);
+            }
+            case kStreamVByte:
+                return in + streamvbyte_decode_0124(in, out, static_cast<uint32_t>(n));
+            case kPatchedBitpack:
+                return decode_patched_bitpack(in, out, n);
+            default:
+                throw std::runtime_error("invalid adaptive block encoding tag");
+        }
+    }
+    // Current wire tags. Values 1..32 directly represent fixed bit widths.
+    static constexpr uint8_t kAllZero = 0;
+    static constexpr uint8_t kAllEqual8 = 33;
+    static constexpr uint8_t kAllEqual16 = 34;
+    static constexpr uint8_t kAllEqual32 = 35;
+    static constexpr uint8_t kStreamVByte = 36;
+    static constexpr uint8_t kPatchedBitpack = 37;
+    static constexpr uint8_t kMaxPForExceptions = 7;
+    static constexpr size_t kMaxStreamVByteBytes = streamvbyte_max_compressedbytes(kBlockSize);
+
+    struct Selection {
+        uint8_t type;
+        size_t payload_size;
+        uint8_t patched_bits{0};
+        uint8_t exceptions{0};
+        bool constant_base{false};
+        uint32_t base_value{0};
+    };
+
+    [[nodiscard]] static constexpr bool
+    is_bitpacked(uint8_t type) noexcept {
+        return type >= 1 && type <= 32;
+    }
+
+    [[nodiscard]] static constexpr size_t
+    packed_size(size_t n, uint8_t bits) noexcept {
+        return (n * bits + 7) / 8;
+    }
+
+    [[nodiscard]] static constexpr size_t
+    byte_size_0124(uint32_t value) noexcept {
+        if (value == 0) {
+            return 0;
+        }
+        if (value <= UINT8_MAX) {
+            return 1;
+        }
+        if (value <= UINT16_MAX) {
+            return 2;
+        }
+        return 4;
+    }
+
+    [[nodiscard]] static constexpr size_t
+    vint_size(uint32_t value) noexcept {
+        size_t size = 1;
+        while (value >= 128) {
+            value >>= 7;
+            ++size;
+        }
+        return size;
+    }
+
+    [[nodiscard]] static Selection
+    select_full_patched_bitpack(uint32_t const* in, const std::array<uint16_t, 33>& histogram, uint8_t max_bits) {
+        assert(max_bits > 0 && max_bits <= 32);
+
+        const int min_bits = std::max(0, static_cast<int>(max_bits) - 8);
+        size_t cumulative_exceptions = 0;
+        uint8_t patched_bits = max_bits;
+        uint8_t exceptions = 0;
+        for (int bits = max_bits; bits >= min_bits; --bits) {
+            if (cumulative_exceptions > kMaxPForExceptions) {
+                break;
+            }
+            patched_bits = static_cast<uint8_t>(bits);
+            exceptions = static_cast<uint8_t>(cumulative_exceptions);
+            cumulative_exceptions += histogram[bits];
+        }
+
+        // The token has five bits for the base width. Up to seven 32-bit values can be exceptions over a base of at
+        // most 31 bits; only a plan whose base itself still needs 32 bits falls back to plain packing.
+        if (patched_bits == 32) {
+            return {32, packed_size(kBlockSize, 32), 0};
+        }
+
+        const uint32_t mask = patched_bits == 0 ? 0U : (uint32_t{1} << patched_bits) - 1;
+        const uint32_t base_value = in[0] & mask;
+        bool constant_base = max_bits <= 8;
+        for (size_t i = 1; constant_base && i < kBlockSize; ++i) {
+            constant_base = (in[i] & mask) == base_value;
+        }
+
+        const size_t base_size = constant_base ? vint_size(base_value) : packed_size(kBlockSize, patched_bits);
+        const size_t payload_size = 1 + base_size + 2 * static_cast<size_t>(exceptions);
+        return {kPatchedBitpack, payload_size, patched_bits, exceptions, constant_base, base_value};
+    }
+
+    [[nodiscard]] static Selection
+    select_tail_patched_bitpack(uint32_t const* in, size_t n, const std::array<uint16_t, 33>& histogram,
+                                uint8_t max_bits) {
+        assert(n > 0 && n < kBlockSize);
+        assert(max_bits > 0 && max_bits <= 32);
+
+        // Plain bit packing is both the fallback and the upper bound a PFor plan must beat. Enumerate wider bases
+        // first and use strict comparisons so equal-size plans keep fewer exceptions and a shorter scalar patch path.
+        Selection best{max_bits, packed_size(n, max_bits), 0};
+        size_t exceptions = 0;
+        int bits = max_bits;
+        if (bits == 32) {
+            exceptions = histogram[32];
+            --bits;
+        }
+
+        const int min_bits = std::max(1, static_cast<int>(max_bits) - 8);
+        for (; bits >= min_bits && exceptions <= kMaxPForExceptions; --bits) {
+            const auto base_bits = static_cast<uint8_t>(bits);
+            const auto exception_count = static_cast<uint8_t>(exceptions);
+            const size_t exception_bytes = 2 * exceptions;
+
+            Selection candidate{kPatchedBitpack, 1 + packed_size(n, base_bits) + exception_bytes, base_bits,
+                                exception_count};
+            if (candidate.payload_size < best.payload_size) {
+                best = candidate;
+            }
+
+            // A zero token width is reserved for a constant low-bit base. Keep the planned width at least one so
+            // histogram exception counts agree with the encoder for zero values.
+            if (max_bits <= 8) {
+                const uint32_t mask = (uint32_t{1} << base_bits) - 1;
+                const uint32_t base_value = in[0] & mask;
+                bool constant_base = true;
+                for (size_t i = 1; constant_base && i < n; ++i) {
+                    constant_base = (in[i] & mask) == base_value;
+                }
+                if (constant_base) {
+                    candidate = {
+                        kPatchedBitpack, 1 + vint_size(base_value) + exception_bytes, base_bits, exception_count, true,
+                        base_value};
+                    if (candidate.payload_size < best.payload_size) {
+                        best = candidate;
+                    }
+                }
+            }
+
+            exceptions += histogram[base_bits];
+        }
+        return best;
+    }
+
+    [[nodiscard]] static Selection
+    select_encoding(uint32_t const* in, size_t n, bool doc_ids) {
+        uint32_t max_value = 0;
+        bool all_equal = true;
+        const bool tail = n < kBlockSize;
+        const bool streamvbyte_candidate = tail || doc_ids;
+        size_t streamvbyte_size = streamvbyte_candidate ? (n + 3) / 4 : 0;
+        const bool full_tf = !doc_ids && n == kBlockSize;
+        std::array<uint16_t, 33> bit_width_histogram{};
+
+        for (size_t i = 0; i < n; ++i) {
+            const uint32_t value = in[i];
+            max_value = std::max(max_value, value);
+            all_equal = all_equal && value == in[0];
+            if (streamvbyte_candidate) {
+                streamvbyte_size += byte_size_0124(value);
+            }
+            if (!doc_ids) {
+                // Match Lucene PackedInts.bitsRequired: zero still occupies one base bit. A token width of zero is
+                // reserved for the constant-base optimization after exception planning.
+                ++bit_width_histogram[std::max(1U, std::bit_width(value))];
+            }
+        }
+
+        if (full_tf && !all_equal) {
+            // Full TF blocks intentionally keep the PFor layout even when the base width cannot be reduced, trading
+            // its one-byte token for a uniform full-block TF decode path. A 32-bit base is the only plain fallback
+            // because the five-bit PFor token cannot represent width 32.
+            const auto max_bits = static_cast<uint8_t>(std::bit_width(max_value));
+            return select_full_patched_bitpack(in, bit_width_histogram, max_bits);
+        }
+
+        Selection best{kStreamVByte, streamvbyte_size, 0};
+        if (!tail) {
+            // Start complete blocks from fixed-width packing. A complete document-ID block changes to
+            // StreamVByte-0124 only when its payload is strictly smaller, so ties retain bit packing or all-equal.
+            if (max_value == 0) {
+                best = {kAllZero, 0, 0};
+            } else {
+                const auto bits = static_cast<uint8_t>(std::bit_width(max_value));
+                best = {bits, packed_size(n, bits), 0};
+            }
+        } else if (max_value != 0) {
+            const auto bits = static_cast<uint8_t>(std::bit_width(max_value));
+            const size_t size = packed_size(n, bits);
+            if (size < best.payload_size) {
+                best = {bits, size, 0};
+            }
+        }
+
+        if (all_equal) {
+            Selection all_equal_encoding{};
+            if (max_value == 0) {
+                all_equal_encoding = {kAllZero, 0, 0};
+            } else if (max_value <= UINT8_MAX) {
+                all_equal_encoding = {kAllEqual8, 1, 0};
+            } else if (max_value <= UINT16_MAX) {
+                all_equal_encoding = {kAllEqual16, 2, 0};
+            } else {
+                all_equal_encoding = {kAllEqual32, 4, 0};
+            }
+            // Prefer all-equal on ties because it avoids the general StreamVByte or bit-unpack path.
+            if (all_equal_encoding.payload_size <= best.payload_size) {
+                best = all_equal_encoding;
+            }
+        }
+
+        if (doc_ids && !tail && streamvbyte_size < best.payload_size) {
+            best = {kStreamVByte, streamvbyte_size, 0};
+        }
+
+        if (!doc_ids && tail && !all_equal) {
+            const auto max_bits = static_cast<uint8_t>(std::bit_width(max_value));
+            const Selection pfor = select_tail_patched_bitpack(in, n, bit_width_histogram, max_bits);
+            // PFor must be strictly smaller; a tie retains the current StreamVByte or bit-packed plan and avoids the
+            // PFor token/exception decode path.
+            if (pfor.type == kPatchedBitpack && pfor.payload_size < best.payload_size) {
+                best = pfor;
+            }
+        }
+
+        return best;
+    }
+
+    static void
+    pack_bits(uint32_t const* in, size_t n, uint8_t bits, uint8_t* out) {
+        simd_bitpacking::pack(in, n, bits, out);
+    }
+
+    [[nodiscard]] static uint8_t const*
+    unpack_bits(uint8_t const* in, uint32_t* out, size_t n, uint8_t bits) {
+        return simd_bitpacking::unpack(in, out, n, bits);
+    }
+
+    static void
+    append_vint(uint32_t value, std::vector<uint8_t>& out) {
+        while (value >= 128) {
+            out.push_back(static_cast<uint8_t>(value | 0x80U));
+            value >>= 7;
+        }
+        out.push_back(static_cast<uint8_t>(value));
+    }
+
+    [[nodiscard]] static uint8_t const*
+    read_vint(uint8_t const* in, uint32_t& value) {
+        value = 0;
+        uint32_t shift = 0;
+        for (;;) {
+            const uint8_t byte = *in++;
+            value |= static_cast<uint32_t>(byte & 0x7fU) << shift;
+            if ((byte & 0x80U) == 0) {
+                return in;
+            }
+            shift += 7;
+        }
+    }
+
+    static void
+    encode_patched_bitpack(uint32_t const* in, size_t n, const Selection& selection, std::vector<uint8_t>& out) {
+        assert(n > 0 && n <= kBlockSize);
+        assert(selection.patched_bits <= 31);
+        assert(selection.exceptions <= kMaxPForExceptions);
+
+        const uint8_t token_bits = selection.constant_base ? 0 : selection.patched_bits;
+        out.push_back(static_cast<uint8_t>((selection.exceptions << 5) | token_bits));
+
+        if (!selection.constant_base && selection.exceptions == 0) {
+            assert(selection.patched_bits != 0);
+            const size_t begin = out.size();
+            out.resize(begin + packed_size(n, selection.patched_bits));
+            pack_bits(in, n, selection.patched_bits, out.data() + begin);
+            return;
+        }
+
+        const uint32_t mask = selection.patched_bits == 0 ? 0U : (uint32_t{1} << selection.patched_bits) - 1;
+        alignas(64) thread_local std::array<uint32_t, kBlockSize> low_values{};
+        std::array<uint8_t, 2 * kMaxPForExceptions> exception_data{};
+        uint8_t exception_count = 0;
+        for (size_t i = 0; i < n; ++i) {
+            const uint32_t value = in[i];
+            if (!selection.constant_base) {
+                low_values[i] = value & mask;
+            }
+            if (value > mask) {
+                assert(exception_count < selection.exceptions);
+                const uint32_t patch = selection.constant_base ? value & ~mask : value >> selection.patched_bits;
+                assert(patch > 0 && patch <= UINT8_MAX);
+                exception_data[2 * exception_count] = static_cast<uint8_t>(i);
+                exception_data[2 * exception_count + 1] = static_cast<uint8_t>(patch);
+                ++exception_count;
+            }
+        }
+        assert(exception_count == selection.exceptions);
+
+        if (selection.constant_base) {
+            append_vint(selection.base_value, out);
+        } else {
+            assert(selection.patched_bits != 0);
+            const size_t begin = out.size();
+            out.resize(begin + packed_size(n, selection.patched_bits));
+            pack_bits(low_values.data(), n, selection.patched_bits, out.data() + begin);
+        }
+        out.insert(out.end(), exception_data.data(), exception_data.data() + 2 * exception_count);
+    }
+
+    [[nodiscard]] static uint8_t const*
+    decode_patched_bitpack(uint8_t const* in, uint32_t* out, size_t n) {
+        assert(n > 0 && n <= kBlockSize);
+
+        const uint8_t token = *in++;
+        const uint8_t bits = token & 0x1fU;
+        const uint8_t exceptions = token >> 5;
+        if (bits == 0) {
+            uint32_t base_value = 0;
+            in = read_vint(in, base_value);
+            std::fill_n(out, n, base_value);
+        } else {
+            in = unpack_bits(in, out, n, bits);
+        }
+
+        for (uint8_t exception = 0; exception < exceptions; ++exception) {
+            const uint8_t position = *in++;
+            const uint8_t patch = *in++;
+            out[position] |= static_cast<uint32_t>(patch) << bits;
+        }
+        return in;
+    }
+
+    static void
+    append_u16(uint32_t value, std::vector<uint8_t>& out) {
+        out.push_back(static_cast<uint8_t>(value));
+        out.push_back(static_cast<uint8_t>(value >> 8));
+    }
+
+    static void
+    append_u32(uint32_t value, std::vector<uint8_t>& out) {
+        out.push_back(static_cast<uint8_t>(value));
+        out.push_back(static_cast<uint8_t>(value >> 8));
+        out.push_back(static_cast<uint8_t>(value >> 16));
+        out.push_back(static_cast<uint8_t>(value >> 24));
+    }
+
+    [[nodiscard]] static uint32_t
+    read_u16(uint8_t const* in) {
+        return static_cast<uint32_t>(in[0]) | (static_cast<uint32_t>(in[1]) << 8);
+    }
+
+    [[nodiscard]] static uint32_t
+    read_u32(uint8_t const* in) {
+        return static_cast<uint32_t>(in[0]) | (static_cast<uint32_t>(in[1]) << 8) |
+               (static_cast<uint32_t>(in[2]) << 16) | (static_cast<uint32_t>(in[3]) << 24);
+    }
+};
+
+}  // namespace knowhere::sparse::inverted

--- a/src/index/sparse/codec/adaptive.h
+++ b/src/index/sparse/codec/adaptive.h
@@ -350,7 +350,7 @@ class AdaptiveBlockCodec final : public BlockCodec {
             if (!doc_ids) {
                 // Match Lucene PackedInts.bitsRequired: zero still occupies one base bit. A token width of zero is
                 // reserved for the constant-base optimization after exception planning.
-                ++bit_width_histogram[std::max(1U, std::bit_width(value))];
+                ++bit_width_histogram[std::max(1, static_cast<int>(std::bit_width(value)))];
             }
         }
 

--- a/src/index/sparse/codec/block_codec.h
+++ b/src/index/sparse/codec/block_codec.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string_view>
 #include <vector>
+
+#include "index/sparse/codec/simd_prefix_sum.h"
 
 namespace knowhere::sparse::inverted {
 
@@ -22,6 +25,15 @@ class BlockCodec {
     encode(uint32_t const* in, size_t n, std::vector<uint8_t>& out) const = 0;
 
     /**
+     * Encodes document-ID gaps. Codecs may override this method to use a document-ID-specific candidate set or
+     * tie-breaking policy. The default preserves the regular encoding behavior.
+     */
+    virtual void
+    encode_doc_ids(uint32_t const* in, size_t n, std::vector<uint8_t>& out) const {
+        encode(in, n, out);
+    }
+
+    /**
      * Decodes a list of `n` unsigned integers from a binary buffer and writes them to pre-allocated
      * memory.
      */
@@ -29,10 +41,20 @@ class BlockCodec {
     decode(uint8_t const* in, uint32_t* out, size_t n) const = 0;
 
     /**
-     * Returns the block size of the encoding.
-     *
-     * Block codecs write blocks of fixed size, e.g., 128 integers. Thus, it is only possible to
-     * encode at most `block_size()` elements with a single `encode` call.
+     * Decodes document-ID gaps and reconstructs absolute IDs with the shared SIMD prefix sum. `previous_value` is
+     * the document ID immediately before this block; UINT32_MAX represents the implicit value before document zero.
+     * Codecs may override this to fuse unpacking and prefix sums.
+     */
+    virtual uint8_t const*
+    decode_doc_ids(uint8_t const* in, uint32_t* out, size_t n, uint32_t previous_value) const {
+        uint8_t const* next = decode(in, out, n);
+        simd_prefix_sum::integrate_doc_id_gaps(out, n, previous_value);
+        return next;
+    }
+
+    /**
+     * Returns the maximum logical block length. Complete blocks contain `block_size()` values; the final block may
+     * be shorter, and one encode/decode call handles at most this many values.
      */
     [[nodiscard]] virtual auto
     block_size() const noexcept -> size_t = 0;
@@ -42,6 +64,16 @@ class BlockCodec {
      */
     [[nodiscard]] virtual auto
     get_name() const noexcept -> std::string_view = 0;
+
+    /**
+     * Returns whether BlockInvertedIndex may use its singleton short form: omit the document-ID payload, store the
+     * sole document ID in the posting block max-ID slot, encode BM25's TF - 1 as an untagged internal varint, and
+     * leave an IP value in its regular raw representation.
+     */
+    [[nodiscard]] virtual bool
+    supports_singleton_short_form() const noexcept {
+        return false;
+    }
 };
 
 using BlockCodecPtr = std::shared_ptr<BlockCodec>;

--- a/src/index/sparse/codec/simd_bitpacking.h
+++ b/src/index/sparse/codec/simd_bitpacking.h
@@ -1,0 +1,145 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+// for the specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include <bit>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+
+#include "index/sparse/codec/simd_prefix_sum.h"
+
+namespace knowhere::sparse::inverted::simd_bitpacking {
+
+// Complete 128-value chunks at widths 1..31 use a four-lane vertical SIMD kernel; width 32 is copied directly. A
+// full 256-value compressed payload invokes the kernel twice, while only the remaining fewer than 128 values use
+// the compact scalar path. The payload is exactly ceil(n * bit_width / 8) bytes, including for partial blocks.
+inline constexpr size_t kChunkSize = 128;
+
+static_assert(std::endian::native == std::endian::little,
+              "the SIMD bit-packing disk layout requires a little-endian target");
+
+namespace detail {
+
+inline uint8_t*
+pack_tail(uint32_t const* in, size_t n, uint8_t bits, uint8_t* out) noexcept {
+    uint64_t accumulator = 0;
+    uint32_t buffered_bits = 0;
+    for (size_t i = 0; i < n; ++i) {
+        accumulator |= static_cast<uint64_t>(in[i]) << buffered_bits;
+        buffered_bits += bits;
+        while (buffered_bits >= 8) {
+            *out++ = static_cast<uint8_t>(accumulator);
+            accumulator >>= 8;
+            buffered_bits -= 8;
+        }
+    }
+    if (buffered_bits != 0) {
+        *out++ = static_cast<uint8_t>(accumulator);
+    }
+    return out;
+}
+
+inline uint8_t const*
+unpack_tail(uint8_t const* in, uint32_t* out, size_t n, uint8_t bits) noexcept {
+    const uint64_t mask = bits == 32 ? UINT32_MAX : (uint64_t{1} << bits) - 1;
+    uint64_t accumulator = 0;
+    uint32_t buffered_bits = 0;
+    for (size_t i = 0; i < n; ++i) {
+        while (buffered_bits < bits) {
+            accumulator |= static_cast<uint64_t>(*in++) << buffered_bits;
+            buffered_bits += 8;
+        }
+        out[i] = static_cast<uint32_t>(accumulator & mask);
+        accumulator >>= bits;
+        buffered_bits -= bits;
+    }
+    return in;
+}
+
+inline void
+validate_arguments(void const* in, void const* out, uint8_t bits) {
+    assert(in != nullptr);
+    assert(out != nullptr);
+    if (bits == 0 || bits > 32) {
+        throw std::invalid_argument("SIMD bit width must be in [1, 32]");
+    }
+}
+
+}  // namespace detail
+
+[[nodiscard]] inline constexpr size_t
+packed_size(size_t n, uint8_t bits) noexcept {
+    return (n * bits + 7) / 8;
+}
+
+inline void
+pack(uint32_t const* in, size_t n, uint8_t bits, uint8_t* out) {
+    detail::validate_arguments(in, out, bits);
+
+    const size_t chunks = n / kChunkSize;
+    if (chunks != 0) {
+        knowhere_simd_pack_128_blocks(in, out, chunks, bits);
+        const size_t chunk_values = chunks * kChunkSize;
+        in += chunk_values;
+        out += chunks * static_cast<size_t>(bits) * 16;
+        n -= chunk_values;
+    }
+    static_cast<void>(detail::pack_tail(in, n, bits, out));
+}
+
+[[nodiscard]] inline uint8_t const*
+unpack(uint8_t const* in, uint32_t* out, size_t n, uint8_t bits) {
+    detail::validate_arguments(in, out, bits);
+
+    const size_t chunks = n / kChunkSize;
+    if (chunks != 0) {
+        knowhere_simd_unpack_128_blocks(in, out, chunks, bits);
+        const size_t chunk_values = chunks * kChunkSize;
+        in += chunks * static_cast<size_t>(bits) * 16;
+        out += chunk_values;
+        n -= chunk_values;
+    }
+    return detail::unpack_tail(in, out, n, bits);
+}
+
+// Doc-ID payloads store (current - previous - 1). Complete 128-value chunks use a simdcomp simdunpackd1 kernel whose
+// prefix sum folds in the omitted one and directly reconstructs absolute document IDs. A compact tail is unpacked
+// normally and then integrated by the shared SIMD prefix helper. Width 32 uses the regular unpack path (a direct
+// copy for complete chunks) because upstream d1 treats it as raw absolute values rather than packed deltas.
+[[nodiscard]] inline uint8_t const*
+unpack_doc_ids(uint8_t const* in, uint32_t* out, size_t n, uint8_t bits, uint32_t previous_value) {
+    detail::validate_arguments(in, out, bits);
+
+    if (bits == 32) {
+        uint8_t const* next = unpack(in, out, n, bits);
+        simd_prefix_sum::integrate_doc_id_gaps(out, n, previous_value);
+        return next;
+    }
+
+    const size_t chunks = n / kChunkSize;
+    if (chunks != 0) {
+        knowhere_simd_unpack_d1_128_blocks(in, out, chunks, bits, previous_value);
+        const size_t chunk_values = chunks * kChunkSize;
+        in += chunks * static_cast<size_t>(bits) * 16;
+        out += chunk_values;
+        n -= chunk_values;
+        previous_value = out[-1];
+    }
+
+    uint8_t const* next = detail::unpack_tail(in, out, n, bits);
+    simd_prefix_sum::integrate_doc_id_gaps(out, n, previous_value);
+    return next;
+}
+
+}  // namespace knowhere::sparse::inverted::simd_bitpacking

--- a/src/index/sparse/codec/simd_bitpacking_kernel.c
+++ b/src/index/sparse/codec/simd_bitpacking_kernel.c
@@ -1,0 +1,173 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+// for the specific language governing permissions and limitations under the License.
+
+#include "index/sparse/codec/simd_bitpacking_kernel.h"
+
+#include <string.h>
+
+// These are pruned generated kernels derived from fast-pack/simdcomp; see simdcomp/UPSTREAM.md and LICENSE.
+// Every retained entry point is static and is consumed only by the block-oriented wrappers below.
+#include "simdcomp/src/simdbitpacking.c"
+#include "simdcomp/src/simdintegratedbitpacking.c"
+
+enum { KNOWHERE_SIMD_BLOCK_SIZE = 128 };
+
+#define KNOWHERE_SIMD_PACK_CASE(BITS)                                 \
+    case BITS:                                                        \
+        do {                                                          \
+            __SIMD_fastpackwithoutmask##BITS##_32(in, (__m128i*)out); \
+            in += KNOWHERE_SIMD_BLOCK_SIZE;                           \
+            out += (size_t)(BITS) * sizeof(__m128i);                  \
+        } while (--block_count != 0);                                 \
+        return
+
+void
+knowhere_simd_pack_128_blocks(const uint32_t* in, uint8_t* out, size_t block_count, uint32_t bits) {
+    if (block_count == 0) {
+        return;
+    }
+    if (bits == 32) {
+        memcpy(out, in, block_count * KNOWHERE_SIMD_BLOCK_SIZE * sizeof(*in));
+        return;
+    }
+    switch (bits) {
+        KNOWHERE_SIMD_PACK_CASE(1);
+        KNOWHERE_SIMD_PACK_CASE(2);
+        KNOWHERE_SIMD_PACK_CASE(3);
+        KNOWHERE_SIMD_PACK_CASE(4);
+        KNOWHERE_SIMD_PACK_CASE(5);
+        KNOWHERE_SIMD_PACK_CASE(6);
+        KNOWHERE_SIMD_PACK_CASE(7);
+        KNOWHERE_SIMD_PACK_CASE(8);
+        KNOWHERE_SIMD_PACK_CASE(9);
+        KNOWHERE_SIMD_PACK_CASE(10);
+        KNOWHERE_SIMD_PACK_CASE(11);
+        KNOWHERE_SIMD_PACK_CASE(12);
+        KNOWHERE_SIMD_PACK_CASE(13);
+        KNOWHERE_SIMD_PACK_CASE(14);
+        KNOWHERE_SIMD_PACK_CASE(15);
+        KNOWHERE_SIMD_PACK_CASE(16);
+        KNOWHERE_SIMD_PACK_CASE(17);
+        KNOWHERE_SIMD_PACK_CASE(18);
+        KNOWHERE_SIMD_PACK_CASE(19);
+        KNOWHERE_SIMD_PACK_CASE(20);
+        KNOWHERE_SIMD_PACK_CASE(21);
+        KNOWHERE_SIMD_PACK_CASE(22);
+        KNOWHERE_SIMD_PACK_CASE(23);
+        KNOWHERE_SIMD_PACK_CASE(24);
+        KNOWHERE_SIMD_PACK_CASE(25);
+        KNOWHERE_SIMD_PACK_CASE(26);
+        KNOWHERE_SIMD_PACK_CASE(27);
+        KNOWHERE_SIMD_PACK_CASE(28);
+        KNOWHERE_SIMD_PACK_CASE(29);
+        KNOWHERE_SIMD_PACK_CASE(30);
+        KNOWHERE_SIMD_PACK_CASE(31);
+        default:
+            return;
+    }
+}
+
+#undef KNOWHERE_SIMD_PACK_CASE
+
+#define KNOWHERE_SIMD_UNPACK_CASE(BITS)                            \
+    case BITS:                                                     \
+        do {                                                       \
+            __SIMD_fastunpack##BITS##_32((const __m128i*)in, out); \
+            in += (size_t)(BITS) * sizeof(__m128i);                \
+            out += KNOWHERE_SIMD_BLOCK_SIZE;                       \
+        } while (--block_count != 0);                              \
+        return
+
+void
+knowhere_simd_unpack_128_blocks(const uint8_t* in, uint32_t* out, size_t block_count, uint32_t bits) {
+    if (block_count == 0) {
+        return;
+    }
+    if (bits == 32) {
+        memcpy(out, in, block_count * KNOWHERE_SIMD_BLOCK_SIZE * sizeof(*out));
+        return;
+    }
+    switch (bits) {
+        KNOWHERE_SIMD_UNPACK_CASE(1);
+        KNOWHERE_SIMD_UNPACK_CASE(2);
+        KNOWHERE_SIMD_UNPACK_CASE(3);
+        KNOWHERE_SIMD_UNPACK_CASE(4);
+        KNOWHERE_SIMD_UNPACK_CASE(5);
+        KNOWHERE_SIMD_UNPACK_CASE(6);
+        KNOWHERE_SIMD_UNPACK_CASE(7);
+        KNOWHERE_SIMD_UNPACK_CASE(8);
+        KNOWHERE_SIMD_UNPACK_CASE(9);
+        KNOWHERE_SIMD_UNPACK_CASE(10);
+        KNOWHERE_SIMD_UNPACK_CASE(11);
+        KNOWHERE_SIMD_UNPACK_CASE(12);
+        KNOWHERE_SIMD_UNPACK_CASE(13);
+        KNOWHERE_SIMD_UNPACK_CASE(14);
+        KNOWHERE_SIMD_UNPACK_CASE(15);
+        KNOWHERE_SIMD_UNPACK_CASE(16);
+        KNOWHERE_SIMD_UNPACK_CASE(17);
+        KNOWHERE_SIMD_UNPACK_CASE(18);
+        KNOWHERE_SIMD_UNPACK_CASE(19);
+        KNOWHERE_SIMD_UNPACK_CASE(20);
+        KNOWHERE_SIMD_UNPACK_CASE(21);
+        KNOWHERE_SIMD_UNPACK_CASE(22);
+        KNOWHERE_SIMD_UNPACK_CASE(23);
+        KNOWHERE_SIMD_UNPACK_CASE(24);
+        KNOWHERE_SIMD_UNPACK_CASE(25);
+        KNOWHERE_SIMD_UNPACK_CASE(26);
+        KNOWHERE_SIMD_UNPACK_CASE(27);
+        KNOWHERE_SIMD_UNPACK_CASE(28);
+        KNOWHERE_SIMD_UNPACK_CASE(29);
+        KNOWHERE_SIMD_UNPACK_CASE(30);
+        KNOWHERE_SIMD_UNPACK_CASE(31);
+        default:
+            return;
+    }
+}
+
+#undef KNOWHERE_SIMD_UNPACK_CASE
+
+void
+knowhere_simd_unpack_d1_128_blocks(const uint8_t* in, uint32_t* out, size_t block_count, uint32_t bits,
+                                   uint32_t previous_value) {
+    if (block_count == 0 || bits == 0 || bits >= 32) {
+        return;
+    }
+    do {
+        simdunpackd1(previous_value, (const __m128i*)in, out, bits);
+        previous_value = out[KNOWHERE_SIMD_BLOCK_SIZE - 1];
+        in += (size_t)bits * sizeof(__m128i);
+        out += KNOWHERE_SIMD_BLOCK_SIZE;
+    } while (--block_count != 0);
+}
+
+void
+knowhere_simd_integrate_doc_id_gaps(uint32_t* values, size_t count, uint32_t previous_value) {
+    const __m128i one = _mm_set1_epi32(1);
+    __m128i previous = _mm_set1_epi32(previous_value);
+    const size_t vector_end = count & ~(size_t)3;
+    size_t i = 0;
+    for (; i < vector_end; i += 4) {
+        const __m128i gaps = _mm_loadu_si128((const __m128i*)(values + i));
+        const __m128i deltas = _mm_add_epi32(gaps, one);
+        const __m128i pairs = _mm_add_epi32(_mm_slli_si128(deltas, 8), deltas);
+        const __m128i prefix = _mm_add_epi32(_mm_slli_si128(pairs, 4), pairs);
+        previous = _mm_add_epi32(prefix, _mm_shuffle_epi32(previous, 0xff));
+        _mm_storeu_si128((__m128i*)(values + i), previous);
+    }
+
+    if (vector_end != 0) {
+        previous_value = (uint32_t)_mm_cvtsi128_si32(_mm_shuffle_epi32(previous, 0xff));
+    }
+    for (; i < count; ++i) {
+        previous_value += values[i] + 1;
+        values[i] = previous_value;
+    }
+}

--- a/src/index/sparse/codec/simd_bitpacking_kernel.h
+++ b/src/index/sparse/codec/simd_bitpacking_kernel.h
@@ -1,0 +1,36 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+// for the specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void
+knowhere_simd_pack_128_blocks(const uint32_t* in, uint8_t* out, size_t block_count, uint32_t bits);
+
+void
+knowhere_simd_unpack_128_blocks(const uint8_t* in, uint32_t* out, size_t block_count, uint32_t bits);
+
+void
+knowhere_simd_unpack_d1_128_blocks(const uint8_t* in, uint32_t* out, size_t block_count, uint32_t bits,
+                                   uint32_t previous_value);
+
+void
+knowhere_simd_integrate_doc_id_gaps(uint32_t* values, size_t count, uint32_t previous_value);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/index/sparse/codec/simd_prefix_sum.h
+++ b/src/index/sparse/codec/simd_prefix_sum.h
@@ -1,0 +1,35 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+// for the specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+#include "index/sparse/codec/simd_bitpacking_kernel.h"
+
+namespace knowhere::sparse::inverted::simd_prefix_sum {
+
+inline void
+integrate_doc_id_gaps(uint32_t* values, size_t n, uint32_t previous_value) noexcept {
+    assert(values != nullptr || n == 0);
+    if (n < 4) {
+        for (size_t i = 0; i < n; ++i) {
+            previous_value += values[i] + 1;
+            values[i] = previous_value;
+        }
+        return;
+    }
+    knowhere_simd_integrate_doc_id_gaps(values, n, previous_value);
+}
+
+}  // namespace knowhere::sparse::inverted::simd_prefix_sum

--- a/src/index/sparse/codec/simdcomp/include/neon128.h
+++ b/src/index/sparse/codec/simdcomp/include/neon128.h
@@ -1,0 +1,87 @@
+/** Port from https://github.com/fast-pack/simdcomp
+ *
+ * This code is released under a BSD License.
+ *
+ * Minimal SSE2-on-NEON shim for the generated kernels retained by Knowhere.
+ */
+#ifndef KNOWHERE_SIMDCOMP_NEON128_H_
+#define KNOWHERE_SIMDCOMP_NEON128_H_
+
+#include <arm_neon.h>
+#include <stdint.h>
+
+#if defined(__GNUC__) || defined(__clang__)
+#define KNOWHERE_SIMDCOMP_NEON_INLINE __inline__ __attribute__((always_inline))
+#else
+#define KNOWHERE_SIMDCOMP_NEON_INLINE inline
+#endif
+
+/* The packed stream can be byte-aligned even though every load moves 128 bits. */
+#if defined(__GNUC__) || defined(__clang__)
+typedef int32x4_t __m128i __attribute__((aligned(1)));
+#else
+typedef int32x4_t __m128i;
+#endif
+
+static KNOWHERE_SIMDCOMP_NEON_INLINE __m128i
+_mm_loadu_si128(const __m128i* p) {
+    return vreinterpretq_s32_u8(vld1q_u8((const uint8_t*)p));
+}
+
+static KNOWHERE_SIMDCOMP_NEON_INLINE void
+_mm_storeu_si128(__m128i* p, __m128i value) {
+    vst1q_u8((uint8_t*)p, vreinterpretq_u8_s32(value));
+}
+
+static KNOWHERE_SIMDCOMP_NEON_INLINE __m128i
+_mm_set1_epi32(int value) {
+    return vdupq_n_s32(value);
+}
+
+static KNOWHERE_SIMDCOMP_NEON_INLINE __m128i
+_mm_and_si128(__m128i lhs, __m128i rhs) {
+    return vandq_s32(lhs, rhs);
+}
+
+static KNOWHERE_SIMDCOMP_NEON_INLINE __m128i
+_mm_or_si128(__m128i lhs, __m128i rhs) {
+    return vorrq_s32(lhs, rhs);
+}
+
+static KNOWHERE_SIMDCOMP_NEON_INLINE __m128i
+_mm_add_epi32(__m128i lhs, __m128i rhs) {
+    return vaddq_s32(lhs, rhs);
+}
+
+/* NEON yields zero when the absolute shift count is at least the lane width. */
+static KNOWHERE_SIMDCOMP_NEON_INLINE __m128i
+_mm_slli_epi32(__m128i value, int count) {
+    return vreinterpretq_s32_u32(vshlq_u32(vreinterpretq_u32_s32(value), vdupq_n_s32(count)));
+}
+
+static KNOWHERE_SIMDCOMP_NEON_INLINE __m128i
+_mm_srli_epi32(__m128i value, int count) {
+    return vreinterpretq_s32_u32(vshlq_u32(vreinterpretq_u32_s32(value), vdupq_n_s32(-count)));
+}
+
+static KNOWHERE_SIMDCOMP_NEON_INLINE int
+_mm_cvtsi128_si32(__m128i value) {
+    return vgetq_lane_s32(value, 0);
+}
+
+/* The immediate arguments remain compile-time constants in every retained call site. */
+#define _mm_shuffle_epi32(value, imm)                                                                          \
+    vsetq_lane_s32(                                                                                            \
+        vgetq_lane_s32((value), ((imm) >> 6) & 3),                                                             \
+        vsetq_lane_s32(vgetq_lane_s32((value), ((imm) >> 4) & 3),                                              \
+                       vsetq_lane_s32(vgetq_lane_s32((value), ((imm) >> 2) & 3),                               \
+                                      vsetq_lane_s32(vgetq_lane_s32((value), (imm)&3), vdupq_n_s32(0), 0), 1), \
+                       2),                                                                                     \
+        3)
+
+#define _mm_slli_si128(value, imm) \
+    vreinterpretq_s32_u8(vextq_u8(vdupq_n_u8(0), vreinterpretq_u8_s32(value), 16 - (imm)))
+
+#undef KNOWHERE_SIMDCOMP_NEON_INLINE
+
+#endif /* KNOWHERE_SIMDCOMP_NEON128_H_ */

--- a/src/index/sparse/codec/simdcomp/include/portability.h
+++ b/src/index/sparse/codec/simdcomp/include/portability.h
@@ -1,0 +1,22 @@
+/** Port from https://github.com/fast-pack/simdcomp
+ *
+ * This code is released under a BSD License.
+ */
+#ifndef KNOWHERE_SIMDCOMP_PORTABILITY_H_
+#define KNOWHERE_SIMDCOMP_PORTABILITY_H_
+
+#include <stdint.h>
+
+#if defined(__aarch64__) || defined(__arm__) || defined(__ARM_NEON) || defined(_M_ARM64)
+#include "neon128.h"
+#elif defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
+#include <emmintrin.h>
+#else
+/* Keep the generated SSE2 kernels available on the other architectures supported by Knowhere. */
+#ifndef SIMDE_ENABLE_NATIVE_ALIASES
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#endif
+#include <simde/x86/sse2.h>
+#endif
+
+#endif /* KNOWHERE_SIMDCOMP_PORTABILITY_H_ */

--- a/src/index/sparse/codec/simdcomp/src/simdbitpacking.c
+++ b/src/index/sparse/codec/simdcomp/src/simdbitpacking.c
@@ -6,9138 +6,8754 @@
 
 /* Knowhere retains only the generated 1..31-bit pack-without-mask and unpack kernels. */
 
-static void __SIMD_fastpackwithoutmask1_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
+static void
+__SIMD_fastpackwithoutmask1_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask2_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask3_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 3 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 3 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask5_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 5 - 3);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 5 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 5 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 5 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask6_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 6 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 6 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 6 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 6 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask7_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 7 - 3);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 7 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 7 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 7 - 5);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 7 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 7 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask9_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 9 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 9 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 9 - 3);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 9 - 7);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 9 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 9 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 9 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 9 - 5);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask10_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 10 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 10 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 10 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 10 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 10 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 10 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 10 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 10 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask11_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 11 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 11 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 11 - 3);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 11 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 11 - 5);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 11 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 11 - 7);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 11 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 11 - 9);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 11 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask12_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 12 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 12 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 12 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 12 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 12 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 12 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 12 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 12 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask13_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 13 - 7);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 13 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 13 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 13 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 13 - 9);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 13 - 3);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 13 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 13 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 13 - 11);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 13 - 5);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 13 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 13 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask14_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 14 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 14 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 14 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 14 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 14 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 14 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 14 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 14 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 14 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 14 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 14 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 14 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask15_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 15 - 13);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 15 - 11);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 15 - 9);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 15 - 7);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 15 - 5);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 15 - 3);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 15 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 15 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 15 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 15 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 15 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 15 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 15 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 15 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask17_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 3);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 5);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 7);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 9);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 11);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 13);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 17 - 15);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask18_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 18 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask19_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 5);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 11);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 17);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 3);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 9);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 15);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 7);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 19 - 13);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask20_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 20 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask21_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 9);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 19);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 7);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 17);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 5);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 15);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 3);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 13);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 21 - 11);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask22_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 22 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask23_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 5);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 19);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 15);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 11);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 7);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 21);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 3);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 17);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 13);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 23 - 9);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask24_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 24 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask25_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 11);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 15);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 19);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 5);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 23);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 9);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 13);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 17);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 3);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 21);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 25 - 7);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask26_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 26 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask27_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 17);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 7);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 19);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 9);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 26);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 21);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 11);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 23);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 13);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 3);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 25);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 15);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 27 - 5);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask28_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 28 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask29_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 26);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 23);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 17);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 11);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 5);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 25);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 19);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 13);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 7);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 27);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 21);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 15);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 9);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 29 - 3);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask30_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 26);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 26);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 30 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask31_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg = _mm_loadu_si128(in);
-
-  OutReg = InReg;
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 30);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 29);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 27);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 26);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 25);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 23);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 21);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 19);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 17);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 15);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 13);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 11);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 9);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 7);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 5);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 3);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 2);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
-  _mm_storeu_si128(out, OutReg);
-  ++out;
-  OutReg = _mm_srli_epi32(InReg, 31 - 1);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
-  _mm_storeu_si128(out, OutReg);
-}
-
-static void __SIMD_fastpackwithoutmask4_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg;
-  uint32_t outer;
-
-  for (outer = 0; outer < 4; ++outer) {
-    InReg = _mm_loadu_si128(in);
     OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-    InReg = _mm_loadu_si128(in + 1);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    InReg = _mm_loadu_si128(++in);
+
     OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
 
-    InReg = _mm_loadu_si128(in + 2);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    InReg = _mm_loadu_si128(++in);
+
     OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
 
-    InReg = _mm_loadu_si128(in + 3);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    InReg = _mm_loadu_si128(++in);
+
     OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
 
-    InReg = _mm_loadu_si128(in + 4);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    InReg = _mm_loadu_si128(++in);
+
     OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
 
-    InReg = _mm_loadu_si128(in + 5);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    InReg = _mm_loadu_si128(++in);
+
     OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    InReg = _mm_loadu_si128(++in);
 
-    InReg = _mm_loadu_si128(in + 6);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    InReg = _mm_loadu_si128(++in);
+
     OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    InReg = _mm_loadu_si128(++in);
 
-    InReg = _mm_loadu_si128(in + 7);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+}
+
+static void
+__SIMD_fastpackwithoutmask2_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+}
+
+static void
+__SIMD_fastpackwithoutmask3_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 3 - 1);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 3 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+}
+
+static void
+__SIMD_fastpackwithoutmask5_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 5 - 3);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    InReg = _mm_loadu_si128(++in);
+
     OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
     _mm_storeu_si128(out, OutReg);
     ++out;
+    OutReg = _mm_srli_epi32(InReg, 5 - 1);
+    InReg = _mm_loadu_si128(++in);
 
-    in += 8;
-  }
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 5 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 5 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastpackwithoutmask8_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg;
-  uint32_t outer;
+static void
+__SIMD_fastpackwithoutmask6_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  for (outer = 0; outer < 8; ++outer) {
-    InReg = _mm_loadu_si128(in);
     OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-    InReg = _mm_loadu_si128(in + 1);
-    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
 
-    InReg = _mm_loadu_si128(in + 2);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 6 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
     OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
 
-    InReg = _mm_loadu_si128(in + 3);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 6 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 6 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 6 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+}
+
+static void
+__SIMD_fastpackwithoutmask7_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 7 - 3);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 7 - 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 7 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 7 - 5);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 7 - 1);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 7 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    _mm_storeu_si128(out, OutReg);
+}
+
+static void
+__SIMD_fastpackwithoutmask9_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 9 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 9 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 9 - 3);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 9 - 7);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 9 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 9 - 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    InReg = _mm_loadu_si128(++in);
+
     OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
     _mm_storeu_si128(out, OutReg);
     ++out;
+    OutReg = _mm_srli_epi32(InReg, 9 - 1);
+    InReg = _mm_loadu_si128(++in);
 
-    in += 4;
-  }
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 9 - 5);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastpackwithoutmask16_32(const uint32_t *_in, __m128i *out) {
-  const __m128i *in = (const __m128i *)(_in);
-  __m128i OutReg;
-  __m128i InReg;
-  uint32_t outer;
+static void
+__SIMD_fastpackwithoutmask10_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  for (outer = 0; outer < 16; ++outer) {
-    InReg = _mm_loadu_si128(in);
     OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-    InReg = _mm_loadu_si128(in + 1);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 10 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 10 - 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 10 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 10 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 10 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 10 - 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 10 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 10 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+}
+
+static void
+__SIMD_fastpackwithoutmask11_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 11 - 1);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 11 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 11 - 3);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 11 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 11 - 5);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 11 - 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 11 - 7);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 11 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 11 - 9);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 11 - 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    _mm_storeu_si128(out, OutReg);
+}
+
+static void
+__SIMD_fastpackwithoutmask12_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 12 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 12 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 12 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 12 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 12 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 12 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 12 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 12 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+}
+
+static void
+__SIMD_fastpackwithoutmask13_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 13 - 7);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 13 - 1);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 13 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 13 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 13 - 9);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 13 - 3);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 13 - 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 13 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 13 - 11);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 13 - 5);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 13 - 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 13 - 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    _mm_storeu_si128(out, OutReg);
+}
+
+static void
+__SIMD_fastpackwithoutmask14_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 14 - 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 14 - 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 14 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 14 - 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 14 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 14 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 14 - 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 14 - 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 14 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 14 - 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 14 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 14 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+}
+
+static void
+__SIMD_fastpackwithoutmask15_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 15 - 13);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 15 - 11);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 15 - 9);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 15 - 7);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 15 - 5);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 15 - 3);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 15 - 1);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 15 - 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 15 - 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 15 - 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 15 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 15 - 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 15 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 15 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    _mm_storeu_si128(out, OutReg);
+}
+
+static void
+__SIMD_fastpackwithoutmask17_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 16);
+    InReg = _mm_loadu_si128(++in);
+
     OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
     _mm_storeu_si128(out, OutReg);
     ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 1);
+    InReg = _mm_loadu_si128(++in);
 
-    in += 2;
-  }
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 3);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 5);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 7);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 9);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 11);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 13);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 17 - 15);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack1_32(const __m128i *in, uint32_t *_out) {
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg1 = _mm_loadu_si128(in);
-  __m128i InReg2 = InReg1;
-  __m128i OutReg1, OutReg2, OutReg3, OutReg4;
-  const __m128i mask = _mm_set1_epi32(1);
+static void
+__SIMD_fastpackwithoutmask18_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  uint32_t i, shift = 0;
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  for (i = 0; i < 8; ++i) {
-    OutReg1 = _mm_and_si128(_mm_srli_epi32(InReg1, shift++), mask);
-    OutReg2 = _mm_and_si128(_mm_srli_epi32(InReg2, shift++), mask);
-    OutReg3 = _mm_and_si128(_mm_srli_epi32(InReg1, shift++), mask);
-    OutReg4 = _mm_and_si128(_mm_srli_epi32(InReg2, shift++), mask);
-    _mm_storeu_si128(out++, OutReg1);
-    _mm_storeu_si128(out++, OutReg2);
-    _mm_storeu_si128(out++, OutReg3);
-    _mm_storeu_si128(out++, OutReg4);
-  }
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 18 - 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack2_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask19_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 2) - 1);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 6);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 18);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 5);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 11);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 17);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 10);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 26), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 28), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 3);
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 9);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 15);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 2);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 14);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 1);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 7);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 19 - 13);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 26), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 28), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 30);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack3_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask20_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 3) - 1);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 21), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 27), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 3 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 25), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 28), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 3 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 20 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 23), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 26), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 29);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack4_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask21_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 4) - 1);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 10);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 9);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 19);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 18);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 7);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 17);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 6);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 5);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 15);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 14);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 3);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 13);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 2);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 1);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 21 - 11);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 28);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack5_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask22_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 5) - 1);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 2);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 14);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 25), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 3), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 6);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 18);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 23), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 10);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 2);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 21), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 14);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 26), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 6);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 18);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 29);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 22 - 10);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 27);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack6_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask23_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 6) - 1);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 14);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 5);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 19);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 10);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 1);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 15);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 6);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 11);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 2);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 7);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 21);
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 3);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 17);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 13);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 18);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 23 - 9);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 26);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack7_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask24_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 7) - 1);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 21), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 3), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 27);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 23), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 5), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 24 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 29);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 25);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack8_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask25_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 8) - 1);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 18);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 11);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 15);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 1);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 19);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 5);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 23);
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 9);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 2);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 13);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 6);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 17);
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 10);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 3);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 21);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 14);
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 25 - 7);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack9_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask26_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 9) - 1);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 14);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 27);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 2);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 10);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 18);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 3), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 6);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 21), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 14);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 7), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 2);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 25);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 10);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 29);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 18);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 26 - 6);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 5), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 23);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack10_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask27_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 10) - 1);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 17);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 7);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 2);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 19);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 14);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 9);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 21);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 11);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 6);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 1);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 23);
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 18);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 13);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 3);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 25);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 15);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 10);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 27 - 5);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 22);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack11_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask28_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 11) - 1);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 23);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 3), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 25);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 5), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 27);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 7), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 28 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 29);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 9), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 21);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack12_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask29_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 12) - 1);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 23);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 17);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 14);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 11);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 5);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 2);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 25);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 19);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 13);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 10);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 7);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 1);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 27);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 21);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 18);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 15);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 9);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 6);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 29 - 3);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 20);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack13_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask30_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 13) - 1);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 7), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 18);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 14);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 27);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 10);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 6);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 21);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 2);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 9), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 3), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 18);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 29);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 14);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 10);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 23);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 6);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 30 - 2);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 11), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 5), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 25);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 19);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack14_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask31_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg = _mm_loadu_si128(in);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 14) - 1);
+    OutReg = InReg;
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 30);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 29);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 27);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 25);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 23);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 21);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 19);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 18);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 17);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 16);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 15);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 14);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 13);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 12);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 11);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 10);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 9);
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 8);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 7);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 6);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 5);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 4);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 3);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 2);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+    OutReg = _mm_srli_epi32(InReg, 31 - 1);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 18);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+    _mm_storeu_si128(out, OutReg);
 }
 
-static void __SIMD_fastunpack15_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask4_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg;
+    uint32_t outer;
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 15) - 1);
+    for (outer = 0; outer < 4; ++outer) {
+        InReg = _mm_loadu_si128(in);
+        OutReg = InReg;
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+        InReg = _mm_loadu_si128(in + 1);
+        OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
-  _mm_storeu_si128(out++, OutReg);
+        InReg = _mm_loadu_si128(in + 2);
+        OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+        InReg = _mm_loadu_si128(in + 3);
+        OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 13), mask));
-  _mm_storeu_si128(out++, OutReg);
+        InReg = _mm_loadu_si128(in + 4);
+        OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
-  _mm_storeu_si128(out++, OutReg);
+        InReg = _mm_loadu_si128(in + 5);
+        OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+        InReg = _mm_loadu_si128(in + 6);
+        OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 11), mask));
-  _mm_storeu_si128(out++, OutReg);
+        InReg = _mm_loadu_si128(in + 7);
+        OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+        _mm_storeu_si128(out, OutReg);
+        ++out;
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 9), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 7), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 5), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 3), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 29);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 27);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 25);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 23);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 21);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 19);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 17);
-  _mm_storeu_si128(out++, OutReg);
+        in += 8;
+    }
 }
 
-static void __SIMD_fastunpack16_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask8_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg;
+    uint32_t outer;
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 16) - 1);
+    for (outer = 0; outer < 8; ++outer) {
+        InReg = _mm_loadu_si128(in);
+        OutReg = InReg;
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+        InReg = _mm_loadu_si128(in + 1);
+        OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+        InReg = _mm_loadu_si128(in + 2);
+        OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
 
-  _mm_storeu_si128(out++, OutReg);
+        InReg = _mm_loadu_si128(in + 3);
+        OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+        _mm_storeu_si128(out, OutReg);
+        ++out;
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  _mm_storeu_si128(out++, OutReg);
+        in += 4;
+    }
 }
 
-static void __SIMD_fastunpack17_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastpackwithoutmask16_32(const uint32_t* _in, __m128i* out) {
+    const __m128i* in = (const __m128i*)(_in);
+    __m128i OutReg;
+    __m128i InReg;
+    uint32_t outer;
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 17) - 1);
+    for (outer = 0; outer < 16; ++outer) {
+        InReg = _mm_loadu_si128(in);
+        OutReg = InReg;
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+        InReg = _mm_loadu_si128(in + 1);
+        OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+        _mm_storeu_si128(out, OutReg);
+        ++out;
 
-  OutReg = _mm_srli_epi32(InReg, 17);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 19);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 21);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 23);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 25);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 27);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 29);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 3), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 5), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 7), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 9), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 11), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 13), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 15), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 15);
-  _mm_storeu_si128(out++, OutReg);
+        in += 2;
+    }
 }
 
-static void __SIMD_fastunpack18_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastunpack1_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg1 = _mm_loadu_si128(in);
+    __m128i InReg2 = InReg1;
+    __m128i OutReg1, OutReg2, OutReg3, OutReg4;
+    const __m128i mask = _mm_set1_epi32(1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 18) - 1);
+    uint32_t i, shift = 0;
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 14);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 14);
-  _mm_storeu_si128(out++, OutReg);
+    for (i = 0; i < 8; ++i) {
+        OutReg1 = _mm_and_si128(_mm_srli_epi32(InReg1, shift++), mask);
+        OutReg2 = _mm_and_si128(_mm_srli_epi32(InReg2, shift++), mask);
+        OutReg3 = _mm_and_si128(_mm_srli_epi32(InReg1, shift++), mask);
+        OutReg4 = _mm_and_si128(_mm_srli_epi32(InReg2, shift++), mask);
+        _mm_storeu_si128(out++, OutReg1);
+        _mm_storeu_si128(out++, OutReg2);
+        _mm_storeu_si128(out++, OutReg3);
+        _mm_storeu_si128(out++, OutReg4);
+    }
 }
 
-static void __SIMD_fastunpack19_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastunpack2_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 2) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 19) - 1);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 19);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 25);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 18), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 5), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 26), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 11), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 28), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 17), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 17);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 23);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 29);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 3), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 9), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 26), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 28), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 15), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 15);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 21);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 27);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 7), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 13), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 13);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    _mm_storeu_si128(out++, OutReg);
 }
 
-static void __SIMD_fastunpack20_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastunpack3_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 3) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 20) - 1);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 21), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 27), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 3 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 25), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 28), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 3 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 23), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 26), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 12);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 29);
+    _mm_storeu_si128(out++, OutReg);
 }
 
-static void __SIMD_fastunpack21_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastunpack4_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 4) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 21) - 1);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 21);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 9), mask));
-  _mm_storeu_si128(out++, OutReg);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 19), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 19);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 29);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 18), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 7), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 17), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 17);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 27);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 5), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 15), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 15);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 25);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 3), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 13), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 13);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 23);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 11), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 11);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    _mm_storeu_si128(out++, OutReg);
 }
 
-static void __SIMD_fastunpack22_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastunpack5_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 5) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 22) - 1);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 25), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 3), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 14);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 23), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 18), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 21), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 26), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 10);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 29);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 18), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 10);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 27);
+    _mm_storeu_si128(out++, OutReg);
 }
 
-static void __SIMD_fastunpack23_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastunpack6_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 6) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 23) - 1);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 23);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 14);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 5), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 19), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 19);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 10);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 15), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 15);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 29);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 11), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 11);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 25);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 7), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 21), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 21);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 3), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 17), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 17);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 22), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 13), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 13);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 27);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 18), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 9), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 9);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 26);
+    _mm_storeu_si128(out++, OutReg);
 }
 
-static void __SIMD_fastunpack24_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastunpack7_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 7) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 24) - 1);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 21), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 3), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 27);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 23), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 5), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 29);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 8);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 25);
+    _mm_storeu_si128(out++, OutReg);
 }
 
-static void __SIMD_fastunpack25_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastunpack8_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 8) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 25) - 1);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 25);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 18), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 11), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 11);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 29);
-  InReg = _mm_loadu_si128(++in);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 22), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 15), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 15);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 19), mask));
-  _mm_storeu_si128(out++, OutReg);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 19);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 5), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
-  _mm_storeu_si128(out++, OutReg);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 23), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 23);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 9), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 9);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 27);
-  InReg = _mm_loadu_si128(++in);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 13), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 13);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 24), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 17), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 17);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 3), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 21), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 21);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 7), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 7);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    _mm_storeu_si128(out++, OutReg);
 }
 
-static void __SIMD_fastunpack26_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastunpack9_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 9) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 26) - 1);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 27);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 14);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 22), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 3), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 21), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 10);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 7), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 24), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 25);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 18), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 29);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 6);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 14);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 5), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 22), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 24), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 18), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 6);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 23);
+    _mm_storeu_si128(out++, OutReg);
 }
 
-static void __SIMD_fastunpack27_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastunpack10_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 10) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 27) - 1);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 27);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 22), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 17), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 17);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 7), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 7);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 29);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 24), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 19), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 19);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 14);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 9), mask));
-  _mm_storeu_si128(out++, OutReg);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 9);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 26), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 21), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 21);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 11), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 11);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 6);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 23), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 23);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 18), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 13), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 13);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 3), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 25), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 25);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 15), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 15);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 5), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 5);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 22);
+    _mm_storeu_si128(out++, OutReg);
 }
 
-static void __SIMD_fastunpack28_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastunpack11_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 11) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 28) - 1);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 23);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 3), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 4);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 25);
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 5), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 27);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 7), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 4);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 29);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 9), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 4);
-  InReg = _mm_loadu_si128(++in);
-
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 4);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 21);
+    _mm_storeu_si128(out++, OutReg);
 }
 
-static void __SIMD_fastunpack29_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastunpack12_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 12) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 29) - 1);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 29);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 26), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 23), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 23);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 17), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 17);
-  InReg = _mm_loadu_si128(++in);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 14);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 11), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 11);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 5), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 5);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 28), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 25), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 25);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 22), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 19), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 19);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 13), mask));
-  _mm_storeu_si128(out++, OutReg);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 13);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 10);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 7), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 7);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 4);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 27), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 27);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 24), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 21), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 21);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 18), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 15), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 15);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 9), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 9);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 3), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 3);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 20);
+    _mm_storeu_si128(out++, OutReg);
 }
 
-static void __SIMD_fastunpack30_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastunpack13_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 13) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 30) - 1);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 28), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 7), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 26), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 24), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 22), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 27);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 21);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 18), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 9), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 14);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 3), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 10);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 29);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 6);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 23);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 4);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 2);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
 
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 11), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 28), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 5), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 26), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 24), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 22), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 25);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 18), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 14);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 10);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 6);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 4);
-  InReg = _mm_loadu_si128(++in);
-
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
-
-  OutReg = _mm_srli_epi32(InReg, 2);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 19);
+    _mm_storeu_si128(out++, OutReg);
 }
 
-static void __SIMD_fastunpack31_32(const __m128i *in, uint32_t *_out) {
+static void
+__SIMD_fastunpack14_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 14) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  const __m128i mask = _mm_set1_epi32((1U << 31) - 1);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_and_si128(InReg, mask);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 31);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 30), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 30);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 29), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 29);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 28), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 28);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 27), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 27);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 26), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 26);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 25), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 25);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 24), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 24);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 23), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 23);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 22), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 22);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 21), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 21);
-  InReg = _mm_loadu_si128(++in);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 20), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 20);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 19), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 19);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 18), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 18);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 17), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 17);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 16), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 16);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 15), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 15);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 14), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 14);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 13), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 13);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 12), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 12);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 11), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 11);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 10), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 10);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 18);
+    _mm_storeu_si128(out++, OutReg);
+}
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 9), mask));
-  _mm_storeu_si128(out++, OutReg);
+static void
+__SIMD_fastunpack15_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 15) - 1);
 
-  OutReg = _mm_srli_epi32(InReg, 9);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 8), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 8);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 7), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 13), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 7);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 6), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 6);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 11), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 5), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 5);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 4), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 9), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 4);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 3), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg = _mm_srli_epi32(InReg, 3);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 7), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 2), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 2);
-  InReg = _mm_loadu_si128(++in);
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
 
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 1), mask));
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 5), mask));
+    _mm_storeu_si128(out++, OutReg);
 
-  OutReg = _mm_srli_epi32(InReg, 1);
-  _mm_storeu_si128(out++, OutReg);
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 3), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 29);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 27);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 25);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 23);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 21);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 19);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 17);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack16_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 16) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack17_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 17) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 17);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 19);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 21);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 23);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 25);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 27);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 29);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 3), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 5), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 7), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 9), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 11), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 13), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 15), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 15);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack18_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 18) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack19_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 19) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 19);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 25);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 18), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 5), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 11), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 17), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 17);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 23);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 29);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 3), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 9), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 15), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 15);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 21);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 27);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 7), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 13), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 13);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack20_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 20) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack21_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 21) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 21);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 9), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 19), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 19);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 29);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 18), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 7), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 17), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 17);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 27);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 5), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 15), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 15);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 25);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 3), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 13), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 13);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 23);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 11), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 11);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack22_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 22) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 18), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 10);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 18), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 10);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack23_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 23) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 23);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 5), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 19), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 19);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 15), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 15);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 29);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 11), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 11);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 25);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 7), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 21), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 21);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 3), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 17), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 17);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 22), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 13), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 13);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 27);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 18), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 9), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 9);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack24_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 24) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack25_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 25) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 25);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 18), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 11), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 11);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 29);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 22), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 15), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 15);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 19), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 19);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 5), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 23), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 23);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 9), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 9);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 27);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 13), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 13);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 24), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 17), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 17);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 3), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 21), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 21);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 7), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 7);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack26_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 26) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 22), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 24), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 18), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 6);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 22), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 24), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 18), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 6);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack27_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 27) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 27);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 22), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 17), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 17);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 7), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 7);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 29);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 24), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 19), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 19);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 9), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 9);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 26), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 21), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 21);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 11), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 11);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 23), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 23);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 18), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 13), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 13);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 3), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 25), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 25);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 15), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 15);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 5), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 5);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack28_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 28) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 4);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 4);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 4);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 4);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack29_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 29) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 29);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 26), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 23), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 23);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 17), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 17);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 11), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 11);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 5), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 5);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 28), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 25), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 25);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 22), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 19), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 19);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 13), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 13);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 7), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 7);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 27), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 27);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 24), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 21), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 21);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 18), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 15), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 15);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 9), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 9);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 3), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 3);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack30_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 30) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 28), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 26), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 24), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 22), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 18), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 2);
+    InReg = _mm_loadu_si128(++in);
+
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 28), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 26), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 24), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 22), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 18), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 2);
+    _mm_storeu_si128(out++, OutReg);
+}
+
+static void
+__SIMD_fastunpack31_32(const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    const __m128i mask = _mm_set1_epi32((1U << 31) - 1);
+
+    OutReg = _mm_and_si128(InReg, mask);
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 31);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 30), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 30);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 29), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 29);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 28), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 28);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 27), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 27);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 26), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 26);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 25), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 25);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 24), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 24);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 23), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 23);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 22), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 22);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 21), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 21);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 20), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 20);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 19), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 19);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 18), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 18);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 17), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 17);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 16), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 16);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 15), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 15);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 14), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 14);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 13), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 13);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 12), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 12);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 11), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 11);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 10), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 10);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 9), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 9);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 8), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 8);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 7), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 7);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 6), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 6);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 5), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 5);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 4), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 4);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 3), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 3);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 2), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 2);
+    InReg = _mm_loadu_si128(++in);
+
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 1), mask));
+    _mm_storeu_si128(out++, OutReg);
+
+    OutReg = _mm_srli_epi32(InReg, 1);
+    _mm_storeu_si128(out++, OutReg);
 }

--- a/src/index/sparse/codec/simdcomp/src/simdbitpacking.c
+++ b/src/index/sparse/codec/simdcomp/src/simdbitpacking.c
@@ -1,0 +1,9143 @@
+/** Port from https://github.com/fast-pack/simdcomp
+ *
+ * This code is released under a BSD License.
+ */
+#include "../include/portability.h"
+
+/* Knowhere retains only the generated 1..31-bit pack-without-mask and unpack kernels. */
+
+static void __SIMD_fastpackwithoutmask1_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask2_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask3_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 3 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 3 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask5_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 5 - 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 5 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 5 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 5 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask6_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 6 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 6 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 6 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 6 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask7_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 7 - 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 7 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 7 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 7 - 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 7 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 7 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask9_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 9 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 9 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 9 - 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 9 - 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 9 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 9 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 9 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 9 - 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask10_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 10 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 10 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 10 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 10 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 10 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 10 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 10 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 10 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask11_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 11 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 11 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 11 - 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 11 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 11 - 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 11 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 11 - 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 11 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 11 - 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 11 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask12_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 12 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 12 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 12 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 12 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 12 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 12 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 12 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 12 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask13_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 13 - 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 13 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 13 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 13 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 13 - 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 13 - 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 13 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 13 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 13 - 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 13 - 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 13 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 13 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask14_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 14 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 14 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 14 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 14 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 14 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 14 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 14 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 14 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 14 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 14 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 14 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 14 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask15_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 15 - 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 15 - 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 15 - 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 15 - 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 15 - 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 15 - 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 15 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 15 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 15 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 15 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 15 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 15 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 15 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 15 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask17_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 17 - 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask18_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 18 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask19_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 19 - 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask20_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 20 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask21_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 21 - 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask22_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 22 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask23_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 23 - 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask24_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 24 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask25_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 25 - 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask26_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 26 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask27_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 27 - 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask28_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 28 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask29_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 29 - 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask30_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 30 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask31_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg = _mm_loadu_si128(in);
+
+  OutReg = InReg;
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 31));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 30));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 29));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 27));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 26));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 25));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 23));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 22));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 21));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 19));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 18));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 17));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 15));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 14));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 13));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 11));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 10));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 9));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 7));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 6));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 5));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 3));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 2));
+  _mm_storeu_si128(out, OutReg);
+  ++out;
+  OutReg = _mm_srli_epi32(InReg, 31 - 1);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 1));
+  _mm_storeu_si128(out, OutReg);
+}
+
+static void __SIMD_fastpackwithoutmask4_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg;
+  uint32_t outer;
+
+  for (outer = 0; outer < 4; ++outer) {
+    InReg = _mm_loadu_si128(in);
+    OutReg = InReg;
+
+    InReg = _mm_loadu_si128(in + 1);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 4));
+
+    InReg = _mm_loadu_si128(in + 2);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+
+    InReg = _mm_loadu_si128(in + 3);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 12));
+
+    InReg = _mm_loadu_si128(in + 4);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+
+    InReg = _mm_loadu_si128(in + 5);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 20));
+
+    InReg = _mm_loadu_si128(in + 6);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+
+    InReg = _mm_loadu_si128(in + 7);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 28));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+
+    in += 8;
+  }
+}
+
+static void __SIMD_fastpackwithoutmask8_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg;
+  uint32_t outer;
+
+  for (outer = 0; outer < 8; ++outer) {
+    InReg = _mm_loadu_si128(in);
+    OutReg = InReg;
+
+    InReg = _mm_loadu_si128(in + 1);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 8));
+
+    InReg = _mm_loadu_si128(in + 2);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+
+    InReg = _mm_loadu_si128(in + 3);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 24));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+
+    in += 4;
+  }
+}
+
+static void __SIMD_fastpackwithoutmask16_32(const uint32_t *_in, __m128i *out) {
+  const __m128i *in = (const __m128i *)(_in);
+  __m128i OutReg;
+  __m128i InReg;
+  uint32_t outer;
+
+  for (outer = 0; outer < 16; ++outer) {
+    InReg = _mm_loadu_si128(in);
+    OutReg = InReg;
+
+    InReg = _mm_loadu_si128(in + 1);
+    OutReg = _mm_or_si128(OutReg, _mm_slli_epi32(InReg, 16));
+    _mm_storeu_si128(out, OutReg);
+    ++out;
+
+    in += 2;
+  }
+}
+
+static void __SIMD_fastunpack1_32(const __m128i *in, uint32_t *_out) {
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg1 = _mm_loadu_si128(in);
+  __m128i InReg2 = InReg1;
+  __m128i OutReg1, OutReg2, OutReg3, OutReg4;
+  const __m128i mask = _mm_set1_epi32(1);
+
+  uint32_t i, shift = 0;
+
+  for (i = 0; i < 8; ++i) {
+    OutReg1 = _mm_and_si128(_mm_srli_epi32(InReg1, shift++), mask);
+    OutReg2 = _mm_and_si128(_mm_srli_epi32(InReg2, shift++), mask);
+    OutReg3 = _mm_and_si128(_mm_srli_epi32(InReg1, shift++), mask);
+    OutReg4 = _mm_and_si128(_mm_srli_epi32(InReg2, shift++), mask);
+    _mm_storeu_si128(out++, OutReg1);
+    _mm_storeu_si128(out++, OutReg2);
+    _mm_storeu_si128(out++, OutReg3);
+    _mm_storeu_si128(out++, OutReg4);
+  }
+}
+
+static void __SIMD_fastunpack2_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 2) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 26), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 28), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 26), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 28), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack3_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 3) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 21), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 27), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 3 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 25), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 28), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 3 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 23), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 26), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack4_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 4) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack5_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 5) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 25), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 3), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 23), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 21), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 26), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 27);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack6_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 6) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack7_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 7) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 21), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 3), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 24), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 23), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 5), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 25);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack8_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 8) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack9_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 9) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 22), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 3), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 21), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 7), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 5), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 23);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack10_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 10) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack11_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 11) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 3), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 5), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 7), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 19), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 9), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 20), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 21);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack12_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 12) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack13_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 13) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 7), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 9), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 3), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 17), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 11), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 5), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 18), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 19);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack14_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 14) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack15_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 15) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 15), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 13), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 11), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 9), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 7), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 5), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 3), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 16), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 17);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack16_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 16) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack17_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 17) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 14), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 3), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 5), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 7), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 9), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 11), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 13), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 13), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 15), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 15);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack18_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 18) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack19_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 19) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 12), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 18), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 5), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 11), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 11), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 17), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 3), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 9), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 15), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 7), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 13), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 13);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack20_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 20) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack21_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 21) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 10), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 9), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 9), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 19), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 18), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 7), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 17), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 5), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 15), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 3), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 13), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 11), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 11);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack22_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 22) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 18), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 10);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 18), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 10);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack23_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 23) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 5), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 19), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 15), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 11), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 7), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 7), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 21), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 3), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 17), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 8), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 22), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 13), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 18), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 9), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 9);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack24_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 24) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack25_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 25) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 18), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 11), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 22), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 15), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 19), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 5), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 5), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 23), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 9), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 13), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 6), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 24), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 17), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 3), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 21), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 7), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 7);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack26_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 26) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 22), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 24), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 18), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 6);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 22), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 24), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 18), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 6);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack27_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 27) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 22), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 17), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 7), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 24), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 19), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 9), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 4), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 26), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 21), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 11), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 23), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 18), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 13), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 3), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 3), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 25), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 15), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 5), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 5);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack28_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 28) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 4);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 4);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 4);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 4);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack29_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 29) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 26), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 23), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 17), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 11), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 5), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 2), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 28), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 25), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 22), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 19), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 13), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 7), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(_mm_srli_epi32(InReg, 1), mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 27), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 24), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 21), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 18), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 15), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 9), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 3), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 3);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack30_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 30) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 28), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 26), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 24), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 22), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 18), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 2);
+  InReg = _mm_loadu_si128(++in);
+
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 28), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 26), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 24), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 22), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 18), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 2);
+  _mm_storeu_si128(out++, OutReg);
+}
+
+static void __SIMD_fastunpack31_32(const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  const __m128i mask = _mm_set1_epi32((1U << 31) - 1);
+
+  OutReg = _mm_and_si128(InReg, mask);
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 31);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 30), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 30);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 29), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 29);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 28), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 28);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 27), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 27);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 26), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 26);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 25), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 25);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 24), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 24);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 23), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 23);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 22), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 22);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 21), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 21);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 20), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 20);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 19), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 19);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 18), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 18);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 17), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 17);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 16), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 16);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 15), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 15);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 14), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 14);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 13), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 13);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 12), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 12);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 11), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 11);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 10), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 10);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 9), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 9);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 8), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 8);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 7), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 7);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 6), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 6);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 5), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 5);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 4), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 4);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 3), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 3);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 2), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 2);
+  InReg = _mm_loadu_si128(++in);
+
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 1), mask));
+  _mm_storeu_si128(out++, OutReg);
+
+  OutReg = _mm_srli_epi32(InReg, 1);
+  _mm_storeu_si128(out++, OutReg);
+}

--- a/src/index/sparse/codec/simdcomp/src/simdintegratedbitpacking.c
+++ b/src/index/sparse/codec/simdcomp/src/simdintegratedbitpacking.c
@@ -1,0 +1,8626 @@
+/** Port from https://github.com/fast-pack/simdcomp
+ *
+ * This code is released under a BSD License.
+ */
+#include "../include/portability.h"
+
+/*
+ * Knowhere keeps only simdunpackd1 and the generated unpack helpers used by the sparse codec. Its document-ID
+ * payload stores delta - 1, so the omitted one is folded into every SIMD prefix sum below. The private decoder
+ * therefore reconstructs absolute document IDs directly without a second output pass.
+ */
+
+#define PrefixSum(ret, curr, prev)                                             \
+  do {                                                                         \
+    const __m128i _adjusted = _mm_add_epi32(curr, _mm_set1_epi32(1));          \
+    const __m128i _tmp1 =                                                       \
+        _mm_add_epi32(_mm_slli_si128(_adjusted, 8), _adjusted);                \
+    const __m128i _tmp2 = _mm_add_epi32(_mm_slli_si128(_tmp1, 4), _tmp1);      \
+    ret = _mm_add_epi32(_tmp2, _mm_shuffle_epi32(prev, 0xff));                 \
+  } while (0)
+
+static __m128i iunpack1(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 1) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack2(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 2) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack3(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 3) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 3 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 3 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack4(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 4) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack5(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 5) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 3), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack6(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 6) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack7(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 7) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 3), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 5), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack8(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 8) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack9(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 9) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 3), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 7), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 5), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack10(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 10) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack11(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 11) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 3), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 5), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 7), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 9), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack12(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 12) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack13(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 13) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 7), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 9), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 3), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 11), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 5), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack14(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 14) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack15(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 15) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 13), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 11), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 9), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 7), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 5), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 3), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack16(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 16) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack17(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 17) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 3), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 5), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 7), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 9), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 11), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 13), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 15), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack18(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 18) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack19(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 19) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 18), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 5), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 11), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 17), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 3), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 9), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 15), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 7), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 13), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack20(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 20) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack21(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 21) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 9), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 19), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 18), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 7), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 17), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 5), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 15), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 3), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 13), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 11), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack22(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 22) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 18), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 18), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack23(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 23) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 5), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 19), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 15), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 11), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 7), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 21), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 3), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 17), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 22), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 13), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 18), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 9), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack24(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 24) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack25(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 25) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 18), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 11), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 22), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 15), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 19), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 5), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 23), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 9), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 13), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 24), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 17), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 3), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 21), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 7), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack26(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 26) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 22), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 24), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 18), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 22), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 24), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 18), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack27(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 27) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 22), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 17), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 7), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 24), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 19), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 9), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 26), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 21), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 11), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 23), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 18), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 13), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 3), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 25), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 15), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 5), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack28(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 28) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack29(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 29) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 26), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 23), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 17), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 11), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 5), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 28), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 25), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 22), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 19), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 13), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 7), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 27), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 24), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 21), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 18), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 15), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 9), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 3), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack30(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 30) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 28), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 26), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 24), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 22), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 18), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 28), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 26), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 24), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 22), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 18), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static __m128i iunpack31(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+
+  __m128i *out = (__m128i *)(_out);
+  __m128i InReg = _mm_loadu_si128(in);
+  __m128i OutReg;
+  __m128i tmp;
+  __m128i mask = _mm_set1_epi32((1U << 31) - 1);
+
+  tmp = InReg;
+  OutReg = _mm_and_si128(tmp, mask);
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 31);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 30), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 30);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 29), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 29);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 28), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 28);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 27), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 27);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 26), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 26);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 25), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 25);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 24), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 24);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 23), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 23);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 22), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 22);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 21), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 21);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 20), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 20);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 19), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 19);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 18), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 18);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 17), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 17);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 16), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 16);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 15), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 15);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 14), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 14);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 13), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 13);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 12), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 12);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 11), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 11);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 10), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 10);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 9), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 9);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 8), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 8);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 7), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 7);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 6), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 6);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 5), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 5);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 4), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 4);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 3), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 3);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 2), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 2);
+  OutReg = tmp;
+  ++in;
+  InReg = _mm_loadu_si128(in);
+  OutReg =
+      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 1), mask));
+
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  tmp = _mm_srli_epi32(InReg, 1);
+  OutReg = tmp;
+  PrefixSum(OutReg, OutReg, initOffset);
+  initOffset = OutReg;
+  _mm_storeu_si128(out++, OutReg);
+
+  return initOffset;
+}
+
+static void simdunpackd1(uint32_t initvalue, const __m128i *in, uint32_t *out,
+                         const uint32_t bit) {
+  __m128i initOffset = _mm_set1_epi32(initvalue);
+  switch (bit) {
+  case 1:
+    iunpack1(initOffset, in, out);
+    break;
+
+  case 2:
+    iunpack2(initOffset, in, out);
+    break;
+
+  case 3:
+    iunpack3(initOffset, in, out);
+    break;
+
+  case 4:
+    iunpack4(initOffset, in, out);
+    break;
+
+  case 5:
+    iunpack5(initOffset, in, out);
+    break;
+
+  case 6:
+    iunpack6(initOffset, in, out);
+    break;
+
+  case 7:
+    iunpack7(initOffset, in, out);
+    break;
+
+  case 8:
+    iunpack8(initOffset, in, out);
+    break;
+
+  case 9:
+    iunpack9(initOffset, in, out);
+    break;
+
+  case 10:
+    iunpack10(initOffset, in, out);
+    break;
+
+  case 11:
+    iunpack11(initOffset, in, out);
+    break;
+
+  case 12:
+    iunpack12(initOffset, in, out);
+    break;
+
+  case 13:
+    iunpack13(initOffset, in, out);
+    break;
+
+  case 14:
+    iunpack14(initOffset, in, out);
+    break;
+
+  case 15:
+    iunpack15(initOffset, in, out);
+    break;
+
+  case 16:
+    iunpack16(initOffset, in, out);
+    break;
+
+  case 17:
+    iunpack17(initOffset, in, out);
+    break;
+
+  case 18:
+    iunpack18(initOffset, in, out);
+    break;
+
+  case 19:
+    iunpack19(initOffset, in, out);
+    break;
+
+  case 20:
+    iunpack20(initOffset, in, out);
+    break;
+
+  case 21:
+    iunpack21(initOffset, in, out);
+    break;
+
+  case 22:
+    iunpack22(initOffset, in, out);
+    break;
+
+  case 23:
+    iunpack23(initOffset, in, out);
+    break;
+
+  case 24:
+    iunpack24(initOffset, in, out);
+    break;
+
+  case 25:
+    iunpack25(initOffset, in, out);
+    break;
+
+  case 26:
+    iunpack26(initOffset, in, out);
+    break;
+
+  case 27:
+    iunpack27(initOffset, in, out);
+    break;
+
+  case 28:
+    iunpack28(initOffset, in, out);
+    break;
+
+  case 29:
+    iunpack29(initOffset, in, out);
+    break;
+
+  case 30:
+    iunpack30(initOffset, in, out);
+    break;
+
+  case 31:
+    iunpack31(initOffset, in, out);
+    break;
+
+  default:
+    break;
+  }
+}
+
+#undef PrefixSum

--- a/src/index/sparse/codec/simdcomp/src/simdintegratedbitpacking.c
+++ b/src/index/sparse/codec/simdcomp/src/simdintegratedbitpacking.c
@@ -10,8617 +10,8200 @@
  * therefore reconstructs absolute document IDs directly without a second output pass.
  */
 
-#define PrefixSum(ret, curr, prev)                                             \
-  do {                                                                         \
-    const __m128i _adjusted = _mm_add_epi32(curr, _mm_set1_epi32(1));          \
-    const __m128i _tmp1 =                                                       \
-        _mm_add_epi32(_mm_slli_si128(_adjusted, 8), _adjusted);                \
-    const __m128i _tmp2 = _mm_add_epi32(_mm_slli_si128(_tmp1, 4), _tmp1);      \
-    ret = _mm_add_epi32(_tmp2, _mm_shuffle_epi32(prev, 0xff));                 \
-  } while (0)
+#define PrefixSum(ret, curr, prev)                                                    \
+    do {                                                                              \
+        const __m128i _adjusted = _mm_add_epi32(curr, _mm_set1_epi32(1));             \
+        const __m128i _tmp1 = _mm_add_epi32(_mm_slli_si128(_adjusted, 8), _adjusted); \
+        const __m128i _tmp2 = _mm_add_epi32(_mm_slli_si128(_tmp1, 4), _tmp1);         \
+        ret = _mm_add_epi32(_tmp2, _mm_shuffle_epi32(prev, 0xff));                    \
+    } while (0)
 
-static __m128i iunpack1(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack1(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 1) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 1) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack2(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack2(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 2) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 2) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack3(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack3(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 3) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 3) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 3 - 1), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 3 - 1), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 3 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 3 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack4(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack4(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 4) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 4) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack5(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack5(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 5) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 5) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 3), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 3), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 1), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 1), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 5 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack6(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack6(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 6) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 6) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 6 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack7(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack7(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 7) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 7) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 3), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 3), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 5), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 5), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 1), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 1), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 7 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack8(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack8(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 8) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 8) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack9(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack9(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 9) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 9) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 3), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 3), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 7), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 7), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 1), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 1), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 5), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 9 - 5), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack10(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack10(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 10) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 10) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 10 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack11(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack11(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 11) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 11) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 1), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 1), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 3), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 3), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 5), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 5), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 7), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 7), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 9), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 9), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 11 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack12(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack12(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 12) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 12) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 12 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack13(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack13(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 13) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 13) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 7), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 7), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 1), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 1), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 9), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 9), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 3), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 3), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 11), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 11), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 5), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 5), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 13 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack14(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack14(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 14) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 14) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 14 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack15(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack15(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 15) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 15) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 13), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 13), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 11), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 11), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 9), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 9), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 7), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 7), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 5), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 5), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 3), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 3), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 1), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 1), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 15 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack16(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack16(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 16) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 16) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack17(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack17(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 17) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 17) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 1), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 1), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 3), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 3), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 5), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 5), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 7), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 7), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 9), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 9), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 11), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 11), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 13), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 13), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 15), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 17 - 15), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack18(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack18(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 18) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 18) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 18 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack19(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack19(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 19) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 19) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 18), mask));
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 18), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 5), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 5), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 11), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 11), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 17), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 17), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 3), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 3), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 9), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 9), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 15), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 15), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 1), mask));
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 1), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 7), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 7), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 13), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 19 - 13), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack20(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack20(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 20) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 20) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 20 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack21(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack21(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 21) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 21) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 9), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 9), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 19), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 19), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 18), mask));
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 18), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 7), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 7), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 17), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 17), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 5), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 5), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 15), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 15), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 3), mask));
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 3), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 13), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 13), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 1), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 1), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 11), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 21 - 11), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack22(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack22(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 22) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 22) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 18), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 18), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 18), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 18), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 22 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack23(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack23(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 23) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 23) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 5), mask));
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 5), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 19), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 19), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 1), mask));
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 1), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 15), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 15), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 11), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 11), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 7), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 7), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 21), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 21), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 3), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 3), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 17), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 17), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 22), mask));
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 22), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 13), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 13), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 18), mask));
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 18), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 9), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 23 - 9), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack24(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack24(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 24) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 24) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 24 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack25(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack25(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 25) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 25) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 18), mask));
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 18), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 11), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 11), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 22), mask));
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 22), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 15), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 15), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 1), mask));
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 1), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 19), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 19), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 5), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 5), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 23), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 23), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 9), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 9), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 13), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 13), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 24), mask));
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 24), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 17), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 17), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 3), mask));
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 3), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 21), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 21), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 7), mask));
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 25 - 7), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack26(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack26(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 26) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 26) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 22), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 22), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 24), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 24), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 18), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 18), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 22), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 22), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 24), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 24), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 18), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 18), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 26 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack27(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack27(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 27) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 27) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 22), mask));
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 22), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 17), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 17), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 7), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 7), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 24), mask));
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 24), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 19), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 19), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 9), mask));
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 9), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 26), mask));
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 26), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 21), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 21), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 11), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 11), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 1), mask));
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 1), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 23), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 23), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 18), mask));
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 18), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 13), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 13), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 3), mask));
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 3), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 25), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 25), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 15), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 15), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 5), mask));
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 27 - 5), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack28(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack28(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 28) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 28) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 24), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 28 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack29(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack29(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 29) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 29) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 26), mask));
 
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 26), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 23), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 23), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 17), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 17), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 11), mask));
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 11), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 5), mask));
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 5), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 28), mask));
 
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 28), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 25), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 25), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 22), mask));
 
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 22), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 19), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 19), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 13), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 13), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 7), mask));
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 7), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 1), mask));
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 1), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 27), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 27), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 24), mask));
 
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 24), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 21), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 21), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 18), mask));
 
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 18), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 15), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 15), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 9), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 9), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 3), mask));
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 29 - 3), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack30(__m128i initOffset, const __m128i *in, uint32_t *_out) {
+static __m128i
+iunpack30(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 30) - 1);
 
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 30) - 1);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 28), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 28), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 26), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 26), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 24), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 24), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 22), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 22), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 18), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 18), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 28), mask));
 
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 28), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 26), mask));
 
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 26), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 24), mask));
 
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 24), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 22), mask));
 
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 22), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 20), mask));
 
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 20), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 18), mask));
 
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 18), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 16), mask));
 
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 16), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 14), mask));
 
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 14), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 12), mask));
 
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 12), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 10), mask));
 
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 10), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 8), mask));
 
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 8), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 6), mask));
 
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 6), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 4), mask));
 
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 4), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 2), mask));
 
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 30 - 2), mask));
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
 
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+    return initOffset;
 }
 
-static __m128i iunpack31(__m128i initOffset, const __m128i *in, uint32_t *_out) {
-
-  __m128i *out = (__m128i *)(_out);
-  __m128i InReg = _mm_loadu_si128(in);
-  __m128i OutReg;
-  __m128i tmp;
-  __m128i mask = _mm_set1_epi32((1U << 31) - 1);
-
-  tmp = InReg;
-  OutReg = _mm_and_si128(tmp, mask);
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 31);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 30), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 30);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 29), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 29);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 28), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 28);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 27), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 27);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 26), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 26);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 25), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 25);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 24), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 24);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 23), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 23);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 22), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 22);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 21), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 21);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 20), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 20);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 19), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 19);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 18), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 18);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 17), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 17);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 16), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 16);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 15), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 15);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 14), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 14);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 13), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 13);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 12), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 12);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 11), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 11);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 10), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 10);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 9), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 9);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 8), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 8);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 7), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 7);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 6), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 6);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 5), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 5);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 4), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 4);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 3), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 3);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 2), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 2);
-  OutReg = tmp;
-  ++in;
-  InReg = _mm_loadu_si128(in);
-  OutReg =
-      _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 1), mask));
-
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  tmp = _mm_srli_epi32(InReg, 1);
-  OutReg = tmp;
-  PrefixSum(OutReg, OutReg, initOffset);
-  initOffset = OutReg;
-  _mm_storeu_si128(out++, OutReg);
-
-  return initOffset;
+static __m128i
+iunpack31(__m128i initOffset, const __m128i* in, uint32_t* _out) {
+    __m128i* out = (__m128i*)(_out);
+    __m128i InReg = _mm_loadu_si128(in);
+    __m128i OutReg;
+    __m128i tmp;
+    __m128i mask = _mm_set1_epi32((1U << 31) - 1);
+
+    tmp = InReg;
+    OutReg = _mm_and_si128(tmp, mask);
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 31);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 30), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 30);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 29), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 29);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 28), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 28);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 27), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 27);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 26), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 26);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 25), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 25);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 24), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 24);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 23), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 23);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 22), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 22);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 21), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 21);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 20), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 20);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 19), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 19);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 18), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 18);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 17), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 17);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 16), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 16);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 15), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 15);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 14), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 14);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 13), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 13);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 12), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 12);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 11), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 11);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 10), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 10);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 9), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 9);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 8), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 8);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 7), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 7);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 6), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 6);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 5), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 5);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 4), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 4);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 3), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 3);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 2), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 2);
+    OutReg = tmp;
+    ++in;
+    InReg = _mm_loadu_si128(in);
+    OutReg = _mm_or_si128(OutReg, _mm_and_si128(_mm_slli_epi32(InReg, 31 - 1), mask));
+
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    tmp = _mm_srli_epi32(InReg, 1);
+    OutReg = tmp;
+    PrefixSum(OutReg, OutReg, initOffset);
+    initOffset = OutReg;
+    _mm_storeu_si128(out++, OutReg);
+
+    return initOffset;
 }
 
-static void simdunpackd1(uint32_t initvalue, const __m128i *in, uint32_t *out,
-                         const uint32_t bit) {
-  __m128i initOffset = _mm_set1_epi32(initvalue);
-  switch (bit) {
-  case 1:
-    iunpack1(initOffset, in, out);
-    break;
+static void
+simdunpackd1(uint32_t initvalue, const __m128i* in, uint32_t* out, const uint32_t bit) {
+    __m128i initOffset = _mm_set1_epi32(initvalue);
+    switch (bit) {
+        case 1:
+            iunpack1(initOffset, in, out);
+            break;
 
-  case 2:
-    iunpack2(initOffset, in, out);
-    break;
+        case 2:
+            iunpack2(initOffset, in, out);
+            break;
 
-  case 3:
-    iunpack3(initOffset, in, out);
-    break;
+        case 3:
+            iunpack3(initOffset, in, out);
+            break;
 
-  case 4:
-    iunpack4(initOffset, in, out);
-    break;
+        case 4:
+            iunpack4(initOffset, in, out);
+            break;
 
-  case 5:
-    iunpack5(initOffset, in, out);
-    break;
+        case 5:
+            iunpack5(initOffset, in, out);
+            break;
 
-  case 6:
-    iunpack6(initOffset, in, out);
-    break;
+        case 6:
+            iunpack6(initOffset, in, out);
+            break;
 
-  case 7:
-    iunpack7(initOffset, in, out);
-    break;
+        case 7:
+            iunpack7(initOffset, in, out);
+            break;
 
-  case 8:
-    iunpack8(initOffset, in, out);
-    break;
+        case 8:
+            iunpack8(initOffset, in, out);
+            break;
 
-  case 9:
-    iunpack9(initOffset, in, out);
-    break;
+        case 9:
+            iunpack9(initOffset, in, out);
+            break;
 
-  case 10:
-    iunpack10(initOffset, in, out);
-    break;
+        case 10:
+            iunpack10(initOffset, in, out);
+            break;
 
-  case 11:
-    iunpack11(initOffset, in, out);
-    break;
+        case 11:
+            iunpack11(initOffset, in, out);
+            break;
 
-  case 12:
-    iunpack12(initOffset, in, out);
-    break;
+        case 12:
+            iunpack12(initOffset, in, out);
+            break;
 
-  case 13:
-    iunpack13(initOffset, in, out);
-    break;
+        case 13:
+            iunpack13(initOffset, in, out);
+            break;
 
-  case 14:
-    iunpack14(initOffset, in, out);
-    break;
+        case 14:
+            iunpack14(initOffset, in, out);
+            break;
 
-  case 15:
-    iunpack15(initOffset, in, out);
-    break;
+        case 15:
+            iunpack15(initOffset, in, out);
+            break;
 
-  case 16:
-    iunpack16(initOffset, in, out);
-    break;
+        case 16:
+            iunpack16(initOffset, in, out);
+            break;
 
-  case 17:
-    iunpack17(initOffset, in, out);
-    break;
+        case 17:
+            iunpack17(initOffset, in, out);
+            break;
 
-  case 18:
-    iunpack18(initOffset, in, out);
-    break;
+        case 18:
+            iunpack18(initOffset, in, out);
+            break;
 
-  case 19:
-    iunpack19(initOffset, in, out);
-    break;
+        case 19:
+            iunpack19(initOffset, in, out);
+            break;
 
-  case 20:
-    iunpack20(initOffset, in, out);
-    break;
+        case 20:
+            iunpack20(initOffset, in, out);
+            break;
 
-  case 21:
-    iunpack21(initOffset, in, out);
-    break;
+        case 21:
+            iunpack21(initOffset, in, out);
+            break;
 
-  case 22:
-    iunpack22(initOffset, in, out);
-    break;
+        case 22:
+            iunpack22(initOffset, in, out);
+            break;
 
-  case 23:
-    iunpack23(initOffset, in, out);
-    break;
+        case 23:
+            iunpack23(initOffset, in, out);
+            break;
 
-  case 24:
-    iunpack24(initOffset, in, out);
-    break;
+        case 24:
+            iunpack24(initOffset, in, out);
+            break;
 
-  case 25:
-    iunpack25(initOffset, in, out);
-    break;
+        case 25:
+            iunpack25(initOffset, in, out);
+            break;
 
-  case 26:
-    iunpack26(initOffset, in, out);
-    break;
+        case 26:
+            iunpack26(initOffset, in, out);
+            break;
 
-  case 27:
-    iunpack27(initOffset, in, out);
-    break;
+        case 27:
+            iunpack27(initOffset, in, out);
+            break;
 
-  case 28:
-    iunpack28(initOffset, in, out);
-    break;
+        case 28:
+            iunpack28(initOffset, in, out);
+            break;
 
-  case 29:
-    iunpack29(initOffset, in, out);
-    break;
+        case 29:
+            iunpack29(initOffset, in, out);
+            break;
 
-  case 30:
-    iunpack30(initOffset, in, out);
-    break;
+        case 30:
+            iunpack30(initOffset, in, out);
+            break;
 
-  case 31:
-    iunpack31(initOffset, in, out);
-    break;
+        case 31:
+            iunpack31(initOffset, in, out);
+            break;
 
-  default:
-    break;
-  }
+        default:
+            break;
+    }
 }
 
 #undef PrefixSum

--- a/src/index/sparse/codec/streamvbyte.h
+++ b/src/index/sparse/codec/streamvbyte.h
@@ -35,13 +35,15 @@ streamvbyte_max_compressedbytes(uint32_t length) {
 }
 
 /**
- * StreamVByte coding.
+ * StreamVByte-0124 block coding.
  *
  * Daniel Lemire, Nathan Kurz, Christoph Rupp: Stream VByte: Faster byte-oriented integer
  * compression. Inf. Process. Lett. 130: 1-6 (2018). DOI: https://doi.org/10.1016/j.ipl.2017.09.011
+ *
+ * This local variant assigns each control code a payload width of 0, 1, 2, or 4 bytes, so zero consumes no payload
+ * byte. It is not wire-compatible with the upstream StreamVByte 1/2/3/4-byte format.
  */
 class StreamVByteBlockCodec : public BlockCodec {
-    static constexpr uint64_t m_streamvbyte_padding = 16;
     static constexpr uint64_t m_block_size = 256;
     static constexpr size_t m_max_compressed_bytes = streamvbyte_max_compressedbytes(m_block_size);
 

--- a/src/index/sparse/codec/streamvbyte_0124_decode.c
+++ b/src/index/sparse/codec/streamvbyte_0124_decode.c
@@ -294,6 +294,12 @@ typedef __m128i decode_t;
 
 static inline decode_t
 svb_decode_uint32x4(const uint8_t key, const uint8_t* __restrict__* dataPtrPtr) {
+    // A zero control consumes no payload bytes. Avoid issuing a 16-byte load at the logical end of the stream;
+    // this keeps the fast decoder's required trailing guard at 15 bytes.
+    if (key == 0) {
+        return _mm_setzero_si128();
+    }
+
     uint8_t len = 0;
     decode_t Data = _mm_loadu_si128((const decode_t*)*dataPtrPtr);
     uint8_t* pshuf = (uint8_t*)&shuffleTable[key];
@@ -315,6 +321,12 @@ typedef uint8x16_t decode_t;
 
 static inline decode_t
 svb_decode_uint32x4(const uint8_t key, const uint8_t* __restrict__* dataPtrPtr) {
+    // A zero control consumes no payload bytes. Avoid issuing a 16-byte load at the logical end of the stream;
+    // this keeps the fast decoder's required trailing guard at 15 bytes.
+    if (key == 0) {
+        return vdupq_n_u8(0);
+    }
+
     uint8_t len = 0;
     uint8_t* pshuf = (uint8_t*)&shuffleTable[key];
     uint8x16_t decodingShuffle = vld1q_u8(pshuf);

--- a/src/index/sparse/inverted_index.h
+++ b/src/index/sparse/inverted_index.h
@@ -48,7 +48,8 @@ enum class InvertedIndexEncoding : uint32_t {
     FLAT = 0,
     BLOCK_STREAMVBYTE = 1,
     BLOCK_MASKEDVBYTE = 2,
-    FIXED_DOCID_WINDOWS = 3
+    FIXED_DOCID_WINDOWS = 3,
+    BLOCK_ADAPTIVE = 4,
 };
 
 enum class InvertedIndexPrometheusBuildStats : uint32_t { DATASET_NNZ_STATS = 0, POSTING_LIST_LENGTH_STATS = 1 };
@@ -373,8 +374,8 @@ class InvertedIndex {
      */
     [[nodiscard]] BlockMaxDataCursor
     get_block_max_data_cursor(uint32_t dim_id) const {
-        uint32_t start = dim_id == 0 ? 0 : this->meta_data_.block_max_data_.block_offsets_[dim_id - 1];
-        uint32_t num = this->meta_data_.block_max_data_.block_offsets_[dim_id] - start;
+        const size_t start = dim_id == 0 ? 0 : this->meta_data_.block_max_data_.block_offsets_[dim_id - 1];
+        const size_t num = this->meta_data_.block_max_data_.block_offsets_[dim_id] - start;
         return {this->meta_data_.block_max_data_.block_max_ids_.subspan(start, num),
                 this->meta_data_.block_max_data_.block_max_scores_.subspan(start, num)};
     }

--- a/src/index/sparse/sparse_index_config.h
+++ b/src/index/sparse/sparse_index_config.h
@@ -51,7 +51,7 @@ IsSupportedSparseInvertedIndexAlgo(const std::string& algo) {
 
 inline bool
 IsSupportedSparseInvertedIndexCodec(const std::string& codec) {
-    return codec.empty() || codec == "block_streamvbyte" || codec == "block_maskedvbyte";
+    return codec.empty() || codec == "block_streamvbyte" || codec == "block_maskedvbyte" || codec == "block_adaptive";
 }
 
 class SparseInvertedIndexConfig : public BaseConfig {
@@ -175,7 +175,8 @@ class SparseInvertedIndexConfig : public BaseConfig {
         if (inverted_index_codec.has_value() && !IsSupportedSparseInvertedIndexCodec(inverted_index_codec.value())) {
             return HandleError(err_msg,
                                "inverted_index_codec " + inverted_index_codec.value() +
-                                   " not found or not supported, supported: [block_streamvbyte block_maskedvbyte]",
+                                   " not found or not supported, supported: [block_streamvbyte block_maskedvbyte "
+                                   "block_adaptive]",
                                Status::invalid_args);
         }
         if (quant_type.has_value() && !quant_type.value().empty()) {

--- a/src/index/sparse/sparse_index_node.cc
+++ b/src/index/sparse/sparse_index_node.cc
@@ -18,6 +18,7 @@
 #include <optional>
 
 #include "index/sparse/block_inverted_index.h"
+#include "index/sparse/codec/adaptive.h"
 #include "index/sparse/codec/maskedvbyte.h"
 #include "index/sparse/codec/streamvbyte.h"
 #include "index/sparse/flatten_inverted_index.h"
@@ -78,7 +79,7 @@ peek_encoding_type_from_index_data(const uint8_t* data, size_t size) {
     }
 
     // encoding_type is the first uint32_t at the section's data offset
-    if (first_section.offset + sizeof(uint32_t) > size) {
+    if (first_section.offset > size || sizeof(uint32_t) > size - first_section.offset) {
         return std::nullopt;
     }
 
@@ -490,6 +491,12 @@ class SparseInvertedIndexNode : public IndexNode {
                         index = std::make_unique<sparse::inverted::BlockInvertedIndex<DType, QType, MetricType>>(codec);
                         break;
                     }
+                    case InvertedIndexEncoding::BLOCK_ADAPTIVE: {
+                        LOG_KNOWHERE_INFO_ << "Detected BLOCK_ADAPTIVE encoding in index file";
+                        auto codec = std::make_shared<sparse::inverted::AdaptiveBlockCodec>();
+                        index = std::make_unique<sparse::inverted::BlockInvertedIndex<DType, QType, MetricType>>(codec);
+                        break;
+                    }
                     case InvertedIndexEncoding::FIXED_DOCID_WINDOWS:
                         // SINDI encoding should not reach create_index_before_v10; fall through to default codec
                         LOG_KNOWHERE_WARNING_ << "Unexpected FIXED_DOCID_WINDOWS encoding in create_index_before_v10";
@@ -507,12 +514,15 @@ class SparseInvertedIndexNode : public IndexNode {
                     index = std::make_unique<sparse::inverted::FlattenInvertedIndex<DType, QType>>();
                 } else {
                     // use different index type based on codec
-                    if (inverted_index_codec == "block_streamvbyte" || inverted_index_codec == "block_maskedvbyte") {
+                    if (inverted_index_codec == "block_streamvbyte" || inverted_index_codec == "block_maskedvbyte" ||
+                        inverted_index_codec == "block_adaptive") {
                         sparse::inverted::BlockCodecPtr codec;
                         if (inverted_index_codec == "block_streamvbyte") {
                             codec = std::make_shared<sparse::inverted::StreamVByteBlockCodec>();
-                        } else {
+                        } else if (inverted_index_codec == "block_maskedvbyte") {
                             codec = std::make_shared<sparse::inverted::MaskedVByteBlockCodec>();
+                        } else {
+                            codec = std::make_shared<sparse::inverted::AdaptiveBlockCodec>();
                         }
                         index = std::make_unique<sparse::inverted::BlockInvertedIndex<DType, QType, MetricType>>(codec);
                     } else if (!inverted_index_codec.empty()) {

--- a/tests/ut/test_sparse.cc
+++ b/tests/ut/test_sparse.cc
@@ -639,8 +639,8 @@ TEST_CASE("Test Sparse Index Codec and Algo Combinations", "[sparse]") {
     auto version = GenTestVersionList();
 
     // Test different codecs
-    auto inverted_index_codec =
-        GENERATE(std::string("block_streamvbyte"), std::string("block_maskedvbyte"), std::string("default"));
+    auto inverted_index_codec = GENERATE(std::string("block_streamvbyte"), std::string("block_maskedvbyte"),
+                                         std::string("block_adaptive"), std::string("default"));
 
     // Test different build algorithms (which also test metadata generation)
     auto inverted_index_algo =

--- a/tests/ut/test_sparse_simd.cc
+++ b/tests/ut/test_sparse_simd.cc
@@ -16,6 +16,7 @@
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/generators/catch_generators.hpp"
 #include "catch2/matchers/catch_matchers_floating_point.hpp"
+#include "index/sparse/codec/simd_bitpacking_kernel.h"
 #include "simd/instruction_set.h"
 #include "simd/sparse_simd.h"
 
@@ -51,6 +52,89 @@ accumulate_posting_list_ip_scalar_ref(const uint32_t* doc_ids, const float* doc_
                                       float* scores) {
     for (size_t i = 0; i < list_size; ++i) {
         scores[doc_ids[i]] += q_weight * doc_vals[i];
+    }
+}
+
+std::vector<uint8_t>
+simdcomp_pack_scalar_reference(const uint32_t* input, size_t block_count, uint32_t bits) {
+    constexpr size_t values_per_block = 128;
+    constexpr size_t lanes = 4;
+    constexpr size_t values_per_lane = values_per_block / lanes;
+    const size_t words_per_block = static_cast<size_t>(bits) * lanes;
+    std::vector<uint32_t> packed_words(block_count * words_per_block, 0);
+
+    for (size_t block = 0; block < block_count; ++block) {
+        const size_t input_base = block * values_per_block;
+        const size_t output_base = block * words_per_block;
+        for (size_t lane = 0; lane < lanes; ++lane) {
+            for (size_t value_index = 0; value_index < values_per_lane; ++value_index) {
+                const uint32_t value = input[input_base + value_index * lanes + lane];
+                const size_t bit_offset = value_index * bits;
+                const size_t word_index = bit_offset / 32;
+                const uint32_t shift = static_cast<uint32_t>(bit_offset % 32);
+                packed_words[output_base + word_index * lanes + lane] |= value << shift;
+                if (shift + bits > 32) {
+                    packed_words[output_base + (word_index + 1) * lanes + lane] |= value >> (32 - shift);
+                }
+            }
+        }
+    }
+
+    std::vector<uint8_t> packed(packed_words.size() * sizeof(uint32_t));
+    std::memcpy(packed.data(), packed_words.data(), packed.size());
+    return packed;
+}
+
+TEST_CASE("Test simdcomp bit-packing kernels", "[sparse][simd][simdcomp]") {
+    constexpr uint32_t input_guard = 0xa5a55a5aU;
+    constexpr uint32_t output_guard = 0xdeadbeefU;
+    constexpr uint8_t byte_guard = 0x6d;
+    constexpr size_t values_per_block = 128;
+    std::mt19937 rng(20260730);
+
+    for (const size_t block_count : {size_t{1}, size_t{2}, size_t{4}}) {
+        const size_t value_count = block_count * values_per_block;
+        for (uint32_t bits = 1; bits <= 32; ++bits) {
+            CAPTURE(block_count, bits);
+            const uint32_t mask = bits == 32 ? std::numeric_limits<uint32_t>::max() : (uint32_t{1} << bits) - 1;
+            std::vector<uint32_t> input(value_count + 2, input_guard);
+            for (size_t i = 0; i < value_count; ++i) {
+                input[i + 1] = rng() & mask;
+            }
+            input[1] = 0;
+            input[2] = mask;
+            input[3] = uint32_t{1} << (bits - 1);
+            input[value_count] = mask;
+
+            const auto expected = simdcomp_pack_scalar_reference(input.data() + 1, block_count, bits);
+            std::vector<uint8_t> packed(expected.size() + 2, byte_guard);
+            knowhere_simd_pack_128_blocks(input.data() + 1, packed.data() + 1, block_count, bits);
+            REQUIRE(packed.front() == byte_guard);
+            REQUIRE(packed.back() == byte_guard);
+            REQUIRE(std::equal(expected.begin(), expected.end(), packed.begin() + 1));
+            REQUIRE(input.front() == input_guard);
+            REQUIRE(input.back() == input_guard);
+
+            std::vector<uint32_t> unpacked(value_count + 2, output_guard);
+            knowhere_simd_unpack_128_blocks(packed.data() + 1, unpacked.data() + 1, block_count, bits);
+            REQUIRE(std::equal(input.begin() + 1, input.end() - 1, unpacked.begin() + 1));
+            REQUIRE(unpacked.front() == output_guard);
+            REQUIRE(unpacked.back() == output_guard);
+
+            if (bits < 32) {
+                constexpr uint32_t previous_doc_id = 17;
+                std::vector<uint32_t> doc_ids(value_count + 2, output_guard);
+                knowhere_simd_unpack_d1_128_blocks(packed.data() + 1, doc_ids.data() + 1, block_count, bits,
+                                                   previous_doc_id);
+                uint32_t expected_doc_id = previous_doc_id;
+                for (size_t i = 0; i < value_count; ++i) {
+                    expected_doc_id += input[i + 1] + 1;
+                    REQUIRE(doc_ids[i + 1] == expected_doc_id);
+                }
+                REQUIRE(doc_ids.front() == output_guard);
+                REQUIRE(doc_ids.back() == output_guard);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
#1730 

/kind improvement

adaptively select better encoding algo bitpacking/pfor/RLE/streamvbyte for DocID block and TF block by trading off compression size and decompression speed, similar idea to lucene.

dataset_english/dataset_standard means text datasets use different analyzer to generate sparse datasets.

Arm G4  8c32G

| Dataset | StreamVByte QPS | Adaptive QPS | QPS Change | StreamVByte Total Index (MiB) | Adaptive Total Index (MiB) | Index Reduction |
|---|---:|---:|---:|---:|---:|---:|
| msmarco_english | 1819.29 | 1920.27 | +6.01% | 535.81 | 457.79 | 14.56% |
| hotpotqa_english | 815.20 | 850.87 | +4.14% | 345.10 | 286.21 | 17.06% |
| nq_english | 2721.12 | 2876.05 | +6.26% | 230.30 | 200.26 | 13.05% |
| fever_english | 2139.70 | 2280.93 | +6.71% | 551.53 | 446.62 | 19.02% |
| msmarco_standard | 1684.39 | 1795.93 | +8.53% | 686.50 | 563.05 | 17.98% |
| hotpotqa_standard | 597.00 | 636.78 | +6.87% | 415.05 | 333.88 | 19.56% |
| nq_standard | 2443.49 | 2675.84 | +9.29% | 287.18 | 242.46 | 15.57% |
| fever_standard | 1716.55 | 1911.17 | +11.64% | 659.70 | 522.57 | 20.79% |