### PR TITLE
ci: pin 2.6 Python wheel build toolchain

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -44,13 +44,13 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BEFORE_ALL_LINUX: "bash scripts/python_deps.sh && rm -rf build && mkdir build && cd build && conan install .. --build=missing -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .. && cd -"
           # Use portable wheel build script instead of plain setup.py
-          CIBW_BEFORE_BUILD: "pip3 install pytest numpy faiss-cpu bfloat16 auditwheel"
+          CIBW_BEFORE_BUILD: "python -m pip install -r {project}/python/requirements-wheel-build.txt pytest numpy faiss-cpu bfloat16"
           # Custom build command using our portable wheel builder
           CIBW_BUILD_FRONTEND: "build"
           # Note: cibuildwheel will use our build_portable_wheel.sh via setup.py
           # The script automatically handles auditwheel repair
           CIBW_TEST_REQUIRES: "pytest numpy<2 faiss-cpu bfloat16"
-          CIBW_TEST_COMMAND: "pytest {project}/tests/python/test_index_with_random.py"
+          CIBW_TEST_COMMAND: "python -m pytest {project}/tests/python/test_index_with_random.py"
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.tag }}"
         with:
           package-dir: python

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -70,9 +70,8 @@ jobs:
         run: |
           sudo apt update \
           && sudo apt install -y cmake g++ gcc libopenblas-openmp-dev libaio-dev libcurl4-openssl-dev libevent-dev libgflags-dev python3 python3-pip python3-setuptools ccache unzip binutils patchelf \
-          && pip3 install conan==1.61.0 pytest faiss-cpu 'numpy>=2,<3' wheel ml-dtypes \
-          && (conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local || true) \
-          && pip3 install -U setuptools
+          && python -m pip install -r python/requirements-wheel-build.txt conan==1.61.0 pytest faiss-cpu 'numpy>=2,<3' ml-dtypes \
+          && (conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local || true)
       - name: Restore Cache
         uses: ./.github/actions/cache-restore
         with:
@@ -95,4 +94,4 @@ jobs:
           cd python && pip3 install dist/*-manylinux*.whl
       - name: Test
         run: |
-          pytest tests/python/test_index_with_random.py
+          python -m pytest tests/python/test_index_with_random.py

--- a/ci/E2E-arm.groovy
+++ b/ci/E2E-arm.groovy
@@ -26,13 +26,12 @@ pipeline {
                         version="${env.CHANGE_ID}.${date}.${gitShortCommit}"
                         sh "apt-get update || true"
                         sh "apt-get install -y libaio-dev libopenblas-openmp-dev libcurl4-openssl-dev libdouble-conversion-dev libevent-dev libgflags-dev unzip binutils patchelf"
-                        sh "pip3 install conan==1.61.0 'numpy>=2,<3' ml-dtypes"
+                        // Pin the tools that rewrite wheel ELF metadata so existing commits remain reproducible.
+                        sh "python3 -m pip install -r python/requirements-wheel-build.txt conan==1.61.0 'numpy>=2,<3' ml-dtypes"
                         // sh "conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local"
-                        sh "pip3 install -U setuptools"
                         sh "cmake --version"
                         sh "mkdir build"
                         sh "cd build/ && conan install .. --build=missing -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .."
-                        sh "pip3 install auditwheel"
                         sh "cd python && VERSION=${version} ./build_portable_wheel.sh"
                         dir('python/dist'){
                         knowhere_wheel=sh(returnStdout: true, script: 'ls | grep manylinux.*\\.whl').trim()

--- a/ci/E2E2.groovy
+++ b/ci/E2E2.groovy
@@ -27,13 +27,12 @@ pipeline {
                         version="${env.CHANGE_ID}.${date}.${gitShortCommit}"
                         sh "apt-get update || true"
                         sh "apt-get install -y libaio-dev libopenblas-openmp-dev libcurl4-openssl-dev libdouble-conversion-dev libevent-dev libgflags-dev unzip binutils patchelf"
-                        sh "pip3 install conan==1.61.0 'numpy>=2,<3' ml-dtypes"
+                        // Pin the tools that rewrite wheel ELF metadata so existing commits remain reproducible.
+                        sh "python3 -m pip install -r python/requirements-wheel-build.txt conan==1.61.0 'numpy>=2,<3' ml-dtypes"
                         // sh "conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local"
-                        sh "pip3 install -U setuptools"
                         sh "cmake --version"
                         sh "mkdir build"
                         sh "cd build/ && conan install .. --build=missing -o with_diskann=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .."
-                        sh "pip3 install auditwheel"
                         sh "cd python && VERSION=${version} ./build_portable_wheel.sh"
                         dir('python/dist'){
                         knowhere_wheel=sh(returnStdout: true, script: 'ls | grep manylinux.*\\.whl').trim()

--- a/ci/E2E_GPU.groovy
+++ b/ci/E2E_GPU.groovy
@@ -30,15 +30,14 @@ pipeline {
                         sh "apt-get install -y build-essential libopenblas-openmp-dev libcurl4-openssl-dev libaio-dev libdouble-conversion-dev libevent-dev libgflags-dev unzip binutils patchelf"
                         sh "git config --global --add safe.directory '*'"
                         sh "git submodule update --recursive --init"
-                        sh "pip3 install conan==1.61.0 'numpy<2' bfloat16"
+                        // Pin the tools that rewrite wheel ELF metadata so existing commits remain reproducible.
+                        sh "python3 -m pip install -r python/requirements-wheel-build.txt conan==1.61.0 'numpy<2' bfloat16"
                         // sh "conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local"
-                        sh "pip3 install -U setuptools"
                         sh "cmake --version"
                         sh "nvidia-smi --query-gpu=name --format=csv,noheader"
                         sh "./scripts/prepare_gpu_build.sh"
                         sh "mkdir build"
                         sh "cd build/ && conan install .. --build=missing -o with_diskann=True -o with_cuvs=True -s compiler.libcxx=libstdc++11 -s build_type=Release && conan build .."
-                        sh "pip3 install auditwheel"
                         sh "cd python && VERSION=${version} ./build_portable_wheel.sh"
                         dir('python/dist'){
                         knowhere_wheel=sh(returnStdout: true, script: 'ls | grep manylinux.*\\.whl').trim()

--- a/python/build_portable_wheel.sh
+++ b/python/build_portable_wheel.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="${SCRIPT_DIR}/../build/Release"
 PYTHON="${PYTHON:-python3}"
+WHEEL_BUILD_REQUIREMENTS="${SCRIPT_DIR}/requirements-wheel-build.txt"
 
 # Color output (optional)
 if [ -t 1 ]; then
@@ -66,12 +67,22 @@ check_deps() {
         fi
     done
 
-    command -v auditwheel >/dev/null || {
-        log_warn "auditwheel not found, installing..."
-        pip3 install -q auditwheel
+    command -v "$PYTHON" >/dev/null || { log_error "Python not found: $PYTHON"; exit 1; }
+    [ -f "$WHEEL_BUILD_REQUIREMENTS" ] || {
+        log_error "Wheel build requirements not found: $WHEEL_BUILD_REQUIREMENTS"
+        exit 1
     }
 
-    command -v "$PYTHON" >/dev/null || { log_error "Python not found: $PYTHON"; exit 1; }
+    "$PYTHON" -m pip install -r "$WHEEL_BUILD_REQUIREMENTS"
+    export PATH="$(dirname "$PYTHON"):${PATH}"
+
+    "$PYTHON" - <<'PY'
+from importlib.metadata import version
+
+packages = ("auditwheel", "setuptools", "wheel", "packaging", "pyelftools")
+print("Wheel toolchain: " + ", ".join(f"{package}={version(package)}" for package in packages))
+PY
+    patchelf --version | head -1
 
     $PYTHON -c "import numpy" 2>/dev/null || {
         log_error "numpy not found. Install with: pip3 install 'numpy>=2,<3'"
@@ -130,11 +141,7 @@ build_wheel() {
     log_info "Building wheel with $PYTHON..." >&2
     cd "$SCRIPT_DIR"
 
-    if [ "$VERBOSE" = true ]; then
-        $PYTHON setup.py bdist_wheel >&2
-    else
-        $PYTHON setup.py bdist_wheel >/dev/null 2>&1
-    fi
+    $PYTHON setup.py bdist_wheel >&2
 
     local wheel=$(ls -t dist/*-linux_*.whl 2>/dev/null | head -1)
     [ -n "$wheel" ] || { log_error "Wheel build failed" >&2; exit 1; }
@@ -156,10 +163,18 @@ repair_wheel() {
                 sed 's/.*\[\(.*\)\]/\1/' | \
                 tr ':' '\n' | grep -v '^$' | tr '\n' ':')
 
-    export LD_LIBRARY_PATH="${lib_paths}:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu"
+    local multiarch
+    multiarch=$(gcc -print-multiarch 2>/dev/null || true)
+
+    local system_lib_paths="/lib:/usr/lib"
+    if [ -n "$multiarch" ]; then
+        system_lib_paths="${system_lib_paths}:/lib/${multiarch}:/usr/lib/${multiarch}"
+    fi
+
+    export LD_LIBRARY_PATH="${lib_paths}:${system_lib_paths}:${LD_LIBRARY_PATH:-}"
 
     # Run auditwheel repair (all output to stderr so it doesn't leak into command substitution)
-    if ! auditwheel repair "$wheel" -w dist/ --plat "$platform" 2>&1 >&2; then
+    if ! "$PYTHON" -m auditwheel repair "$wheel" -w dist/ --plat "$platform" >&2; then
         log_error "auditwheel repair failed" >&2
         exit 1
     fi
@@ -181,47 +196,64 @@ repair_wheel() {
 # Verify wheel
 verify_wheel() {
     local wheel="$1"
+    local tag
+    local lib_count
+    local tmpdir
+    local so_file
+    local libs_dir
+    local expected_rpath
+    local rpath
+    local unresolved
+    local size
 
     echo ""
     log_info "Verifying wheel: $(basename "$wheel")"
 
-    # Disable exit on error for verification
-    set +e
-
     # Check platform tag
-    local tag=$(unzip -p "$wheel" '*.dist-info/WHEEL' 2>/dev/null | grep "Tag:" | cut -d: -f2 | tr -d ' ')
+    tag=$(unzip -p "$wheel" '*.dist-info/WHEEL' 2>/dev/null | grep "Tag:" | cut -d: -f2 | tr -d ' ' || true)
     [ -z "$tag" ] && tag="unknown"
     echo "  Platform: $tag"
 
-    # Count bundled libraries
-    local lib_count=$(unzip -l "$wheel" 2>/dev/null | grep "\.libs/.*\.so" | wc -l)
-    echo "  Bundled libs: $lib_count"
-
-    # Check RPATH
-    local tmpdir=$(mktemp -d)
-    if unzip -q "$wheel" -d "$tmpdir" 2>/dev/null; then
-        local so_file=$(find "$tmpdir" -name "_swigknowhere*.so" 2>/dev/null | head -1)
-
-        if [ -n "$so_file" ] && [ -f "$so_file" ]; then
-            local rpath=$(readelf -d "$so_file" 2>/dev/null | grep -E "RPATH|RUNPATH" | sed 's/.*\[\(.*\)\]/\1/')
-            if [ -n "$rpath" ]; then
-                if [[ "$rpath" == *'$ORIGIN'* ]]; then
-                    echo "  RPATH: $rpath (portable)"
-                else
-                    echo "  RPATH: $rpath (WARNING: not portable)"
-                fi
-            fi
-        fi
+    tmpdir=$(mktemp -d)
+    if ! unzip -q "$wheel" -d "$tmpdir"; then
+        log_error "Unable to extract repaired wheel"
+        rm -rf "$tmpdir"
+        return 1
     fi
 
-    rm -rf "$tmpdir" 2>/dev/null || true
+    lib_count=$(find "$tmpdir" -path '*.libs/*' -type f -name '*.so*' | wc -l | tr -d ' ')
+    echo "  Bundled libs: $lib_count"
+
+    so_file=$(find "$tmpdir" -type f -name '_swigknowhere*.so' | head -1)
+    libs_dir=$(find "$tmpdir" -maxdepth 1 -type d -name '*.libs' | head -1)
+    if [ -z "$so_file" ] || [ -z "$libs_dir" ]; then
+        log_error "Repaired wheel is missing its extension or bundled library directory"
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
+    expected_rpath="\$ORIGIN/../$(basename "$libs_dir")"
+    rpath=$(readelf -d "$so_file" 2>/dev/null | grep -E 'RPATH|RUNPATH' | sed 's/.*\[\(.*\)\]/\1/' || true)
+    if [[ ":${rpath}:" != *":${expected_rpath}:"* ]]; then
+        log_error "Unexpected extension RPATH: ${rpath:-missing}; expected ${expected_rpath}"
+        rm -rf "$tmpdir"
+        return 1
+    fi
+    echo "  RPATH: $rpath (portable)"
+
+    unresolved=$(ldd "$so_file" 2>&1 | awk '/not found/ { print $1 }' | sort -u || true)
+    if [ -n "$unresolved" ]; then
+        log_error "Repaired wheel has unresolved ELF dependencies:"
+        printf '%s\n' "$unresolved" >&2
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
+    rm -rf "$tmpdir"
 
     # Show file size
-    local size=$(du -h "$wheel" 2>/dev/null | cut -f1)
+    size=$(du -h "$wheel" 2>/dev/null | cut -f1 || true)
     [ -n "$size" ] && echo "  Size: $size"
-
-    # Re-enable exit on error
-    set -e
 }
 
 # Main

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,0 +1,18 @@
+# These tools create or rewrite wheel artifacts. Keep them exact so a new
+# upstream release cannot change an existing commit's CI output.
+# auditwheel 6.8.0 produces invalid ELF metadata with Ubuntu 22.04's
+# patchelf 0.14.3, so retain the last known-good release.
+#
+# The 2.6 release workflow still lists Python 3.8 and 3.9, so use the latest
+# known-compatible auditwheel toolchain for each supported interpreter.
+auditwheel==6.1.0; python_version < "3.9"
+auditwheel==6.4.2; python_version == "3.9"
+auditwheel==6.7.0; python_version >= "3.10"
+packaging==26.2; python_version < "3.9"
+packaging==26.3; python_version >= "3.9"
+pyelftools==0.32; python_version < "3.10"
+pyelftools==0.33; python_version >= "3.10"
+setuptools==75.3.2; python_version < "3.10"
+setuptools==83.0.0; python_version >= "3.10"
+wheel==0.45.1; python_version < "3.9"
+wheel==0.47.0; python_version >= "3.9"


### PR DESCRIPTION
issue: #1767

## Question

Why did the Python wheel and Jenkins checks begin failing on a Knowhere 2.6 PR even though the branch had not changed its packaging code?

[PR #1764](https://github.com/zilliztech/knowhere/pull/1764) installed the latest available auditwheel during its August 11 runs. The [Python wheel job](https://github.com/zilliztech/knowhere/actions/runs/31465216747/job/93696621759) and ARM Jenkins check then failed after the auditwheel 6.8.0 release. The same release produced invalid ELF metadata on Knowhere `main`.

PR [#1765](https://github.com/zilliztech/knowhere/pull/1765) applies the corresponding policy to `main`. This PR backports the same wheel-toolchain ownership and verification model to `2.6` without changing its Conan 1 build contract.

## Solution

- Add one exact requirements file for tools that create or rewrite wheel artifacts.
- Select auditwheel by interpreter compatibility: 6.1.0 for Python 3.8, 6.4.2 for Python 3.9, and the last known-good 6.7.0 for Python 3.10 and newer.
- Pin compatible setuptools, wheel, packaging, and pyelftools versions for the same Python ranges.
- Remove standalone unpinned auditwheel/setuptools installs from GHA and all three Jenkins E2E pipelines.
- Enforce the same requirements when `build_portable_wheel.sh` is called directly.
- Invoke auditwheel through the selected Python interpreter and preserve the actual build error output.
- Make wheel verification fail on unexpected RPATH or unresolved ELF dependencies.
- Use `python -m pytest` so the tested interpreter is explicit.

The older `release-python.yml` dependency choices such as `bfloat16` are pre-existing and outside this incident fix. This PR only makes its packaging toolchain deterministic across the declared Python versions.

## Verification

- `bash -n python/build_portable_wheel.sh`
- `pre-commit run --files python/build_portable_wheel.sh python/requirements-wheel-build.txt .github/workflows/ut.yaml .github/workflows/release-python.yml ci/E2E-arm.groovy ci/E2E2.groovy ci/E2E_GPU.groovy`
- Parsed both modified workflow files as YAML.
- Verified the Python 3.8 and 3.9 pinned toolchains resolve as binary distributions.
- Installed the Python 3.10+ requirements into a clean environment and verified auditwheel 6.7.0 with the expected pinned toolchain.
- Full Linux wheel and Jenkins verification is pending this PR's CI.