### PR TITLE
fix: correct DiskANN distance calculation for fully cached vectors

### DIFF
--- a/tests/ut/test_diskann.cc
+++ b/tests/ut/test_diskann.cc
@@ -20,6 +20,7 @@
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/generators/catch_generators.hpp"
 #include "diskann/diskann_gpu.h"
+#include "diskann/utils.h"
 #include "filemanager/FileManager.h"
 #include "filemanager/impl/LocalFileManager.h"
 #include "index/diskann/diskann_config.h"
@@ -407,6 +408,62 @@ base_search() {
 
 TEST_CASE("Test DiskANNIndexNode.", "[diskann]") {
     base_search<knowhere::fp32>();
+}
+
+TEST_CASE("Test DiskANN CalcDistByIDs with all vectors cached", "[diskann]") {
+    fs::remove_all(kDir);
+    REQUIRE_NOTHROW(fs::create_directories(kCOSINEIndexDir));
+
+    auto version = GenTestVersionList();
+    auto base_ds = knowhere::ConvertToDataTypeIfNeeded<knowhere::fp16>(GenDataSet(kNumRows, kDim, 30));
+    auto base_ptr = static_cast<const knowhere::fp16*>(base_ds->GetTensor());
+    WriteRawDataToDisk<knowhere::fp16>(kRawDataPath, base_ptr, kNumRows, kDim);
+
+    knowhere::Json build_json;
+    build_json["dim"] = kDim;
+    build_json["metric_type"] = knowhere::metric::COSINE;
+    build_json["index_prefix"] = kCOSINEIndexPrefix;
+    build_json["data_path"] = kRawDataPath;
+    build_json["max_degree"] = 56;
+    build_json["search_list_size"] = 128;
+    build_json["pq_code_budget_gb"] = sizeof(knowhere::fp16) * kDim * kNumRows * 0.125 / (1024 * 1024 * 1024);
+    build_json["search_cache_budget_gb"] = sizeof(knowhere::fp16) * kDim * kNumRows * 0.125 / (1024 * 1024 * 1024);
+    build_json["build_dram_budget_gb"] = 32.0;
+
+    std::shared_ptr<milvus::FileManager> file_manager = std::make_shared<milvus::LocalFileManager>();
+    auto diskann_index_pack = knowhere::Pack(file_manager);
+    auto diskann =
+        knowhere::IndexFactory::Instance().Create<knowhere::fp16>("DISKANN", version, diskann_index_pack).value();
+    REQUIRE(diskann.Build(nullptr, build_json) == knowhere::Status::success);
+
+    knowhere::BinarySet binset;
+    REQUIRE(diskann.Serialize(binset) == knowhere::Status::success);
+
+    knowhere::Json deserialize_json;
+    deserialize_json["dim"] = kDim;
+    deserialize_json["metric_type"] = knowhere::metric::COSINE;
+    deserialize_json["index_prefix"] = kCOSINEIndexPrefix;
+    deserialize_json["search_cache_budget_gb"] = build_json["search_cache_budget_gb"];
+
+    auto loaded_diskann =
+        knowhere::IndexFactory::Instance().Create<knowhere::fp16>("DISKANN", version, diskann_index_pack).value();
+    REQUIRE(loaded_diskann.Deserialize(binset, deserialize_json) == knowhere::Status::success);
+
+    std::unique_ptr<uint32_t[]> cached_ids;
+    size_t num_cached_ids = 0;
+    size_t cached_id_dim = 0;
+    diskann::load_bin<uint32_t>(diskann::get_cached_nodes_file(kCOSINEIndexPrefix), cached_ids, num_cached_ids,
+                                cached_id_dim);
+    REQUIRE(num_cached_ids > 0);
+    REQUIRE(cached_id_dim == 1);
+
+    const int64_t cached_id = cached_ids[0];
+    auto query_ds = knowhere::GenDataSet(1, kDim, base_ptr + cached_id * kDim);
+    auto result = loaded_diskann.CalcDistByIDs(query_ds, nullptr, &cached_id, 1, true);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetDistance()[0] == Catch::Approx(1.0f).margin(0.001f));
+
+    fs::remove_all(kDir);
 }
 
 #ifdef KNOWHERE_WITH_CUVS

--- a/thirdparty/DiskANN/src/pq_flash_index.cpp
+++ b/thirdparty/DiskANN/src/pq_flash_index.cpp
@@ -1546,6 +1546,28 @@ namespace diskann {
     auto     query_scratch = &(data.scratch);
     const T *query = data.scratch.aligned_query_T;
 
+    auto finalize = [&]() {
+      // dist_cmp_wrap returns DiskANN's internal distance representation.
+      // Convert it before returning, regardless of whether vectors came from
+      // the coordinate cache or disk.
+      if (metric == diskann::Metric::INNER_PRODUCT) {
+        for (int64_t i = 0; i < n; ++i) {
+          output_dists[i] = 1.0 - output_dists[i] / 2.0;
+          if (max_base_norm != 0) {
+            output_dists[i] *= (max_base_norm * query_norm);
+          }
+        }
+      } else if (metric == diskann::Metric::COSINE) {
+        for (int64_t i = 0; i < n; ++i) {
+          output_dists[i] = -output_dists[i];
+        }
+      }
+
+      this->reader->put_ctx(ctx);
+      this->thread_data.push(data);
+      this->thread_data.push_notify_all();
+    };
+
     // First, check cache for vectors and calculate distances
     std::vector<_u64> uncached_ids;
     uncached_ids.reserve(n);
@@ -1572,9 +1594,7 @@ namespace diskann {
 
     // If all vectors are cached, we're done
     if (uncached_ids.empty()) {
-      this->reader->put_ctx(ctx);
-      this->thread_data.push(data);
-      this->thread_data.push_notify_all();
+      finalize();
       return;
     }
 
@@ -1639,23 +1659,7 @@ namespace diskann {
       }
     }
 
-    // transform l2-dist to ip-dist / cosine-dist
-    if (metric == diskann::Metric::INNER_PRODUCT) {
-      for (int64_t i = 0; i < n; ++i) {
-        output_dists[i] = 1.0 - output_dists[i] / 2.0;
-        if (max_base_norm != 0) {
-          output_dists[i] *= (max_base_norm * query_norm);
-        }
-      }
-    } else if (metric == diskann::Metric::COSINE) {
-      for (int64_t i = 0; i < n; ++i) {
-        output_dists[i] = -output_dists[i];
-      }
-    }
-
-    this->reader->put_ctx(ctx);
-    this->thread_data.push(data);
-    this->thread_data.push_notify_all();
+    finalize();
   }
 
   template<typename T>


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/1762

Fix incorrect COSINE and INNER_PRODUCT results returned by DiskANN CalcDistByIDs when all requested vectors are cached.