### PR TITLE
fix: release nullable maps and separate storage-id distance APIs

### DIFF
--- a/include/knowhere/id_map.h
+++ b/include/knowhere/id_map.h
@@ -436,41 +436,32 @@ class IdMap {
         }
     }
 
-    expected<int64_t>
-    CompactOutToIn(int64_t out_id, size_t compact_count) const {
-        const auto compact_id = OutCount() == 0 ? out_id : static_cast<int64_t>(GetOutToInId(out_id));
-        if (compact_id < 0 || static_cast<size_t>(compact_id) >= compact_count) {
-            return expected<int64_t>::Err(Status::invalid_args,
-                                          "selected id maps outside compact storage: " + std::to_string(out_id));
+    int64_t
+    MapOutToIn(int64_t out_id) const {
+        if (out_id < 0) {
+            return kInvalidId;
         }
-        return compact_id;
+        return OutCount() == 0 ? out_id : static_cast<int64_t>(GetOutToInId(out_id));
     }
 
-    expected<const int64_t*>
-    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids,
-                   size_t compact_count) const {
+    Status
+    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids) const {
         if (count != 0 && out_ids == nullptr) {
-            return expected<const int64_t*>::Err(Status::invalid_args, "selected ids are null");
-        }
-        if (OutCount() == 0) {
-            for (size_t i = 0; i < count; ++i) {
-                auto compact_id = CompactOutToIn(out_ids[i], compact_count);
-                if (!compact_id.has_value()) {
-                    return expected<const int64_t*>::Err(compact_id.error(), compact_id.what());
-                }
-            }
-            return out_ids;
+            return Status::invalid_args;
         }
 
-        compact_ids.resize(count);
+        // Retrieve-style APIs may receive arbitrary public ids. Keep only ids
+        // that have a stored vector payload; distance-refine callers already
+        // pass compact/internal ids and must not use this helper.
+        compact_ids.clear();
+        compact_ids.reserve(count);
         for (size_t i = 0; i < count; ++i) {
-            auto compact_id = CompactOutToIn(out_ids[i], compact_count);
-            if (!compact_id.has_value()) {
-                return expected<const int64_t*>::Err(compact_id.error(), compact_id.what());
+            const auto compact_id = MapOutToIn(out_ids[i]);
+            if (compact_id >= 0) {
+                compact_ids.push_back(compact_id);
             }
-            compact_ids[i] = compact_id.value();
         }
-        return compact_ids.data();
+        return Status::success;
     }
 
  private:

--- a/include/knowhere/id_map.h
+++ b/include/knowhere/id_map.h
@@ -334,6 +334,17 @@ class IdMap {
     }
 
     void
+    ClearIds() {
+        in_to_out_ids_.Clear();
+        out_to_in_ids_.Clear();
+    }
+
+    void
+    ClearEblIds() {
+        in_to_out_ebl_ids_.Clear();
+    }
+
+    void
     AppendEmbListIds(int64_t ebl_id_begin, const size_t* ebl_offsets, int64_t ebl_count) {
         // Appends base-vector ids for a growing EmbList batch.
         const auto list_count = static_cast<size_t>(ebl_count);

--- a/include/knowhere/id_map.h
+++ b/include/knowhere/id_map.h
@@ -452,7 +452,7 @@ class IdMap {
 
         // Retrieve-style APIs may receive arbitrary public ids. Keep only ids
         // that have a stored vector payload; distance-refine callers already
-        // pass compact/internal ids and must not use this helper.
+        // pass storage ids and must not use this helper.
         compact_ids.clear();
         compact_ids.reserve(count);
         for (size_t i = 0; i < count; ++i) {
@@ -608,9 +608,9 @@ class IdMap {
     }
 
     Type type_ = Type::DISABLED;
-    // Compact vector internal id -> public row id.
+    // Compact vector storage id -> public row id.
     IdArray in_to_out_ids_;
-    // Compact base-vector internal id -> public embedding-list id. Only
+    // Compact base-vector storage id -> public embedding-list id. Only
     // populated for EmbList strategies whose base index filters at vector level.
     IdArray in_to_out_ebl_ids_;
     // Public row/list id -> compact vector/list id for selected-id APIs.

--- a/include/knowhere/index/emb_list_strategy.h
+++ b/include/knowhere/index/emb_list_strategy.h
@@ -85,20 +85,21 @@ ParseEmbListMetric(const BaseConfig& config) {
 }
 
 /**
- * @brief Rerank candidate documents by computing exact distances via IndexNode::CalcDistByIDs.
+ * @brief Rerank candidate documents by computing exact distances via IndexNode::CalcDistByStorageIds.
  *
  * Shared rerank logic used by all EmbList strategies (TokenANN, MUVERA, LEMUR).
- * For each candidate document, retrieves its vector IDs, computes distances to
- * query vectors, and aggregates scores using agg_func.
+ * For each candidate document, retrieves its storage ids, computes distances
+ * to query vectors, and aggregates scores using agg_func.
  *
  * @return Status::success or Status::emb_list_inner_error on failure
  */
 Status
-RerankByCalcDistByIDs(const std::vector<int64_t>& candidate_docs, const DataSetPtr& query_dataset, size_t nq, int32_t k,
-                      bool larger_is_closer, bool is_cosine, const std::shared_ptr<EmbListOffset>& emb_list_offset,
-                      const IndexNode* index, const BitsetView& bitset, milvus::OpContext* op_context,
-                      const EmbListAggFunc& agg_func, int64_t* out_ids, float* out_dists, size_t& out_doc_vecs,
-                      size_t& out_distance_computations);
+RerankByCalcDistByStorageIds(const std::vector<int64_t>& candidate_docs, const DataSetPtr& query_dataset, size_t nq,
+                             int32_t k, bool larger_is_closer, bool is_cosine,
+                             const std::shared_ptr<EmbListOffset>& emb_list_offset, const IndexNode* index,
+                             const BitsetView& bitset, milvus::OpContext* op_context, const EmbListAggFunc& agg_func,
+                             int64_t* out_ids, float* out_dists, size_t& out_doc_vecs,
+                             size_t& out_distance_computations);
 
 /**
  * @brief Serialize EmbListOffset to raw bytes: [size_t count][size_t[count] offsets]
@@ -198,7 +199,7 @@ class EmbListStrategy {
      *
      * MUVERA/LEMUR encode documents into different representations for ANN search,
      * so the base index doesn't hold raw vectors. They need a separate raw vector
-     * store for reranking via CalcDistByIDs.
+     * store for reranking via CalcDistByStorageIds.
      * TokenANN indexes raw vectors directly, so it doesn't need this.
      */
     [[nodiscard]] virtual bool
@@ -210,11 +211,11 @@ class EmbListStrategy {
      * @brief Execute search with full control over the search flow.
      *
      * Strategy controls the entire search pipeline and can call IndexNode methods
-     * directly (Search, CalcDistByIDs, etc.) via the provided index pointer.
+     * directly (Search, CalcDistByStorageIds, etc.) via the provided index pointer.
      *
      * @param query_dataset Original query dataset containing query vectors
      * @param query_offset Query document offsets (queries can also be multi-vector)
-     * @param index IndexNode pointer for calling Search/CalcDistByIDs
+     * @param index IndexNode pointer for calling Search/CalcDistByStorageIds
      * @param cfg Config (read before ANN search, consumed by IndexNode::Search)
      * @param bitset Filtering bitset
      * @param op_context Operation context

--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -165,15 +165,16 @@ class IndexNode : public Object {
            milvus::OpContext* op_context = nullptr) const = 0;
 
     /**
-     * @brief Performs a brute-force search operation on the index for given labels.
+     * @brief Computes exact distances for known compact/internal vector ids.
      *
      * @param dataset Query vectors.
-     * @param labels
+     * @param labels Compact/internal ids in the backend payload domain.
      * @param labels_len
      * @param is_cosine
      * @return An expected<> object containing the search results or an error.
      *
      * @note emb-list index search will use this method to perform brute-force distance calculation.
+     * @note Public-id retrieve compaction belongs to GetVectorByIds/GetEmbListByIds, not this API.
      * @note Any index_node that supports emb list search must implement this method.
      */
     virtual expected<DataSetPtr>
@@ -390,15 +391,14 @@ class IndexNode : public Object {
         GetIdMap().SetType(type);
     }
 
-    virtual expected<int64_t>
-    CompactOutToIn(int64_t out_id, size_t compact_count) const {
-        return GetIdMap().CompactOutToIn(out_id, compact_count);
+    virtual int64_t
+    MapOutToIn(int64_t out_id) const {
+        return GetIdMap().MapOutToIn(out_id);
     }
 
-    virtual expected<const int64_t*>
-    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids,
-                   size_t compact_count) const {
-        return GetIdMap().CompactOutToIn(out_ids, count, compact_ids, compact_count);
+    virtual Status
+    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids) const {
+        return GetIdMap().CompactOutToIn(out_ids, count, compact_ids);
     }
 
     /**

--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -165,23 +165,41 @@ class IndexNode : public Object {
            milvus::OpContext* op_context = nullptr) const = 0;
 
     /**
-     * @brief Computes exact distances for known compact/internal vector ids.
+     * @brief Computes exact distances for ids already in the base-vector storage domain.
      *
-     * @param dataset Query vectors.
-     * @param labels Compact/internal ids in the backend payload domain.
-     * @param labels_len
-     * @param is_cosine
-     * @return An expected<> object containing the search results or an error.
+     * Storage ids are the dense ids consumed by the backend payload after nullable rows/lists have been compacted.
+     * Public API callers should use CalcDistByIDs; emb-list rerank and backend adapters use this method after they
+     * already hold storage ids.
+     */
+    virtual expected<DataSetPtr>
+    CalcDistByStorageIds(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels,
+                         const size_t labels_len, const bool is_cosine, milvus::OpContext* op_context = nullptr) const {
+        return expected<DataSetPtr>::Err(Status::not_implemented, "CalcDistByStorageIds not implemented");
+    }
+
+    /**
+     * @brief Computes exact distances for public vector ids.
      *
-     * @note emb-list index search will use this method to perform brute-force distance calculation.
-     * @note Public-id retrieve compaction belongs to GetVectorByIds/GetEmbListByIds, not this API.
-     * @note Any index_node that supports emb list search must implement this method.
+     * Public ids are row/list ids used by retrieve APIs and filter bitsets. This method compacts them to storage ids
+     * before dispatching to CalcDistByStorageIds. Missing nullable public ids are ignored, matching GetVectorByIds.
      */
     virtual expected<DataSetPtr>
     CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
                   const bool is_cosine, milvus::OpContext* op_context = nullptr) const {
-        return expected<DataSetPtr>::Err(Status::not_implemented,
-                                         "BruteForceByIDs not supported for current index type");
+        if (dataset == nullptr) {
+            return expected<DataSetPtr>::Err(Status::invalid_args, "CalcDistByIDs dataset is null");
+        }
+        std::vector<int64_t> storage_ids;
+        auto status = CompactOutToIn(labels, labels_len, storage_ids);
+        if (status != Status::success) {
+            return expected<DataSetPtr>::Err(status, "CalcDistByIDs failed to map ids");
+        }
+        if (storage_ids.empty()) {
+            return GenResultDataSet(dataset->GetRows(), 0, static_cast<const int64_t*>(nullptr),
+                                    static_cast<const float*>(nullptr));
+        }
+        return CalcDistByStorageIds(dataset, bitset, storage_ids.empty() ? nullptr : storage_ids.data(),
+                                    storage_ids.size(), is_cosine, op_context);
     };
 
     // not thread safe.
@@ -427,6 +445,11 @@ class IndexNode : public Object {
         return expected<DataSetPtr>::Err(Status::not_implemented, "GetVectorByStorageIds not implemented");
     }
 
+    // Retrieve embedding lists by compact ids in this node's list storage domain.
+    virtual expected<DataSetPtr>
+    GetEmbListByStorageIds(const DataSetPtr dataset, const std::string& metric_type,
+                           milvus::OpContext* op_context = nullptr) const;
+
     Status
     AppendEmbListOffsetAndIdMap(const size_t* lims, size_t append_row_count, size_t append_el_count_hint = 0) {
         // lims is absolute in the whole index; AppendEmbListIds consumes the
@@ -496,7 +519,7 @@ class IndexNode : public Object {
 
     void
     PrepareBitsetMap(PreparedBitset& prepared, const IdMap& id_map) const {
-        // Backend selectors test internal ids; bitsets use public ids.
+        // Backend selectors test storage ids; bitsets use public ids.
         const auto& ebl_out_ids = id_map.InToOutIds(IdMap::Domain::EMB_LIST);
         const auto& out_ids = ebl_out_ids.empty() ? id_map.InToOutIds() : ebl_out_ids;
         if (!out_ids.empty()) {
@@ -1008,7 +1031,7 @@ class IndexNode : public Object {
     /**
      * @brief Compute distances using emb_list_raw_index_ (raw vector storage).
      *
-     * Used by CalcDistByIDs implementations when emb_list_raw_index_ is present
+     * Used by CalcDistByStorageIds implementations when emb_list_raw_index_ is present
      * (MUVERA/LEMUR strategies). The raw index stores original vectors indexed by
      * global vector IDs, so no ID translation is needed.
      *

--- a/include/knowhere/index/index_node_data_mock_wrapper.h
+++ b/include/knowhere/index/index_node_data_mock_wrapper.h
@@ -136,15 +136,14 @@ class IndexNodeDataMockWrapper : public IndexNode {
         index_node_->SetIdMapType(type);
     }
 
-    expected<int64_t>
-    CompactOutToIn(int64_t out_id, size_t compact_count) const override {
-        return index_node_->CompactOutToIn(out_id, compact_count);
+    int64_t
+    MapOutToIn(int64_t out_id) const override {
+        return index_node_->MapOutToIn(out_id);
     }
 
-    expected<const int64_t*>
-    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids,
-                   size_t compact_count) const override {
-        return index_node_->CompactOutToIn(out_ids, count, compact_ids, compact_count);
+    Status
+    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids) const override {
+        return index_node_->CompactOutToIn(out_ids, count, compact_ids);
     }
 
     expected<PreparedBitset>

--- a/include/knowhere/index/index_node_data_mock_wrapper.h
+++ b/include/knowhere/index/index_node_data_mock_wrapper.h
@@ -55,8 +55,8 @@ class IndexNodeDataMockWrapper : public IndexNode {
     GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context) const override;
 
     expected<DataSetPtr>
-    CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
-                  const bool is_cosine, milvus::OpContext* op_context) const override;
+    CalcDistByStorageIds(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels,
+                         const size_t labels_len, const bool is_cosine, milvus::OpContext* op_context) const override;
     std::optional<size_t>
     GetQueryCodeSize(const DataSetPtr dataset) const override {
         auto dim = dataset->GetDim();

--- a/include/knowhere/index/index_node_thread_pool_wrapper.h
+++ b/include/knowhere/index/index_node_thread_pool_wrapper.h
@@ -117,15 +117,14 @@ class IndexNodeThreadPoolWrapper : public IndexNode {
         index_node_->SetIdMapType(type);
     }
 
-    expected<int64_t>
-    CompactOutToIn(int64_t out_id, size_t compact_count) const override {
-        return index_node_->CompactOutToIn(out_id, compact_count);
+    int64_t
+    MapOutToIn(int64_t out_id) const override {
+        return index_node_->MapOutToIn(out_id);
     }
 
-    expected<const int64_t*>
-    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids,
-                   size_t compact_count) const override {
-        return index_node_->CompactOutToIn(out_ids, count, compact_ids, compact_count);
+    Status
+    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids) const override {
+        return index_node_->CompactOutToIn(out_ids, count, compact_ids);
     }
 
     expected<PreparedBitset>

--- a/include/knowhere/version.h
+++ b/include/knowhere/version.h
@@ -21,8 +21,8 @@ namespace knowhere {
 namespace {
 static constexpr int32_t default_version = 0;
 static constexpr int32_t minimal_version = 0;
-static constexpr int32_t current_version = 8;
-static constexpr int32_t maximum_version = 11;
+static constexpr int32_t current_version = 12;
+static constexpr int32_t maximum_version = 12;
 }  // namespace
 
 class Version {

--- a/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
+++ b/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
@@ -74,8 +74,8 @@ class IndexNodeWithDataViewRefiner : public IndexNode {
     }
 
     expected<DataSetPtr>
-    CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
-                  const bool is_cosine, milvus::OpContext* op_context) const override;
+    CalcDistByStorageIds(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels,
+                         const size_t labels_len, const bool is_cosine, milvus::OpContext* op_context) const override;
 
     expected<DataSetPtr>
     SearchEmbList(const DataSetPtr dataset, std::unique_ptr<Config> cfg, const BitsetView& bitset,
@@ -537,17 +537,15 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::SearchEmbList(const DataS
 
 template <typename DataType, typename BaseIndexNode>
 expected<DataSetPtr>
-IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::CalcDistByIDs(const DataSetPtr dataset,
-                                                                     const BitsetView& /*bitset*/,
-                                                                     const int64_t* labels, const size_t labels_len,
-                                                                     const bool is_cosine,
-                                                                     milvus::OpContext* op_context) const {
+IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::CalcDistByStorageIds(
+    const DataSetPtr dataset, const BitsetView& /*bitset*/, const int64_t* labels, const size_t labels_len,
+    const bool is_cosine, milvus::OpContext* op_context) const {
     if (this->emb_list_raw_index_) {
         return CalcDistByRawIndex(dataset, labels, labels_len, is_cosine, ThreadPool::GetGlobalSearchThreadPool(),
                                   op_context);
     }
 
-    // CalcDistByIDs is a refine/rerank primitive: labels are already in the
+    // CalcDistByStorageIds is a refine/rerank primitive: labels are already in the
     // backend compact id domain. Do not apply nullable public-id mapping here.
     const int64_t* labels_to_calc = labels;
 

--- a/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
+++ b/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
@@ -547,18 +547,9 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::CalcDistByIDs(const DataS
                                   op_context);
     }
 
-    const bool is_emb_list_rerank = this->emb_list_offset_ != nullptr && this->emb_list_strategy_ != nullptr &&
-                                    this->emb_list_strategy_->NeedsBaseIndexIDMap();
-    std::vector<int64_t> in_labels;
-    // Public APIs pass public ids. EmbList rerank passes compact list ids.
+    // CalcDistByIDs is a refine/rerank primitive: labels are already in the
+    // backend compact id domain. Do not apply nullable public-id mapping here.
     const int64_t* labels_to_calc = labels;
-    if (!is_emb_list_rerank) {
-        auto storage_labels = this->CompactOutToIn(labels, labels_len, in_labels, static_cast<size_t>(Count()));
-        if (!storage_labels.has_value()) {
-            return expected<DataSetPtr>::Err(storage_labels.error(), storage_labels.what());
-        }
-        labels_to_calc = storage_labels.value();
-    }
 
     auto num_queries = dataset->GetRows();
     auto query_data = dataset->GetTensor();

--- a/src/index/diskann/diskann.cc
+++ b/src/index/diskann/diskann.cc
@@ -98,8 +98,8 @@ class DiskANNIndexNode : public IndexNode {
     }
 
     expected<DataSetPtr>
-    CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
-                  const bool is_cosine, milvus::OpContext* op_context) const override;
+    CalcDistByStorageIds(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels,
+                         const size_t labels_len, const bool is_cosine, milvus::OpContext* op_context) const override;
 
     static bool
     StaticHasRawData(const knowhere::BaseConfig& config, const IndexVersion& version) {
@@ -942,9 +942,9 @@ DiskANNIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Con
 
 template <typename DataType>
 expected<DataSetPtr>
-DiskANNIndexNode<DataType>::CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels,
-                                          const size_t labels_len, const bool is_cosine,
-                                          milvus::OpContext* op_context) const {
+DiskANNIndexNode<DataType>::CalcDistByStorageIds(const DataSetPtr dataset, const BitsetView& bitset,
+                                                 const int64_t* labels, const size_t labels_len, const bool is_cosine,
+                                                 milvus::OpContext* op_context) const {
     (void)bitset;
     (void)is_cosine;
     if (dataset == nullptr || dataset->GetTensor() == nullptr) {
@@ -961,7 +961,7 @@ DiskANNIndexNode<DataType>::CalcDistByIDs(const DataSetPtr dataset, const Bitset
     auto dim = dataset->GetDim();
     auto xq = static_cast<const DataType*>(dataset->GetTensor());
     auto p_dist = std::make_unique<DistType[]>(nq * labels_len);
-    // CalcDistByIDs is a refine/rerank primitive: labels are already in the
+    // CalcDistByStorageIds is a refine/rerank primitive: labels are already in the
     // backend compact id domain. Do not apply nullable public-id mapping here.
     const int64_t* labels_to_calc = labels;
     if (!is_prepared_.load() || !pq_flash_index_) {

--- a/src/index/diskann/diskann.cc
+++ b/src/index/diskann/diskann.cc
@@ -961,18 +961,9 @@ DiskANNIndexNode<DataType>::CalcDistByIDs(const DataSetPtr dataset, const Bitset
     auto dim = dataset->GetDim();
     auto xq = static_cast<const DataType*>(dataset->GetTensor());
     auto p_dist = std::make_unique<DistType[]>(nq * labels_len);
-    const bool is_emb_list_rerank = this->emb_list_offset_ != nullptr && this->emb_list_strategy_ != nullptr &&
-                                    this->emb_list_strategy_->NeedsBaseIndexIDMap();
-    std::vector<int64_t> in_labels;
-    // Public APIs pass public ids. EmbList rerank passes compact list ids.
+    // CalcDistByIDs is a refine/rerank primitive: labels are already in the
+    // backend compact id domain. Do not apply nullable public-id mapping here.
     const int64_t* labels_to_calc = labels;
-    if (!is_emb_list_rerank) {
-        auto storage_labels = this->CompactOutToIn(labels, labels_len, in_labels, static_cast<size_t>(Count()));
-        if (!storage_labels.has_value()) {
-            return expected<DataSetPtr>::Err(storage_labels.error(), storage_labels.what());
-        }
-        labels_to_calc = storage_labels.value();
-    }
     if (!is_prepared_.load() || !pq_flash_index_) {
         LOG_KNOWHERE_ERROR_ << "Failed to load diskann.";
         return expected<DataSetPtr>::Err(Status::empty_index, "DiskANN not loaded");
@@ -1013,11 +1004,18 @@ DiskANNIndexNode<DataType>::GetVectorByIds(const DataSetPtr dataset, milvus::OpC
     auto rows = dataset->GetRows();
     auto ids = dataset->GetIds();
     std::vector<int64_t> in_ids;
-    auto storage_ids = this->CompactOutToIn(ids, rows, in_ids, static_cast<size_t>(Count()));
-    if (!storage_ids.has_value()) {
-        return expected<DataSetPtr>::Err(storage_ids.error(), storage_ids.what());
+    auto status = this->CompactOutToIn(ids, rows, in_ids);
+    if (status != Status::success) {
+        return expected<DataSetPtr>::Err(status, "GetVectorByIds failed to map ids");
     }
-    ids = storage_ids.value();
+    ids = in_ids.data();
+    rows = static_cast<int64_t>(in_ids.size());
+    if (rows == 0) {
+        // Public-id retrieve may compact missing nullable ids to an empty
+        // storage-id set. Return an empty vector result without touching
+        // backend storage.
+        return GenResultDataSet(0, Dim(), nullptr);
+    }
     auto storage_ds = GenIdsDataSet(rows, ids);
     return GetVectorByStorageIds(storage_ds, op_context);
 }

--- a/src/index/diskann/diskann.cc
+++ b/src/index/diskann/diskann.cc
@@ -44,7 +44,8 @@ class DiskANNIndexNode : public IndexNode {
 
  public:
     using DistType = float;
-    DiskANNIndexNode(const int32_t& version, const Object& object) : is_prepared_(false), dim_(-1), count_(-1) {
+    DiskANNIndexNode(const int32_t& version, const Object& object)
+        : IndexNode(version), is_prepared_(false), dim_(-1), count_(-1) {
         assert(typeid(object) == typeid(Pack<std::shared_ptr<milvus::FileManager>>));
         auto diskann_index_pack = dynamic_cast<const Pack<std::shared_ptr<milvus::FileManager>>*>(&object);
         assert(diskann_index_pack != nullptr);

--- a/src/index/diskann/diskann_aisaq.cc
+++ b/src/index/diskann/diskann_aisaq.cc
@@ -34,7 +34,8 @@ class AisaqIndexNode : public IndexNode {
  public:
     using DistType = float;
 
-    AisaqIndexNode(const int32_t& version, const Object& object) : is_prepared_(false), dim_(-1), count_(-1) {
+    AisaqIndexNode(const int32_t& version, const Object& object)
+        : IndexNode(version), is_prepared_(false), dim_(-1), count_(-1) {
         assert(typeid(object) == typeid(Pack<std::shared_ptr<milvus::FileManager>>));
         auto diskann_index_pack = dynamic_cast<const Pack<std::shared_ptr<milvus::FileManager>>*>(&object);
         assert(diskann_index_pack != nullptr);

--- a/src/index/diskann/diskann_aisaq.cc
+++ b/src/index/diskann/diskann_aisaq.cc
@@ -741,10 +741,6 @@ AisaqIndexNode<DataType>::Search(const DataSetPtr dataset, std::unique_ptr<Confi
 template <typename DataType>
 expected<DataSetPtr>
 AisaqIndexNode<DataType>::GetVectorByIds(const DataSetPtr dataset, milvus::OpContext* op_context) const {
-    if (!is_prepared_.load() || !pq_flash_index_) {
-        LOG_KNOWHERE_ERROR_ << "Failed to load AiSAQ.";
-        return expected<DataSetPtr>::Err(Status::empty_index, "index not loaded");
-    }
     if (dataset == nullptr) {
         return expected<DataSetPtr>::Err(Status::invalid_args, "GetVectorByIds dataset is null");
     }
@@ -752,11 +748,22 @@ AisaqIndexNode<DataType>::GetVectorByIds(const DataSetPtr dataset, milvus::OpCon
     auto rows = dataset->GetRows();
     auto ids = dataset->GetIds();
     std::vector<int64_t> in_ids;
-    auto storage_ids = CompactOutToIn(ids, rows, in_ids, static_cast<size_t>(Count()));
-    if (!storage_ids.has_value()) {
-        return expected<DataSetPtr>::Err(storage_ids.error(), storage_ids.what());
+    auto status = CompactOutToIn(ids, rows, in_ids);
+    if (status != Status::success) {
+        return expected<DataSetPtr>::Err(status, "GetVectorByIds failed to map ids");
     }
-    ids = storage_ids.value();
+    ids = in_ids.data();
+    rows = static_cast<int64_t>(in_ids.size());
+    if (rows == 0) {
+        // Public-id retrieve may compact missing nullable ids to an empty
+        // storage-id set. Return an empty vector result without touching
+        // backend storage.
+        return GenResultDataSet(0, dim, nullptr);
+    }
+    if (!is_prepared_.load() || !pq_flash_index_) {
+        LOG_KNOWHERE_ERROR_ << "Failed to load AiSAQ.";
+        return expected<DataSetPtr>::Err(Status::empty_index, "index not loaded");
+    }
     auto* data = new DataType[dim * rows];
     if (data == nullptr) {
         LOG_KNOWHERE_ERROR_ << "Failed to allocate memory for data.";

--- a/src/index/emb_list/emb_list_strategy.cc
+++ b/src/index/emb_list/emb_list_strategy.cc
@@ -43,11 +43,12 @@ CreateEmbListStrategy(const std::string& strategy_type, const BaseConfig& config
 }
 
 Status
-RerankByCalcDistByIDs(const std::vector<int64_t>& candidate_docs, const DataSetPtr& query_dataset, size_t nq, int32_t k,
-                      bool larger_is_closer, bool is_cosine, const std::shared_ptr<EmbListOffset>& emb_list_offset,
-                      const IndexNode* index, const BitsetView& bitset, milvus::OpContext* op_context,
-                      const EmbListAggFunc& agg_func, int64_t* out_ids, float* out_dists, size_t& out_doc_vecs,
-                      size_t& out_distance_computations) {
+RerankByCalcDistByStorageIds(const std::vector<int64_t>& candidate_docs, const DataSetPtr& query_dataset, size_t nq,
+                             int32_t k, bool larger_is_closer, bool is_cosine,
+                             const std::shared_ptr<EmbListOffset>& emb_list_offset, const IndexNode* index,
+                             const BitsetView& bitset, milvus::OpContext* op_context, const EmbListAggFunc& agg_func,
+                             int64_t* out_ids, float* out_dists, size_t& out_doc_vecs,
+                             size_t& out_distance_computations) {
     std::priority_queue<DistId, std::vector<DistId>, std::greater<>> minheap;
     std::priority_queue<DistId, std::vector<DistId>, std::less<>> maxheap;
 
@@ -63,9 +64,9 @@ RerankByCalcDistByIDs(const std::vector<int64_t>& candidate_docs, const DataSetP
         out_doc_vecs += vids.size();
         out_distance_computations += nq * vids.size();
         auto bf_search_res =
-            index->CalcDistByIDs(query_dataset, bitset, vids.data(), vids.size(), is_cosine, op_context);
+            index->CalcDistByStorageIds(query_dataset, bitset, vids.data(), vids.size(), is_cosine, op_context);
         if (!bf_search_res.has_value()) {
-            LOG_KNOWHERE_ERROR_ << "CalcDistByIDs failed for doc " << doc_id << ": " << bf_search_res.what();
+            LOG_KNOWHERE_ERROR_ << "CalcDistByStorageIds failed for doc " << doc_id << ": " << bf_search_res.what();
             return Status::emb_list_inner_error;
         }
         const auto* bf_dists = bf_search_res.value()->GetDistance();

--- a/src/index/emb_list/emb_list_strategy_lemur.cc
+++ b/src/index/emb_list/emb_list_strategy_lemur.cc
@@ -374,7 +374,11 @@ class LemurEmbListStrategy : public EmbListStrategy {
             if (out_id < 0) {
                 return -1;
             }
-            return index->CompactOutToIn(out_id, static_cast<size_t>(num_docs_));
+            const auto in_id = index->MapOutToIn(out_id);
+            if (in_id < 0) {
+                return expected<int64_t>::Err(Status::invalid_args, "list id maps outside compact storage");
+            }
+            return in_id;
         };
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)

--- a/src/index/emb_list/emb_list_strategy_lemur.cc
+++ b/src/index/emb_list/emb_list_strategy_lemur.cc
@@ -454,10 +454,10 @@ class LemurEmbListStrategy : public EmbListStrategy {
             // Build query dataset for this query document
             auto bf_query_dataset = GenDataSet(nq, original_dim_, query_data + q_vec_start * original_dim_);
 
-            auto status =
-                RerankByCalcDistByIDs(candidate_docs, bf_query_dataset, nq, k, mi.larger_is_closer, mi.is_cosine,
-                                      emb_list_offset_, index, bitset, op_context, mi.agg_func, ids.get() + q * k,
-                                      dists.get() + q * k, total_doc_vecs, total_distance_computations);
+            auto status = RerankByCalcDistByStorageIds(candidate_docs, bf_query_dataset, nq, k, mi.larger_is_closer,
+                                                       mi.is_cosine, emb_list_offset_, index, bitset, op_context,
+                                                       mi.agg_func, ids.get() + q * k, dists.get() + q * k,
+                                                       total_doc_vecs, total_distance_computations);
             if (status != Status::success) {
                 return expected<DataSetPtr>::Err(Status::emb_list_inner_error, "rerank distance computation error");
             }

--- a/src/index/emb_list/emb_list_strategy_muvera.cc
+++ b/src/index/emb_list/emb_list_strategy_muvera.cc
@@ -296,10 +296,10 @@ class MuveraEmbListStrategy : public EmbListStrategy {
             // Build query dataset for this query document
             auto bf_query_dataset = GenDataSet(nq, original_dim_, query_data + q_vec_start * original_dim_);
 
-            auto status =
-                RerankByCalcDistByIDs(candidate_docs, bf_query_dataset, nq, k, mi.larger_is_closer, mi.is_cosine,
-                                      emb_list_offset_, index, bitset, op_context, mi.agg_func, ids.get() + q * k,
-                                      dists.get() + q * k, total_doc_vecs, total_distance_computations);
+            auto status = RerankByCalcDistByStorageIds(candidate_docs, bf_query_dataset, nq, k, mi.larger_is_closer,
+                                                       mi.is_cosine, emb_list_offset_, index, bitset, op_context,
+                                                       mi.agg_func, ids.get() + q * k, dists.get() + q * k,
+                                                       total_doc_vecs, total_distance_computations);
 
             if (status != Status::success) {
                 return expected<DataSetPtr>::Err(Status::emb_list_inner_error, "rerank distance computation error");

--- a/src/index/emb_list/emb_list_strategy_muvera.cc
+++ b/src/index/emb_list/emb_list_strategy_muvera.cc
@@ -216,7 +216,11 @@ class MuveraEmbListStrategy : public EmbListStrategy {
             if (out_id < 0) {
                 return -1;
             }
-            return index->CompactOutToIn(out_id, static_cast<size_t>(num_docs_));
+            const auto in_id = index->MapOutToIn(out_id);
+            if (in_id < 0) {
+                return expected<int64_t>::Err(Status::invalid_args, "list id maps outside compact storage");
+            }
+            return in_id;
         };
 
 #if defined(NOT_COMPILE_FOR_SWIG) && !defined(KNOWHERE_WITH_LIGHT)

--- a/src/index/emb_list/emb_list_strategy_token_ann.cc
+++ b/src/index/emb_list/emb_list_strategy_token_ann.cc
@@ -148,10 +148,10 @@ class TokenANNEmbListStrategy : public EmbListStrategy {
             size_t tensor_offset = start_offset * query_code_size;
             auto bf_query_dataset = GenDataSet(nq, dim, tensor + tensor_offset);
 
-            auto status =
-                RerankByCalcDistByIDs(candidate_docs, bf_query_dataset, nq, k, mi.larger_is_closer, mi.is_cosine,
-                                      emb_list_offset_, index, bitset, op_context, mi.agg_func, ids.get() + i * k,
-                                      dists.get() + i * k, total_doc_vecs, total_distance_computations);
+            auto status = RerankByCalcDistByStorageIds(candidate_docs, bf_query_dataset, nq, k, mi.larger_is_closer,
+                                                       mi.is_cosine, emb_list_offset_, index, bitset, op_context,
+                                                       mi.agg_func, ids.get() + i * k, dists.get() + i * k,
+                                                       total_doc_vecs, total_distance_computations);
 
             if (status != Status::success) {
                 return expected<DataSetPtr>::Err(Status::emb_list_inner_error, "rerank distance computation error");

--- a/src/index/flat/flat.cc
+++ b/src/index/flat/flat.cc
@@ -242,11 +242,18 @@ class FlatIndexNode : public IndexNode {
         auto rows = dataset->GetRows();
         auto ids = dataset->GetIds();
         std::vector<int64_t> in_ids;
-        auto storage_ids = this->CompactOutToIn(ids, rows, in_ids, static_cast<size_t>(index_->ntotal));
-        if (!storage_ids.has_value()) {
-            return expected<DataSetPtr>::Err(storage_ids.error(), storage_ids.what());
+        auto status = this->CompactOutToIn(ids, rows, in_ids);
+        if (status != Status::success) {
+            return expected<DataSetPtr>::Err(status, "GetVectorByIds failed to map ids");
         }
-        ids = storage_ids.value();
+        ids = in_ids.data();
+        rows = static_cast<int64_t>(in_ids.size());
+        if (rows == 0) {
+            // Public-id retrieve may compact missing nullable ids to an empty
+            // storage-id set. Return an empty vector result without touching
+            // backend storage.
+            return GenResultDataSet(0, dim, nullptr);
+        }
         if constexpr (std::is_same_v<IndexType, faiss::cppcontrib::knowhere::IndexFlat>) {
             DataType* data = nullptr;
             try {

--- a/src/index/hnsw/faiss_hnsw.cc
+++ b/src/index/hnsw/faiss_hnsw.cc
@@ -1547,8 +1547,8 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
     }
 
     expected<DataSetPtr>
-    CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset_, const int64_t* labels, const size_t labels_len,
-                  const bool is_cosine, milvus::OpContext* op_context) const override {
+    CalcDistByStorageIds(const DataSetPtr dataset, const BitsetView& bitset_, const int64_t* labels,
+                         const size_t labels_len, const bool is_cosine, milvus::OpContext* op_context) const override {
         // When emb_list_raw_index_ exists (MUVERA/LEMUR), use it for exact distance computation
         if (emb_list_raw_index_) {
             return CalcDistByRawIndex(dataset, labels, labels_len, is_cosine, search_pool, op_context);
@@ -1569,7 +1569,7 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         const auto rows = dataset->GetRows();
         const float* data = static_cast<const float*>(dataset->GetTensor());
         auto distances = std::make_unique<float[]>(rows * labels_len);
-        // CalcDistByIDs is a refine/rerank primitive: labels are already in the
+        // CalcDistByStorageIds is a refine/rerank primitive: labels are already in the
         // backend compact id domain. Do not apply nullable public-id mapping here.
         const int64_t* labels_to_calc = labels;
 
@@ -2443,12 +2443,13 @@ class HNSWIndexNodeWithFallback : public IndexNode {
     }
 
     expected<DataSetPtr>
-    CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
-                  const bool is_cosine, milvus::OpContext* op_context) const override {
+    CalcDistByStorageIds(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels,
+                         const size_t labels_len, const bool is_cosine, milvus::OpContext* op_context) const override {
         if (use_base_index) {
-            return base_index->CalcDistByIDs(dataset, bitset, labels, labels_len, is_cosine, op_context);
+            return base_index->CalcDistByStorageIds(dataset, bitset, labels, labels_len, is_cosine, op_context);
         } else {
-            return fallback_search_index->CalcDistByIDs(dataset, bitset, labels, labels_len, is_cosine, op_context);
+            return fallback_search_index->CalcDistByStorageIds(dataset, bitset, labels, labels_len, is_cosine,
+                                                               op_context);
         }
     }
 

--- a/src/index/hnsw/faiss_hnsw.cc
+++ b/src/index/hnsw/faiss_hnsw.cc
@@ -1178,11 +1178,18 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         auto rows = dataset->GetRows();
         auto ids = dataset->GetIds();
         std::vector<int64_t> in_ids;
-        auto storage_ids = this->CompactOutToIn(ids, rows, in_ids, static_cast<size_t>(Count()));
-        if (!storage_ids.has_value()) {
-            return expected<DataSetPtr>::Err(storage_ids.error(), storage_ids.what());
+        auto status = this->CompactOutToIn(ids, rows, in_ids);
+        if (status != Status::success) {
+            return expected<DataSetPtr>::Err(status, "GetVectorByIds failed to map ids");
         }
-        ids = storage_ids.value();
+        ids = in_ids.data();
+        rows = static_cast<int64_t>(in_ids.size());
+        if (rows == 0) {
+            // Public-id retrieve may compact missing nullable ids to an empty
+            // storage-id set. Return an empty vector result without touching
+            // backend storage.
+            return GenResultDataSet(0, Dim(), nullptr);
+        }
         auto storage_ds = GenIdsDataSet(rows, ids);
         return GetVectorByStorageIds(storage_ds, op_context);
     }
@@ -1562,18 +1569,9 @@ class BaseFaissRegularIndexHNSWNode : public BaseFaissRegularIndexNode {
         const auto rows = dataset->GetRows();
         const float* data = static_cast<const float*>(dataset->GetTensor());
         auto distances = std::make_unique<float[]>(rows * labels_len);
-        const bool is_emb_list_rerank = this->emb_list_offset_ != nullptr && this->emb_list_strategy_ != nullptr &&
-                                        this->emb_list_strategy_->NeedsBaseIndexIDMap();
-        std::vector<int64_t> in_labels;
-        // Public APIs pass public ids. EmbList rerank passes compact list ids.
+        // CalcDistByIDs is a refine/rerank primitive: labels are already in the
+        // backend compact id domain. Do not apply nullable public-id mapping here.
         const int64_t* labels_to_calc = labels;
-        if (!is_emb_list_rerank) {
-            auto storage_labels = this->CompactOutToIn(labels, labels_len, in_labels, static_cast<size_t>(Count()));
-            if (!storage_labels.has_value()) {
-                return expected<DataSetPtr>::Err(storage_labels.error(), storage_labels.what());
-            }
-            labels_to_calc = storage_labels.value();
-        }
 
         BitsetView bitset(bitset_);
         auto index_id = getIndexToSearchByScalarInfo(bitset);
@@ -2341,22 +2339,21 @@ class HNSWIndexNodeWithFallback : public IndexNode {
         }
     }
 
-    expected<int64_t>
-    CompactOutToIn(int64_t out_id, size_t compact_count) const override {
+    int64_t
+    MapOutToIn(int64_t out_id) const override {
         if (use_base_index) {
-            return base_index->CompactOutToIn(out_id, compact_count);
+            return base_index->MapOutToIn(out_id);
         } else {
-            return fallback_search_index->CompactOutToIn(out_id, compact_count);
+            return fallback_search_index->MapOutToIn(out_id);
         }
     }
 
-    expected<const int64_t*>
-    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids,
-                   size_t compact_count) const override {
+    Status
+    CompactOutToIn(const int64_t* out_ids, size_t count, std::vector<int64_t>& compact_ids) const override {
         if (use_base_index) {
-            return base_index->CompactOutToIn(out_ids, count, compact_ids, compact_count);
+            return base_index->CompactOutToIn(out_ids, count, compact_ids);
         } else {
-            return fallback_search_index->CompactOutToIn(out_ids, count, compact_ids, compact_count);
+            return fallback_search_index->CompactOutToIn(out_ids, count, compact_ids);
         }
     }
 

--- a/src/index/index_node.cc
+++ b/src/index/index_node.cc
@@ -350,11 +350,12 @@ IndexNode::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_t
     auto el_ids = dataset->GetIds();
     auto dim = use_raw_index ? emb_list_raw_index_->d : Dim();
     std::vector<int64_t> in_el_ids;
-    auto storage_ids = CompactOutToIn(el_ids, num_el_ids, in_el_ids, emb_list_offset_->num_el());
-    if (!storage_ids.has_value()) {
-        return expected<DataSetPtr>::Err(storage_ids.error(), storage_ids.what());
+    auto status = CompactOutToIn(el_ids, num_el_ids, in_el_ids);
+    if (status != Status::success) {
+        return expected<DataSetPtr>::Err(status, "GetEmbListByIds failed to map ids");
     }
-    const auto* ids_to_retrieve = storage_ids.value();
+    const auto* ids_to_retrieve = in_el_ids.data();
+    num_el_ids = static_cast<int64_t>(in_el_ids.size());
 
     std::vector<size_t> out_offsets(num_el_ids + 1);
     out_offsets[0] = 0;

--- a/src/index/index_node.cc
+++ b/src/index/index_node.cc
@@ -11,6 +11,7 @@
 
 #include "knowhere/index/index_node.h"
 
+#include <algorithm>
 #include <cmath>
 #include <fstream>
 #include <queue>
@@ -325,14 +326,39 @@ IndexNode::AnnIteratorEmbListIfNeed(const DataSetPtr dataset, std::unique_ptr<Co
 expected<DataSetPtr>
 IndexNode::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_type,
                            milvus::OpContext* op_context) const {
+    if (dataset == nullptr) {
+        return expected<DataSetPtr>::Err(Status::invalid_args, "GetEmbListByIds dataset is null");
+    }
     if (emb_list_offset_ == nullptr) {
         return expected<DataSetPtr>::Err(Status::emb_list_inner_error,
                                          "GetEmbListByIds requires emb_list_offset, but it is not available");
     }
+
+    std::vector<int64_t> storage_ids;
+    auto status = CompactOutToIn(dataset->GetIds(), dataset->GetRows(), storage_ids);
+    if (status != Status::success) {
+        return expected<DataSetPtr>::Err(status, "GetEmbListByIds failed to map ids");
+    }
+    storage_ids.erase(
+        std::remove_if(storage_ids.begin(), storage_ids.end(),
+                       [this](int64_t id) { return id < 0 || static_cast<size_t>(id) >= emb_list_offset_->num_el(); }),
+        storage_ids.end());
+
+    auto storage_dataset = GenIdsDataSet(storage_ids.size(), storage_ids.data());
+    return GetEmbListByStorageIds(storage_dataset, metric_type, op_context);
+}
+
+expected<DataSetPtr>
+IndexNode::GetEmbListByStorageIds(const DataSetPtr dataset, const std::string& metric_type,
+                                  milvus::OpContext* op_context) const {
+    if (emb_list_offset_ == nullptr) {
+        return expected<DataSetPtr>::Err(Status::emb_list_inner_error,
+                                         "GetEmbListByStorageIds requires emb_list_offset, but it is not available");
+    }
     auto sub_metric = get_sub_metric_type(metric_type);
     if (!sub_metric.has_value()) {
         return expected<DataSetPtr>::Err(Status::not_implemented,
-                                         "GetEmbListByIds: invalid metric type " + metric_type);
+                                         "GetEmbListByStorageIds: invalid metric type " + metric_type);
     }
 
     // Raw vectors come from strategy-owned storage or the base index.
@@ -340,22 +366,23 @@ IndexNode::GetEmbListByIds(const DataSetPtr dataset, const std::string& metric_t
     if (!use_raw_index && !HasRawData(sub_metric.value())) {
         return expected<DataSetPtr>::Err(
             Status::not_implemented,
-            "GetEmbListByIds requires raw data support, but the index does not store raw vectors");
+            "GetEmbListByStorageIds requires raw data support, but the index does not store raw vectors");
     }
 
     if (dataset == nullptr) {
-        return expected<DataSetPtr>::Err(Status::invalid_args, "GetEmbListByIds dataset is null");
+        return expected<DataSetPtr>::Err(Status::invalid_args, "GetEmbListByStorageIds dataset is null");
     }
     auto num_el_ids = dataset->GetRows();
-    auto el_ids = dataset->GetIds();
-    auto dim = use_raw_index ? emb_list_raw_index_->d : Dim();
-    std::vector<int64_t> in_el_ids;
-    auto status = CompactOutToIn(el_ids, num_el_ids, in_el_ids);
-    if (status != Status::success) {
-        return expected<DataSetPtr>::Err(status, "GetEmbListByIds failed to map ids");
+    const auto* ids_to_retrieve = dataset->GetIds();
+    if (num_el_ids != 0 && ids_to_retrieve == nullptr) {
+        return expected<DataSetPtr>::Err(Status::invalid_args, "GetEmbListByStorageIds ids are null");
     }
-    const auto* ids_to_retrieve = in_el_ids.data();
-    num_el_ids = static_cast<int64_t>(in_el_ids.size());
+    for (int64_t i = 0; i < num_el_ids; ++i) {
+        if (ids_to_retrieve[i] < 0 || static_cast<size_t>(ids_to_retrieve[i]) >= emb_list_offset_->num_el()) {
+            return expected<DataSetPtr>::Err(Status::invalid_args, "GetEmbListByStorageIds id is out of range");
+        }
+    }
+    auto dim = use_raw_index ? emb_list_raw_index_->d : Dim();
 
     std::vector<size_t> out_offsets(num_el_ids + 1);
     out_offsets[0] = 0;

--- a/src/index/index_node_data_mock_wrapper.cc
+++ b/src/index/index_node_data_mock_wrapper.cc
@@ -95,11 +95,11 @@ IndexNodeDataMockWrapper<DataType>::GetVectorByIds(const DataSetPtr dataset, mil
 
 template <typename DataType>
 expected<DataSetPtr>
-IndexNodeDataMockWrapper<DataType>::CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset,
-                                                  const int64_t* labels, const size_t labels_len, const bool is_cosine,
-                                                  milvus::OpContext* op_context) const {
+IndexNodeDataMockWrapper<DataType>::CalcDistByStorageIds(const DataSetPtr dataset, const BitsetView& bitset,
+                                                         const int64_t* labels, const size_t labels_len,
+                                                         const bool is_cosine, milvus::OpContext* op_context) const {
     auto ds_ptr = ConvertFromDataTypeIfNeeded<DataType>(dataset);
-    return index_node_->CalcDistByIDs(ds_ptr, bitset, labels, labels_len, is_cosine, op_context);
+    return index_node_->CalcDistByStorageIds(ds_ptr, bitset, labels, labels_len, is_cosine, op_context);
 }
 
 template class knowhere::IndexNodeDataMockWrapper<knowhere::fp16>;

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -1192,18 +1192,9 @@ IvfIndexNode<DataType, IndexType>::CalcDistByIDs(const DataSetPtr dataset, const
         auto query_data = dataset->GetTensor();
         auto dim = dataset->GetDim();
         auto distances = std::make_unique<float[]>(num_queries * labels_len);
-        const bool is_emb_list_rerank = this->emb_list_offset_ != nullptr && this->emb_list_strategy_ != nullptr &&
-                                        this->emb_list_strategy_->NeedsBaseIndexIDMap();
-        std::vector<int64_t> in_labels;
-        // Public APIs pass public ids. EmbList rerank passes compact list ids.
+        // CalcDistByIDs is a refine/rerank primitive: labels are already in the
+        // backend compact id domain. Do not apply nullable public-id mapping here.
         const int64_t* labels_to_calc = labels;
-        if (!is_emb_list_rerank) {
-            auto storage_labels = this->CompactOutToIn(labels, labels_len, in_labels, static_cast<size_t>(Count()));
-            if (!storage_labels.has_value()) {
-                return expected<DataSetPtr>::Err(storage_labels.error(), storage_labels.what());
-            }
-            labels_to_calc = storage_labels.value();
-        }
 
         try {
             std::vector<folly::Future<folly::Unit>> futs;
@@ -1589,11 +1580,18 @@ IvfIndexNode<DataType, IndexType>::GetVectorByIds(const DataSetPtr dataset, milv
     auto rows = dataset->GetRows();
     auto ids = dataset->GetIds();
     std::vector<int64_t> in_ids;
-    auto storage_ids = this->CompactOutToIn(ids, rows, in_ids, static_cast<size_t>(Count()));
-    if (!storage_ids.has_value()) {
-        return expected<DataSetPtr>::Err(storage_ids.error(), storage_ids.what());
+    auto status = this->CompactOutToIn(ids, rows, in_ids);
+    if (status != Status::success) {
+        return expected<DataSetPtr>::Err(status, "GetVectorByIds failed to map ids");
     }
-    ids = storage_ids.value();
+    ids = in_ids.data();
+    rows = static_cast<int64_t>(in_ids.size());
+    if (rows == 0) {
+        // Public-id retrieve may compact missing nullable ids to an empty
+        // storage-id set. Return an empty vector result without touching
+        // backend storage.
+        return GenResultDataSet(0, Dim(), nullptr);
+    }
     auto storage_ds = GenIdsDataSet(rows, ids);
     return GetVectorByStorageIds(storage_ds, op_context);
 }

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -137,8 +137,8 @@ class IvfIndexNode : public IndexNode {
         return 4 * dataset->GetDim();
     }
     expected<DataSetPtr>
-    CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels, const size_t labels_len,
-                  const bool is_cosine, milvus::OpContext* op_context) const override;
+    CalcDistByStorageIds(const DataSetPtr dataset, const BitsetView& bitset, const int64_t* labels,
+                         const size_t labels_len, const bool is_cosine, milvus::OpContext* op_context) const override;
     static Status
     StaticConfigCheck(const Config& cfg, PARAM_TYPE paramType, std::string& msg) {
         auto ivf_cfg = static_cast<const IvfConfig&>(cfg);
@@ -1177,9 +1177,9 @@ IvfIndexNode<DataType, IndexType>::SearchEmbList(const DataSetPtr dataset, std::
 
 template <typename DataType, typename IndexType>
 expected<DataSetPtr>
-IvfIndexNode<DataType, IndexType>::CalcDistByIDs(const DataSetPtr dataset, const BitsetView& bitset,
-                                                 const int64_t* labels, const size_t labels_len, const bool is_cosine,
-                                                 milvus::OpContext* op_context) const {
+IvfIndexNode<DataType, IndexType>::CalcDistByStorageIds(const DataSetPtr dataset, const BitsetView& bitset,
+                                                        const int64_t* labels, const size_t labels_len,
+                                                        const bool is_cosine, milvus::OpContext* op_context) const {
     // When emb_list_raw_index_ exists (MUVERA/LEMUR), base index holds encoded vectors,
     // so use the raw index for exact distance computation during reranking.
     if (emb_list_raw_index_) {
@@ -1192,7 +1192,7 @@ IvfIndexNode<DataType, IndexType>::CalcDistByIDs(const DataSetPtr dataset, const
         auto query_data = dataset->GetTensor();
         auto dim = dataset->GetDim();
         auto distances = std::make_unique<float[]>(num_queries * labels_len);
-        // CalcDistByIDs is a refine/rerank primitive: labels are already in the
+        // CalcDistByStorageIds is a refine/rerank primitive: labels are already in the
         // backend compact id domain. Do not apply nullable public-id mapping here.
         const int64_t* labels_to_calc = labels;
 
@@ -1222,7 +1222,8 @@ IvfIndexNode<DataType, IndexType>::CalcDistByIDs(const DataSetPtr dataset, const
     }
 
     // only support IndexIVFFlat and IndexIVFFlatCC
-    return expected<DataSetPtr>::Err(Status::not_implemented, "CalcDistByIDs not implemented for current index type");
+    return expected<DataSetPtr>::Err(Status::not_implemented,
+                                     "CalcDistByStorageIds not implemented for current index type");
 }
 
 template <typename DataType, typename IndexType>

--- a/src/index/sparse/sparse_index_node.cc
+++ b/src/index/sparse/sparse_index_node.cc
@@ -989,11 +989,20 @@ class SparseInvertedIndexNodeCC : public SparseInvertedIndexNode<T, use_wand> {
         auto rows = dataset->GetRows();
         auto ids = dataset->GetIds();
         std::vector<int64_t> in_ids;
-        auto storage_ids = this->CompactOutToIn(ids, rows, in_ids, raw_data_.size());
-        if (!storage_ids.has_value()) {
-            return expected<DataSetPtr>::Err(storage_ids.error(), storage_ids.what());
+        auto status = this->CompactOutToIn(ids, rows, in_ids);
+        if (status != Status::success) {
+            return expected<DataSetPtr>::Err(status, "GetVectorByIds failed to map ids");
         }
-        ids = storage_ids.value();
+        ids = in_ids.data();
+        rows = static_cast<int64_t>(in_ids.size());
+        if (rows == 0) {
+            // Public-id retrieve may compact missing nullable ids to an empty
+            // storage-id set. Return an empty sparse result without touching
+            // backend storage.
+            auto res = GenResultDataSet(0, 0, static_cast<const sparse::SparseRow<value_type>*>(nullptr));
+            res->SetIsSparse(true);
+            return res;
+        }
         auto data = std::make_unique<sparse::SparseRow<value_type>[]>(rows);
         int64_t dim = 0;
 

--- a/tests/ut/test_diskann.cc
+++ b/tests/ut/test_diskann.cc
@@ -414,6 +414,14 @@ TEST_CASE("Test DiskANN CalcDistByIDs with all vectors cached", "[diskann]") {
     fs::remove_all(kDir);
     REQUIRE_NOTHROW(fs::create_directories(kCOSINEIndexDir));
 
+#ifdef KNOWHERE_WITH_CARDINAL
+    // This case verifies native DiskANN's cached-node file contract.
+    // Cardinal-backed DISKANN keeps its cache inside Cardinal storage instead.
+    constexpr const char* diskann_type = "DISKANN_DEPRECATED";
+#else
+    constexpr const char* diskann_type = "DISKANN";
+#endif
+
     auto version = GenTestVersionList();
     auto base_ds = knowhere::ConvertToDataTypeIfNeeded<knowhere::fp16>(GenDataSet(kNumRows, kDim, 30));
     auto base_ptr = static_cast<const knowhere::fp16*>(base_ds->GetTensor());
@@ -433,7 +441,7 @@ TEST_CASE("Test DiskANN CalcDistByIDs with all vectors cached", "[diskann]") {
     std::shared_ptr<milvus::FileManager> file_manager = std::make_shared<milvus::LocalFileManager>();
     auto diskann_index_pack = knowhere::Pack(file_manager);
     auto diskann =
-        knowhere::IndexFactory::Instance().Create<knowhere::fp16>("DISKANN", version, diskann_index_pack).value();
+        knowhere::IndexFactory::Instance().Create<knowhere::fp16>(diskann_type, version, diskann_index_pack).value();
     REQUIRE(diskann.Build(nullptr, build_json) == knowhere::Status::success);
 
     knowhere::BinarySet binset;
@@ -446,7 +454,7 @@ TEST_CASE("Test DiskANN CalcDistByIDs with all vectors cached", "[diskann]") {
     deserialize_json["search_cache_budget_gb"] = build_json["search_cache_budget_gb"];
 
     auto loaded_diskann =
-        knowhere::IndexFactory::Instance().Create<knowhere::fp16>("DISKANN", version, diskann_index_pack).value();
+        knowhere::IndexFactory::Instance().Create<knowhere::fp16>(diskann_type, version, diskann_index_pack).value();
     REQUIRE(loaded_diskann.Deserialize(binset, deserialize_json) == knowhere::Status::success);
 
     std::unique_ptr<uint32_t[]> cached_ids;

--- a/tests/ut/test_get_emb_list.cc
+++ b/tests/ut/test_get_emb_list.cc
@@ -323,7 +323,7 @@ TEST_CASE("Test GetEmbListByIds error cases", "[GetEmbListByIds]") {
         REQUIRE(!result.has_value());
     }
 
-    SECTION("Error when el_id out of range") {
+    SECTION("Empty result when el_id is out of range") {
         auto train_ds = GenEmbListDataSet(nb, dim, 42, each_el_len);
         auto idx =
             knowhere::IndexFactory::Instance().Create<knowhere::fp32>(knowhere::IndexEnum::INDEX_HNSW, version).value();
@@ -333,10 +333,11 @@ TEST_CASE("Test GetEmbListByIds error cases", "[GetEmbListByIds]") {
         int64_t boundary_el_id = num_el;
         auto ids_ds = knowhere::GenIdsDataSet(1, &boundary_el_id);
         auto result = idx.GetEmbListByIds(ids_ds, knowhere::metric::MAX_SIM_COSINE);
-        REQUIRE(!result.has_value());
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetRows() == 0);
     }
 
-    SECTION("Error when el_id is negative") {
+    SECTION("Empty result when el_id is negative") {
         auto train_ds = GenEmbListDataSet(nb, dim, 42, each_el_len);
         auto idx =
             knowhere::IndexFactory::Instance().Create<knowhere::fp32>(knowhere::IndexEnum::INDEX_HNSW, version).value();
@@ -346,7 +347,8 @@ TEST_CASE("Test GetEmbListByIds error cases", "[GetEmbListByIds]") {
         int64_t bad_el_id = -1;
         auto ids_ds = knowhere::GenIdsDataSet(1, &bad_el_id);
         auto result = idx.GetEmbListByIds(ids_ds, knowhere::metric::MAX_SIM_COSINE);
-        REQUIRE(!result.has_value());
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetRows() == 0);
     }
 
     SECTION("Error when metric_type is invalid") {

--- a/tests/ut/test_nullable_id_map.cc
+++ b/tests/ut/test_nullable_id_map.cc
@@ -1885,13 +1885,32 @@ RequireDenseVectorsMatchLogicalIds(const knowhere::DataSet& vectors, const std::
 }
 
 void
-RequireDenseCalcDistByIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
+RequireDenseCalcDistByPublicIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
+    std::vector<int64_t> labels(data.query_ids.begin(), data.query_ids.end());
+    auto result = index.CalcDistByIDs(data.query_ds, knowhere::BitsetView{}, labels.data(), labels.size(), false);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetRows() == data.query_ds->GetRows());
+    REQUIRE(result.value()->GetDim() == static_cast<int64_t>(labels.size()));
+    const auto* distances = result.value()->GetDistance();
+    REQUIRE(distances != nullptr);
+    for (size_t i = 0; i < data.query_ids.size(); ++i) {
+        for (size_t j = 0; j < labels.size(); ++j) {
+            const auto label_logical_id = labels[j];
+            const auto expected = DenseL2ForLogicalIds(data.query_ids[i], label_logical_id, data.dim);
+            CAPTURE(i, j, data.query_ids[i], labels[j]);
+            REQUIRE(distances[i * labels.size() + j] == Catch::Approx(expected));
+        }
+    }
+}
+
+void
+RequireDenseCalcDistByStorageIds(const knowhere::IndexNode& node, const MatrixData& data) {
     std::vector<int64_t> labels;
     labels.reserve(data.query_ids.size());
     for (auto logical_id : data.query_ids) {
         labels.push_back(CompactIdForLogicalId(data.valid_ids, logical_id));
     }
-    auto result = index.CalcDistByIDs(data.query_ds, knowhere::BitsetView{}, labels.data(), labels.size(), false);
+    auto result = node.CalcDistByStorageIds(data.query_ds, knowhere::BitsetView{}, labels.data(), labels.size(), false);
     REQUIRE(result.has_value());
     REQUIRE(result.value()->GetRows() == data.query_ds->GetRows());
     REQUIRE(result.value()->GetDim() == static_cast<int64_t>(labels.size()));
@@ -1910,10 +1929,7 @@ RequireDenseCalcDistByIds(const knowhere::Index<knowhere::IndexNode>& index, con
 void
 RequireDenseRetrieveCompactsMissingOutIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
     const auto missing_id = FirstMissingOutId(data.valid_ids, data.total_count);
-    std::vector<int64_t> rejected_ids = {-1, data.total_count};
-    if (missing_id < data.total_count) {
-        rejected_ids.push_back(missing_id);
-    }
+    const std::vector<int64_t> rejected_ids = {-1, data.total_count};
 
     for (auto rejected_id : rejected_ids) {
         CAPTURE(rejected_id);
@@ -1926,6 +1942,12 @@ RequireDenseRetrieveCompactsMissingOutIds(const knowhere::Index<knowhere::IndexN
     auto null_retrieve = index.GetVectorByIds(knowhere::GenIdsDataSet(1, static_cast<const int64_t*>(nullptr)));
     REQUIRE_FALSE(null_retrieve.has_value());
     REQUIRE(null_retrieve.error() == knowhere::Status::invalid_args);
+
+    if (missing_id < data.total_count) {
+        auto retrieve = index.GetVectorByIds(knowhere::GenIdsDataSet(1, &missing_id));
+        REQUIRE(retrieve.has_value());
+        RequireDenseVectorsMatchLogicalIds(*retrieve.value(), {}, data.dim);
+    }
 
     if (missing_id < data.total_count && data.query_ids.size() >= 2) {
         std::vector<int32_t> expected_ids = {data.query_ids[0], data.query_ids[1]};
@@ -1952,7 +1974,7 @@ RequireDenseVectorPublicApisUseOutIds(const knowhere::Index<knowhere::IndexNode>
     REQUIRE(retrieve.has_value());
     RequireDenseVectorsMatchLogicalIds(*retrieve.value(), data.query_ids, data.dim);
 
-    RequireDenseCalcDistByIds(index, data);
+    RequireDenseCalcDistByPublicIds(index, data);
     RequireDenseRetrieveCompactsMissingOutIds(index, data);
 }
 
@@ -2022,10 +2044,7 @@ RequireEmbListRetrieveUsesOutIds(const knowhere::Index<knowhere::IndexNode>& ind
 void
 RequireEmbListRetrieveCompactsMissingOutId(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
     const auto missing_id = FirstMissingOutId(data.valid_ids, data.total_count);
-    std::vector<int64_t> rejected_ids = {-1, data.total_count};
-    if (missing_id < data.total_count) {
-        rejected_ids.push_back(missing_id);
-    }
+    const std::vector<int64_t> rejected_ids = {-1, data.total_count};
 
     for (auto rejected_id : rejected_ids) {
         CAPTURE(rejected_id);
@@ -2039,6 +2058,12 @@ RequireEmbListRetrieveCompactsMissingOutId(const knowhere::Index<knowhere::Index
         index.GetEmbListByIds(knowhere::GenIdsDataSet(1, static_cast<const int64_t*>(nullptr)), "MAX_SIM_L2");
     REQUIRE_FALSE(null_retrieve.has_value());
     REQUIRE(null_retrieve.error() == knowhere::Status::invalid_args);
+
+    if (missing_id < data.total_count) {
+        auto retrieve = index.GetEmbListByIds(knowhere::GenIdsDataSet(1, &missing_id), "MAX_SIM_L2");
+        REQUIRE(retrieve.has_value());
+        RequireEmbListVectorsMatchLogicalIds(*retrieve.value(), {}, data.dim, kEmbVectorsPerDoc);
+    }
 
     if (missing_id < data.total_count && data.query_ids.size() >= 2) {
         std::vector<int32_t> logical_ids = {data.query_ids[0], data.query_ids[1]};
@@ -2868,8 +2893,8 @@ void
 RequireReadApisReturnError(knowhere::IndexNode& node) {
     auto dataset = GenNullableDenseDataSet(4, {0, 2}, kDenseDim);
     auto query = GenDenseQueryDataSet({0}, kDenseDim);
-    int64_t id = 0;
-    auto ids = knowhere::GenIdsDataSet(1, &id);
+    int64_t storage_id = 0;
+    auto ids = knowhere::GenIdsDataSet(1, &storage_id);
     auto new_config = [] { return std::make_unique<knowhere::BaseConfig>(); };
 
     auto search = node.Search(query, new_config(), knowhere::BitsetView{});
@@ -2888,7 +2913,8 @@ RequireReadApisReturnError(knowhere::IndexNode& node) {
     REQUIRE(!vector.has_value());
     REQUIRE(vector.error() == Status::not_implemented);
 
-    auto calc_dist = node.CalcDistByIDs(dataset, knowhere::BitsetView{}, &id, 1, false);
+    // Storage-id APIs should surface the default not_implemented boundary directly.
+    auto calc_dist = node.CalcDistByStorageIds(dataset, knowhere::BitsetView{}, &storage_id, 1, false);
     REQUIRE(!calc_dist.has_value());
     REQUIRE(calc_dist.error() == Status::not_implemented);
 
@@ -4041,9 +4067,9 @@ TEST_CASE("Nullable vector Build plus Add matches full Build", "[nullable][ivf][
     RequireDenseVectorsMatchLogicalIds(*full_vectors.value(), {1, 9}, kDenseDim);
     RequireDenseVectorsMatchLogicalIds(*split_vectors.value(), {1, 9}, kDenseDim);
 
-    int64_t selected_compact_ids[] = {CompactIdForLogicalId(full_ids, 1), CompactIdForLogicalId(full_ids, 9)};
-    auto full_dist = full_index.CalcDistByIDs(query, knowhere::BitsetView{}, selected_compact_ids, 2, false);
-    auto split_dist = split_index.CalcDistByIDs(query, knowhere::BitsetView{}, selected_compact_ids, 2, false);
+    int64_t selected_public_ids[] = {1, 9};
+    auto full_dist = full_index.CalcDistByIDs(query, knowhere::BitsetView{}, selected_public_ids, 2, false);
+    auto split_dist = split_index.CalcDistByIDs(query, knowhere::BitsetView{}, selected_public_ids, 2, false);
     REQUIRE(full_dist.has_value());
     REQUIRE(split_dist.has_value());
     RequireDatasetsEqual(*full_dist.value(), *split_dist.value());
@@ -4426,7 +4452,7 @@ TEST_CASE("Nullable SCANN_DVR emb-list cosine rerank maps calc-dist ids", "[null
     for (int64_t i = 0; i < rows * k; ++i) {
         if (ids[i] >= 0) {
             REQUIRE(ContainsId(data.valid_ids, ids[i]));
-            labels.push_back(CompactIdForLogicalId(data.valid_ids, ids[i]));
+            labels.push_back(ids[i]);
         }
     }
     REQUIRE_FALSE(labels.empty());
@@ -4447,9 +4473,19 @@ TEST_CASE("Nullable SCANN_DVR emb-list cosine rerank maps calc-dist ids", "[null
             ++label_pos;
         }
     }
+
+    std::vector<int64_t> storage_labels;
+    storage_labels.reserve(labels.size());
+    for (auto public_id : labels) {
+        storage_labels.push_back(CompactIdForLogicalId(data.valid_ids, public_id));
+    }
+    REQUIRE(created.index.Node() != nullptr);
+    auto storage_calc = created.index.Node()->CalcDistByStorageIds(data.query_ds, knowhere::BitsetView{},
+                                                                   storage_labels.data(), storage_labels.size(), true);
+    REQUIRE(storage_calc.has_value());
 }
 
-TEST_CASE("Nullable SCANN_DVR CalcDistByIDs uses compact ids", "[nullable][scann_dvr][api]") {
+TEST_CASE("Nullable SCANN_DVR calc-dist APIs keep public and storage ids separate", "[nullable][scann_dvr][api]") {
     IndexRow row{"SCANN_DVR", knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, DataKind::DenseFp32};
     Scenario scenario;
     scenario.mode = Mode::Vector;
@@ -4458,7 +4494,9 @@ TEST_CASE("Nullable SCANN_DVR CalcDistByIDs uses compact ids", "[nullable][scann
     auto artifact = BuildArtifactForScenario(row, scenario);
     REQUIRE(artifact->create_ok);
     REQUIRE(artifact->build_status == knowhere::Status::success);
-    RequireDenseCalcDistByIds(artifact->index, artifact->data);
+    RequireDenseCalcDistByPublicIds(artifact->index, artifact->data);
+    REQUIRE(artifact->index.Node() != nullptr);
+    RequireDenseCalcDistByStorageIds(*artifact->index.Node(), artifact->data);
 }
 
 TEST_CASE("Nullable IVF_FLAT vector APIs use restored logical-id map after reload", "[nullable][ivf][api]") {
@@ -4502,7 +4540,7 @@ TEST_CASE("Nullable FAISS HNSW vector APIs use restored logical-id map after rel
         REQUIRE(retrieve.has_value());
         RequireDenseVectorsMatchLogicalIds(*retrieve.value(), artifact->data.query_ids, artifact->data.dim);
 
-        RequireDenseCalcDistByIds(index, artifact->data);
+        RequireDenseCalcDistByPublicIds(index, artifact->data);
     };
 
     require_vector_apis(artifact->index, true);

--- a/tests/ut/test_nullable_id_map.cc
+++ b/tests/ut/test_nullable_id_map.cc
@@ -1752,6 +1752,13 @@ RequireInvalidCompactOutToIn(const knowhere::IdMap& map, int64_t out_id, size_t 
     REQUIRE(compact_id.error() == knowhere::Status::invalid_args);
 }
 
+void
+RequireInvalidCompactOutToIn(const knowhere::IndexNode& index_node, int64_t out_id, size_t compact_count) {
+    auto compact_id = index_node.CompactOutToIn(out_id, compact_count);
+    REQUIRE_FALSE(compact_id.has_value());
+    REQUIRE(compact_id.error() == knowhere::Status::invalid_args);
+}
+
 knowhere::IdArray
 RequireIdMapArrayContent(const knowhere::Index<knowhere::IndexNode>& index, const std::vector<int32_t>& valid_ids,
                          int64_t count) {
@@ -1789,15 +1796,27 @@ RequireIdMapBitmap(const knowhere::Index<knowhere::IndexNode>& index, int64_t co
 }
 
 void
-RequireVectorIdMapCompacted(const knowhere::Index<knowhere::IndexNode>& index, int64_t count) {
+RequireVectorIdMapCompacted(const knowhere::Index<knowhere::IndexNode>& index, const std::vector<int32_t>& valid_ids,
+                            int64_t count) {
     REQUIRE(index.Node() != nullptr);
     const auto& map = index.Node()->GetIdMap();
     REQUIRE(map.OutCount() == static_cast<size_t>(count));
+    REQUIRE(map.InCount() == valid_ids.size());
     auto valid = map.ValidBitmap();
     REQUIRE(valid.size() == static_cast<size_t>(count));
     REQUIRE(valid.data() != nullptr);
     REQUIRE(map.InToOutIds().empty());
     REQUIRE(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST).empty());
+    for (size_t i = 0; i < valid_ids.size(); ++i) {
+        CAPTURE(i, valid_ids[i]);
+        RequireInvalidCompactOutToIn(map, valid_ids[i], valid_ids.size());
+        REQUIRE(RequireCompactOutToIn(*index.Node(), valid_ids[i], valid_ids.size()) == static_cast<int64_t>(i));
+    }
+    const auto missing_id = FirstMissingOutId(valid_ids, count);
+    if (missing_id < count) {
+        RequireInvalidCompactOutToIn(map, missing_id, valid_ids.size());
+        RequireInvalidCompactOutToIn(*index.Node(), missing_id, valid_ids.size());
+    }
 }
 
 void
@@ -1806,6 +1825,7 @@ RequireEmbListIdMapCompacted(const knowhere::Index<knowhere::IndexNode>& index, 
     REQUIRE(index.Node() != nullptr);
     const auto& map = index.Node()->GetIdMap();
     REQUIRE(map.OutCount() == static_cast<size_t>(count));
+    REQUIRE(map.InCount() == valid_ids.size());
     auto valid = map.ValidBitmap();
     REQUIRE(valid.size() == static_cast<size_t>(count));
     REQUIRE(valid.data() != nullptr);
@@ -1816,6 +1836,11 @@ RequireEmbListIdMapCompacted(const knowhere::Index<knowhere::IndexNode>& index, 
         REQUIRE(RequireCompactOutToIn(index.Node()->GetIdMap(), valid_ids[i], valid_ids.size()) ==
                 static_cast<int64_t>(i));
         REQUIRE(RequireCompactOutToIn(*index.Node(), valid_ids[i], valid_ids.size()) == static_cast<int64_t>(i));
+    }
+    const auto missing_id = FirstMissingOutId(valid_ids, count);
+    if (missing_id < count) {
+        RequireInvalidCompactOutToIn(map, missing_id, valid_ids.size());
+        RequireInvalidCompactOutToIn(*index.Node(), missing_id, valid_ids.size());
     }
 }
 
@@ -3325,6 +3350,39 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         REQUIRE((valid_after_noop.data()[9 >> 3] & (1U << (9 & 7))) != 0);
     }
 
+    SECTION("IdMap clears handed-off vector-domain maps in both directions") {
+        auto bitmap = MakeValidBitmap(10, {1, 4, 9});
+        knowhere::IdMap map;
+        map.SetType(knowhere::IdMap::Type::SEALED);
+        map.AddFromData(knowhere::IdMapData::FromValidBitmap(bitmap.data(), 10));
+        map.FinalizeVectorIds();
+
+        const size_t offsets[] = {0, 2, 3, 6};
+        map.FinalizeEmbListIds(offsets, 3);
+        RequireIdArrayEquals(map.InToOutIds(), {1, 4, 9});
+        RequireIdArrayEquals(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {1, 1, 4, 9, 9, 9});
+        REQUIRE(map.OutCount() == 10);
+        REQUIRE(map.InCount() == 3);
+        REQUIRE(RequireCompactOutToIn(map, 9, map.InCount()) == 2);
+
+        map.ClearEblIds();
+        RequireIdArrayEquals(map.InToOutIds(), {1, 4, 9});
+        REQUIRE(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST).empty());
+        REQUIRE(map.OutCount() == 10);
+        REQUIRE(map.InCount() == 3);
+        REQUIRE(RequireCompactOutToIn(map, 4, map.InCount()) == 1);
+
+        map.ClearIds();
+        REQUIRE(map.InToOutIds().empty());
+        REQUIRE(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST).empty());
+        REQUIRE(map.OutCount() == 10);
+        REQUIRE(map.InCount() == 3);
+        REQUIRE(!map.ValidBitmap().empty());
+        RequireInvalidCompactOutToIn(map, 1, map.InCount());
+        RequireInvalidCompactOutToIn(map, 4, map.InCount());
+        RequireInvalidCompactOutToIn(map, 9, map.InCount());
+    }
+
     SECTION("IdMap supports mmap-backed id arrays") {
         auto work_dir = NullableIdMapWorkDir("id_map_mmap");
         RemoveAllNoThrow(work_dir);
@@ -4787,15 +4845,15 @@ TEST_CASE("Nullable raw-data vector APIs map compact serialized ids after reload
     REQUIRE(artifact->create_ok);
     REQUIRE(artifact->build_status == knowhere::Status::success);
 
-    RequireVectorIdMapCompacted(artifact->index, artifact->data.total_count);
+    RequireVectorIdMapCompacted(artifact->index, artifact->data.valid_ids, artifact->data.total_count);
     RequireDenseVectorPublicApisUseOutIds(artifact->index, artifact->data, artifact->json, false);
 
     REQUIRE(EnsureBinaryLoaded(*artifact) == knowhere::Status::success);
-    RequireVectorIdMapCompacted(artifact->binary_loaded, artifact->data.total_count);
+    RequireVectorIdMapCompacted(artifact->binary_loaded, artifact->data.valid_ids, artifact->data.total_count);
     RequireDenseVectorPublicApisUseOutIds(artifact->binary_loaded, artifact->data, artifact->json, false);
 
     REQUIRE(EnsureFileLoaded(*artifact) == knowhere::Status::success);
-    RequireVectorIdMapCompacted(artifact->file_loaded, artifact->data.total_count);
+    RequireVectorIdMapCompacted(artifact->file_loaded, artifact->data.valid_ids, artifact->data.total_count);
     RequireDenseVectorPublicApisUseOutIds(artifact->file_loaded, artifact->data, artifact->json, false);
 }
 

--- a/tests/ut/test_nullable_id_map.cc
+++ b/tests/ut/test_nullable_id_map.cc
@@ -699,6 +699,13 @@ ContainsId(const std::vector<int32_t>& ids, int64_t id) {
 }
 
 int64_t
+CompactIdForLogicalId(const std::vector<int32_t>& valid_ids, int64_t logical_id) {
+    auto it = std::find(valid_ids.begin(), valid_ids.end(), static_cast<int32_t>(logical_id));
+    REQUIRE(it != valid_ids.end());
+    return static_cast<int64_t>(std::distance(valid_ids.begin(), it));
+}
+
+int64_t
 FirstMissingOutId(const std::vector<int32_t>& valid_ids, int64_t total_count) {
     for (int64_t id = 0; id < total_count; ++id) {
         if (!ContainsId(valid_ids, id)) {
@@ -1732,31 +1739,27 @@ RequireIdArrayEquals(const knowhere::IdArray& view, const std::vector<int32_t>& 
 }
 
 int64_t
-RequireCompactOutToIn(const knowhere::IdMap& map, int64_t out_id, size_t compact_count) {
-    auto compact_id = map.CompactOutToIn(out_id, compact_count);
-    REQUIRE(compact_id.has_value());
-    return compact_id.value();
+RequireCompactOutToIn(const knowhere::IdMap& map, int64_t out_id) {
+    auto compact_id = map.MapOutToIn(out_id);
+    REQUIRE(compact_id >= 0);
+    return compact_id;
 }
 
 int64_t
-RequireCompactOutToIn(const knowhere::IndexNode& index_node, int64_t out_id, size_t compact_count) {
-    auto compact_id = index_node.CompactOutToIn(out_id, compact_count);
-    REQUIRE(compact_id.has_value());
-    return compact_id.value();
+RequireCompactOutToIn(const knowhere::IndexNode& index_node, int64_t out_id) {
+    auto compact_id = index_node.MapOutToIn(out_id);
+    REQUIRE(compact_id >= 0);
+    return compact_id;
 }
 
 void
-RequireInvalidCompactOutToIn(const knowhere::IdMap& map, int64_t out_id, size_t compact_count) {
-    auto compact_id = map.CompactOutToIn(out_id, compact_count);
-    REQUIRE_FALSE(compact_id.has_value());
-    REQUIRE(compact_id.error() == knowhere::Status::invalid_args);
+RequireInvalidCompactOutToIn(const knowhere::IdMap& map, int64_t out_id) {
+    REQUIRE(map.MapOutToIn(out_id) < 0);
 }
 
 void
-RequireInvalidCompactOutToIn(const knowhere::IndexNode& index_node, int64_t out_id, size_t compact_count) {
-    auto compact_id = index_node.CompactOutToIn(out_id, compact_count);
-    REQUIRE_FALSE(compact_id.has_value());
-    REQUIRE(compact_id.error() == knowhere::Status::invalid_args);
+RequireInvalidCompactOutToIn(const knowhere::IndexNode& index_node, int64_t out_id) {
+    REQUIRE(index_node.MapOutToIn(out_id) < 0);
 }
 
 knowhere::IdArray
@@ -1781,7 +1784,7 @@ RequireIdMapContent(const knowhere::Index<knowhere::IndexNode>& index, const std
     for (size_t i = 0; i < valid_ids.size(); ++i) {
         CAPTURE(i, valid_ids[i]);
         REQUIRE(map.MapInToOut(static_cast<int64_t>(i)) == valid_ids[i]);
-        REQUIRE(RequireCompactOutToIn(*index.Node(), valid_ids[i], valid_ids.size()) == static_cast<int64_t>(i));
+        REQUIRE(RequireCompactOutToIn(*index.Node(), valid_ids[i]) == static_cast<int64_t>(i));
     }
 }
 
@@ -1809,13 +1812,13 @@ RequireVectorIdMapCompacted(const knowhere::Index<knowhere::IndexNode>& index, c
     REQUIRE(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST).empty());
     for (size_t i = 0; i < valid_ids.size(); ++i) {
         CAPTURE(i, valid_ids[i]);
-        RequireInvalidCompactOutToIn(map, valid_ids[i], valid_ids.size());
-        REQUIRE(RequireCompactOutToIn(*index.Node(), valid_ids[i], valid_ids.size()) == static_cast<int64_t>(i));
+        RequireInvalidCompactOutToIn(map, valid_ids[i]);
+        REQUIRE(RequireCompactOutToIn(*index.Node(), valid_ids[i]) == static_cast<int64_t>(i));
     }
     const auto missing_id = FirstMissingOutId(valid_ids, count);
     if (missing_id < count) {
-        RequireInvalidCompactOutToIn(map, missing_id, valid_ids.size());
-        RequireInvalidCompactOutToIn(*index.Node(), missing_id, valid_ids.size());
+        RequireInvalidCompactOutToIn(map, missing_id);
+        RequireInvalidCompactOutToIn(*index.Node(), missing_id);
     }
 }
 
@@ -1833,14 +1836,13 @@ RequireEmbListIdMapCompacted(const knowhere::Index<knowhere::IndexNode>& index, 
     REQUIRE(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST).empty());
     for (size_t i = 0; i < valid_ids.size(); ++i) {
         CAPTURE(i, valid_ids[i]);
-        REQUIRE(RequireCompactOutToIn(index.Node()->GetIdMap(), valid_ids[i], valid_ids.size()) ==
-                static_cast<int64_t>(i));
-        REQUIRE(RequireCompactOutToIn(*index.Node(), valid_ids[i], valid_ids.size()) == static_cast<int64_t>(i));
+        REQUIRE(RequireCompactOutToIn(index.Node()->GetIdMap(), valid_ids[i]) == static_cast<int64_t>(i));
+        REQUIRE(RequireCompactOutToIn(*index.Node(), valid_ids[i]) == static_cast<int64_t>(i));
     }
     const auto missing_id = FirstMissingOutId(valid_ids, count);
     if (missing_id < count) {
-        RequireInvalidCompactOutToIn(map, missing_id, valid_ids.size());
-        RequireInvalidCompactOutToIn(*index.Node(), missing_id, valid_ids.size());
+        RequireInvalidCompactOutToIn(map, missing_id);
+        RequireInvalidCompactOutToIn(*index.Node(), missing_id);
     }
 }
 
@@ -1868,6 +1870,9 @@ RequireDenseVectorsMatchLogicalIds(const knowhere::DataSet& vectors, const std::
                                    int64_t dim) {
     REQUIRE(vectors.GetRows() == static_cast<int64_t>(logical_ids.size()));
     REQUIRE(vectors.GetDim() == dim);
+    if (logical_ids.empty()) {
+        return;
+    }
     const auto* tensor = static_cast<const float*>(vectors.GetTensor());
     REQUIRE(tensor != nullptr);
     for (size_t i = 0; i < logical_ids.size(); ++i) {
@@ -1881,7 +1886,11 @@ RequireDenseVectorsMatchLogicalIds(const knowhere::DataSet& vectors, const std::
 
 void
 RequireDenseCalcDistByIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
-    std::vector<int64_t> labels(data.query_ids.begin(), data.query_ids.end());
+    std::vector<int64_t> labels;
+    labels.reserve(data.query_ids.size());
+    for (auto logical_id : data.query_ids) {
+        labels.push_back(CompactIdForLogicalId(data.valid_ids, logical_id));
+    }
     auto result = index.CalcDistByIDs(data.query_ds, knowhere::BitsetView{}, labels.data(), labels.size(), false);
     REQUIRE(result.has_value());
     REQUIRE(result.value()->GetRows() == data.query_ds->GetRows());
@@ -1890,7 +1899,8 @@ RequireDenseCalcDistByIds(const knowhere::Index<knowhere::IndexNode>& index, con
     REQUIRE(distances != nullptr);
     for (size_t i = 0; i < data.query_ids.size(); ++i) {
         for (size_t j = 0; j < labels.size(); ++j) {
-            const auto expected = DenseL2ForLogicalIds(data.query_ids[i], static_cast<int32_t>(labels[j]), data.dim);
+            const auto label_logical_id = data.valid_ids[static_cast<size_t>(labels[j])];
+            const auto expected = DenseL2ForLogicalIds(data.query_ids[i], label_logical_id, data.dim);
             CAPTURE(i, j, data.query_ids[i], labels[j]);
             REQUIRE(distances[i * labels.size() + j] == Catch::Approx(expected));
         }
@@ -1898,7 +1908,7 @@ RequireDenseCalcDistByIds(const knowhere::Index<knowhere::IndexNode>& index, con
 }
 
 void
-RequireDenseSelectedIdsRejectMissingOutId(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
+RequireDenseRetrieveCompactsMissingOutIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
     const auto missing_id = FirstMissingOutId(data.valid_ids, data.total_count);
     std::vector<int64_t> rejected_ids = {-1, data.total_count};
     if (missing_id < data.total_count) {
@@ -1909,23 +1919,21 @@ RequireDenseSelectedIdsRejectMissingOutId(const knowhere::Index<knowhere::IndexN
         CAPTURE(rejected_id);
         int64_t retrieve_id = rejected_id;
         auto retrieve = index.GetVectorByIds(knowhere::GenIdsDataSet(1, &retrieve_id));
-        REQUIRE_FALSE(retrieve.has_value());
-        REQUIRE(retrieve.error() == knowhere::Status::invalid_args);
-
-        int64_t calc_dist_id = rejected_id;
-        auto calc_dist = index.CalcDistByIDs(data.query_ds, knowhere::BitsetView{}, &calc_dist_id, 1, false);
-        REQUIRE_FALSE(calc_dist.has_value());
-        REQUIRE(calc_dist.error() == knowhere::Status::invalid_args);
+        REQUIRE(retrieve.has_value());
+        RequireDenseVectorsMatchLogicalIds(*retrieve.value(), {}, data.dim);
     }
 
     auto null_retrieve = index.GetVectorByIds(knowhere::GenIdsDataSet(1, static_cast<const int64_t*>(nullptr)));
     REQUIRE_FALSE(null_retrieve.has_value());
     REQUIRE(null_retrieve.error() == knowhere::Status::invalid_args);
 
-    auto null_calc_dist =
-        index.CalcDistByIDs(data.query_ds, knowhere::BitsetView{}, static_cast<const int64_t*>(nullptr), 1, false);
-    REQUIRE_FALSE(null_calc_dist.has_value());
-    REQUIRE(null_calc_dist.error() == knowhere::Status::invalid_args);
+    if (missing_id < data.total_count && data.query_ids.size() >= 2) {
+        std::vector<int32_t> expected_ids = {data.query_ids[0], data.query_ids[1]};
+        std::vector<int64_t> ids = {data.query_ids[0], missing_id, data.query_ids[1]};
+        auto retrieve = index.GetVectorByIds(knowhere::GenIdsDataSet(static_cast<int64_t>(ids.size()), ids.data()));
+        REQUIRE(retrieve.has_value());
+        RequireDenseVectorsMatchLogicalIds(*retrieve.value(), expected_ids, data.dim);
+    }
 }
 
 void
@@ -1945,7 +1953,7 @@ RequireDenseVectorPublicApisUseOutIds(const knowhere::Index<knowhere::IndexNode>
     RequireDenseVectorsMatchLogicalIds(*retrieve.value(), data.query_ids, data.dim);
 
     RequireDenseCalcDistByIds(index, data);
-    RequireDenseSelectedIdsRejectMissingOutId(index, data);
+    RequireDenseRetrieveCompactsMissingOutIds(index, data);
 }
 
 void
@@ -1962,6 +1970,10 @@ RequireEmbListVectorsMatchLogicalIds(const knowhere::DataSet& vectors, const std
     REQUIRE(vectors.GetDim() == dim);
     const auto* offsets = vectors.Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
     REQUIRE(offsets != nullptr);
+    if (logical_ids.empty()) {
+        REQUIRE(offsets[0] == 0);
+        return;
+    }
     const auto* tensor = static_cast<const float*>(vectors.GetTensor());
     REQUIRE(tensor != nullptr);
     for (size_t i = 0; i < logical_ids.size(); ++i) {
@@ -1977,7 +1989,7 @@ RequireEmbListVectorsMatchLogicalIds(const knowhere::DataSet& vectors, const std
 }
 
 void
-RequireEmbListRetrieveRejectsMissingOutId(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data);
+RequireEmbListRetrieveCompactsMissingOutId(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data);
 
 void
 RequireEmbListApisUseOutIds(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data,
@@ -2004,11 +2016,11 @@ RequireEmbListRetrieveUsesOutIds(const knowhere::Index<knowhere::IndexNode>& ind
         index.GetEmbListByIds(knowhere::GenIdsDataSet(static_cast<int64_t>(ids.size()), ids.data()), "MAX_SIM_L2");
     REQUIRE(retrieve.has_value());
     RequireEmbListVectorsMatchLogicalIds(*retrieve.value(), logical_ids, data.dim, kEmbVectorsPerDoc);
-    RequireEmbListRetrieveRejectsMissingOutId(index, data);
+    RequireEmbListRetrieveCompactsMissingOutId(index, data);
 }
 
 void
-RequireEmbListRetrieveRejectsMissingOutId(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
+RequireEmbListRetrieveCompactsMissingOutId(const knowhere::Index<knowhere::IndexNode>& index, const MatrixData& data) {
     const auto missing_id = FirstMissingOutId(data.valid_ids, data.total_count);
     std::vector<int64_t> rejected_ids = {-1, data.total_count};
     if (missing_id < data.total_count) {
@@ -2019,14 +2031,23 @@ RequireEmbListRetrieveRejectsMissingOutId(const knowhere::Index<knowhere::IndexN
         CAPTURE(rejected_id);
         int64_t id = rejected_id;
         auto retrieve = index.GetEmbListByIds(knowhere::GenIdsDataSet(1, &id), "MAX_SIM_L2");
-        REQUIRE_FALSE(retrieve.has_value());
-        REQUIRE(retrieve.error() == knowhere::Status::invalid_args);
+        REQUIRE(retrieve.has_value());
+        RequireEmbListVectorsMatchLogicalIds(*retrieve.value(), {}, data.dim, kEmbVectorsPerDoc);
     }
 
     auto null_retrieve =
         index.GetEmbListByIds(knowhere::GenIdsDataSet(1, static_cast<const int64_t*>(nullptr)), "MAX_SIM_L2");
     REQUIRE_FALSE(null_retrieve.has_value());
     REQUIRE(null_retrieve.error() == knowhere::Status::invalid_args);
+
+    if (missing_id < data.total_count && data.query_ids.size() >= 2) {
+        std::vector<int32_t> logical_ids = {data.query_ids[0], data.query_ids[1]};
+        std::vector<int64_t> ids = {data.query_ids[0], missing_id, data.query_ids[1]};
+        auto retrieve =
+            index.GetEmbListByIds(knowhere::GenIdsDataSet(static_cast<int64_t>(ids.size()), ids.data()), "MAX_SIM_L2");
+        REQUIRE(retrieve.has_value());
+        RequireEmbListVectorsMatchLogicalIds(*retrieve.value(), logical_ids, data.dim, kEmbVectorsPerDoc);
+    }
 }
 
 std::vector<std::vector<float>>
@@ -2902,7 +2923,7 @@ RequireIdMapVectorState(const knowhere::IdMap& map, size_t out_count, const std:
     for (size_t in_id = 0; in_id < in_to_out_ids.size(); ++in_id) {
         CAPTURE(in_id);
         REQUIRE(map.MapInToOut(static_cast<int64_t>(in_id)) == in_to_out_ids[in_id]);
-        REQUIRE(RequireCompactOutToIn(map, in_to_out_ids[in_id], in_to_out_ids.size()) == static_cast<int64_t>(in_id));
+        REQUIRE(RequireCompactOutToIn(map, in_to_out_ids[in_id]) == static_cast<int64_t>(in_id));
     }
 }
 
@@ -3027,8 +3048,8 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         REQUIRE(map.OutCount() == 8);
         REQUIRE(map.MapInToOut(2) == 4);
         REQUIRE(map.MapInToOut(static_cast<int64_t>(ids.size())) == -1);
-        REQUIRE(RequireCompactOutToIn(map, 4, map.InCount()) == 2);
-        RequireInvalidCompactOutToIn(map, 5, map.InCount());
+        REQUIRE(RequireCompactOutToIn(map, 4) == 2);
+        RequireInvalidCompactOutToIn(map, 5);
 
         std::vector<int64_t> result_ids = {0, 1, 2, 3, 4, -1};
         map.MapInToOut(result_ids.data(), result_ids.size());
@@ -3061,9 +3082,9 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
 
             REQUIRE_THROWS(map.AddFromData(data));
             RequireIdMapVectorStateOnly(map, 4, {1, 3});
-            RequireInvalidCompactOutToIn(map, 0, map.InCount());
-            RequireInvalidCompactOutToIn(map, 2, map.InCount());
-            RequireInvalidCompactOutToIn(map, 4, map.InCount());
+            RequireInvalidCompactOutToIn(map, 0);
+            RequireInvalidCompactOutToIn(map, 2);
+            RequireInvalidCompactOutToIn(map, 4);
         };
 
         int32_t negative_ids[] = {0, -1};
@@ -3135,10 +3156,10 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         map.FinalizeVectorIds();
         REQUIRE(!map.InToOutIds().empty());
         RequireIdArrayEquals(map.InToOutIds(), {1, 4, 9});
-        REQUIRE(RequireCompactOutToIn(map, 1, map.InCount()) == 0);
-        REQUIRE(RequireCompactOutToIn(map, 4, map.InCount()) == 1);
-        REQUIRE(RequireCompactOutToIn(map, 9, map.InCount()) == 2);
-        RequireInvalidCompactOutToIn(map, 8, map.InCount());
+        REQUIRE(RequireCompactOutToIn(map, 1) == 0);
+        REQUIRE(RequireCompactOutToIn(map, 4) == 1);
+        REQUIRE(RequireCompactOutToIn(map, 9) == 2);
+        RequireInvalidCompactOutToIn(map, 8);
     }
 
     SECTION("IdMap views keep array buffers alive") {
@@ -3170,8 +3191,8 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         map.AddFromData(knowhere::IdMapData::FromIds(ids, 2, 4));
         REQUIRE(map.OutCount() == 4);
         REQUIRE(map.MapInToOut(1) == 2);
-        REQUIRE(RequireCompactOutToIn(map, 2, map.InCount()) == 1);
-        RequireInvalidCompactOutToIn(map, 1, map.InCount());
+        REQUIRE(RequireCompactOutToIn(map, 2) == 1);
+        RequireInvalidCompactOutToIn(map, 1);
 
         std::vector<int64_t> result_ids = {0, 1, -1};
         map.MapInToOut(result_ids.data(), result_ids.size());
@@ -3258,7 +3279,7 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         REQUIRE(map.OutCount() == 12);
         REQUIRE(map.InCount() == 6);
         RequireIdArrayEquals(map.InToOutIds(), {0, 2, 3, 5, 8, 11});
-        REQUIRE(RequireCompactOutToIn(map, 11, map.InCount()) == 5);
+        REQUIRE(RequireCompactOutToIn(map, 11) == 5);
     }
 
     SECTION("Sealed IdMap uses array storage") {
@@ -3268,13 +3289,13 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         map.AddFromData(knowhere::IdMapData::FromValidData(base_valid, 4));
         map.FinalizeVectorIds();
         RequireIdArrayEquals(map.InToOutIds(), {0, 1, 2, 3});
-        REQUIRE(RequireCompactOutToIn(map, 3, map.InCount()) == 3);
+        REQUIRE(RequireCompactOutToIn(map, 3) == 3);
 
         const int32_t append_ids[] = {0, 2};
         map.AddFromData(knowhere::IdMapData::FromIds(append_ids, 2, 4));
         REQUIRE(map.OutCount() == 4);
         RequireIdArrayEquals(map.InToOutIds(), {0, 2});
-        REQUIRE(RequireCompactOutToIn(map, 2, map.InCount()) == 1);
+        REQUIRE(RequireCompactOutToIn(map, 2) == 1);
         REQUIRE(map.InToOutIds().is_array());
     }
 
@@ -3330,7 +3351,7 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         map.FinalizeEmbListIds(offsets, 3);
         RequireIdArrayEquals(map.InToOutIds(), {1, 4, 9});
         RequireIdArrayEquals(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {1, 1, 4, 9, 9, 9});
-        REQUIRE(RequireCompactOutToIn(map, 4, map.InCount()) == 1);
+        REQUIRE(RequireCompactOutToIn(map, 4) == 1);
 
         auto valid_before_noop = map.ValidBitmap();
         REQUIRE(valid_before_noop.size() == 10);
@@ -3341,7 +3362,7 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         map.FinalizeEmbListIds(nullptr, 0);
         RequireIdArrayEquals(map.InToOutIds(), {1, 4, 9});
         RequireIdArrayEquals(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {1, 1, 4, 9, 9, 9});
-        REQUIRE(RequireCompactOutToIn(map, 4, map.InCount()) == 1);
+        REQUIRE(RequireCompactOutToIn(map, 4) == 1);
 
         auto valid_after_noop = map.ValidBitmap();
         REQUIRE(valid_after_noop.size() == 10);
@@ -3363,14 +3384,14 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         RequireIdArrayEquals(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST), {1, 1, 4, 9, 9, 9});
         REQUIRE(map.OutCount() == 10);
         REQUIRE(map.InCount() == 3);
-        REQUIRE(RequireCompactOutToIn(map, 9, map.InCount()) == 2);
+        REQUIRE(RequireCompactOutToIn(map, 9) == 2);
 
         map.ClearEblIds();
         RequireIdArrayEquals(map.InToOutIds(), {1, 4, 9});
         REQUIRE(map.InToOutIds(knowhere::IdMap::Domain::EMB_LIST).empty());
         REQUIRE(map.OutCount() == 10);
         REQUIRE(map.InCount() == 3);
-        REQUIRE(RequireCompactOutToIn(map, 4, map.InCount()) == 1);
+        REQUIRE(RequireCompactOutToIn(map, 4) == 1);
 
         map.ClearIds();
         REQUIRE(map.InToOutIds().empty());
@@ -3378,9 +3399,9 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         REQUIRE(map.OutCount() == 10);
         REQUIRE(map.InCount() == 3);
         REQUIRE(!map.ValidBitmap().empty());
-        RequireInvalidCompactOutToIn(map, 1, map.InCount());
-        RequireInvalidCompactOutToIn(map, 4, map.InCount());
-        RequireInvalidCompactOutToIn(map, 9, map.InCount());
+        RequireInvalidCompactOutToIn(map, 1);
+        RequireInvalidCompactOutToIn(map, 4);
+        RequireInvalidCompactOutToIn(map, 9);
     }
 
     SECTION("IdMap supports mmap-backed id arrays") {
@@ -3411,8 +3432,8 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
             valid_array = map.ValidBitmap();
             RequireIdArrayEquals(ids_array, {1, 4, 6, 9});
             RequireIdArrayEquals(ebl_ids_array, {1, 4, 4, 9});
-            REQUIRE(RequireCompactOutToIn(map, 6, map.InCount()) == 2);
-            RequireInvalidCompactOutToIn(map, 5, map.InCount());
+            REQUIRE(RequireCompactOutToIn(map, 6) == 2);
+            RequireInvalidCompactOutToIn(map, 5);
             REQUIRE(valid_array.size() == 10);
 
             size_t mmap_file_count = 0;
@@ -3461,7 +3482,7 @@ TEST_CASE("Nullable IdMap primitives", "[nullable][id_map]") {
         REQUIRE(map.OutCount() == 10);
         REQUIRE(map.InCount() == 0);
         REQUIRE(map.InToOutIds().empty());
-        RequireInvalidCompactOutToIn(map, 0, map.InCount());
+        RequireInvalidCompactOutToIn(map, 0);
         REQUIRE_FALSE(map.IsValidOutId(0));
 
         size_t mmap_file_count = 0;
@@ -3877,8 +3898,8 @@ TEST_CASE("Nullable IVF_FLAT_CC emb-list Add preserves append public list ids", 
 
     int64_t missing_id = 3;
     auto missing = index.GetEmbListByIds(knowhere::GenIdsDataSet(1, &missing_id), "MAX_SIM_L2");
-    REQUIRE_FALSE(missing.has_value());
-    REQUIRE(missing.error() == knowhere::Status::invalid_args);
+    REQUIRE(missing.has_value());
+    RequireEmbListRetrieveMatches(*missing.value(), {}, {}, kDenseDim);
 }
 
 TEST_CASE("Nullable Index rejects plain and mapped Add mixing", "[nullable][id_map][add]") {
@@ -4020,8 +4041,9 @@ TEST_CASE("Nullable vector Build plus Add matches full Build", "[nullable][ivf][
     RequireDenseVectorsMatchLogicalIds(*full_vectors.value(), {1, 9}, kDenseDim);
     RequireDenseVectorsMatchLogicalIds(*split_vectors.value(), {1, 9}, kDenseDim);
 
-    auto full_dist = full_index.CalcDistByIDs(query, knowhere::BitsetView{}, selected_ids, 2, false);
-    auto split_dist = split_index.CalcDistByIDs(query, knowhere::BitsetView{}, selected_ids, 2, false);
+    int64_t selected_compact_ids[] = {CompactIdForLogicalId(full_ids, 1), CompactIdForLogicalId(full_ids, 9)};
+    auto full_dist = full_index.CalcDistByIDs(query, knowhere::BitsetView{}, selected_compact_ids, 2, false);
+    auto split_dist = split_index.CalcDistByIDs(query, knowhere::BitsetView{}, selected_compact_ids, 2, false);
     REQUIRE(full_dist.has_value());
     REQUIRE(split_dist.has_value());
     RequireDatasetsEqual(*full_dist.value(), *split_dist.value());
@@ -4083,11 +4105,10 @@ TEST_CASE("Nullable emb-list Build plus Add matches full Build with empty lists"
     RequireEmbListRetrieveMatches(*split_retrieve.value(), {1, 7, 9, 10}, {2, 0, 2, 0}, kDenseDim);
 }
 
-TEST_CASE("Nullable selected-id APIs reject missing public ids", "[nullable][id_map][api]") {
+TEST_CASE("Nullable retrieve compacts missing public ids", "[nullable][id_map][api]") {
     struct SelectedIdCase {
         std::string label;
         IndexRow row;
-        bool check_calc_dist = false;
         bool maybe_unavailable = false;
     };
 
@@ -4095,17 +4116,15 @@ TEST_CASE("Nullable selected-id APIs reject missing public ids", "[nullable][id_
     diskann.maybe_unavailable = true;
 
     std::vector<SelectedIdCase> cases = {
-        {"FLAT", {"FLAT", knowhere::IndexEnum::INDEX_FAISS_IDMAP, DataKind::DenseFp32}, false, false},
+        {"FLAT", {"FLAT", knowhere::IndexEnum::INDEX_FAISS_IDMAP, DataKind::DenseFp32}, false},
         {"IVF_FLAT_CC",
          {"IVF_FLAT_CC / IVFFLATCC", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, DataKind::DenseFp32},
-         true,
          false},
-        {"HNSW", NativeFaissHnswRow(), true, true},
-        {"DISKANN", diskann, true, true},
+        {"HNSW", NativeFaissHnswRow(), true},
+        {"DISKANN", diskann, true},
         {"SPARSE_CC",
          {"SPARSE_INVERTED_INDEX_CC (Knowhere native)", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC,
           DataKind::Sparse},
-         false,
          false},
     };
 
@@ -4131,15 +4150,8 @@ TEST_CASE("Nullable selected-id APIs reject missing public ids", "[nullable][id_
         for (auto rejected_id : rejected_ids) {
             CAPTURE(rejected_id);
             auto get_vector = artifact->index.GetVectorByIds(knowhere::GenIdsDataSet(1, &rejected_id));
-            REQUIRE_FALSE(get_vector.has_value());
-            REQUIRE(get_vector.error() == Status::invalid_args);
-
-            if (test_case.check_calc_dist) {
-                auto calc_dist = artifact->index.CalcDistByIDs(artifact->data.query_ds, knowhere::BitsetView{},
-                                                               &rejected_id, 1, false);
-                REQUIRE_FALSE(calc_dist.has_value());
-                REQUIRE(calc_dist.error() == Status::invalid_args);
-            }
+            REQUIRE(get_vector.has_value());
+            REQUIRE(get_vector.value()->GetRows() == 0);
         }
 
         auto null_get_vector =
@@ -4147,11 +4159,16 @@ TEST_CASE("Nullable selected-id APIs reject missing public ids", "[nullable][id_
         REQUIRE_FALSE(null_get_vector.has_value());
         REQUIRE(null_get_vector.error() == Status::invalid_args);
 
-        if (test_case.check_calc_dist) {
-            auto null_calc_dist = artifact->index.CalcDistByIDs(artifact->data.query_ds, knowhere::BitsetView{},
-                                                                static_cast<const int64_t*>(nullptr), 1, false);
-            REQUIRE_FALSE(null_calc_dist.has_value());
-            REQUIRE(null_calc_dist.error() == Status::invalid_args);
+        if (missing_id < artifact->data.total_count && artifact->data.query_ids.size() >= 2) {
+            std::vector<int64_t> retrieve_ids = {artifact->data.query_ids[0], missing_id, artifact->data.query_ids[1]};
+            auto get_vector = artifact->index.GetVectorByIds(
+                knowhere::GenIdsDataSet(static_cast<int64_t>(retrieve_ids.size()), retrieve_ids.data()));
+            if (!get_vector.has_value()) {
+                REQUIRE((test_case.maybe_unavailable || test_case.row.maybe_unavailable));
+                continue;
+            }
+            REQUIRE(get_vector.has_value());
+            REQUIRE(get_vector.value()->GetRows() == 2);
         }
     }
 }
@@ -4175,10 +4192,10 @@ TEST_CASE("Nullable Index Add keeps id map append when backend add fails", "[nul
 
     REQUIRE(index.GetIdMap().OutCount() == 8);
     RequireIdArrayEquals(index.GetIdMap().InToOutIds(), {1, 3, 4, 6});
-    REQUIRE(RequireCompactOutToIn(index.GetIdMap(), 1, index.GetIdMap().InCount()) == 0);
-    REQUIRE(RequireCompactOutToIn(index.GetIdMap(), 3, index.GetIdMap().InCount()) == 1);
-    REQUIRE(RequireCompactOutToIn(index.GetIdMap(), 4, index.GetIdMap().InCount()) == 2);
-    REQUIRE(RequireCompactOutToIn(index.GetIdMap(), 6, index.GetIdMap().InCount()) == 3);
+    REQUIRE(RequireCompactOutToIn(index.GetIdMap(), 1) == 0);
+    REQUIRE(RequireCompactOutToIn(index.GetIdMap(), 3) == 1);
+    REQUIRE(RequireCompactOutToIn(index.GetIdMap(), 4) == 2);
+    REQUIRE(RequireCompactOutToIn(index.GetIdMap(), 6) == 3);
 }
 
 TEST_CASE("Nullable DataView full-scan uses internal source ids", "[nullable][data_view][api]") {
@@ -4409,7 +4426,7 @@ TEST_CASE("Nullable SCANN_DVR emb-list cosine rerank maps calc-dist ids", "[null
     for (int64_t i = 0; i < rows * k; ++i) {
         if (ids[i] >= 0) {
             REQUIRE(ContainsId(data.valid_ids, ids[i]));
-            labels.push_back(ids[i]);
+            labels.push_back(CompactIdForLogicalId(data.valid_ids, ids[i]));
         }
     }
     REQUIRE_FALSE(labels.empty());
@@ -4432,7 +4449,7 @@ TEST_CASE("Nullable SCANN_DVR emb-list cosine rerank maps calc-dist ids", "[null
     }
 }
 
-TEST_CASE("Nullable SCANN_DVR CalcDistByIDs uses external source ids", "[nullable][scann_dvr][api]") {
+TEST_CASE("Nullable SCANN_DVR CalcDistByIDs uses compact ids", "[nullable][scann_dvr][api]") {
     IndexRow row{"SCANN_DVR", knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, DataKind::DenseFp32};
     Scenario scenario;
     scenario.mode = Mode::Vector;
@@ -4486,7 +4503,6 @@ TEST_CASE("Nullable FAISS HNSW vector APIs use restored logical-id map after rel
         RequireDenseVectorsMatchLogicalIds(*retrieve.value(), artifact->data.query_ids, artifact->data.dim);
 
         RequireDenseCalcDistByIds(index, artifact->data);
-        RequireDenseSelectedIdsRejectMissingOutId(index, artifact->data);
     };
 
     require_vector_apis(artifact->index, true);


### PR DESCRIPTION
## Summary
- Release vector-domain compact/public maps after Cardinal takes ownership of both lookup directions, while keeping EmbList list-domain lookup in Knowhere.
- Compact nullable public ids for retrieve-style APIs before backend storage access, skipping missing nullable ids consistently for vector and EmbList reads.
- Split distance calculation semantics: `CalcDistByIDs` accepts public/out ids and maps them through `IdMap`; backend/refine/rerank paths use `CalcDistByStorageIds` with storage ids.
- Expand nullable id-map coverage for malformed ids, mapped/plain mode contracts, EmbList append/list-id edge cases, handoff state, and public-vs-storage distance APIs.

issue: #1687

## Test plan
- [x] `PATH=/tmp/knowhere-ci12-bin:$PATH make pre-commit`
- [x] `cmake --build build/Release --target knowhere_tests -j8`
- [x] `make WITH_UT=True WITH_ASAN=True`
- [x] `make test`
- [x] `. build/Release/generators/conanrun.sh && ./build/Release/tests/ut/knowhere_tests "Test GetEmbListByIds error cases" -r compact`
- [x] `. build/Release/generators/conanrun.sh && ./build/Release/tests/ut/knowhere_tests "[nullable][id_map][api]" -r compact`
- [x] `. build/Release/generators/conanrun.sh && ./build/Release/tests/ut/knowhere_tests "[nullable][emblist][api]" -r compact`
- [x] `. build/Release/generators/conanrun.sh && ./build/Release/tests/ut/knowhere_tests "[nullable][ivf][emblist][add]" -r compact`
- [x] `. build/Release/generators/conanrun.sh && ./build/Release/tests/ut/knowhere_tests "[nullable][scann_dvr]" -r compact`
- [x] `. build/Release/generators/conanrun.sh && ./build/Release/tests/ut/knowhere_tests "[nullable][hnsw][api]" -r compact`
