### PR TITLE
fix: normalize invalid cuVS search result ids

### DIFF
--- a/src/common/cuvs/integration/cuvs_knowhere_index.cuh
+++ b/src/common/cuvs/integration/cuvs_knowhere_index.cuh
@@ -33,6 +33,7 @@
 #include <raft/linalg/matrix_vector_op.cuh>
 #include <raft/linalg/normalize.cuh>
 #include <raft/linalg/reduce.cuh>
+#include <raft/matrix/init.cuh>
 #include <tuple>
 #include <type_traits>
 
@@ -97,8 +98,8 @@ struct check_valid_entry {
     }
     __device__ thrust::tuple<V, U>
     operator()(V id, U distance) {
-        if (distance >= max_distance_ || id >= max_id_)
-            return thrust::tuple<V, U>(V{-1}, distance);
+        if (distance >= max_distance_ || id < V{0} || id >= max_id_)
+            return thrust::tuple<V, U>(V{-1}, max_distance_);
         if (distance < 0)
             return thrust::tuple<V, U>(id, U{0});
         return thrust::tuple<V, U>(id, distance);
@@ -559,6 +560,13 @@ struct cuvs_knowhere_index<IndexKind, DataType>::impl {
         auto device_ids = device_ids_storage.view();
         auto device_distances = device_distances_storage.view();
 
+        auto max_distance =
+            std::nextafter(std::numeric_limits<knowhere_distance_type>::max(), knowhere_distance_type{0});
+        auto invalid_id = std::numeric_limits<indexing_type>::max();
+        // cuVS may leave result slots untouched when fewer candidates than k are selected.
+        raft::matrix::fill(res, device_ids, invalid_id);
+        raft::matrix::fill(res, device_distances, max_distance);
+
         RAFT_EXPECTS(index_, "Index has not yet been trained");
         auto dataset_view = device_dataset_storage
                                 ? std::make_optional(device_dataset_storage->view())
@@ -593,8 +601,6 @@ struct cuvs_knowhere_index<IndexKind, DataType>::impl {
             }
         }();
 
-        auto max_distance =
-            std::nextafter(std::numeric_limits<knowhere_distance_type>::max(), knowhere_distance_type{0});
         auto device_post_process = detail::check_valid_entry<knowhere_distance_type, knowhere_indexing_type>{
             max_distance, knowhere_indexing_type(size())};
         thrust::transform(

--- a/tests/ut/test_gpu_search.cc
+++ b/tests/ut/test_gpu_search.cc
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -514,6 +515,108 @@ TEST_CASE("Test All GPU Index", "[search]") {
         for (int i = 1; i < nq; ++i) {
             // Check query distance
             CHECK(GetRelativeLoss(gt_dist[i], dist[i]) < 0.1f);
+        }
+    }
+}
+
+TEST_CASE("Test GPU cuVS indexes pad filtered results", "[search][gpu][cuvs]") {
+    constexpr int64_t rows = 512;
+    constexpr int64_t queries = 2;
+    constexpr int64_t dim = 16;
+    constexpr int64_t topk = 10;
+    constexpr int64_t seed = 42;
+
+    const auto version = GenTestVersionList();
+
+    auto base_config = [=](const std::string& metric) {
+        knowhere::Json config{
+            {knowhere::meta::DIM, dim},
+            {knowhere::meta::METRIC_TYPE, metric},
+            {knowhere::meta::TOPK, topk},
+        };
+        return config;
+    };
+
+    auto ivf_flat_config = [&base_config](const std::string& metric) {
+        auto config = base_config(metric);
+        config[knowhere::indexparam::NLIST] = 16;
+        config[knowhere::indexparam::NPROBE] = 16;
+        return config;
+    };
+
+    auto ivf_pq_config = [&ivf_flat_config](const std::string& metric) {
+        auto config = ivf_flat_config(metric);
+        config[knowhere::indexparam::M] = 4;
+        config[knowhere::indexparam::NBITS] = 8;
+        return config;
+    };
+
+    auto cagra_config = [&base_config](const std::string& metric) {
+        auto config = base_config(metric);
+        config[knowhere::indexparam::INTERMEDIATE_GRAPH_DEGREE] = 32;
+        config[knowhere::indexparam::GRAPH_DEGREE] = 32;
+        config[knowhere::indexparam::ITOPK_SIZE] = 32;
+        return config;
+    };
+
+    const std::vector<std::pair<std::string, knowhere::Json>> index_cases = {
+        {knowhere::IndexEnum::INDEX_GPU_BRUTEFORCE, base_config(knowhere::metric::L2)},
+        {knowhere::IndexEnum::INDEX_GPU_BRUTEFORCE, base_config(knowhere::metric::IP)},
+        {knowhere::IndexEnum::INDEX_GPU_BRUTEFORCE, base_config(knowhere::metric::COSINE)},
+        {knowhere::IndexEnum::INDEX_CUVS_BRUTEFORCE, base_config(knowhere::metric::L2)},
+        {knowhere::IndexEnum::INDEX_CUVS_BRUTEFORCE, base_config(knowhere::metric::IP)},
+        {knowhere::IndexEnum::INDEX_CUVS_BRUTEFORCE, base_config(knowhere::metric::COSINE)},
+        {knowhere::IndexEnum::INDEX_CUVS_IVFFLAT, ivf_flat_config(knowhere::metric::L2)},
+        {knowhere::IndexEnum::INDEX_CUVS_IVFPQ, ivf_pq_config(knowhere::metric::L2)},
+        {knowhere::IndexEnum::INDEX_CUVS_CAGRA, cagra_config(knowhere::metric::L2)},
+    };
+
+    for (const auto& [name, config] : index_cases) {
+        CAPTURE(name, config.dump());
+        auto train_ds = GenDataSet(rows, dim, seed);
+        auto query_ds = GenDataSet(queries, dim, seed + 1);
+        auto index = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version).value();
+        REQUIRE(index.Build(train_ds, config) == knowhere::Status::success);
+
+        for (const int64_t live_count : {topk, int64_t{5}, int64_t{0}}) {
+            CAPTURE(live_count);
+            std::vector<uint8_t> bitset_data((rows + 7) / 8, 0xFF);
+            for (int64_t id = 0; id < live_count; ++id) {
+                bitset_data[id / 8] &= static_cast<uint8_t>(~(uint8_t{1} << (id % 8)));
+            }
+            knowhere::BitsetView bitset(bitset_data.data(), rows);
+
+            for (int repeat = 0; repeat < 3; ++repeat) {
+                CAPTURE(repeat);
+                auto result = index.Search(query_ds, config, bitset);
+                REQUIRE(result.has_value());
+                const auto* ids = result.value()->GetIds();
+                const auto* distances = result.value()->GetDistance();
+
+                for (int64_t query = 0; query < queries; ++query) {
+                    std::vector<bool> seen(rows, false);
+                    int64_t returned_count = 0;
+                    for (int64_t slot = 0; slot < topk; ++slot) {
+                        const auto offset = query * topk + slot;
+                        const auto id = ids[offset];
+                        if (id == -1) {
+                            CHECK(distances[offset] >= std::numeric_limits<float>::max() / 2);
+                            continue;
+                        }
+                        REQUIRE(id >= 0);
+                        REQUIRE(id < rows);
+                        REQUIRE_FALSE(bitset.test(id));
+                        REQUIRE_FALSE(seen[id]);
+                        seen[id] = true;
+                        ++returned_count;
+                    }
+                    REQUIRE(returned_count <= live_count);
+                    if (name == knowhere::IndexEnum::INDEX_GPU_BRUTEFORCE ||
+                        name == knowhere::IndexEnum::INDEX_CUVS_BRUTEFORCE) {
+                        REQUIRE(returned_count == live_count);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
issue: #1744

## What

- Initialize cuVS search output id and distance buffers in the shared Knowhere cuVS wrapper before calling cuVS.
- Normalize any invalid cuVS id (`id < 0` or `id >= size`) to Knowhere's invalid result contract: id `-1` with max distance.
- Add a GPU regression test that covers filtered searches where `topk` exceeds the number of valid candidates across cuVS-backed GPU indexes.

## Why

This fixes the invalid result id issue reported in https://github.com/milvus-io/milvus/issues/51862. In the failing path, cuVS search with filtering may leave output slots unwritten when there are fewer valid candidates than `topk`; Knowhere then copied those uninitialized ids back to Milvus. Knowhere should normalize those unwritten or otherwise invalid ids before returning search results.

## Validation

- `cmake --build build/Release --target knowhere_tests -- -j16`
- `./build/Release/tests/ut/knowhere_tests "Test GPU cuVS indexes pad filtered results" --durations yes` passed, 3600 assertions
- `./build/Release/tests/ut/knowhere_tests "Test All GPU Index" -c "Test Gpu Index Search Simple Bitset" --durations yes` passed, 350 assertions
