### PR TITLE
lazy doc gap decoding to avoid the full block prefix sum

### DIFF
--- a/src/index/sparse/block_inverted_index.h
+++ b/src/index/sparse/block_inverted_index.h
@@ -127,7 +127,7 @@ class BlockInvertedIndexCursor {
             }
             decode_vecids_block(cur_block_ + 1);
         } else {
-            cur_vec_id_ = ids_buf_[pos_in_block_];
+            cur_vec_id_ += ids_buf_[pos_in_block_] + 1;
         }
         if (cur_vec_id_ >= valid_upper_bound_) {
             set_invalid();
@@ -259,7 +259,7 @@ class BlockInvertedIndexCursor {
     void
     advance_to(uint32_t lower_bound) {
         while (cur_vec_id_ < lower_bound) {
-            cur_vec_id_ = ids_buf_[++pos_in_block_];
+            cur_vec_id_ += ids_buf_[++pos_in_block_] + 1;
         }
     }
 
@@ -293,9 +293,12 @@ class BlockInvertedIndexCursor {
             ids_buf_[0] = cur_block_maxid_;
             vals_block_data_ = block_data;
         } else {
-            const uint32_t previous_vec_id = blkid == 0 ? UINT32_MAX : block_maxid(blkid - 1);
-            vals_block_data_ =
-                block_codec_->decode_doc_ids(block_data, ids_buf_.data(), cur_block_size_, previous_vec_id);
+            vals_block_data_ = block_codec_->decode(block_data, ids_buf_.data(), cur_block_size_);
+
+            // Materialize only the first document ID. The remaining decoded values stay as gaps and are integrated
+            // lazily as the cursor advances, avoiding a full-block prefix sum.
+            const uint32_t block_base = blkid == 0 ? 0 : block_maxid(blkid - 1) + 1;
+            ids_buf_[0] += block_base;
         }
 #if defined(__GNUC__) || defined(__clang__)
         __builtin_prefetch(vals_block_data_, 0, 3);
@@ -822,8 +825,6 @@ BlockInvertedIndex<DType, QType, MetricType>::encode_posting_list(std::vector<ui
             assert(cur_block_size == 1 && b == 0);
             varint_encode(singleton_stored_value, out_buf);
             ++vals_it;
-            out_buf.insert(out_buf.end(), reinterpret_cast<uint8_t*>(ip_vals_buf.data()),
-                           reinterpret_cast<uint8_t*>(ip_vals_buf.data() + cur_block_size));
         } else {
             for (size_t i = 0; i < cur_block_size; ++i) {
                 bm25_vals_buf[i] = get_quant_val<DType, QType>(*vals_it++ - 1);

--- a/src/index/sparse/codec/adaptive.h
+++ b/src/index/sparse/codec/adaptive.h
@@ -40,8 +40,8 @@ namespace knowhere::sparse::inverted {
  * count and are never padded to 256 values.
  *
  * Complete 128-value chunks at widths 1..31 use vertical SIMD kernels derived from fast-pack/simdcomp; width 32 is a
- * direct copy. Document-ID decoding uses the integrated d1 unpacker to reconstruct absolute IDs; TF decoding remains
- * ordinary bit unpacking. A logical block still carries one outer encoding tag.
+ * direct copy. Decoding returns the stored integers verbatim; document-ID gaps are integrated lazily by the posting
+ * cursor. A logical block still carries one outer encoding tag.
  *
  * Block layout:
  *   byte 0      : encoding tag
@@ -77,19 +77,6 @@ class AdaptiveBlockCodec final : public BlockCodec {
         assert(out != nullptr);
         assert(n > 0 && n <= kBlockSize);
         return decode_block(in, out, n);
-    }
-
-    uint8_t const*
-    decode_doc_ids(uint8_t const* in, uint32_t* out, size_t n, uint32_t previous_value) const override {
-        assert(in != nullptr);
-        assert(out != nullptr);
-        assert(n > 0 && n <= kBlockSize);
-
-        const uint8_t type = *in;
-        if (is_bitpacked(type)) {
-            return simd_bitpacking::unpack_doc_ids(in + 1, out, n, type, previous_value);
-        }
-        return BlockCodec::decode_doc_ids(in, out, n, previous_value);
     }
 
     [[nodiscard]] auto

--- a/src/index/sparse/codec/block_codec.h
+++ b/src/index/sparse/codec/block_codec.h
@@ -6,8 +6,6 @@
 #include <string_view>
 #include <vector>
 
-#include "index/sparse/codec/simd_prefix_sum.h"
-
 namespace knowhere::sparse::inverted {
 
 /**
@@ -39,18 +37,6 @@ class BlockCodec {
      */
     virtual uint8_t const*
     decode(uint8_t const* in, uint32_t* out, size_t n) const = 0;
-
-    /**
-     * Decodes document-ID gaps and reconstructs absolute IDs with the shared SIMD prefix sum. `previous_value` is
-     * the document ID immediately before this block; UINT32_MAX represents the implicit value before document zero.
-     * Codecs may override this to fuse unpacking and prefix sums.
-     */
-    virtual uint8_t const*
-    decode_doc_ids(uint8_t const* in, uint32_t* out, size_t n, uint32_t previous_value) const {
-        uint8_t const* next = decode(in, out, n);
-        simd_prefix_sum::integrate_doc_id_gaps(out, n, previous_value);
-        return next;
-    }
 
     /**
      * Returns the maximum logical block length. Complete blocks contain `block_size()` values; the final block may


### PR DESCRIPTION
issue: #1730 

in #1741 we eagerly decode doc gap in a block, but in this pr we choose to roll back this, replace a fixed reconstruct-every-ID in every decoded block cost with a pay-as-you-go cost. MaxScore’s pruning and selective access make that trade-off profitable. Experiments show that this could gain a ~5% performance.