### PR TITLE
fix: keep IndexNode ABI stable across Cardinal builds

### DIFF
--- a/cmake/libs/cardinal/v1/CMakeLists.txt
+++ b/cmake/libs/cardinal/v1/CMakeLists.txt
@@ -3,7 +3,7 @@ project(knowhere CXX C)
 
 # Use short SHA1 as version
 # currently check out a commit for cardinal v1. TODO: need a tag here
-set(CARDINAL_VERSION v2.5.110)
+set(CARDINAL_VERSION v2.5.111)
 set(CARDINAL_REPO_URL "https://github.com/zilliztech/cardinal.git")
 
 set(CARDINAL_ROOT  "${KNOWHERE_THRID_ROOT}/cardinalv1")

--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -103,15 +103,16 @@ class IndexNode : public Object {
         return Add(dataset, std::move(cfg), use_knowhere_build_pool);
     }
 
-/*
- *@ @brief Builds the index using the provided dataset,configuration and handle.
- */
-#ifdef KNOWHERE_WITH_CARDINAL
+    /**
+     * @brief Builds the index asynchronously using the provided dataset, configuration, and interrupt handle.
+     *
+     * @note Keep this virtual function unconditionally declared. Feature macros must not change the public
+     * `IndexNode` vtable layout across library boundaries.
+     */
     virtual Status
     BuildAsync(const DataSetPtr dataset, std::shared_ptr<Config> cfg, const Interrupt* = nullptr) {
         return Build(dataset, std::move(cfg), true);
     }
-#endif
 
     /**
      * @brief Trains the index model using the provided dataset and configuration.

--- a/tests/ut/test_index_node.cc
+++ b/tests/ut/test_index_node.cc
@@ -147,6 +147,8 @@ TEST_CASE("Test index node") {
         KNOWHERE_SIMPLE_REGISTER_GLOBAL(BASE_FLAT, BaseFlatIndexNode, fp32, knowhere::feature::FLOAT32);
         auto index = IndexFactory::Instance().Create<fp32>("BASE_FLAT", version).value();
         REQUIRE(index.Build(ds, {}) == Status::success);
+        std::shared_ptr<Config> async_cfg = index.Node()->CreateConfig();
+        REQUIRE(index.Node()->BuildAsync(ds, std::move(async_cfg)) == Status::success);
         REQUIRE(index.Train(ds, {}) == Status::success);
         REQUIRE(index.Add(ds, {}) == Status::success);
         REQUIRE(index.Search(ds, {}, nullptr).error() == Status::not_implemented);


### PR DESCRIPTION
issue: #1687

## What

- Declare `IndexNode::BuildAsync()` unconditionally so `KNOWHERE_WITH_CARDINAL` no longer changes the public `IndexNode` vtable layout.
- Add a non-Cardinal regression call that exercises the default `IndexNode::BuildAsync()` implementation.
- Bump Cardinal v1 from `v2.5.110` to `v2.5.111`; the new tag points to Cardinal merge commit `84968da` from zilliztech/cardinal#916.

## Why

`KNOWHERE_WITH_CARDINAL` is currently defined inside the embedded Knowhere CMake directory. Knowhere/Cardinal translation units see the macro, while an external consumer can include the same public header without it.

Because `BuildAsync()` was conditionally present near the start of `IndexNode`, every later virtual slot had two possible layouts. A consumer-side inline `GetIdMap()` call could therefore dispatch the Cardinal object's `Count()` slot instead, interpreting the integer return value as an `IdMap&` and crashing on a null dereference. This was observed in milvus-io/milvus#52724.

Public feature macros must not alter a cross-library base-class vtable. Keeping the virtual method present in both builds preserves one layout; non-Cardinal nodes use the existing default implementation, which delegates to `Build()`.

## Commits

1. `fix: keep IndexNode BuildAsync in public vtable`
2. `fix: bump Cardinal v1 to v2.5.111`

## Validation

- [x] Non-Cardinal CPU + UT build passed.
- [x] Focused non-Cardinal `Test index node` passed (49 assertions / 1 case), including the default `BuildAsync()` call.
- [x] Cardinal CPU library build passed.
- [x] Cardinal refs verified: v1 `v2.5.111@84968da`, v2 `v3.0.5@cf22bdf`.
- [x] Cross-macro smoke passed: consumer compiled without `KNOWHERE_WITH_CARDINAL` against the Cardinal-enabled fixed `libknowhere` and called `GetIdMap()` successfully.
- [x] Milvus `3e402910f` A/B test with `index_engine=cardinal`:
  - original Knowhere `d85f7080`: ordinary `Indexing.HnswEmbListEmptyNullableUsesLogicalIds` crashed in `CardinalIndexNode::Count()` with SIGSEGV / exit 139;
  - same workspace and build tree with this fix cherry-picked: the exact same test passed 1/1 / exit 0.

The Milvus fixed build deliberately retained the real compile-definition split (`libknowhere` macro ON, Milvus `VectorDiskIndex.cpp` macro OFF). Passing under that split confirms the fix stabilizes the public vtable rather than masking the issue by changing consumer flags.
