### PR TITLE
ci: pin Python wheel build toolchain

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -43,12 +43,12 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
           CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
           CIBW_BEFORE_ALL_LINUX: "bash scripts/install_deps.sh && make"
-          CIBW_BEFORE_BUILD: "python -m pip install wheel pytest 'numpy>=2,<3' ml-dtypes faiss-cpu auditwheel"
+          CIBW_BEFORE_BUILD: "python -m pip install -r {project}/python/requirements-wheel-build.txt pytest 'numpy>=2,<3' ml-dtypes faiss-cpu"
           # Custom build command using our portable wheel builder
           CIBW_BUILD_FRONTEND: "build"
           # Note: cibuildwheel will use our build_portable_wheel.sh via setup.py
           # The script automatically handles auditwheel repair
-          CIBW_TEST_REQUIRES: "wheel pytest numpy>=2,<3 ml-dtypes faiss-cpu"
+          CIBW_TEST_REQUIRES: "pytest numpy>=2,<3 ml-dtypes faiss-cpu"
           CIBW_TEST_COMMAND: "python -m pytest {project}/tests/python/test_index_with_random.py"
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.tag }}"
         with:

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -107,7 +107,7 @@ jobs:
       - name: Install Dependency
         run: |
           bash scripts/install_deps.sh
-          python -m pip install wheel pytest 'numpy>=2,<3' ml-dtypes faiss-cpu
+          python -m pip install pytest 'numpy>=2,<3' ml-dtypes faiss-cpu
       - name: Install GCC 12
         # GCC 11 (ubuntu-22.04 default) has incomplete C++20 support:
         # std::partial_ordering, std::strong_ordering, std::weak_ordering

--- a/python/build_portable_wheel.sh
+++ b/python/build_portable_wheel.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="${SCRIPT_DIR}/../build/Release"
 VENV_DIR="${KNOWHERE_PYTHON_VENV:-${SCRIPT_DIR}/.venv}"
+WHEEL_BUILD_REQUIREMENTS="${SCRIPT_DIR}/requirements-wheel-build.txt"
 
 # Prefer the project-local uv venv for standalone builds, but still honor an
 # explicit PYTHON from cibuildwheel or a workflow-specific interpreter.
@@ -79,17 +80,28 @@ check_deps() {
     done
 
     command -v "$PYTHON" >/dev/null || { log_error "Python not found: $PYTHON"; exit 1; }
+    [ -f "$WHEEL_BUILD_REQUIREMENTS" ] || {
+        log_error "Wheel build requirements not found: $WHEEL_BUILD_REQUIREMENTS"
+        exit 1
+    }
 
-    if ! command -v auditwheel >/dev/null; then
-        if command -v uv >/dev/null; then
-            log_warn "auditwheel not found, installing into $PYTHON environment with uv..."
-            uv pip install --python "$PYTHON" auditwheel
-            export PATH="$(dirname "$PYTHON"):${PATH}"
-        else
-            log_error "auditwheel not found. Run scripts/install_deps.sh to create the uv-managed Python environment."
-            exit 1
-        fi
+    if command -v uv >/dev/null; then
+        uv pip install --python "$PYTHON" -r "$WHEEL_BUILD_REQUIREMENTS"
+    elif "$PYTHON" -m pip --version >/dev/null 2>&1; then
+        "$PYTHON" -m pip install -r "$WHEEL_BUILD_REQUIREMENTS"
+    else
+        log_error "Neither uv nor pip is available for $PYTHON"
+        exit 1
     fi
+    export PATH="$(dirname "$PYTHON"):${PATH}"
+
+    "$PYTHON" - <<'PY'
+from importlib.metadata import version
+
+packages = ("auditwheel", "setuptools", "wheel", "packaging", "pyelftools")
+print("Wheel toolchain: " + ", ".join(f"{package}={version(package)}" for package in packages))
+PY
+    patchelf --version | head -1
 
     $PYTHON -c "import numpy" 2>/dev/null || {
         log_error "numpy not found. Install with: uv pip install --python '$PYTHON' 'numpy>=2,<3'"
@@ -182,7 +194,7 @@ repair_wheel() {
     export LD_LIBRARY_PATH="${lib_paths}:${system_lib_paths}:${LD_LIBRARY_PATH:-}"
 
     # Run auditwheel repair (all output to stderr so it doesn't leak into command substitution)
-    if ! auditwheel repair "$wheel" -w dist/ --plat "$platform" >&2; then
+    if ! "$PYTHON" -m auditwheel repair "$wheel" -w dist/ --plat "$platform" >&2; then
         log_error "auditwheel repair failed" >&2
         exit 1
     fi
@@ -204,47 +216,64 @@ repair_wheel() {
 # Verify wheel
 verify_wheel() {
     local wheel="$1"
+    local tag
+    local lib_count
+    local tmpdir
+    local so_file
+    local libs_dir
+    local expected_rpath
+    local rpath
+    local unresolved
+    local size
 
     echo ""
     log_info "Verifying wheel: $(basename "$wheel")"
 
-    # Disable exit on error for verification
-    set +e
-
     # Check platform tag
-    local tag=$(unzip -p "$wheel" '*.dist-info/WHEEL' 2>/dev/null | grep "Tag:" | cut -d: -f2 | tr -d ' ')
+    tag=$(unzip -p "$wheel" '*.dist-info/WHEEL' 2>/dev/null | grep "Tag:" | cut -d: -f2 | tr -d ' ' || true)
     [ -z "$tag" ] && tag="unknown"
     echo "  Platform: $tag"
 
-    # Count bundled libraries
-    local lib_count=$(unzip -l "$wheel" 2>/dev/null | grep "\.libs/.*\.so" | wc -l)
-    echo "  Bundled libs: $lib_count"
-
-    # Check RPATH
-    local tmpdir=$(mktemp -d)
-    if unzip -q "$wheel" -d "$tmpdir" 2>/dev/null; then
-        local so_file=$(find "$tmpdir" -name "_swigknowhere*.so" 2>/dev/null | head -1)
-
-        if [ -n "$so_file" ] && [ -f "$so_file" ]; then
-            local rpath=$(readelf -d "$so_file" 2>/dev/null | grep -E "RPATH|RUNPATH" | sed 's/.*\[\(.*\)\]/\1/')
-            if [ -n "$rpath" ]; then
-                if [[ "$rpath" == *'$ORIGIN'* ]]; then
-                    echo "  RPATH: $rpath (portable)"
-                else
-                    echo "  RPATH: $rpath (WARNING: not portable)"
-                fi
-            fi
-        fi
+    tmpdir=$(mktemp -d)
+    if ! unzip -q "$wheel" -d "$tmpdir"; then
+        log_error "Unable to extract repaired wheel"
+        rm -rf "$tmpdir"
+        return 1
     fi
 
-    rm -rf "$tmpdir" 2>/dev/null || true
+    lib_count=$(find "$tmpdir" -path '*.libs/*' -type f -name '*.so*' | wc -l | tr -d ' ')
+    echo "  Bundled libs: $lib_count"
+
+    so_file=$(find "$tmpdir" -type f -name '_swigknowhere*.so' | head -1)
+    libs_dir=$(find "$tmpdir" -maxdepth 1 -type d -name '*.libs' | head -1)
+    if [ -z "$so_file" ] || [ -z "$libs_dir" ]; then
+        log_error "Repaired wheel is missing its extension or bundled library directory"
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
+    expected_rpath="\$ORIGIN/../$(basename "$libs_dir")"
+    rpath=$(readelf -d "$so_file" 2>/dev/null | grep -E 'RPATH|RUNPATH' | sed 's/.*\[\(.*\)\]/\1/' || true)
+    if [[ ":${rpath}:" != *":${expected_rpath}:"* ]]; then
+        log_error "Unexpected extension RPATH: ${rpath:-missing}; expected ${expected_rpath}"
+        rm -rf "$tmpdir"
+        return 1
+    fi
+    echo "  RPATH: $rpath (portable)"
+
+    unresolved=$(ldd "$so_file" 2>&1 | awk '/not found/ { print $1 }' | sort -u || true)
+    if [ -n "$unresolved" ]; then
+        log_error "Repaired wheel has unresolved ELF dependencies:"
+        printf '%s\n' "$unresolved" >&2
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
+    rm -rf "$tmpdir"
 
     # Show file size
-    local size=$(du -h "$wheel" 2>/dev/null | cut -f1)
+    size=$(du -h "$wheel" 2>/dev/null | cut -f1 || true)
     [ -n "$size" ] && echo "  Size: $size"
-
-    # Re-enable exit on error
-    set -e
 }
 
 # Main

--- a/python/build_portable_wheel.sh
+++ b/python/build_portable_wheel.sh
@@ -8,7 +8,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="${SCRIPT_DIR}/../build/Release"
 VENV_DIR="${KNOWHERE_PYTHON_VENV:-${SCRIPT_DIR}/.venv}"
-WHEEL_BUILD_REQUIREMENTS="${SCRIPT_DIR}/requirements-wheel-build.txt"
 
 # Prefer the project-local uv venv for standalone builds, but still honor an
 # explicit PYTHON from cibuildwheel or a workflow-specific interpreter.
@@ -80,28 +79,17 @@ check_deps() {
     done
 
     command -v "$PYTHON" >/dev/null || { log_error "Python not found: $PYTHON"; exit 1; }
-    [ -f "$WHEEL_BUILD_REQUIREMENTS" ] || {
-        log_error "Wheel build requirements not found: $WHEEL_BUILD_REQUIREMENTS"
-        exit 1
-    }
 
-    if command -v uv >/dev/null; then
-        uv pip install --python "$PYTHON" -r "$WHEEL_BUILD_REQUIREMENTS"
-    elif "$PYTHON" -m pip --version >/dev/null 2>&1; then
-        "$PYTHON" -m pip install -r "$WHEEL_BUILD_REQUIREMENTS"
-    else
-        log_error "Neither uv nor pip is available for $PYTHON"
-        exit 1
+    if ! command -v auditwheel >/dev/null; then
+        if command -v uv >/dev/null; then
+            log_warn "auditwheel not found, installing into $PYTHON environment with uv..."
+            uv pip install --python "$PYTHON" auditwheel
+            export PATH="$(dirname "$PYTHON"):${PATH}"
+        else
+            log_error "auditwheel not found. Run scripts/install_deps.sh to create the uv-managed Python environment."
+            exit 1
+        fi
     fi
-    export PATH="$(dirname "$PYTHON"):${PATH}"
-
-    "$PYTHON" - <<'PY'
-from importlib.metadata import version
-
-packages = ("auditwheel", "setuptools", "wheel", "packaging", "pyelftools")
-print("Wheel toolchain: " + ", ".join(f"{package}={version(package)}" for package in packages))
-PY
-    patchelf --version | head -1
 
     $PYTHON -c "import numpy" 2>/dev/null || {
         log_error "numpy not found. Install with: uv pip install --python '$PYTHON' 'numpy>=2,<3'"
@@ -194,7 +182,7 @@ repair_wheel() {
     export LD_LIBRARY_PATH="${lib_paths}:${system_lib_paths}:${LD_LIBRARY_PATH:-}"
 
     # Run auditwheel repair (all output to stderr so it doesn't leak into command substitution)
-    if ! "$PYTHON" -m auditwheel repair "$wheel" -w dist/ --plat "$platform" >&2; then
+    if ! auditwheel repair "$wheel" -w dist/ --plat "$platform" >&2; then
         log_error "auditwheel repair failed" >&2
         exit 1
     fi
@@ -216,64 +204,47 @@ repair_wheel() {
 # Verify wheel
 verify_wheel() {
     local wheel="$1"
-    local tag
-    local lib_count
-    local tmpdir
-    local so_file
-    local libs_dir
-    local expected_rpath
-    local rpath
-    local unresolved
-    local size
 
     echo ""
     log_info "Verifying wheel: $(basename "$wheel")"
 
+    # Disable exit on error for verification
+    set +e
+
     # Check platform tag
-    tag=$(unzip -p "$wheel" '*.dist-info/WHEEL' 2>/dev/null | grep "Tag:" | cut -d: -f2 | tr -d ' ' || true)
+    local tag=$(unzip -p "$wheel" '*.dist-info/WHEEL' 2>/dev/null | grep "Tag:" | cut -d: -f2 | tr -d ' ')
     [ -z "$tag" ] && tag="unknown"
     echo "  Platform: $tag"
 
-    tmpdir=$(mktemp -d)
-    if ! unzip -q "$wheel" -d "$tmpdir"; then
-        log_error "Unable to extract repaired wheel"
-        rm -rf "$tmpdir"
-        return 1
-    fi
-
-    lib_count=$(find "$tmpdir" -path '*.libs/*' -type f -name '*.so*' | wc -l | tr -d ' ')
+    # Count bundled libraries
+    local lib_count=$(unzip -l "$wheel" 2>/dev/null | grep "\.libs/.*\.so" | wc -l)
     echo "  Bundled libs: $lib_count"
 
-    so_file=$(find "$tmpdir" -type f -name '_swigknowhere*.so' | head -1)
-    libs_dir=$(find "$tmpdir" -maxdepth 1 -type d -name '*.libs' | head -1)
-    if [ -z "$so_file" ] || [ -z "$libs_dir" ]; then
-        log_error "Repaired wheel is missing its extension or bundled library directory"
-        rm -rf "$tmpdir"
-        return 1
+    # Check RPATH
+    local tmpdir=$(mktemp -d)
+    if unzip -q "$wheel" -d "$tmpdir" 2>/dev/null; then
+        local so_file=$(find "$tmpdir" -name "_swigknowhere*.so" 2>/dev/null | head -1)
+
+        if [ -n "$so_file" ] && [ -f "$so_file" ]; then
+            local rpath=$(readelf -d "$so_file" 2>/dev/null | grep -E "RPATH|RUNPATH" | sed 's/.*\[\(.*\)\]/\1/')
+            if [ -n "$rpath" ]; then
+                if [[ "$rpath" == *'$ORIGIN'* ]]; then
+                    echo "  RPATH: $rpath (portable)"
+                else
+                    echo "  RPATH: $rpath (WARNING: not portable)"
+                fi
+            fi
+        fi
     fi
 
-    expected_rpath="\$ORIGIN/../$(basename "$libs_dir")"
-    rpath=$(readelf -d "$so_file" 2>/dev/null | grep -E 'RPATH|RUNPATH' | sed 's/.*\[\(.*\)\]/\1/' || true)
-    if [[ ":${rpath}:" != *":${expected_rpath}:"* ]]; then
-        log_error "Unexpected extension RPATH: ${rpath:-missing}; expected ${expected_rpath}"
-        rm -rf "$tmpdir"
-        return 1
-    fi
-    echo "  RPATH: $rpath (portable)"
-
-    unresolved=$(ldd "$so_file" 2>&1 | awk '/not found/ { print $1 }' | sort -u || true)
-    if [ -n "$unresolved" ]; then
-        log_error "Repaired wheel has unresolved ELF dependencies:"
-        printf '%s\n' "$unresolved" >&2
-        rm -rf "$tmpdir"
-        return 1
-    fi
-
-    rm -rf "$tmpdir"
+    rm -rf "$tmpdir" 2>/dev/null || true
 
     # Show file size
-    size=$(du -h "$wheel" 2>/dev/null | cut -f1 || true)
+    local size=$(du -h "$wheel" 2>/dev/null | cut -f1)
     [ -n "$size" ] && echo "  Size: $size"
+
+    # Re-enable exit on error
+    set -e
 }
 
 # Main

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,0 +1,9 @@
+# These tools create or rewrite wheel artifacts. Keep them exact so a new
+# upstream release cannot change an existing commit's CI output.
+# auditwheel 6.8.0 produces invalid ELF metadata with Ubuntu 22.04's
+# patchelf 0.14.3, so retain the last known-good release.
+auditwheel==6.7.0
+packaging==26.3
+pyelftools==0.33
+setuptools==84.0.0
+wheel==0.47.0

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -28,11 +28,13 @@
 set -euo pipefail
 
 CONAN_VERSION="2.28.1"
+UV_VERSION="0.12.3"
 CONAN_REMOTE_URL="https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2"
 CMAKE_MIN_VERSION="${CMAKE_MIN_VERSION:-3.28.1}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 KNOWHERE_PYTHON_VENV="${KNOWHERE_PYTHON_VENV:-${REPO_ROOT}/python/.venv}"
+WHEEL_BUILD_REQUIREMENTS="${REPO_ROOT}/python/requirements-wheel-build.txt"
 
 UNAME="$(uname -s)"
 case "${UNAME}" in
@@ -87,12 +89,17 @@ install_uv() {
     user_bin="$(python_user_bin)"
     export PATH="${user_bin:+${user_bin}:}$HOME/.local/bin:$PATH"
 
-    if ! command -v uv >/dev/null 2>&1; then
-        echo "[install_deps] Installing uv with pip3..."
+    local current_uv_version=""
+    if command -v uv >/dev/null 2>&1; then
+        current_uv_version="$(uv --version | awk '{ print $2 }')"
+    fi
+
+    if [[ "${current_uv_version}" != "${UV_VERSION}" ]]; then
+        echo "[install_deps] Installing uv ${UV_VERSION} with pip3..."
         if [[ -n "${VIRTUAL_ENV:-}" ]]; then
-            pip3_install uv
+            pip3_install --upgrade "uv==${UV_VERSION}"
         else
-            pip3_install --user uv
+            pip3_install --user --upgrade "uv==${UV_VERSION}"
         fi
     fi
 
@@ -140,7 +147,8 @@ install_python_tools() {
         if [[ ! -x "${KNOWHERE_PYTHON_VENV}/bin/python" ]]; then
             uv venv --python python3 "${KNOWHERE_PYTHON_VENV}"
         fi
-        uv pip install --python "${KNOWHERE_PYTHON_VENV}/bin/python" -U setuptools wheel 'numpy>=2,<3' ml-dtypes auditwheel
+        uv pip install --python "${KNOWHERE_PYTHON_VENV}/bin/python" \
+            -r "${WHEEL_BUILD_REQUIREMENTS}" 'numpy>=2,<3' ml-dtypes
     fi
 
     if [[ -x "${KNOWHERE_PYTHON_VENV}/bin/python" ]]; then


### PR DESCRIPTION
issue: #1767

## Question

Why can an unchanged Knowhere commit suddenly produce an invalid Python wheel?

The wheel build installed artifact-mutating tools from unconstrained PyPI versions. A new auditwheel release appeared between the last green and first failing runs. With Ubuntu 22.04's patchelf 0.14.3, it produced a wheel whose bundled ELF dependencies could not be loaded.

The last green [wheel job](https://github.com/zilliztech/knowhere/actions/runs/31400692231/job/93494626856) used auditwheel 6.7.0. The first failing [wheel job](https://github.com/zilliztech/knowhere/actions/runs/31452375557/job/93659151869) used the newer release and failed to import `libfolly.so.0.58.0-dev`.

## Solution

- Add one exact requirements file for tools that create or rewrite wheel artifacts.
- Pin auditwheel to the last known-good 6.7.0 release and pin its packaging toolchain.
- Pin the `uv` bootstrap version used to prepare the Python environment.
- Install the same requirements from `install_deps.sh`, GHA wheel CI, and the release workflow.
- Keep `build_portable_wheel.sh` unchanged so it continues consuming the environment prepared by dependency setup.

Cardinal `master` builds through Knowhere `main`, so this upstream fix also stabilizes Cardinal's Jenkins wheel path without duplicating the pin downstream.

## Verification

- `python/build_portable_wheel.sh` matches the current `main` version exactly.
- `bash -n scripts/install_deps.sh python/build_portable_wheel.sh`
- `git diff --check origin/main...HEAD`
- Full Linux wheel verification is pending this PR's CI.