### PR TITLE
fix: preserve Jaccard identity for empty binary vectors

### DIFF
--- a/tests/ut/test_bruteforce.cc
+++ b/tests/ut/test_bruteforce.cc
@@ -292,6 +292,26 @@ TEST_CASE("Test Brute Force", "[binary vector]") {
     }
 }
 
+TEST_CASE("Binary Jaccard preserves empty-vector identity", "[binary vector][jaccard]") {
+    const int64_t code_size = GENERATE(as<int64_t>{}, 1, 8, 16, 32, 64, 128, 256, 512);
+    const int64_t dim = code_size * 8;
+    std::vector<uint8_t> zeros(code_size, 0);
+    const auto dataset = knowhere::GenDataSet(1, dim, zeros.data());
+    const knowhere::Json conf = {
+        {knowhere::meta::DIM, dim},
+        {knowhere::meta::METRIC_TYPE, knowhere::metric::JACCARD},
+        {knowhere::meta::TOPK, 1},
+    };
+
+    int64_t id = -1;
+    float distance = -1.0f;
+    auto status = knowhere::BruteForce::SearchWithBuf<knowhere::bin1>(dataset, dataset, &id, &distance, conf, nullptr);
+
+    REQUIRE(status == knowhere::Status::success);
+    REQUIRE(id == 0);
+    REQUIRE(distance == 0.0f);
+}
+
 TEST_CASE("Brute Force preserves trailing empty embedding lists", "[emb_list][trailing_empty]") {
     constexpr int64_t dim = 2;
     constexpr int64_t topk = 1;

--- a/thirdparty/faiss/faiss/cppcontrib/knowhere/utils/binary_distances.cpp
+++ b/thirdparty/faiss/faiss/cppcontrib/knowhere/utils/binary_distances.cpp
@@ -176,7 +176,7 @@ float bvec_jaccard(
     int accu_num = 0;
     int accu_den = 0;
     fast_loop_imp(fun_u64, fun_u8);
-    return (accu_den == 0) ? 1.0
+    return (accu_den == 0) ? 0.0f
                            : ((float)(accu_den - accu_num) / (float)(accu_den));
 #undef fun_u64
 #undef fun_u8
@@ -825,6 +825,5 @@ void all_hamming_distances(
     }
 }
 }
-
 
 

--- a/thirdparty/faiss/faiss/cppcontrib/knowhere/utils/jaccard-inl.h
+++ b/thirdparty/faiss/faiss/cppcontrib/knowhere/utils/jaccard-inl.h
@@ -44,7 +44,7 @@ struct JaccardComputer8 {
         int accu_num = popcount64(b[0] & a0);
         int accu_den = popcount64(b[0] | a0);
         return (accu_den == 0)
-                ? 1.0
+                ? 0.0f
                 : ((float)(accu_den - accu_num) / (float)(accu_den));
     }
 };
@@ -70,7 +70,7 @@ struct JaccardComputer16 {
         int accu_num = popcount64(b[0] & a0) + popcount64(b[1] & a1);
         int accu_den = popcount64(b[0] | a0) + popcount64(b[1] | a1);
         return (accu_den == 0)
-                ? 1.0
+                ? 0.0f
                 : ((float)(accu_den - accu_num) / (float)(accu_den));
     }
 };
@@ -100,7 +100,7 @@ struct JaccardComputer32 {
         int accu_den = popcount64(b[0] | a0) + popcount64(b[1] | a1) +
                 popcount64(b[2] | a2) + popcount64(b[3] | a3);
         return (accu_den == 0)
-                ? 1.0
+                ? 0.0f
                 : ((float)(accu_den - accu_num) / (float)(accu_den));
     }
 };
@@ -138,7 +138,7 @@ struct JaccardComputer64 {
                 popcount64(b[4] | a4) + popcount64(b[5] | a5) +
                 popcount64(b[6] | a6) + popcount64(b[7] | a7);
         return (accu_den == 0)
-                ? 1.0
+                ? 0.0f
                 : ((float)(accu_den - accu_num) / (float)(accu_den));
     }
 };
@@ -193,7 +193,7 @@ struct JaccardComputer128 {
                 popcount64(b[12] | a12) + popcount64(b[13] | a13) +
                 popcount64(b[14] | a14) + popcount64(b[15] | a15);
         return (accu_den == 0)
-                ? 1.0
+                ? 0.0f
                 : ((float)(accu_den - accu_num) / (float)(accu_den));
     }
 };
@@ -281,7 +281,7 @@ struct JaccardComputer256 {
                 popcount64(b[28] | a28) + popcount64(b[29] | a29) +
                 popcount64(b[30] | a30) + popcount64(b[31] | a31);
         return (accu_den == 0)
-                ? 1.0
+                ? 0.0f
                 : ((float)(accu_den - accu_num) / (float)(accu_den));
     }
 };
@@ -435,7 +435,7 @@ struct JaccardComputer512 {
                 popcount64(b[60] | a60) + popcount64(b[61] | a61) +
                 popcount64(b[62] | a62) + popcount64(b[63] | a63);
         return (accu_den == 0)
-                ? 1.0
+                ? 0.0f
                 : ((float)(accu_den - accu_num) / (float)(accu_den));
     }
 };


### PR DESCRIPTION
issue: https://github.com/zilliztech/knowhere/issues/1808

## Summary

- Return zero Jaccard distance when both binary vectors have an empty union.
- Cover the generic and fixed-size Jaccard distance implementations with a regression test.

## Verification

- `pre-commit run --files tests/ut/test_bruteforce.cc thirdparty/faiss/faiss/cppcontrib/knowhere/utils/binary_distances.cpp thirdparty/faiss/faiss/cppcontrib/knowhere/utils/jaccard-inl.h`
- `./build/Release/tests/ut/knowhere_tests "Binary Jaccard preserves empty-vector identity"`
- `./build/Release/tests/ut/knowhere_tests "[binary vector]"`
