### PR TITLE
fix: preserve SVS all-pass selector semantics

### DIFF
--- a/src/index/svs/svs_vamana.cc
+++ b/src/index/svs/svs_vamana.cc
@@ -158,7 +158,7 @@ class SvsVamanaIndexNode : public IndexNode {
                     sp.search_window_size = v_cfg.svs_search_window_size.value();
                     sp.search_buffer_capacity = v_cfg.svs_search_buffer_capacity.value();
                     std::unique_ptr<BitsetViewIDSelector> bw_idselector;
-                    if (!bitset.empty()) {
+                    if (!bitset.empty() || bitset.num_bits() != 0) {
                         bw_idselector = std::make_unique<BitsetViewIDSelector>(bitset);
                         sp.sel = bw_idselector.get();
                     }
@@ -216,7 +216,7 @@ class SvsVamanaIndexNode : public IndexNode {
                     sp.search_window_size = v_cfg.svs_search_window_size.value();
                     sp.search_buffer_capacity = v_cfg.svs_search_buffer_capacity.value();
                     std::unique_ptr<BitsetViewIDSelector> bw_idselector;
-                    if (!bitset.empty()) {
+                    if (!bitset.empty() || bitset.num_bits() != 0) {
                         bw_idselector = std::make_unique<BitsetViewIDSelector>(bitset);
                         sp.sel = bw_idselector.get();
                     }

--- a/tests/ut/test_svs.cc
+++ b/tests/ut/test_svs.cc
@@ -221,6 +221,43 @@ TEST_CASE("Test SVS Vamana Build and Search", "[svs][vamana]") {
         }
     }
 
+    SECTION("All-pass bitsets use consistent search semantics") {
+        auto idx =
+            knowhere::IndexFactory::Instance().Create<knowhere::fp32>(knowhere::IndexEnum::INDEX_SVS_VAMANA, version);
+        REQUIRE(idx.has_value());
+        auto index = idx.value();
+
+        auto cfg_json = gen().dump();
+        knowhere::Json json = knowhere::Json::parse(cfg_json);
+        REQUIRE(index.Build(train_ds, json) == knowhere::Status::success);
+
+        std::vector<uint8_t> filter_bits((nb + 7) / 8, 0);
+        knowhere::BitsetView unknown_count(filter_bits.data(), nb);
+        knowhere::BitsetView known_zero_count(filter_bits.data(), nb, 0);
+
+        auto unknown_knn = index.Search(query_ds, json, unknown_count);
+        auto known_zero_knn = index.Search(query_ds, json, known_zero_count);
+        REQUIRE(unknown_knn.has_value());
+        REQUIRE(known_zero_knn.has_value());
+        for (int64_t i = 0; i < nq * topk; ++i) {
+            REQUIRE(unknown_knn.value()->GetIds()[i] == known_zero_knn.value()->GetIds()[i]);
+            REQUIRE(unknown_knn.value()->GetDistance()[i] == known_zero_knn.value()->GetDistance()[i]);
+        }
+
+        json[knowhere::meta::RADIUS] = metric == knowhere::metric::L2 ? 10.0f : 0.99f;
+        auto unknown_range = index.RangeSearch(query_ds, json, unknown_count);
+        auto known_zero_range = index.RangeSearch(query_ds, json, known_zero_count);
+        REQUIRE(unknown_range.has_value());
+        REQUIRE(known_zero_range.has_value());
+        for (int64_t i = 0; i <= nq; ++i) {
+            REQUIRE(unknown_range.value()->GetLims()[i] == known_zero_range.value()->GetLims()[i]);
+        }
+        for (size_t i = 0; i < unknown_range.value()->GetLims()[nq]; ++i) {
+            REQUIRE(unknown_range.value()->GetIds()[i] == known_zero_range.value()->GetIds()[i]);
+            REQUIRE(unknown_range.value()->GetDistance()[i] == known_zero_range.value()->GetDistance()[i]);
+        }
+    }
+
     SECTION("Serialize and Deserialize") {
         knowhere::BinarySet bs;
 


### PR DESCRIPTION
## What

- Keep an explicit all-pass bitmap on the SVS Vamana selector path even when its known filtered count is zero.
- Apply the same dispatch rule to kNN and range search.
- Add regression coverage proving that known-zero and unknown-count all-pass bitsets produce identical results.

## Why

PR #1673 changed `BitsetView::empty()` so a full-sized bitmap with a known filtered count of zero is considered empty. vecTool passes unfiltered searches as exactly that representation, so SVS Vamana stopped constructing its all-pass selector and switched to the native unfiltered search path.

The two SVS paths use different search heuristics and produced different recall at the same search window. This change preserves the global `BitsetView::empty()` semantics introduced by #1673 while retaining the historical SVS behavior whenever a caller explicitly supplies a bitmap.

This is related to the all-clear SVS handling previously addressed for SVS Flat in #1603.

## Reproduction

Using one unchanged vecTool-built SVS Vamana index:

- `BitsetView(bits, N, 0)`: recall at windows 32/64/128 was `0.744950 / 0.854140 / 0.927569`.
- `BitsetView(bits, N)`: recall was `0.905918 / 0.905918 / 0.927569`.

Alternating the two views against the same serialized index reproduced the result deterministically without changing the index artifact.

## Verification

- `git diff --check`
- Focused x86 Knowhere unit-test build is in progress; CI exercises the same SVS-enabled test target.