### PR TITLE
update: bump cardinal to v3.0.6

### DIFF
--- a/cmake/libs/cardinal/v2/CMakeLists.txt
+++ b/cmake/libs/cardinal/v2/CMakeLists.txt
@@ -3,7 +3,7 @@ project(knowhere CXX C)
 
 # Use short SHA1 as version
 # currenly checkout a commit for cardinal v2. TODO: need a tag here
-set(CARDINAL_VERSION v3.0.5)
+set(CARDINAL_VERSION v3.0.6)
 set(CARDINAL_REPO_URL "https://github.com/zilliztech/cardinal.git")
 
 set(CARDINAL_ROOT  "${KNOWHERE_THRID_ROOT}/cardinalv2")


### PR DESCRIPTION
Bump the Cardinal v2 reference in cmake/libs/cardinal/v2/CMakeLists.txt from v3.0.5 to v3.0.6.

- Cardinal tag: v3.0.6
- Cardinal commit: 107dc95327e62801d77bc6a1f4b6d4a76940106e
- Source change: https://github.com/zilliztech/cardinal/pull/917

The new tag is one commit ahead of v3.0.5 and contains only the merged fix from Cardinal PR 917.

Validation:
- Verified that Cardinal v3.0.6 resolves to 107dc95327e62801d77bc6a1f4b6d4a76940106e.
- Local build and tests were not run, per request; Cardinal PR 917 passed its upstream checks.