### PR TITLE
fix: normalize EmbList element id maps

### DIFF
--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -11,7 +11,11 @@
 
 #include "knowhere/index/index.h"
 
+#include <cstdint>
+#include <limits>
+#include <numeric>
 #include <string>
+#include <vector>
 
 #include "folly/futures/Future.h"
 #include "knowhere/comp/time_recorder.h"
@@ -45,7 +49,15 @@ ThrowInvalidIdMapData(const std::string& msg) {
 }
 
 inline bool
-AddDatasetIdMapData(const DataSetPtr& dataset, IdMap& id_map, int64_t indexed_count) {
+UsesElementIdSpace(const DataSetPtr& dataset, const BaseConfig& config) {
+    const auto has_emb_list_layout =
+        (dataset != nullptr && dataset->Get<const size_t*>(meta::EMB_LIST_OFFSET) != nullptr) ||
+        config.emb_list_offset_file_path.has_value();
+    return has_emb_list_layout && !get_el_metric_type(config.metric_type.value()).has_value();
+}
+
+inline bool
+AddDatasetIdMapData(const DataSetPtr& dataset, const BaseConfig& config, IdMap& id_map, int64_t indexed_count) {
     const auto has_id_map_data = dataset != nullptr && dataset->HasIdMapData();
     if (!has_id_map_data) {
         if (id_map.IsEnabled()) {
@@ -61,8 +73,24 @@ AddDatasetIdMapData(const DataSetPtr& dataset, IdMap& id_map, int64_t indexed_co
     }
 
     try {
-        // Consume nullable id-map input into index-owned state.
-        id_map.AddFromData(dataset->GetIdMapData());
+        if (UsesElementIdSpace(dataset, config)) {
+            // An ordinary metric over EmbList input builds a flat vector
+            // index.  The attached nullable metadata describes outer lists,
+            // but null/empty lists contribute no vectors, so flattened vector
+            // ids remain the contiguous public element ids.  Materialize that
+            // vector-domain identity map to preserve the normal IdMap
+            // lifecycle for the element index.
+            const auto vector_count = dataset->GetRows();
+            if (vector_count < 0 || static_cast<uint64_t>(vector_count) > std::numeric_limits<int32_t>::max()) {
+                ThrowInvalidIdMapData("element id map count overflows int32");
+            }
+            std::vector<int32_t> vector_ids(static_cast<size_t>(vector_count));
+            std::iota(vector_ids.begin(), vector_ids.end(), 0);
+            id_map.AddFromData(IdMapData::FromIds(vector_ids.data(), vector_ids.size(), vector_ids.size()));
+        } else {
+            // Consume nullable id-map input into index-owned state.
+            id_map.AddFromData(dataset->GetIdMapData());
+        }
     } catch (const std::exception& e) {
         ThrowInvalidIdMapData(e.what());
     }
@@ -114,7 +142,7 @@ Index<T>::BuildAsync(const DataSetPtr dataset, const Json& json, const std::chro
                 auto cfg = this->node->CreateConfig();
                 RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Build"));
                 auto& id_map = this->node->GetIdMap();
-                const auto has_id_map = AddDatasetIdMapData(dataset, id_map, 0);
+                const auto has_id_map = AddDatasetIdMapData(dataset, *cfg, id_map, 0);
                 if (has_id_map && dataset != nullptr && dataset->GetRows() == 0) {
                     // All-null nullable build produces id-map metadata only.
                     return this->node->FinalizeIdMap();
@@ -163,7 +191,7 @@ Index<T>::Build(const DataSetPtr dataset, const Json& json, bool use_knowhere_bu
         auto cfg = this->node->CreateConfig();
         RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Build"));
         auto& id_map = this->node->GetIdMap();
-        const auto has_id_map = AddDatasetIdMapData(dataset, id_map, 0);
+        const auto has_id_map = AddDatasetIdMapData(dataset, *cfg, id_map, 0);
         if (has_id_map && dataset != nullptr && dataset->GetRows() == 0) {
             // All-null nullable build produces id-map metadata only.
             return this->node->FinalizeIdMap();
@@ -213,7 +241,7 @@ Index<T>::Add(const DataSetPtr dataset, const Json& json, bool use_knowhere_buil
         std::string msg;
         RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Add", &msg));
         auto& id_map = this->node->GetIdMap();
-        AddDatasetIdMapData(dataset, id_map, this->node->Count());
+        AddDatasetIdMapData(dataset, *cfg, id_map, this->node->Count());
         const auto is_emb_list =
             dataset != nullptr && dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET) != nullptr;
         if (dataset != nullptr && dataset->GetRows() == 0 && !is_emb_list) {

--- a/tests/ut/test_nullable_id_map.cc
+++ b/tests/ut/test_nullable_id_map.cc
@@ -4021,6 +4021,104 @@ TEST_CASE("Nullable Index rejects plain and mapped Add mixing", "[nullable][id_m
     }
 }
 
+TEST_CASE("Element index normalizes outer EmbList IdMap to vector ids", "[nullable][id_map][emblist][element]") {
+    constexpr int64_t kParentCount = 2;
+    constexpr int64_t kVectorsPerParent = 512;
+    constexpr int64_t kVectorCount = kParentCount * kVectorsPerParent;
+
+    auto base = GenNullableEmbListDataSet(kParentCount, {0, 1}, kDenseDim, kVectorsPerParent);
+    const int32_t parent_ids[] = {0, 1};
+    base->SetIdMapData(knowhere::IdMapData::FromIds(parent_ids, kParentCount, kParentCount));
+
+    auto json = BaseDenseConfig(knowhere::metric::L2, kDenseDim, 1);
+    json[knowhere::meta::INDEX_TYPE] = knowhere::IndexEnum::INDEX_HNSW;
+    json[knowhere::indexparam::HNSW_M] = 8;
+    json[knowhere::indexparam::EFCONSTRUCTION] = 40;
+    json[knowhere::indexparam::EF] = 64;
+
+    IndexRow row{"HNSW current", knowhere::IndexEnum::INDEX_HNSW, DataKind::DenseFp32, Capabilities{}, false, true};
+    auto version = VersionForRow(row);
+    auto index = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(row.index_type, version).value();
+    index.SetIdMapType(knowhere::IdMap::Type::SEALED);
+    REQUIRE(index.Build(base, json, false) == Status::success);
+
+    auto query = GenDenseQueryDataSet({1}, kDenseDim);
+    auto filter_bits = MakeBitmap(kVectorCount, {});
+    auto result = index.Search(query, json, knowhere::BitsetView(filter_bits.data(), kVectorCount));
+    REQUIRE(result.has_value());
+    REQUIRE(index.GetIdMap().OutCount() == kVectorCount);
+    REQUIRE(index.GetIdMap().InCount() == kVectorCount);
+#ifdef KNOWHERE_WITH_CARDINAL
+    // Cardinal owns the composed internal -> public vector map after build.
+    REQUIRE(index.GetIdMap().InToOutIds().empty());
+#endif
+    REQUIRE(result.value()->GetIds()[0] >= kVectorsPerParent);
+    REQUIRE(result.value()->GetIds()[0] < kVectorCount);
+
+    std::vector<int32_t> filtered_second_parent(kVectorsPerParent);
+    std::iota(filtered_second_parent.begin(), filtered_second_parent.end(), kVectorsPerParent);
+    filter_bits = MakeBitmap(kVectorCount, filtered_second_parent);
+    result = index.Search(query, json, knowhere::BitsetView(filter_bits.data(), kVectorCount));
+    REQUIRE(result.has_value());
+    REQUIRE(result.value()->GetIds()[0] >= 0);
+    REQUIRE(result.value()->GetIds()[0] < kVectorsPerParent);
+}
+
+TEST_CASE("All-null element index keeps an empty vector IdMap", "[nullable][id_map][emblist][element]") {
+    constexpr int64_t kParentCount = 2;
+    constexpr int64_t kVectorsPerParent = 512;
+
+    auto base = GenNullableEmbListDataSet(kParentCount, {}, kDenseDim, kVectorsPerParent);
+    base->SetIdMapData(knowhere::IdMapData::FromIds(nullptr, 0, kParentCount));
+
+    auto json = BaseDenseConfig(knowhere::metric::L2, kDenseDim, 1);
+    json[knowhere::meta::INDEX_TYPE] = knowhere::IndexEnum::INDEX_HNSW;
+    json[knowhere::indexparam::HNSW_M] = 8;
+    json[knowhere::indexparam::EFCONSTRUCTION] = 40;
+
+    IndexRow row{"HNSW current", knowhere::IndexEnum::INDEX_HNSW, DataKind::DenseFp32, Capabilities{}, false, true};
+    auto version = VersionForRow(row);
+    auto index = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(row.index_type, version).value();
+    index.SetIdMapType(knowhere::IdMap::Type::SEALED);
+    REQUIRE(index.Build(base, json, false) == Status::success);
+    REQUIRE(index.GetIdMap().IsEnabled());
+    REQUIRE(index.GetIdMap().OutCount() == 0);
+}
+
+TEST_CASE("Element index Add appends vector IdMap ranges", "[nullable][id_map][emblist][element]") {
+    constexpr int64_t kVectorsPerParent = 512;
+    constexpr int64_t kVectorCount = 2 * kVectorsPerParent;
+
+    auto first_batch = GenNullableEmbListDataSet(1, {0}, kDenseDim, kVectorsPerParent);
+    const int32_t first_parent_id[] = {0};
+    first_batch->SetIdMapData(knowhere::IdMapData::FromIds(first_parent_id, 1, 1));
+    auto second_batch = GenNullableEmbListDataSet(2, {1}, kDenseDim, kVectorsPerParent);
+    const int32_t second_parent_id[] = {1};
+    second_batch->SetIdMapData(knowhere::IdMapData::FromIds(second_parent_id, 1, 2));
+
+    auto row = NativeFaissHnswRow();
+    auto json = BaseDenseConfig(knowhere::metric::L2, kDenseDim, 1);
+    json[knowhere::meta::INDEX_TYPE] = row.index_type;
+    json[knowhere::indexparam::HNSW_M] = 8;
+    json[knowhere::indexparam::EFCONSTRUCTION] = 40;
+    json[knowhere::indexparam::EF] = 64;
+
+    auto version = VersionForRow(row);
+    auto index = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(row.index_type, version).value();
+    index.SetIdMapType(knowhere::IdMap::Type::GROWING);
+    REQUIRE(index.Build(first_batch, json, false) == Status::success);
+    REQUIRE(index.Add(second_batch, json, false) == Status::success);
+
+    auto query = GenDenseQueryDataSet({1}, kDenseDim);
+    auto filter_bits = MakeBitmap(kVectorCount, {});
+    auto result = index.Search(query, json, knowhere::BitsetView(filter_bits.data(), kVectorCount));
+    REQUIRE(result.has_value());
+    REQUIRE(index.GetIdMap().OutCount() == kVectorCount);
+    REQUIRE(index.GetIdMap().InCount() == kVectorCount);
+    REQUIRE(result.value()->GetIds()[0] >= kVectorsPerParent);
+    REQUIRE(result.value()->GetIds()[0] < kVectorCount);
+}
+
 TEST_CASE("Nullable vector Build plus Add matches full Build", "[nullable][ivf][add]") {
     auto json = BaseDenseConfig(knowhere::metric::L2, kDenseDim, 2);
     json[knowhere::meta::INDEX_TYPE] = knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC;


### PR DESCRIPTION
issue: #1802

## Summary
- Normalize outer/list nullable metadata to a contiguous vector IdMap when ordinary metrics build an element index over EmbList input.
- Preserve the normal IdMap handoff so Cardinal can compose its internal relayout with the public vector ID space instead of dropping the mapping.
- Keep EBL metric/list-domain mapping unchanged, and cover sealed, filtered, all-null, and growing element-index paths.

## Test Plan
- [x] `PATH=/usr/lib/llvm-15/bin:$PATH /home/ubuntu/.local/bin/pre-commit run --files src/index/index.cc tests/ut/test_nullable_id_map.cc`
- [x] `cmake --build artifacts/build-ut/Release --target knowhere_tests`
- [x] `source artifacts/build-ut/Release/generators/conanrun.sh && artifacts/build-ut/Release/tests/ut/knowhere_tests '[nullable][id_map]'` (559 assertions in 7 cases)
- [x] `cmake --build artifacts/build-cardinal-ut/Release --target knowhere_tests`
- [x] `source artifacts/build-cardinal-ut/Release/generators/conanrun.sh && artifacts/build-cardinal-ut/Release/tests/ut/knowhere_tests '[nullable][id_map]'` (1984 assertions in 9 cases)
- [x] Native and Cardinal-enabled `Nullable IVF_FLAT_CC emb-list Add preserves append public list ids` (129 assertions each)
- [ ] Milvus end-to-end validation (not run; this PR is validated at the Knowhere component and Cardinal integration tiers)
