### PR TITLE
padding for faster streamvbyte decode

### DIFF
--- a/src/index/sparse/block_inverted_index.h
+++ b/src/index/sparse/block_inverted_index.h
@@ -864,8 +864,8 @@ BlockInvertedIndex<DType, QType, MetricType>::build_block_index(std::span<uint32
         posting_offsets[i + 1] = posting_offsets[i] + encoded_posting_lists[i].size();
     }
 
-    // This is a workaround to QMX codex having to sometimes look beyond the buffer due to some SIMD loads.
-    constexpr size_t padding_size = 15;
+    // This is a workaround to streamvbyte decode having to sometimes look beyond the buffer due to some SIMD loads.
+    constexpr size_t padding_size = 16;
     const auto offsets_byte_size = posting_offsets.size() * sizeof(size_t);
     index_container_->resize(offsets_byte_size + posting_offsets.back() + padding_size);
     index_container_->seal();

--- a/src/index/sparse/codec/streamvbyte_0124_decode.c
+++ b/src/index/sparse/codec/streamvbyte_0124_decode.c
@@ -294,12 +294,6 @@ typedef __m128i decode_t;
 
 static inline decode_t
 svb_decode_uint32x4(const uint8_t key, const uint8_t* __restrict__* dataPtrPtr) {
-    // A zero control consumes no payload bytes. Avoid issuing a 16-byte load at the logical end of the stream;
-    // this keeps the fast decoder's required trailing guard at 15 bytes.
-    if (key == 0) {
-        return _mm_setzero_si128();
-    }
-
     uint8_t len = 0;
     decode_t Data = _mm_loadu_si128((const decode_t*)*dataPtrPtr);
     uint8_t* pshuf = (uint8_t*)&shuffleTable[key];
@@ -321,12 +315,6 @@ typedef uint8x16_t decode_t;
 
 static inline decode_t
 svb_decode_uint32x4(const uint8_t key, const uint8_t* __restrict__* dataPtrPtr) {
-    // A zero control consumes no payload bytes. Avoid issuing a 16-byte load at the logical end of the stream;
-    // this keeps the fast decoder's required trailing guard at 15 bytes.
-    if (key == 0) {
-        return vdupq_n_u8(0);
-    }
-
     uint8_t len = 0;
     uint8_t* pshuf = (uint8_t*)&shuffleTable[key];
     uint8x16_t decodingShuffle = vld1q_u8(pshuf);


### PR DESCRIPTION
issue: #1730 


brought by #1741 , have a branch for streamvbyte decode, which becomes a hotpot for streamvbyte decoding, so padding 16 bytes to resolve the possible out-of-bounds access.
