### PR TITLE
update: bump cardinal to v3.0.8

### DIFF
--- a/cmake/libs/cardinal/v2/CMakeLists.txt
+++ b/cmake/libs/cardinal/v2/CMakeLists.txt
@@ -3,7 +3,7 @@ project(knowhere CXX C)
 
 # Use short SHA1 as version
 # currenly checkout a commit for cardinal v2. TODO: need a tag here
-set(CARDINAL_VERSION v3.0.7)
+set(CARDINAL_VERSION v3.0.8)
 set(CARDINAL_REPO_URL "https://github.com/zilliztech/cardinal.git")
 
 set(CARDINAL_ROOT  "${KNOWHERE_THRID_ROOT}/cardinalv2")


### PR DESCRIPTION
Related: zilliztech/cardinal#935

## Summary

- Bump the Cardinal v2 reference from `v3.0.7` to `v3.0.8`.
- `v3.0.8` points to Cardinal commit `a33638c3aa0e7deac5f8d1d5cc32b25d68b8daf0`, which contains the explicit emb-list count adapter fix merged in Cardinal PR #935.
- Leave the Cardinal v1 reference unchanged at `v2.5.112`.

## Test Plan

- [ ] Local build and tests (not run, per request).
