### PR TITLE
fix: release scratch slot and reader ctx when the bitset filters everything out

### DIFF
--- a/tests/ut/test_diskann.cc
+++ b/tests/ut/test_diskann.cc
@@ -377,6 +377,20 @@ base_search() {
                 }
             }
 
+            // A fully filtered search returns before doing any I/O. Verify that
+            // the early return still restores the scratch slot to thread_data;
+            // cal_size() includes the number of currently available slots.
+            auto fully_filtered_query = knowhere::ConvertToDataTypeIfNeeded<DataType>(GenDataSet(1, kDim, 43));
+            auto fully_filtered_data = GenerateBitsetWithFirstTbitsSet(kNumRows, kNumRows);
+            knowhere::BitsetView fully_filtered_bitset(fully_filtered_data.data(), kNumRows);
+            const auto size_before_fully_filtered_search = diskann.Size();
+            auto fully_filtered_results = diskann.Search(fully_filtered_query, knn_json, fully_filtered_bitset);
+            REQUIRE(fully_filtered_results.has_value());
+            for (uint32_t i = 0; i < kK; ++i) {
+                REQUIRE(fully_filtered_results.value()->GetIds()[i] == -1);
+            }
+            REQUIRE(diskann.Size() == size_before_fully_filtered_search);
+
             // range search process
             auto range_search_json = range_search_gen().dump();
             knowhere::Json range_json = knowhere::Json::parse(range_search_json);

--- a/thirdparty/DiskANN/src/pq_flash_index.cpp
+++ b/thirdparty/DiskANN/src/pq_flash_index.cpp
@@ -1124,6 +1124,14 @@ namespace diskann {
             distances[i] = -1;
           }
         }
+        // Everything is filtered out, but the scratch slot and the reader
+        // context were already acquired above and must be returned, exactly
+        // like on every other exit from this function. Leaking them here
+        // permanently shrinks the thread_data pool: after max_nthreads such
+        // queries every subsequent search blocks in wait_for_push_notify().
+        this->thread_data.push(data);
+        this->thread_data.push_notify_all();
+        this->reader->put_ctx(ctx);
         return;
       }
 


### PR DESCRIPTION
Fixes #1756

## What

`PQFlashIndex::cached_beam_search` acquires a `ThreadData` scratch slot and a reader
context, then returns early when the bitset filters out the entire dataset — without
releasing either:

```cpp
1095:  ThreadData<T> data = this->thread_data.pop();
1107:  auto ctx = this->reader->get_ctx();
       ...
1120:  if (bitset_view.size() == bv_cnt) {
1121:    for (_u64 i = 0; i < k_search; i++) { indices[i] = -1; ... }
1127:    return;              // <-- no push(data), no push_notify_all(), no put_ctx(ctx)
1128:  }
```

Every other exit releases both (`:1133-1135`, `:1145-1147`, and the tail of the
function). Only this branch does not.

(The earlier zero-norm return at `:1102` is correct — `ctx` is not acquired until
`:1107`, so it only needs to release `data`.)

## Why it matters

`thread_data` is a fixed-size pool sized by `max_nthreads`. Each fully-filtered query
permanently consumes one slot. Once the pool is exhausted:

```cpp
1096:  while (data.scratch.sector_scratch == nullptr) {
1097:    this->thread_data.wait_for_push_notify();
1098:    data = this->thread_data.pop();
1099:  }
```

blocks with no producer left to notify it. **This is not gradual degradation — it is a
hard hang of every DiskANN query on the node.** The reader context leak has the same
shape and would exhaust the aio context pool independently.

Reaching this path only needs a filter expression that matches nothing: a partition-key
value with no rows, an over-narrow scalar filter, or a segment whose rows were all
deleted.

## How

Add the same three release calls the other exits use, before the `return`.

## Tests

I did not add one. A faithful regression test has to drive `max_nthreads + 1`
fully-filtered searches and assert the next one still completes — on the unfixed code
that test does not fail, it **hangs**, which is a poor thing to put in CI without a
watchdog. If maintainers would like it, the natural form is to assert the free-slot
count of `thread_data` is restored after a single fully-filtered query, which needs a
test-only accessor on `ConcurrentQueue`. Happy to add that if you prefer.

## Verification performed

I have not reproduced the hang end-to-end (that needs a built index plus
`max_nthreads` fully-filtered queries). The defect is established by direct comparison
of this exit path against the other three in the same function, and the fix is exactly
the release sequence they already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwPz8E9TtKczUVQQAroanY
