### PR TITLE
fix: preserve trailing empty embedding lists

### DIFF
--- a/include/knowhere/comp/index_param.h
+++ b/include/knowhere/comp/index_param.h
@@ -125,6 +125,7 @@ constexpr const char* DIM_MAX_SCORE_RATIO = "dim_max_score_ratio";
 // emb list meta
 constexpr const char* EMB_LIST_META = "EMB_LIST_META";
 constexpr const char* EMB_LIST_OFFSET = "EMB_LIST_OFFSET";
+constexpr const char* EMB_LIST_COUNT = "EMB_LIST_COUNT";
 constexpr const char* EMB_LIST_RAW_INDEX = "EMB_LIST_RAW_INDEX";
 
 // emb list strategy types

--- a/include/knowhere/emb_list_utils.h
+++ b/include/knowhere/emb_list_utils.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "knowhere/bitsetview.h"
+#include "knowhere/expected.h"
 #include "knowhere/log.h"
 #include "knowhere/object.h"
 #include "knowhere/utils.h"
@@ -27,27 +28,24 @@ namespace knowhere {
 
 class EmbListOffset {
  public:
-    EmbListOffset(const size_t* lims, size_t rows) {
-        size_t idx = 0;
-        assert(lims[idx] == 0);
-        assert(rows > 0);
-        while (lims[idx] < rows) {
-            assert(idx == 0 || lims[idx] >= lims[idx - 1]);
-            offset.push_back(lims[idx]);
-            idx++;
-        }
-        assert(lims[idx] == rows);
-        offset.push_back(lims[idx]);
-    }
-
     EmbListOffset(const size_t* lims, size_t rows, size_t num_el) {
-        assert(lims != nullptr);
-        assert(num_el > 0);
-        assert(lims[0] == 0);
+        if (lims == nullptr) {
+            throw StatusException(Status::invalid_args, "emb_list offsets must not be null");
+        }
+        if (num_el == 0) {
+            throw StatusException(Status::invalid_args, "emb_list count must be greater than zero");
+        }
+        if (lims[0] != 0) {
+            throw StatusException(Status::invalid_args, "emb_list offsets must start at zero");
+        }
         offset.assign(lims, lims + num_el + 1);
-        assert(offset.back() == rows);
+        if (offset.back() != rows) {
+            throw StatusException(Status::invalid_args, "emb_list offsets must end at the flattened vector count");
+        }
         for (size_t i = 1; i < offset.size(); ++i) {
-            assert(offset[i] >= offset[i - 1]);
+            if (offset[i] < offset[i - 1]) {
+                throw StatusException(Status::invalid_args, "emb_list offsets must be nondecreasing");
+            }
         }
     }
 
@@ -105,6 +103,18 @@ class EmbListOffset {
 
     std::vector<size_t> offset;
 };
+
+inline size_t
+GetEmbListCount(const DataSetPtr& dataset) {
+    if (dataset == nullptr) {
+        throw StatusException(Status::invalid_args, "emb_list dataset must not be null");
+    }
+    const auto num_el = dataset->Get<int64_t>(meta::EMB_LIST_COUNT);
+    if (num_el <= 0) {
+        throw StatusException(Status::invalid_args, "emb_list dataset must provide a positive EMB_LIST_COUNT");
+    }
+    return static_cast<size_t>(num_el);
+}
 
 inline std::vector<size_t>
 convert_lims_to_vector(const size_t* lims, size_t rows) {

--- a/include/knowhere/index/index_node.h
+++ b/include/knowhere/index/index_node.h
@@ -452,9 +452,13 @@ class IndexNode : public Object {
                            milvus::OpContext* op_context = nullptr) const;
 
     Status
-    AppendEmbListOffsetAndIdMap(const size_t* lims, size_t append_row_count, size_t append_el_count_hint = 0) {
+    AppendEmbListOffsetAndIdMap(const size_t* lims, size_t append_row_count, size_t append_el_count) {
         // lims is absolute in the whole index; AppendEmbListIds consumes the
         // appended local offset window.
+        if (lims == nullptr || append_el_count == 0) {
+            LOG_KNOWHERE_WARNING_ << "emb list offsets and a positive list count are required";
+            return Status::invalid_args;
+        }
         const auto old_el_count = emb_list_offset_->num_el();
         const auto old_vector_count = emb_list_offset_->offset.back();
         const auto new_vector_count = old_vector_count + append_row_count;
@@ -463,22 +467,10 @@ class IndexNode : public Object {
             return Status::emb_list_inner_error;
         }
 
-        size_t append_el_count = 1;
-        if (append_el_count_hint != 0) {
-            append_el_count = append_el_count_hint;
-            for (size_t i = 1; i <= append_el_count; ++i) {
-                if (lims[i] < lims[i - 1]) {
-                    LOG_KNOWHERE_WARNING_ << "emb list offset is not increasing";
-                    return Status::emb_list_inner_error;
-                }
-            }
-        } else {
-            while (lims[append_el_count] < new_vector_count) {
-                if (lims[append_el_count] < lims[append_el_count - 1]) {
-                    LOG_KNOWHERE_WARNING_ << "emb list offset is not increasing";
-                    return Status::emb_list_inner_error;
-                }
-                ++append_el_count;
+        for (size_t i = 1; i <= append_el_count; ++i) {
+            if (lims[i] < lims[i - 1]) {
+                LOG_KNOWHERE_WARNING_ << "emb list offset is not increasing";
+                return Status::emb_list_inner_error;
             }
         }
         if (lims[append_el_count] != new_vector_count) {
@@ -850,8 +842,7 @@ class IndexNode : public Object {
             return Status::emb_list_inner_error;
         }
 
-        return BuildEmbList(dataset, std::move(cfg), lims, dataset->GetRows(),
-                            EmbListCount(dataset, lims, static_cast<size_t>(dataset->GetRows())),
+        return BuildEmbList(dataset, std::move(cfg), lims, dataset->GetRows(), GetEmbListCount(dataset),
                             use_knowhere_build_pool);
     }
 
@@ -1052,21 +1043,6 @@ class IndexNode : public Object {
     expected<DataSetPtr>
     CalcDistByRawIndex(const DataSetPtr dataset, const int64_t* labels, size_t labels_len, bool is_cosine,
                        std::shared_ptr<ThreadPool> pool, milvus::OpContext* op_context = nullptr) const;
-
-    static size_t
-    EmbListCount(const DataSetPtr& dataset, const size_t* lims, size_t num_rows) {
-        if (dataset != nullptr) {
-            const auto nq = dataset->Get<int64_t>(meta::NQ);
-            if (nq > 0) {
-                return static_cast<size_t>(nq);
-            }
-        }
-        size_t count = 0;
-        while (lims[count] < num_rows) {
-            ++count;
-        }
-        return count;
-    }
 
     Version version_;
     std::shared_ptr<EmbListOffset> emb_list_offset_;  // emb_list group offset structure (shared with strategy)

--- a/include/knowhere/utils.h
+++ b/include/knowhere/utils.h
@@ -207,9 +207,11 @@ data_type_conversion(const DataSet& src, const std::optional<int64_t> start = st
         } else {
             auto offset_start = lims[0];
             auto offset_end = offset_start + rows;
-            while (lims[lims_size] < offset_end) {
-                lims_size++;
+            auto num_el = src.Get<int64_t>(knowhere::meta::EMB_LIST_COUNT);
+            if (num_el <= 0) {
+                throw std::runtime_error("emb_list dataset must provide a positive EMB_LIST_COUNT.");
             }
+            lims_size = static_cast<size_t>(num_el);
             if (lims[lims_size] != (size_t)offset_end) {
                 throw std::runtime_error("emb_list offsets mismatch with rows.");
             }
@@ -220,6 +222,7 @@ data_type_conversion(const DataSet& src, const std::optional<int64_t> start = st
         }
         const size_t* lims_data_const = lims_data.release();
         des->Set(knowhere::meta::EMB_LIST_OFFSET, lims_data_const);
+        des->Set(knowhere::meta::EMB_LIST_COUNT, static_cast<int64_t>(lims_size));
         des->Set(knowhere::meta::NQ, static_cast<int64_t>(lims_size));
     }
 

--- a/python/knowhere/knowhere.i
+++ b/python/knowhere/knowhere.i
@@ -21,6 +21,7 @@ typedef uint64_t size_t;
 %{
 #include <stdint.h>
 #include <memory>
+#include <stdexcept>
 #ifdef SWIGPYTHON
 #undef popcount64
 #define SWIG_FILE_WITH_INIT
@@ -330,11 +331,15 @@ GetNullBitSetView() {
 };
 
 void setOffsets(knowhere::DataSetPtr ds, int* offsets, int offset_size) {
+    if (offset_size <= 0) {
+        throw std::invalid_argument("embedding-list offsets must contain at least the initial offset");
+    }
     size_t* offsets_ = new size_t[offset_size];
     for (int i = 0; i < offset_size; ++i) {
         offsets_[i] = (size_t)(offsets[i]);
     }
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, const_cast<const size_t*>(offsets_));
+    ds->Set(knowhere::meta::EMB_LIST_COUNT, static_cast<int64_t>(offset_size - 1));
 }
 
 knowhere::DataSetPtr

--- a/src/common/comp/brute_force.cc
+++ b/src/common/comp/brute_force.cc
@@ -276,8 +276,7 @@ BruteForceSearchImpl(const DataSetPtr base_dataset, const DataSetPtr query_datas
         }
     }
     // if emb_list, nq = num of emb_list; if not, nq = num of query vectors
-    auto nq = metric_is_emb_list ? EmbListOffset(query_emb_list_offset, query_dataset->GetRows()).num_el()
-                                 : query_dataset->GetRows();
+    auto nq = metric_is_emb_list ? GetEmbListCount(query_dataset) : static_cast<size_t>(query_dataset->GetRows());
     int topk = cfg.k.value();
     auto labels = std::make_unique<int64_t[]>(nq * topk);
     auto distances = std::make_unique<float[]>(nq * topk);
@@ -639,8 +638,10 @@ BruteForceSearchWithBufImpl(const DataSetPtr base_dataset, const DataSetPtr quer
         }
         auto el_sub_metric_type = el_sub_metric_type_or.value();
 
-        auto base_el_offset = EmbListOffset(base_dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET), nb);
-        auto query_el_offset = EmbListOffset(query_dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET), nq);
+        auto base_el_offset = EmbListOffset(base_dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET), nb,
+                                            GetEmbListCount(base_dataset));
+        auto query_el_offset = EmbListOffset(query_dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET), nq,
+                                             GetEmbListCount(query_dataset));
         PrepareBitsetForInternalRange(bitset, base_el_offset.num_el(), static_cast<size_t>(xb_id_offset));
         auto num_query_el = query_el_offset.num_el();
 
@@ -902,7 +903,8 @@ BruteForceSearchOnChunkWithBufImpl(const DataSetPtr base_dataset, const DataSetP
             larger_is_closer = false;
         }
 
-        auto query_el_offset = EmbListOffset(query_dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET), nq);
+        auto query_el_offset = EmbListOffset(query_dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET), nq,
+                                             GetEmbListCount(query_dataset));
         auto num_query_el = query_el_offset.num_el();
 
         auto pool = ThreadPool::GetGlobalSearchThreadPool();

--- a/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
+++ b/src/index/data_view_dense_index/index_node_with_data_view_refiner.h
@@ -464,7 +464,7 @@ IndexNodeWithDataViewRefiner<DataType, BaseIndexNode>::AddEmbList(const DataSetP
 
     {
         FairWriteLockGuard guard(*this->base_index_lock_);
-        RETURN_IF_ERROR(this->AppendEmbListOffsetAndIdMap(lims, num_rows, this->EmbListCount(dataset, lims, num_rows)));
+        RETURN_IF_ERROR(this->AppendEmbListOffsetAndIdMap(lims, num_rows, GetEmbListCount(dataset)));
     }
 
     if (num_rows == 0) {

--- a/src/index/index_node.cc
+++ b/src/index/index_node.cc
@@ -261,7 +261,7 @@ IndexNode::SearchEmbList(const DataSetPtr dataset, std::unique_ptr<Config> cfg, 
         return expected<DataSetPtr>::Err(Status::emb_list_inner_error, "missing emb_list offset, could not search");
     }
     auto num_q_vecs = static_cast<size_t>(dataset->GetRows());
-    EmbListOffset query_offset(lims, num_q_vecs);
+    EmbListOffset query_offset(lims, num_q_vecs, GetEmbListCount(dataset));
 
     auto result = emb_list_strategy_->Search(dataset, query_offset, this, std::move(cfg), bitset, op_context);
     if (result.has_value()) {
@@ -399,6 +399,7 @@ IndexNode::GetEmbListByStorageIds(const DataSetPtr dataset, const std::string& m
         auto* offsets_ptr = new size_t[out_offsets.size()];
         std::memcpy(offsets_ptr, out_offsets.data(), out_offsets.size() * sizeof(size_t));
         result->Set(meta::EMB_LIST_OFFSET, static_cast<const size_t*>(offsets_ptr));
+        result->Set(meta::EMB_LIST_COUNT, num_el_ids);
         return result;
     }
 
@@ -444,6 +445,7 @@ IndexNode::GetEmbListByStorageIds(const DataSetPtr dataset, const std::string& m
     auto* offsets_ptr = new size_t[out_offsets.size()];
     std::memcpy(offsets_ptr, out_offsets.data(), out_offsets.size() * sizeof(size_t));
     result->Set(meta::EMB_LIST_OFFSET, static_cast<const size_t*>(offsets_ptr));
+    result->Set(meta::EMB_LIST_COUNT, num_el_ids);
     return result;
 }
 

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -875,7 +875,7 @@ IvfIndexNode<DataType, IndexType>::AddEmbList(const DataSetPtr dataset, std::sha
 
     {
         FairWriteLockGuard guard(*this->base_index_lock_);
-        RETURN_IF_ERROR(this->AppendEmbListOffsetAndIdMap(lims, num_rows, this->EmbListCount(dataset, lims, num_rows)));
+        RETURN_IF_ERROR(this->AppendEmbListOffsetAndIdMap(lims, num_rows, GetEmbListCount(dataset)));
     }
 
     if (num_rows == 0) {

--- a/tests/ut/test_bruteforce.cc
+++ b/tests/ut/test_bruteforce.cc
@@ -292,6 +292,35 @@ TEST_CASE("Test Brute Force", "[binary vector]") {
     }
 }
 
+TEST_CASE("Brute Force preserves trailing empty embedding lists", "[emb_list][trailing_empty]") {
+    constexpr int64_t dim = 2;
+    constexpr int64_t topk = 1;
+
+    std::array<float, 2> base_tensor = {1.0f, 0.0f};
+    std::array<size_t, 4> base_lims = {0, 1, 1, 1};
+    auto base = knowhere::GenDataSet(1, dim, base_tensor.data());
+    base->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(base_lims.data()));
+    base->Set(knowhere::meta::EMB_LIST_COUNT, int64_t{3});
+
+    std::array<float, 2> query_tensor = {1.0f, 0.0f};
+    std::array<size_t, 2> query_lims = {0, 1};
+    auto query = knowhere::GenDataSet(1, dim, query_tensor.data());
+    query->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(query_lims.data()));
+    query->Set(knowhere::meta::EMB_LIST_COUNT, int64_t{1});
+    query->Set(knowhere::meta::NQ, int64_t{1});
+
+    knowhere::Json conf;
+    conf[knowhere::meta::DIM] = dim;
+    conf[knowhere::meta::TOPK] = topk;
+    conf[knowhere::meta::METRIC_TYPE] = knowhere::metric::MAX_SIM_L2;
+
+    auto result = knowhere::BruteForce::Search<knowhere::fp32>(base, query, conf, nullptr);
+
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetRows() == 1);
+    REQUIRE(knowhere::EmbListOffset(base_lims.data(), 1, knowhere::GetEmbListCount(base)).num_el() == 3);
+}
+
 TEST_CASE("Test Brute Force with input ids", "[float vector]") {
     using Catch::Approx;
     const int64_t nb = 1000;

--- a/tests/ut/test_get_emb_list.cc
+++ b/tests/ut/test_get_emb_list.cc
@@ -227,6 +227,7 @@ TEST_CASE("Test GetEmbListByIds with variable-length embedding lists", "[GetEmbL
 
         auto result_ds = result.value();
         auto result_offsets = result_ds->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+        REQUIRE(result_ds->Get<int64_t>(knowhere::meta::EMB_LIST_COUNT) == ids_ds->GetRows());
         size_t el_len = result_offsets[1] - result_offsets[0];
         REQUIRE(el_len == (original_offsets[el_id + 1] - original_offsets[el_id]));
 
@@ -249,6 +250,7 @@ TEST_CASE("Test GetEmbListByIds with variable-length embedding lists", "[GetEmbL
 
         auto result_ds = result.value();
         auto result_offsets = result_ds->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+        REQUIRE(result_ds->Get<int64_t>(knowhere::meta::EMB_LIST_COUNT) == ids_ds->GetRows());
         REQUIRE(result_offsets[0] == 0);
         REQUIRE(result_offsets[1] == 0);
     }

--- a/tests/ut/test_nullable_id_map.cc
+++ b/tests/ut/test_nullable_id_map.cc
@@ -854,6 +854,7 @@ GenNullableEmbListDataSet(int64_t total_docs, const std::vector<int32_t>& valid_
     auto offset_data = std::make_unique<size_t[]>(offsets.size());
     std::copy(offsets.begin(), offsets.end(), offset_data.get());
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(offset_data.release()));
+    ds->Set(knowhere::meta::EMB_LIST_COUNT, static_cast<int64_t>(valid_doc_ids.size()));
     ds->Set(knowhere::meta::NQ, static_cast<int64_t>(valid_doc_ids.size()));
     return ds;
 }
@@ -878,6 +879,7 @@ GenEmbListBatchDataSet(const std::vector<int32_t>& public_doc_ids, const std::ve
     auto offset_data = std::make_unique<size_t[]>(absolute_offsets.size());
     std::copy(absolute_offsets.begin(), absolute_offsets.end(), offset_data.get());
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(offset_data.release()));
+    ds->Set(knowhere::meta::EMB_LIST_COUNT, static_cast<int64_t>(public_doc_ids.size()));
     ds->Set(knowhere::meta::NQ, static_cast<int64_t>(public_doc_ids.size()));
     return ds;
 }
@@ -890,6 +892,7 @@ GenEmbListQueryDataSet(const std::vector<int32_t>& logical_doc_ids, int64_t dim)
         offsets[i] = i;
     }
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, static_cast<const size_t*>(offsets.release()));
+    ds->Set(knowhere::meta::EMB_LIST_COUNT, static_cast<int64_t>(logical_doc_ids.size()));
     ds->Set(knowhere::meta::NQ, static_cast<int64_t>(logical_doc_ids.size()));
     return ds;
 }

--- a/tests/ut/utils.h
+++ b/tests/ut/utils.h
@@ -545,6 +545,7 @@ GenEmbListDataSet(int rows, int dim, const uint64_t seed = 42, int each_el_len =
     ptr[i] = (size_t)rows;
     const size_t* ptr_const = ptr.release();
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, ptr_const);
+    ds->Set(knowhere::meta::EMB_LIST_COUNT, static_cast<int64_t>(i));
     ds->Set(knowhere::meta::NQ, static_cast<int64_t>(i));
     ds->SetIsOwner(true);
     return ds;
@@ -571,6 +572,7 @@ GenChunkDataSet(int rows, int dim, const uint64_t seed = 42, int each_el_len = 1
     auto ds = knowhere::GenDataSet(rows, dim, chunk_ts);
     ds->SetNumChunk(num_chunk);
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, (const size_t*)lims);
+    ds->Set(knowhere::meta::EMB_LIST_COUNT, static_cast<int64_t>(num_chunk));
     ds->Set(knowhere::meta::NQ, static_cast<int64_t>(num_chunk));
     ds->SetIsChunk(true);
     ds->SetIsOwner(true);
@@ -599,6 +601,7 @@ GenChunkBinDataSet(int rows, int dim, const uint64_t seed = 42, int each_el_len 
     auto ds = knowhere::GenDataSet(rows, dim, chunk_ts);
     ds->SetNumChunk(num_chunk);
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, (const size_t*)lims);
+    ds->Set(knowhere::meta::EMB_LIST_COUNT, static_cast<int64_t>(num_chunk));
     ds->Set(knowhere::meta::NQ, static_cast<int64_t>(num_chunk));
     ds->SetIsChunk(true);
     ds->SetIsOwner(true);
@@ -628,6 +631,7 @@ GenEmbListDataSetWithSomeEmpty(int rows, int dim, const uint64_t seed = 42, int 
     ptr[i] = (size_t)rows;
     const size_t* ptr_const = ptr.release();
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, ptr_const);
+    ds->Set(knowhere::meta::EMB_LIST_COUNT, static_cast<int64_t>(i));
     ds->Set(knowhere::meta::NQ, static_cast<int64_t>(i));
     ds->SetIsOwner(true);
     return ds;
@@ -654,6 +658,7 @@ SplitEmbListDataSet(const knowhere::DataSetPtr ds, size_t partition_num, int eac
         auto ds = knowhere::GenDataSet(cur_rows, dim, (const DataType*)data + start_el * each_el_len * dim);
         const size_t* ptr_const = ptr + start_el;
         ds->Set(knowhere::meta::EMB_LIST_OFFSET, ptr_const);
+        ds->Set(knowhere::meta::EMB_LIST_COUNT, static_cast<int64_t>(end_el - start_el));
         ds->Set(knowhere::meta::NQ, static_cast<int64_t>(end_el - start_el));
         ds->SetIsOwner(false);
         res[i] = std::move(ds);
@@ -678,6 +683,7 @@ GenEmbListBinDataSet(int rows, int dim, int seed = 42, int each_el_len = 10) {
     ptr[i] = (size_t)rows;
     const size_t* ptr_const = ptr.release();
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, ptr_const);
+    ds->Set(knowhere::meta::EMB_LIST_COUNT, static_cast<int64_t>(i));
     ds->Set(knowhere::meta::NQ, static_cast<int64_t>(i));
     ds->SetIsOwner(true);
     return ds;
@@ -705,6 +711,7 @@ GenQueryEmbListDataSet(int rows, int dim, const uint64_t seed = 42) {
     ptr[i] = (size_t)rows;
     const size_t* ptr_const = ptr.release();
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, ptr_const);
+    ds->Set(knowhere::meta::EMB_LIST_COUNT, static_cast<int64_t>(i));
     ds->Set(knowhere::meta::NQ, static_cast<int64_t>(i));
     ds->SetIsOwner(true);
     return ds;
@@ -734,6 +741,7 @@ GenQueryEmbListBinDataSet(int rows, int dim, const uint64_t seed = 42) {
     ptr[i] = (size_t)rows;
     const size_t* ptr_const = ptr.release();
     ds->Set(knowhere::meta::EMB_LIST_OFFSET, ptr_const);
+    ds->Set(knowhere::meta::EMB_LIST_COUNT, static_cast<int64_t>(i));
     ds->Set(knowhere::meta::NQ, static_cast<int64_t>(i));
     ds->SetIsOwner(true);
     return ds;


### PR DESCRIPTION
issue: #1794

## Summary
- Add explicit `EMB_LIST_COUNT` metadata so embedding-list offsets are consumed with their real list count instead of inferring array length from the flattened vector count.
- Remove the unsafe two-argument `EmbListOffset` constructor, thread the explicit count through build, add, search, brute-force, conversion, SWIG, and retrieval paths, and validate offset boundaries in release builds.
- Preserve trailing empty embedding lists while keeping `NQ` semantics separate, and add focused regression coverage for trailing-empty offsets and retrieved metadata.

## Test Plan
- [x] `make WITH_UT=True BUILD_DIR="$PWD/build/main/ut"`
- [x] `source build/main/ut/Release/generators/conanrun.sh && build/main/ut/Release/tests/ut/knowhere_tests "[trailing_empty]"` (3 assertions passed)
- [x] `source build/main/ut/Release/generators/conanrun.sh && build/main/ut/Release/tests/ut/knowhere_tests "[GetEmbListByIds],[empty_emb_list],[emb_list]"` (2171 assertions passed; one capability-based skip)
- [x] `pre-commit run --files <touched files>`
- [ ] Full Knowhere unit-test suite (not run; validation was scoped to the affected EmbList paths)
