### PR TITLE
enhance: bump cardinal references to v3.0.5 and v2.5.110

### DIFF
--- a/cmake/libs/cardinal/v1/CMakeLists.txt
+++ b/cmake/libs/cardinal/v1/CMakeLists.txt
@@ -3,7 +3,7 @@ project(knowhere CXX C)
 
 # Use short SHA1 as version
 # currently check out a commit for cardinal v1. TODO: need a tag here
-set(CARDINAL_VERSION v2.5.109)
+set(CARDINAL_VERSION v2.5.110)
 set(CARDINAL_REPO_URL "https://github.com/zilliztech/cardinal.git")
 
 set(CARDINAL_ROOT  "${KNOWHERE_THRID_ROOT}/cardinalv1")

--- a/cmake/libs/cardinal/v2/CMakeLists.txt
+++ b/cmake/libs/cardinal/v2/CMakeLists.txt
@@ -3,7 +3,7 @@ project(knowhere CXX C)
 
 # Use short SHA1 as version
 # currenly checkout a commit for cardinal v2. TODO: need a tag here
-set(CARDINAL_VERSION v3.0.4)
+set(CARDINAL_VERSION v3.0.5)
 set(CARDINAL_REPO_URL "https://github.com/zilliztech/cardinal.git")
 
 set(CARDINAL_ROOT  "${KNOWHERE_THRID_ROOT}/cardinalv2")


### PR DESCRIPTION
Bump both cardinal references to the newly created tags.

- v2 (`cmake/libs/cardinal/v2/CMakeLists.txt`): `v3.0.4` -> `v3.0.5`, tagged on cardinal `master` at `cf22bdfd` ("fix compactibility issue (#909)").
- v1 (`cmake/libs/cardinal/v1/CMakeLists.txt`): `v2.5.109` -> `v2.5.110`, tagged on cardinal `v1` at `8cb8deeb` ("feat: support nullable sparse id mapping (#860)").

Both tags are new (they do not override existing ones) and are already pushed to zilliztech/cardinal.