### PR TITLE
fix: use current maximum index version and cover native sparse nullable

### DIFF
--- a/tests/ut/test_nullable_id_map.cc
+++ b/tests/ut/test_nullable_id_map.cc
@@ -558,7 +558,7 @@ VersionForRow(const IndexRow& row) {
         return knowhere::Version::GetDefaultVersion().VersionNumber();
     }
     if (row.requires_current_version) {
-        return std::max(knowhere::Version::GetCurrentVersion().VersionNumber(), 9);
+        return knowhere::Version::GetMaximumVersion().VersionNumber();
     }
 #endif
     return knowhere::Version::GetCurrentVersion().VersionNumber();
@@ -1455,10 +1455,6 @@ SupportsScenario(const IndexRow& row, const Scenario& scenario) {
         return false;
     }
 #ifdef KNOWHERE_WITH_CARDINAL
-    if (row.data_kind == DataKind::Sparse && !row.requires_current_version &&
-        scenario.nullable_ratio != NullableRatio::R0) {
-        return false;
-    }
     const bool current_version_reads_index =
         scenario.op == Operation::Search || scenario.op == Operation::Range || scenario.op == Operation::Iterator ||
         scenario.op == Operation::SearchFilter || scenario.op == Operation::RangeFilter ||


### PR DESCRIPTION
Issue: #1687

## What changed

Fixes two coverage/version-control gaps in `test_nullable_id_map.cc`:

1. `requires_current_version` rows now create indexes at
   `knowhere::Version::GetMaximumVersion()` instead of a hard-coded
   cardinal routing version. Indexes built for current-version scenarios
   must be created at a version that supports nullable external id maps,
   so the tests no longer bake in a cardinal-internal v1/v2 boundary.

2. Removed the `KNOWHERE_WITH_CARDINAL`-only exclusion that skipped
   nullable scenarios for native sparse indexes
   (`SPARSE_INVERTED_INDEX` / `SPARSE_WAND` / `_CC`). Native sparse
   indexes already own nullable external id maps, so the matrix now
   covers their nullable paths as well.

## Verification

- `make WITH_CARDINAL=True WITH_UT=True`
- Full `knowhere_tests`: 197 test cases, 192 passed, 5 skipped, 0 failed.
- Previously failing `Nullable raw-data vector APIs map compact serialized ids after reload`
  now passes (571 assertions).
- Native sparse nullable scenarios (`nullable50`) now execute and pass in the matrix test.

Signed-off-by: marcelo-cjl <marcelo.chen@zilliz.com>