### PR TITLE
fix: update SVS SQ8 storage enum after Faiss 1.15.0+ upgrade

### DIFF
--- a/src/index/svs/svs_utils.h
+++ b/src/index/svs/svs_utils.h
@@ -31,7 +31,7 @@ str_to_svs_storage_kind(const std::string& s) {
     if (s == "fp16")
         return faiss::SVS_FP16;
     if (s == "sqi8")
-        return faiss::SVS_SQI8;
+        return faiss::SVS_SQ8;
     if (s == "lvq4x0")
         return faiss::SVS_LVQ4x0;
     if (s == "lvq4x4")


### PR DESCRIPTION
Fixes #1785

## What changed

- Update the Knowhere SVS storage-kind helper to use `faiss::SVS_SQ8`.
- Preserve the existing `sqi8` Knowhere configuration value and SQI8 runtime behavior.

## Root cause

Knowhere vendors the Faiss source, including Faiss's SVS integration layer, under `thirdparty/faiss`. The Intel SVS runtime itself remains a separate dependency fetched and linked by the SVS-enabled CMake build.

The relevant dependency boundary is:

```text
Knowhere svs_utils.h
  -> vendored Faiss SVS API
       -> external Intel SVS runtime
```

The Faiss 1.15.0+ upgrade renamed its public storage enum from `SVS_SQI8` to `SVS_SQ8`. Faiss also updated its internal translation so that `SVS_SQ8` continues to map to `svs_runtime::StorageKind::SQI8`. However, Knowhere's own `src/index/svs/svs_utils.h`, which is outside the vendored Faiss tree, retained the old `faiss::SVS_SQI8` reference.

Consequently, the incompatibility is between the stale Knowhere call site and the updated Faiss API; it is not an incompatibility between Faiss and the Intel SVS runtime. Builds with `WITH_SVS=ON` fail because the old Faiss enum no longer exists.

The external configuration remains unchanged:

```text
Knowhere config "sqi8"
  -> faiss::SVS_SQ8
       -> svs_runtime::StorageKind::SQI8
```

## Verification

- `git diff --check`
- Compiled a C++20 syntax probe for `str_to_svs_storage_kind("sqi8")` against the vendored Faiss headers and SVS runtime 0.4.0 headers with `KNOWHERE_WITH_SVS` enabled.