### PR TITLE
update: bump cardinal to v3.0.7 (v2 ref) / v2.5.112 (v1 ref)

### DIFF
--- a/cmake/libs/cardinal/v1/CMakeLists.txt
+++ b/cmake/libs/cardinal/v1/CMakeLists.txt
@@ -3,7 +3,7 @@ project(knowhere CXX C)
 
 # Use short SHA1 as version
 # currently check out a commit for cardinal v1. TODO: need a tag here
-set(CARDINAL_VERSION v2.5.111)
+set(CARDINAL_VERSION v2.5.112)
 set(CARDINAL_REPO_URL "https://github.com/zilliztech/cardinal.git")
 
 set(CARDINAL_ROOT  "${KNOWHERE_THRID_ROOT}/cardinalv1")

--- a/cmake/libs/cardinal/v2/CMakeLists.txt
+++ b/cmake/libs/cardinal/v2/CMakeLists.txt
@@ -3,7 +3,7 @@ project(knowhere CXX C)
 
 # Use short SHA1 as version
 # currenly checkout a commit for cardinal v2. TODO: need a tag here
-set(CARDINAL_VERSION v3.0.6)
+set(CARDINAL_VERSION v3.0.7)
 set(CARDINAL_REPO_URL "https://github.com/zilliztech/cardinal.git")
 
 set(CARDINAL_ROOT  "${KNOWHERE_THRID_ROOT}/cardinalv2")


### PR DESCRIPTION
Bump pinned cardinal tags to the freshly cut releases.

- **v2 line (cardinal master)**: `v3.0.6` → `v3.0.7` 
- **v1 line**: `v2.5.111` → `v2.5.112`

Tags v3.0.7 / v2.5.112 pushed to zilliztech/cardinal.

Files: `cmake/libs/cardinal/v2/CMakeLists.txt`, `cmake/libs/cardinal/v1/CMakeLists.txt`.