### PR TITLE
fix: pin OpenBLAS pthread recipe

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -138,7 +138,7 @@ class KnowhereConan(ConanFile):
         self.requires("simde/0.8.2#5e1edfd5cba92f25d79bf6ef4616b972")
         self.requires("xxhash/0.8.3#caa6d0af1b951c247922e38fbcebdbe6")
         if self.settings.os == "Linux":
-            self.requires("openblas/0.3.30")
+            self.requires("openblas/0.3.30#aca4131c143d4c109923372e052c643c")
         if not self.options.with_light:
             self.requires("opentelemetry-cpp/1.23.0@milvus/dev#11bc565ec6e82910ae8f7471da756720")
         if self.settings.os != "Macos":


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/1754

## What

Pin Linux OpenBLAS to the known-good native pthread recipe revision available from the Conan 2 remote:

`openblas/0.3.30#aca4131c143d4c109923372e052c643c`

Keep `dynamic_arch=True`; remove the temporary `use_openmp=False` override.

## Why

An unpinned `openblas/0.3.30` resolves to the newer OpenMP recipe revision when CI runs `conan install --update`. That configuration was used by the failing CI path which crashed in `alloc_mmap -> blas_memory_alloc -> sgemm_`.

Knowhere CI uses Conan 2 and resolves recipes from `default-conan-local2`; the equivalent no-OpenMP recipe revision in that remote is `aca413…`. Pinning it makes the dependency graph reproducible without changing the global OpenBLAS recipe selection.