### PR TITLE
enhance: only dispatch to the search pool when the iterator has sorting to do

### DIFF
--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -830,19 +830,26 @@ class PrecomputedDistanceIterator : public IndexNode::iterator {
             if (!has_next_unchecked()) {
                 return expected<std::pair<int64_t, float>>::Err(Status::knowhere_inner_error, "No more elements");
             }
-            if (use_knowhere_search_pool_) {
+            // sort_next() is a no-op unless the cursor has caught up with the
+            // sorted prefix, which happens once every sort_size_ elements
+            // (>= 50000). Checking that here rather than inside the task keeps
+            // the common case from paying for a thread-pool round trip and a
+            // blocking wait just to return immediately.
+            if (needs_sort()) {
+                if (use_knowhere_search_pool_) {
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)
-                std::vector<folly::Future<folly::Unit>> futs;
-                futs.emplace_back(ThreadPool::GetGlobalSearchThreadPool()->push([&]() {
-                    ThreadPool::ScopedSearchOmpSetter setter(1);
-                    sort_next();
-                }));
-                WaitAllSuccess(futs);
+                    std::vector<folly::Future<folly::Unit>> futs;
+                    futs.emplace_back(ThreadPool::GetGlobalSearchThreadPool()->push([&]() {
+                        ThreadPool::ScopedSearchOmpSetter setter(1);
+                        sort_next();
+                    }));
+                    WaitAllSuccess(futs);
 #else
-                sort_next();
+                    sort_next();
 #endif
-            } else {
-                sort_next();
+                } else {
+                    sort_next();
+                }
             }
             auto& result = results_[next_++];
             return std::make_pair(result.id, result.val);
@@ -894,10 +901,17 @@ class PrecomputedDistanceIterator : public IndexNode::iterator {
         return std::max((size_t)50000, rows / 10);
     }
 
+    // Whether the cursor has caught up with the sorted prefix and sort_next()
+    // would do real work.
+    inline bool
+    needs_sort() const {
+        return next_ >= sorted_;
+    }
+
     // sort the next sort_size_ elements
     inline void
     sort_next() {
-        if (next_ < sorted_) {
+        if (!needs_sort()) {
             return;
         }
         size_t current_end = std::min(results_.size(), sorted_ + sort_size_);


### PR DESCRIPTION
Fixes #1758

## What

`PrecomputedDistanceIterator::Next()` pushed a task onto the global search thread pool
and blocked on it for **every element retrieved**:

```cpp
if (use_knowhere_search_pool_) {
    std::vector<folly::Future<folly::Unit>> futs;
    futs.emplace_back(ThreadPool::GetGlobalSearchThreadPool()->push([&]() {
        ThreadPool::ScopedSearchOmpSetter setter(1);
        sort_next();
    }));
    WaitAllSuccess(futs);
}
```

The task body starts with an early-out:

```cpp
inline void sort_next() {
    if (next_ < sorted_) { return; }
    ...std::partial_sort...
}
```

and the stride is `get_sort_size(rows) = max(50000, rows / 10)`, so `partial_sort` runs
at most once every **50000** calls. Every other call paid a full round trip — future
allocation, enqueue, worker wake-up, blocking wait, `ScopedSearchOmpSetter`
construction/teardown — to execute two loads and a comparison.

`use_knowhere_search_pool_` defaults to `true` (`index_node.h:820`), which is the path
Milvus's iterative filtering takes.

## How

Hoist the check out of the task, so the pool is only involved when there is work:

```cpp
if (needs_sort()) {
    if (use_knowhere_search_pool_) { ...push / wait... } else { sort_next(); }
}
```

`sort_next()` now expresses its early-out through the same `needs_sort()` predicate, so
the two cannot drift apart. Semantics are unchanged — the skipped dispatches are exactly
the ones where `sort_next()` would have returned immediately.

No new race: `Next()` already mutates `next_` and is not thread-safe, and the task was
awaited synchronously before returning, so moving the read to the calling thread changes
nothing.

## Verification performed

I could not build knowhere in this environment, so **CI must validate**. What I did
check:

- Compiled the resulting shape as a standalone TU with `clang++ -std=c++17 -O2 -Wall
  -Wextra` (including the private `needs_sort()` being used earlier in the class body
  than it is declared, which is fine — member function bodies are compiled once the
  class is complete). Clean.
- Ran it: output remains fully sorted, and dispatch count drops from one-per-element to
  one-per-sort-stride (100 → 9 with a stride of 10 in the model).

In production, with a stride of at least 50000, an iterator pulling fewer than 50000
results dispatches essentially zero times after `initialize()`.

## What is not claimed

No end-to-end measurement. The issue estimates 2–8 µs of scheduling per `Next()` against
~1 ns of protected work; that estimate is **not** a measurement.

It is cheap to check without any code change, because `use_knowhere_search_pool` is a
public parameter of `AnnIterator` (`src/index/index.cc:194`): time a `Next()` loop with
the flag `true` versus `false`. If the gap is under ~10%, folly is inlining push/get on
that machine and this is not worth taking.

There is no iterator benchmark in `benchmark/` today (`grep -rl AnnIterator benchmark/`
is empty), which is plausibly why this went unnoticed. Happy to add one if maintainers
want it in-tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwPz8E9TtKczUVQQAroanY
