### PR TITLE
Add LoongArch64 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,16 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64)")
         PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512vl -mavx512dq -mavx512cd -mavx2 -mfma -mf16c")
 endif()
 
+if(__LOONGARCH64)
+    set_source_files_properties(
+        src/index/sparse/codec/varintdecode.c
+        src/index/sparse/codec/streamvbyte_0124_decode.c
+        src/index/sparse/codec/streamvbyte_0124_encode.c
+        src/index/sparse/codec/simd_bitpacking_kernel.c
+        src/index/sparse/sindi_simd_lsx.cc
+        PROPERTIES COMPILE_OPTIONS "-mlsx;-mno-lasx")
+endif()
+
 if(__AARCH64)
     set(KNOWHERE_SVE_COMPILE_OPTIONS "")
     if(HAS_ARMV9_SVE_BF16)

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ WITH_GPU ?=
 WITH_UT ?=
 WITH_BENCHMARK ?=
 WITH_ASAN ?=
+WITH_DISKANN ?= True
 WITH_SVS ?=
 WITH_CARDINAL ?=
 CARDINAL_VERSION_FORCE_CHECKOUT ?=
@@ -40,7 +41,7 @@ export CMAKE_POLICY_VERSION_MINIMUM ?= 3.5
 # variables such as WITH_ASAN to every sub-process, which causes the custom
 # folly recipe to pick up $ENV{WITH_ASAN} and compile folly itself with
 # -fsanitize=address — breaking the build on GCC.
-unexport WITH_GPU WITH_UT WITH_BENCHMARK WITH_ASAN WITH_CARDINAL CARDINAL_VERSION_FORCE_CHECKOUT WITH_DEBUG
+unexport WITH_GPU WITH_UT WITH_BENCHMARK WITH_ASAN WITH_DISKANN WITH_CARDINAL CARDINAL_VERSION_FORCE_CHECKOUT WITH_DEBUG
 
 # ---------- Derived settings ----------
 ifdef WITH_DEBUG
@@ -66,9 +67,15 @@ CONAN_SETTINGS := -s compiler.libcxx=$(LIBCXX) -s build_type=$(BUILD_TYPE) -s co
 
 # DiskANN and liburing require libaio (Linux-only).
 ifneq ($(UNAME_S),Darwin)
-    CONAN_SETTINGS += -o \&:with_diskann=True
-    ifndef WITH_GPU
-        CONAN_INSTALL_FLAGS += --build=liburing
+    ifneq ($(filter True true ON on 1,$(WITH_DISKANN)),)
+        CONAN_SETTINGS += -o \&:with_diskann=True
+        ifndef WITH_GPU
+            CONAN_INSTALL_FLAGS += --build=liburing
+        endif
+    else ifneq ($(filter False false OFF off 0,$(WITH_DISKANN)),)
+        CONAN_SETTINGS += -o \&:with_diskann=False
+    else
+        $(error WITH_DISKANN must be True/False, ON/OFF, or 1/0)
     endif
 endif
 
@@ -173,6 +180,7 @@ help: ## Show available targets
 	@echo "  WITH_UT=True       Enable unit tests"
 	@echo "  WITH_BENCHMARK=True Enable benchmarks build"
 	@echo "  WITH_ASAN=True     Enable AddressSanitizer"
+	@echo "  WITH_DISKANN=False Disable DiskANN (enabled by default on Linux)"
 	@echo "  WITH_SVS=True      Enable SVS (Intel Scalable Vector Search, x86 only)"
 	@echo "  WITH_CARDINAL=True Enable Cardinal build"
 	@echo "  CARDINAL_VERSION_FORCE_CHECKOUT=True Force Cardinal checkout to configured version"

--- a/cmake/libs/libfaiss.cmake
+++ b/cmake/libs/libfaiss.cmake
@@ -345,6 +345,22 @@ if(__RISCV64)
   )
 endif()
 
+# generate `knowhere_utils` library for LoongArch64
+if(__LOONGARCH64)
+  set(UTILS_SRC
+      src/simd/hook.cc
+      src/simd/distances_ref.cc)
+  add_library(utils_lsx OBJECT src/simd/distances_lsx.cc)
+  add_library(utils_lasx OBJECT src/simd/distances_lasx.cc)
+  target_compile_options(utils_lsx PRIVATE -mlsx -mno-lasx)
+  target_compile_options(utils_lasx PRIVATE -mlasx)
+
+  add_library(knowhere_utils STATIC ${UTILS_SRC} $<TARGET_OBJECTS:utils_lsx> $<TARGET_OBJECTS:utils_lasx>)
+  target_link_libraries(knowhere_utils PUBLIC glog::glog)
+  target_link_libraries(knowhere_utils PUBLIC xxHash::xxhash)
+  target_link_libraries(knowhere_utils PUBLIC milvus-common::milvus-common)
+endif()
+
 # generate `knowhere_utils` library for PPC64
 # ToDo: Add distances_vsx.cc for powerpc64 SIMD acceleration
 if(__PPC64)
@@ -574,6 +590,28 @@ if(__RISCV64)
   target_link_libraries(faiss PUBLIC OpenMP::OpenMP_CXX ${BLAS_LIBRARIES}
                                      ${LAPACK_LIBRARIES} knowhere_utils)
   target_compile_definitions(faiss PRIVATE FINTEGER=int COMPILE_SIMD_RISCV_RVV)
+endif()
+
+# generate `faiss` library for LoongArch64
+if(__LOONGARCH64)
+  add_library(faiss STATIC ${FAISS_SRCS})
+  target_include_directories(faiss PRIVATE ${Boost_INCLUDE_DIRS})
+  target_sources(faiss PRIVATE ${FAISS_FASTSCAN_SRCS})
+
+  target_compile_options(
+    faiss
+    PRIVATE $<$<COMPILE_LANGUAGE:CXX>:
+            -Wno-sign-compare
+            -Wno-unused-variable
+            -Wno-reorder
+            -Wno-unused-local-typedefs
+            -Wno-unused-function
+            -Wno-strict-aliasing>)
+
+  add_dependencies(faiss knowhere_utils)
+  target_link_libraries(faiss PUBLIC OpenMP::OpenMP_CXX ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES}
+                                     knowhere_utils)
+  target_compile_definitions(faiss PRIVATE FINTEGER=int FAISS_ENABLE_DD)
 endif()
 
 # generate `faiss` library for PPC64

--- a/cmake/utils/compile_flags.cmake
+++ b/cmake/utils/compile_flags.cmake
@@ -23,6 +23,13 @@ if(__X86_64)
   set(CMAKE_CXX_FLAGS "-msse4.2 ${CMAKE_CXX_FLAGS}")
 endif()
 
+# Keep LoongArch vector instructions confined to dedicated objects, which opt
+# into LSX or LASX explicitly.
+if(__LOONGARCH64)
+  set(CMAKE_C_FLAGS "-mno-lsx -mno-lasx ${CMAKE_C_FLAGS}")
+  set(CMAKE_CXX_FLAGS "-mno-lsx -mno-lasx ${CMAKE_CXX_FLAGS}")
+endif()
+
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 

--- a/cmake/utils/platform_check.cmake
+++ b/cmake/utils/platform_check.cmake
@@ -5,12 +5,14 @@ macro(detect_target_arch)
   check_symbol_exists(__x86_64__ "" __X86_64)
   check_symbol_exists(__powerpc64__ "" __PPC64)
   check_symbol_exists(__riscv "" __RISCV64)
+  check_symbol_exists(__loongarch64 "" __LOONGARCH64)
 
   if(NOT __AARCH64
      AND NOT __X86_64
      AND NOT __PPC64
-     AND NOT __RISCV64)
-    message(FATAL "knowhere only support amd64, ppc64, riscv64 and arm64 architecture.")
+     AND NOT __RISCV64
+     AND NOT __LOONGARCH64)
+    message(FATAL "knowhere only supports amd64, arm64, loongarch64, ppc64 and riscv64 architectures.")
   endif()
 endmacro()
 

--- a/src/index/sparse/codec/lsx_sse_compat.h
+++ b/src/index/sparse/codec/lsx_sse_compat.h
@@ -1,0 +1,88 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include <lsxintrin.h>
+#include <stdint.h>
+
+// The sparse codecs retain SSE intrinsics from their upstream implementations.
+// Map only the operations they use so LoongArch builds execute native LSX.
+static inline __m128i
+knowhere_lsx_loadu_si128(const __m128i* ptr) {
+    return __lsx_vld((void*)ptr, 0);
+}
+
+static inline void
+knowhere_lsx_storeu_si128(__m128i* ptr, __m128i value) {
+    __lsx_vst(value, ptr, 0);
+}
+
+static inline void
+knowhere_lsx_storel_epi64(__m128i* ptr, __m128i value) {
+    __lsx_vstelm_d(value, ptr, 0, 0);
+}
+
+static inline int
+knowhere_lsx_movemask_epi8(__m128i value) {
+    return (int)__lsx_vpickve2gr_hu(__lsx_vmskltz_b(value), 0);
+}
+
+static inline __m128i
+knowhere_lsx_cvtepi8_epi32(__m128i value) {
+    typedef int8_t i8x4 __attribute__((vector_size(4)));
+    const i8x4 lower = __builtin_shufflevector((v16i8)value, (v16i8)value, 0, 1, 2, 3);
+    return (__m128i) __builtin_convertvector(lower, v4i32);
+}
+
+static inline __m128i
+knowhere_lsx_shuffle_epi8(__m128i value, __m128i mask) {
+    const __m128i index = __lsx_vor_v(__lsx_vandi_b(mask, 0x0f), __lsx_vandi_b(__lsx_vslti_b(mask, 0), 0x10));
+    return __lsx_vshuf_b(__lsx_vldi(0), value, index);
+}
+
+static inline __m128i
+knowhere_lsx_setr_epi16(int16_t e0, int16_t e1, int16_t e2, int16_t e3, int16_t e4, int16_t e5, int16_t e6,
+                        int16_t e7) {
+    return (__m128i)(v8i16){e0, e1, e2, e3, e4, e5, e6, e7};
+}
+
+static inline __m128i
+knowhere_lsx_setr_epi8(int8_t e0, int8_t e1, int8_t e2, int8_t e3, int8_t e4, int8_t e5, int8_t e6, int8_t e7,
+                       int8_t e8, int8_t e9, int8_t e10, int8_t e11, int8_t e12, int8_t e13, int8_t e14, int8_t e15) {
+    return (__m128i)(v16i8){e0, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15};
+}
+
+#define _mm_and_si128(a, b) __lsx_vand_v((a), (b))
+#define _mm_add_epi32(a, b) __lsx_vadd_w((a), (b))
+#define _mm_cvtsi128_si32(a) __lsx_vpickve2gr_w((a), 0)
+#define _mm_cvtepi8_epi32(a) knowhere_lsx_cvtepi8_epi32(a)
+#define _mm_lddqu_si128(ptr) knowhere_lsx_loadu_si128(ptr)
+#define _mm_loadu_si128(ptr) knowhere_lsx_loadu_si128(ptr)
+#define _mm_movemask_epi8(a) knowhere_lsx_movemask_epi8(a)
+#define _mm_mullo_epi16(a, b) __lsx_vmul_h((a), (b))
+#define _mm_or_si128(a, b) __lsx_vor_v((a), (b))
+#define _mm_set1_epi16(a) __lsx_vreplgr2vr_h(a)
+#define _mm_set1_epi32(a) __lsx_vreplgr2vr_w(a)
+#define _mm_set1_epi8(a) __lsx_vreplgr2vr_b(a)
+#define _mm_setr_epi16(...) knowhere_lsx_setr_epi16(__VA_ARGS__)
+#define _mm_setr_epi8(...) knowhere_lsx_setr_epi8(__VA_ARGS__)
+#define _mm_shuffle_epi8(a, b) knowhere_lsx_shuffle_epi8((a), (b))
+#define _mm_shuffle_epi32(a, imm) __lsx_vshuf4i_w((a), (imm))
+#define _mm_slli_epi32(a, imm) __lsx_vslli_w((a), (imm))
+#define _mm_slli_epi64(a, imm) __lsx_vslli_d((a), (imm))
+#define _mm_slli_si128(a, imm) __lsx_vbsll_v((a), (imm))
+#define _mm_srli_epi16(a, imm) __lsx_vsrli_h((a), (imm))
+#define _mm_srli_epi32(a, imm) __lsx_vsrli_w((a), (imm))
+#define _mm_srli_epi64(a, imm) __lsx_vsrli_d((a), (imm))
+#define _mm_srli_si128(a, imm) __lsx_vbsrl_v((a), (imm))
+#define _mm_storel_epi64(ptr, a) knowhere_lsx_storel_epi64((ptr), (a))
+#define _mm_storeu_si128(ptr, a) knowhere_lsx_storeu_si128((ptr), (a))

--- a/src/index/sparse/codec/simdcomp/include/portability.h
+++ b/src/index/sparse/codec/simdcomp/include/portability.h
@@ -11,6 +11,8 @@
 #include "neon128.h"
 #elif defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
 #include <emmintrin.h>
+#elif defined(__loongarch_sx)
+#include "../../lsx_sse_compat.h"
 #else
 /* Keep the generated SSE2 kernels available on the other architectures supported by Knowhere. */
 #ifndef SIMDE_ENABLE_NATIVE_ALIASES

--- a/src/index/sparse/codec/streamvbyte_0124_decode.c
+++ b/src/index/sparse/codec/streamvbyte_0124_decode.c
@@ -9,7 +9,11 @@
 #include <stdint.h>
 #include <string.h>  // for memcpy
 
-#if defined(__SSE4_1__) || defined(__ARM_NEON__) || defined(__ARM_NEON)
+#if defined(__SSE4_1__) || defined(__ARM_NEON__) || defined(__ARM_NEON) || defined(__loongarch_sx)
+#define KNOWHERE_STREAMVBYTE_SIMD
+#endif
+
+#ifdef KNOWHERE_STREAMVBYTE_SIMD
 // using 0,1,2,4 bytes per value
 static uint8_t lengthTable[256] = {
     0, 1, 2, 4,  1, 2, 3, 5,  2, 3, 4,  6,  4,  5,  6,  8,  1, 2, 3,  5,  2, 3,  4,  6,  3,  4,  5,  7,  5,  6,  7,  9,
@@ -285,30 +289,47 @@ static int8_t shuffleTable[256][16] = {
 
 #if defined(__SSE4_1__)
 #include <immintrin.h>
+#elif defined(__loongarch_sx)
+#include <lsxintrin.h>
 #elif defined(__ARM_NEON__) || defined(__ARM_NEON)
 #include <arm_neon.h>
 #endif
 
-#ifdef __SSE4_1__
+#if defined(__SSE4_1__) || defined(__loongarch_sx)
 typedef __m128i decode_t;
 
 static inline decode_t
 svb_decode_uint32x4(const uint8_t key, const uint8_t* __restrict__* dataPtrPtr) {
     uint8_t len = 0;
+#if defined(__loongarch_sx)
+    decode_t Data = __lsx_vld((void*)*dataPtrPtr, 0);
+    decode_t Shuf = __lsx_vld((void*)&shuffleTable[key], 0);
+#else
     decode_t Data = _mm_loadu_si128((const decode_t*)*dataPtrPtr);
     uint8_t* pshuf = (uint8_t*)&shuffleTable[key];
     decode_t Shuf = *(__m128i*)pshuf;
+#endif
     len = lengthTable[key];
+#if defined(__loongarch_sx)
+    // vshuf.b indexes its second input for indices 0..15 and its first
+    // input for 16..31. A table entry of -1 therefore selects a zero byte.
+    Data = __lsx_vshuf_b(__lsx_vldi(0), Data, Shuf);
+#else
     Data = _mm_shuffle_epi8(Data, Shuf);
+#endif
     *dataPtrPtr += len;
     return Data;
 }
 
 static inline void
 svb_write_uint32x4(uint32_t* out, decode_t Vec) {
+#if defined(__loongarch_sx)
+    __lsx_vst(Vec, out, 0);
+#else
     _mm_storeu_si128((__m128i*)out, Vec);
+#endif
 }
-#endif  // __SSE4_1__
+#endif  // __SSE4_1__ || __loongarch_sx
 
 #if defined(__ARM_NEON__) || defined(__ARM_NEON)
 typedef uint8x16_t decode_t;
@@ -376,7 +397,7 @@ svb_decode_scalar(uint32_t* outPtr, const uint8_t* keyPtr, const uint8_t* dataPt
     return dataPtr;  // pointer to first unused byte after end
 }
 
-#if defined(__SSE4_1__) || defined(__ARM_NEON__) || defined(__ARM_NEON)
+#ifdef KNOWHERE_STREAMVBYTE_SIMD
 static const uint8_t*
 svb_decode_vec128_simple(uint32_t* out, const uint8_t* __restrict__ keyPtr, const uint8_t* __restrict__ dataPtr,
                          uint64_t count) {
@@ -449,7 +470,7 @@ svb_decode_vec128_simple(uint32_t* out, const uint8_t* __restrict__ keyPtr, cons
 
     return dataPtr;
 }
-#endif  // __SSE4_1__ || __ARM_NEON__ || __ARM_NEON
+#endif  // KNOWHERE_STREAMVBYTE_SIMD
 
 // Read count 32-bit integers in maskedvbyte format from in, storing the result
 // in out.  Returns the number of bytes read.
@@ -463,12 +484,12 @@ streamvbyte_decode_0124(const uint8_t* in, uint32_t* out, uint32_t count) {
     uint32_t keyLen = ((count + 3) / 4);       // 2-bits per key (rounded up)
     const uint8_t* dataPtr = keyPtr + keyLen;  // data starts at end of keys
 
-#if defined(__SSE4_1__) || defined(__ARM_NEON__) || defined(__ARM_NEON)
+#ifdef KNOWHERE_STREAMVBYTE_SIMD
     dataPtr = svb_decode_vec128_simple(out, keyPtr, dataPtr, count);
     out += count & ~31U;
     keyPtr += (count / 4) & ~7U;
     count &= 31;
-#endif  // __SSE4_1__ || __ARM_NEON__ || __ARM_NEON
+#endif  // KNOWHERE_STREAMVBYTE_SIMD
 
     return (size_t)(svb_decode_scalar(out, keyPtr, dataPtr, count) - in);
 }

--- a/src/index/sparse/codec/streamvbyte_0124_encode.c
+++ b/src/index/sparse/codec/streamvbyte_0124_encode.c
@@ -9,7 +9,11 @@
 #include <stdint.h>
 #include <string.h>  // for memcpy
 
-#if defined(__SSE4_1__)
+#if defined(__SSE4_1__) || defined(__loongarch_sx)
+#define KNOWHERE_STREAMVBYTE_SIMD
+#endif
+
+#ifdef KNOWHERE_STREAMVBYTE_SIMD
 // using 0,1,2,4 bytes per value
 static uint8_t lengthTable[256] = {
     0, 1, 2, 4,  1, 2, 3, 5,  2, 3, 4,  6,  4,  5,  6,  8,  1, 2, 3,  5,  2, 3,  4,  6,  3,  4,  5,  7,  5,  6,  7,  9,
@@ -285,6 +289,8 @@ static int8_t encodingShuffleTable[256][16] = {
 
 #if defined(__SSE4_1__)
 #include <immintrin.h>
+#elif defined(__loongarch_sx)
+#include <lsxintrin.h>
 #endif
 
 static uint8_t
@@ -334,11 +340,30 @@ svb_encode_scalar(const uint32_t* in, uint8_t* __restrict__ keyPtr, uint8_t* __r
     return dataPtr;  // pointer to first unused data byte
 }
 
-#ifdef __SSE4_1__
+#ifdef KNOWHERE_STREAMVBYTE_SIMD
 typedef __m128i encode_t;
 
 static size_t
 streamvbyte_encode4(__m128i in, uint8_t* outData, uint8_t* outCode) {
+#if defined(__loongarch_sx)
+    const __m128i ones = __lsx_vrepli_w(1);
+    const __m128i zero_mask = __lsx_vseqi_w(in, 0);
+    const __m128i byte_mask = __lsx_vseqi_w(__lsx_vsrli_w(in, 8), 0);
+    const __m128i halfword_mask = __lsx_vseqi_w(__lsx_vsrli_w(in, 16), 0);
+    const __m128i nonzero = __lsx_vand_v(__lsx_vnor_v(zero_mask, zero_mask), ones);
+    const __m128i over_byte = __lsx_vand_v(__lsx_vnor_v(byte_mask, byte_mask), ones);
+    const __m128i over_halfword = __lsx_vand_v(__lsx_vnor_v(halfword_mask, halfword_mask), ones);
+    const __m128i symbols = __lsx_vadd_w(__lsx_vadd_w(nonzero, over_byte), over_halfword);
+    const uint8_t code = (uint8_t)(__lsx_vpickve2gr_wu(symbols, 0) | (__lsx_vpickve2gr_wu(symbols, 1) << 2) |
+                                   (__lsx_vpickve2gr_wu(symbols, 2) << 4) | (__lsx_vpickve2gr_wu(symbols, 3) << 6));
+    const size_t length = lengthTable[code];
+    const __m128i shuf = __lsx_vld((void*)&encodingShuffleTable[code], 0);
+    const __m128i out = __lsx_vshuf_b(__lsx_vldi(0), in, shuf);
+
+    __lsx_vst(out, outData, 0);
+    *outCode = code;
+    return length;
+#else
     const __m128i Ones = _mm_set1_epi32(0x01010101);
     const __m128i GatherBits = _mm_set1_epi32(0x08040102);
     const __m128i CodeTable = _mm_set_epi32(0x03030303, 0x03030303, 0x03030303, 0x02020100);
@@ -361,14 +386,19 @@ streamvbyte_encode4(__m128i in, uint8_t* outData, uint8_t* outCode) {
     _mm_storeu_si128((__m128i*)outData, out);
     *outCode = (uint8_t)code;
     return length;
+#endif
 }
 
 static size_t
 streamvbyte_encode_quad(const uint32_t* in, uint8_t* outData, uint8_t* outKey) {
+#if defined(__loongarch_sx)
+    __m128i vin = __lsx_vld((void*)in, 0);
+#else
     __m128i vin = _mm_loadu_si128((const __m128i*)in);
+#endif
     return streamvbyte_encode4(vin, outData, outKey);
 }
-#endif  // __SSE4_1__
+#endif  // KNOWHERE_STREAMVBYTE_SIMD
 
 size_t
 streamvbyte_encode_0124(const uint32_t* in, uint32_t count, uint8_t* out) {
@@ -376,7 +406,7 @@ streamvbyte_encode_0124(const uint32_t* in, uint32_t count, uint8_t* out) {
     uint32_t keyLen = (count + 3) / 4;   // 2-bits rounded to full byte
     uint8_t* dataPtr = keyPtr + keyLen;  // variable byte data after all keys
 
-#ifdef __SSE4_1__
+#ifdef KNOWHERE_STREAMVBYTE_SIMD
     uint32_t count_quads = count / 4;
     count -= 4 * count_quads;
     for (uint32_t c = 0; c < count_quads; c++) {
@@ -384,7 +414,7 @@ streamvbyte_encode_0124(const uint32_t* in, uint32_t count, uint8_t* out) {
         keyPtr++;
         in += 4;
     }
-#endif  // __SSE4_1__
+#endif  // KNOWHERE_STREAMVBYTE_SIMD
 
     return (size_t)(svb_encode_scalar(in, keyPtr, dataPtr, count) - out);
 }

--- a/src/index/sparse/codec/varintdecode.c
+++ b/src/index/sparse/codec/varintdecode.c
@@ -5,6 +5,8 @@
 //   Repository: https://github.com/lemire/MaskedVByte
 //   License: Apache License 2.0
 
+#include <stddef.h>
+
 #if defined(_MSC_VER)
 /* Microsoft C/C++-compatible compiler */
 #if (defined(_M_IX86) || defined(_M_AMD64))
@@ -19,8 +21,10 @@
 
 #elif defined(__aarch64__)
 #define SIMDE_ENABLE_NATIVE_ALIASES
-/* GCC-compatible compiler, targeting ARM with NEON */
+/* GCC-compatible compiler, targeting ARM with NEON through SIMDe */
 #include <simde/x86/sse4.1.h>
+#elif defined(__loongarch_sx)
+#include "lsx_sse_compat.h"
 #elif defined(__GNUC__) && defined(__IWMMXT__)
 /* GCC-compatible compiler, targeting ARM with WMMX */
 #include <mmintrin.h>

--- a/src/index/sparse/sindi_simd.cc
+++ b/src/index/sparse/sindi_simd.cc
@@ -78,6 +78,10 @@ get_ip_kernels() {
             k.batch_insert = batch_insert_sve;
             return k;
         }
+#elif defined(__loongarch__)
+        k.accumulate = ip_accumulate_lsx_fp16;
+        k.batch_insert = batch_insert_lsx;
+        return k;
 #endif
         k.accumulate = ip_accumulate_scalar_fp16;
         k.batch_insert = batch_insert_scalar;
@@ -108,6 +112,10 @@ get_bm25_kernels() {
             k.batch_insert = batch_insert_sve;
             return k;
         }
+#elif defined(__loongarch__)
+        k.accumulate = bm25_accumulate_lsx_u16;
+        k.batch_insert = batch_insert_lsx;
+        return k;
 #endif
         k.accumulate = bm25_accumulate_scalar_u16;
         k.batch_insert = batch_insert_scalar;

--- a/src/index/sparse/sindi_simd.h
+++ b/src/index/sparse/sindi_simd.h
@@ -65,6 +65,17 @@ batch_insert_avx512(const float* scores, size_t docid_start, size_t count,
                     knowhere::ResultMinHeap<float, uint32_t>& topk_q, float& threshold, const BitsetView& bitset);
 #endif
 
+#if defined(__loongarch__)
+float
+ip_accumulate_lsx_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out);
+float
+bm25_accumulate_lsx_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
+                        float b, float avgdl, const float* row_sums);
+void
+batch_insert_lsx(const float* scores, size_t docid_start, size_t count,
+                 knowhere::ResultMinHeap<float, uint32_t>& topk_q, float& threshold, const BitsetView& bitset);
+#endif
+
 #if defined(__aarch64__) && defined(KNOWHERE_USE_SVE)
 // SVE implementations (compiled with SVE support)
 float

--- a/src/index/sparse/sindi_simd_lsx.cc
+++ b/src/index/sparse/sindi_simd_lsx.cc
@@ -1,0 +1,174 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "index/sparse/sindi_simd.h"
+
+#if defined(__loongarch_sx)
+
+#include <lsxintrin.h>
+
+#include <bit>
+#include <cmath>
+
+namespace knowhere::sparse::inverted::sindi {
+namespace {
+
+constexpr size_t kLanes = 4;
+
+inline __m128
+load_f32(const float* ptr) {
+    return std::bit_cast<__m128>(__lsx_vld(const_cast<float*>(ptr), 0));
+}
+
+inline void
+store_f32(float* ptr, __m128 value) {
+    __lsx_vst(std::bit_cast<__m128i>(value), ptr, 0);
+}
+
+inline __m128
+broadcast_f32(float value) {
+    return std::bit_cast<__m128>(__lsx_vreplgr2vr_w(std::bit_cast<int32_t>(value)));
+}
+
+inline float
+reduce_max(__m128 value) {
+    alignas(16) float lanes[kLanes];
+    store_f32(lanes, value);
+    float result = 0.0f;
+    for (float lane : lanes) {
+        result = std::fmax(result, lane);
+    }
+    return result;
+}
+
+}  // namespace
+
+float
+ip_accumulate_lsx_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out) {
+    const __m128 qval_v = broadcast_f32(qval);
+    __m128 maximum = std::bit_cast<__m128>(__lsx_vldi(0));
+    alignas(16) float gathered[kLanes];
+    alignas(16) float updated[kLanes];
+    int32_t i = 0;
+
+    // LSX has no indexed gather/scatter. Process eight FP16 values with native
+    // conversion and vector arithmetic, keeping only the indexed accesses scalar.
+    for (; i + 8 <= num; i += 8) {
+        const __m128i half = __lsx_vld(const_cast<knowhere::fp16*>(vals + i), 0);
+        const __m128 values[2] = {__lsx_vfcvtl_s_h(half), __lsx_vfcvth_s_h(half)};
+        for (int32_t half_index = 0; half_index < 2; ++half_index) {
+            const int32_t offset = i + half_index * static_cast<int32_t>(kLanes);
+            for (size_t lane = 0; lane < kLanes; ++lane) {
+                gathered[lane] = out[ids[offset + static_cast<int32_t>(lane)]];
+            }
+            const __m128 sum = __lsx_vfmadd_s(values[half_index], qval_v, load_f32(gathered));
+            store_f32(updated, sum);
+            for (size_t lane = 0; lane < kLanes; ++lane) {
+                out[ids[offset + static_cast<int32_t>(lane)]] = updated[lane];
+            }
+            maximum = __lsx_vfmax_s(maximum, sum);
+        }
+    }
+
+    float max_val = reduce_max(maximum);
+    for (; i < num; ++i) {
+        const float new_val = (out[ids[i]] += qval * static_cast<float>(vals[i]));
+        max_val = std::fmax(max_val, new_val);
+    }
+    return max_val;
+}
+
+float
+bm25_accumulate_lsx_u16(float qval, const uint16_t* vals, const uint16_t* ids, int32_t num, float* out, float k1,
+                        float b, float avgdl, const float* row_sums) {
+    const float p1 = k1 + 1.0f;
+    const float p2 = k1 * (1.0f - b);
+    const float p3 = k1 * b / avgdl;
+    const __m128 numerator_scale = broadcast_f32(qval * p1);
+    const __m128 p2_v = broadcast_f32(p2);
+    const __m128 p3_v = broadcast_f32(p3);
+    __m128 maximum = std::bit_cast<__m128>(__lsx_vldi(0));
+    alignas(16) float doc_lengths[kLanes];
+    alignas(16) float gathered[kLanes];
+    alignas(16) float updated[kLanes];
+    int32_t i = 0;
+
+    for (; i + 8 <= num; i += 8) {
+        const __m128i packed = __lsx_vld(const_cast<uint16_t*>(vals + i), 0);
+        const __m128 tf[2] = {__lsx_vffint_s_wu(__lsx_vilvl_h(__lsx_vldi(0), packed)),
+                              __lsx_vffint_s_wu(__lsx_vexth_wu_hu(packed))};
+        for (int32_t half_index = 0; half_index < 2; ++half_index) {
+            const int32_t offset = i + half_index * static_cast<int32_t>(kLanes);
+            for (size_t lane = 0; lane < kLanes; ++lane) {
+                const uint16_t id = ids[offset + static_cast<int32_t>(lane)];
+                doc_lengths[lane] = row_sums[id];
+                gathered[lane] = out[id];
+            }
+
+            const __m128 numerator = __lsx_vfmul_s(tf[half_index], numerator_scale);
+            const __m128 denominator = __lsx_vfadd_s(tf[half_index], __lsx_vfmadd_s(load_f32(doc_lengths), p3_v, p2_v));
+            const __m128 sum = __lsx_vfadd_s(load_f32(gathered), __lsx_vfdiv_s(numerator, denominator));
+            store_f32(updated, sum);
+            for (size_t lane = 0; lane < kLanes; ++lane) {
+                out[ids[offset + static_cast<int32_t>(lane)]] = updated[lane];
+            }
+            maximum = __lsx_vfmax_s(maximum, sum);
+        }
+    }
+
+    float max_val = reduce_max(maximum);
+    for (; i < num; ++i) {
+        const float tf = static_cast<float>(vals[i]);
+        const uint16_t docid = ids[i];
+        const float score = qval * p1 * tf / (tf + p2 + p3 * row_sums[docid]);
+        const float new_val = (out[docid] += score);
+        max_val = std::fmax(max_val, new_val);
+    }
+    return max_val;
+}
+
+void
+batch_insert_lsx(const float* scores, size_t docid_start, size_t count,
+                 knowhere::ResultMinHeap<float, uint32_t>& topk_q, float& threshold, const BitsetView& bitset) {
+    alignas(16) int32_t selected[kLanes];
+    size_t i = 0;
+    for (; i + kLanes <= count; i += kLanes) {
+        const __m128 threshold_v = broadcast_f32(threshold);
+        const __m128 values = load_f32(scores + i);
+        __lsx_vst(__lsx_vfcmp_clt_s(threshold_v, values), selected, 0);
+        for (size_t lane = 0; lane < kLanes; ++lane) {
+            if (selected[lane] == 0) {
+                continue;
+            }
+            const size_t index = i + lane;
+            if (!bitset.empty() && bitset.test(static_cast<int64_t>(docid_start + index))) {
+                continue;
+            }
+            if (topk_q.Push(scores[index], static_cast<uint32_t>(docid_start + index)) && topk_q.Full()) {
+                threshold = topk_q.Threshold();
+            }
+        }
+    }
+
+    for (; i < count; ++i) {
+        const float score = scores[i];
+        if (score <= threshold || (!bitset.empty() && bitset.test(static_cast<int64_t>(docid_start + i)))) {
+            continue;
+        }
+        if (topk_q.Push(score, static_cast<uint32_t>(docid_start + i)) && topk_q.Full()) {
+            threshold = topk_q.Threshold();
+        }
+    }
+}
+
+}  // namespace knowhere::sparse::inverted::sindi
+
+#endif

--- a/src/simd/distances_lasx.cc
+++ b/src/simd/distances_lasx.cc
@@ -1,0 +1,312 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "distances_lasx.h"
+
+#include <lasxintrin.h>
+
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+namespace faiss::cppcontrib::knowhere {
+namespace {
+
+constexpr size_t kLanes = 8;
+
+inline __m256
+load_f32(const float* ptr) {
+    return std::bit_cast<__m256>(__lasx_xvld(const_cast<float*>(ptr), 0));
+}
+
+inline void
+store_f32(float* ptr, __m256 value) {
+    __lasx_xvst(std::bit_cast<__m256i>(value), ptr, 0);
+}
+
+inline __m256
+zero_f32() {
+    return std::bit_cast<__m256>(__lasx_xvldi(0));
+}
+
+inline __m256
+broadcast_f32(float value) {
+    return std::bit_cast<__m256>(__lasx_xvreplgr2vr_w(std::bit_cast<int32_t>(value)));
+}
+
+inline __m256
+abs_f32(__m256 value) {
+    return std::bit_cast<__m256>(__lasx_xvbitclri_w(std::bit_cast<__m256i>(value), 31));
+}
+
+inline float
+reduce_sum(__m256 value) {
+    alignas(32) float lanes[kLanes];
+    store_f32(lanes, value);
+    float result = 0.0f;
+    for (float lane : lanes) {
+        result += lane;
+    }
+    return result;
+}
+
+inline float
+reduce_max(__m256 value) {
+    alignas(32) float lanes[kLanes];
+    store_f32(lanes, value);
+    float result = 0.0f;
+    for (float lane : lanes) {
+        result = std::fmax(result, lane);
+    }
+    return result;
+}
+
+}  // namespace
+
+float
+fvec_inner_product_lasx(const float* x, const float* y, size_t d) {
+    __m256 sum = zero_f32();
+    size_t i = 0;
+    for (; i + kLanes <= d; i += kLanes) {
+        sum = __lasx_xvfmadd_s(load_f32(x + i), load_f32(y + i), sum);
+    }
+
+    float result = reduce_sum(sum);
+    for (; i < d; ++i) {
+        result += x[i] * y[i];
+    }
+    return result;
+}
+
+float
+fvec_L2sqr_lasx(const float* x, const float* y, size_t d) {
+    __m256 sum = zero_f32();
+    size_t i = 0;
+    for (; i + kLanes <= d; i += kLanes) {
+        const __m256 diff = __lasx_xvfsub_s(load_f32(x + i), load_f32(y + i));
+        sum = __lasx_xvfmadd_s(diff, diff, sum);
+    }
+
+    float result = reduce_sum(sum);
+    for (; i < d; ++i) {
+        const float diff = x[i] - y[i];
+        result += diff * diff;
+    }
+    return result;
+}
+
+float
+fvec_L1_lasx(const float* x, const float* y, size_t d) {
+    __m256 sum = zero_f32();
+    size_t i = 0;
+    for (; i + kLanes <= d; i += kLanes) {
+        const __m256 diff = __lasx_xvfsub_s(load_f32(x + i), load_f32(y + i));
+        sum = __lasx_xvfadd_s(sum, abs_f32(diff));
+    }
+
+    float result = reduce_sum(sum);
+    for (; i < d; ++i) {
+        result += std::fabs(x[i] - y[i]);
+    }
+    return result;
+}
+
+float
+fvec_Linf_lasx(const float* x, const float* y, size_t d) {
+    __m256 maximum = zero_f32();
+    size_t i = 0;
+    for (; i + kLanes <= d; i += kLanes) {
+        const __m256 diff = __lasx_xvfsub_s(load_f32(x + i), load_f32(y + i));
+        maximum = __lasx_xvfmax_s(maximum, abs_f32(diff));
+    }
+
+    float result = reduce_max(maximum);
+    for (; i < d; ++i) {
+        result = std::fmax(result, std::fabs(x[i] - y[i]));
+    }
+    return result;
+}
+
+float
+fvec_norm_L2sqr_lasx(const float* x, size_t d) {
+    __m256 sum = zero_f32();
+    size_t i = 0;
+    for (; i + kLanes <= d; i += kLanes) {
+        const __m256 value = load_f32(x + i);
+        sum = __lasx_xvfmadd_s(value, value, sum);
+    }
+
+    float result = reduce_sum(sum);
+    for (; i < d; ++i) {
+        result += x[i] * x[i];
+    }
+    return result;
+}
+
+void
+fvec_L2sqr_ny_lasx(float* dis, const float* x, const float* y, size_t d, size_t ny) {
+    for (size_t i = 0; i < ny; ++i) {
+        dis[i] = fvec_L2sqr_lasx(x, y + i * d, d);
+    }
+}
+
+void
+fvec_inner_products_ny_lasx(float* ip, const float* x, const float* y, size_t d, size_t ny) {
+    for (size_t i = 0; i < ny; ++i) {
+        ip[i] = fvec_inner_product_lasx(x, y + i * d, d);
+    }
+}
+
+void
+fvec_L2sqr_ny_transposed_lasx(float* dis, const float* x, const float* y, const float* y_sqlen, size_t d,
+                              size_t d_offset, size_t ny) {
+    const float x_sqlen = fvec_norm_L2sqr_lasx(x, d);
+    const __m256 x_sqlen_v = broadcast_f32(x_sqlen);
+    size_t i = 0;
+    for (; i + kLanes <= ny; i += kLanes) {
+        __m256 dot_product = zero_f32();
+        for (size_t j = 0; j < d; ++j) {
+            dot_product = __lasx_xvfmadd_s(broadcast_f32(x[j]), load_f32(y + i + j * d_offset), dot_product);
+        }
+        const __m256 squared_lengths = __lasx_xvfadd_s(x_sqlen_v, load_f32(y_sqlen + i));
+        store_f32(dis + i, __lasx_xvfsub_s(squared_lengths, __lasx_xvfadd_s(dot_product, dot_product)));
+    }
+
+    for (; i < ny; ++i) {
+        float dot_product = 0.0f;
+        for (size_t j = 0; j < d; ++j) {
+            dot_product += x[j] * y[i + j * d_offset];
+        }
+        dis[i] = x_sqlen + y_sqlen[i] - 2.0f * dot_product;
+    }
+}
+
+size_t
+fvec_L2sqr_ny_nearest_lasx(float* distances_tmp_buffer, const float* x, const float* y, size_t d, size_t ny) {
+    fvec_L2sqr_ny_lasx(distances_tmp_buffer, x, y, d, ny);
+    size_t nearest_idx = 0;
+    float min_distance = std::numeric_limits<float>::infinity();
+    for (size_t i = 0; i < ny; ++i) {
+        if (distances_tmp_buffer[i] < min_distance) {
+            min_distance = distances_tmp_buffer[i];
+            nearest_idx = i;
+        }
+    }
+    return nearest_idx;
+}
+
+size_t
+fvec_L2sqr_ny_nearest_y_transposed_lasx(float* distances_tmp_buffer, const float* x, const float* y,
+                                        const float* y_sqlen, size_t d, size_t d_offset, size_t ny) {
+    fvec_L2sqr_ny_transposed_lasx(distances_tmp_buffer, x, y, y_sqlen, d, d_offset, ny);
+    size_t nearest_idx = 0;
+    float min_distance = std::numeric_limits<float>::infinity();
+    for (size_t i = 0; i < ny; ++i) {
+        if (distances_tmp_buffer[i] < min_distance) {
+            min_distance = distances_tmp_buffer[i];
+            nearest_idx = i;
+        }
+    }
+    return nearest_idx;
+}
+
+void
+fvec_madd_lasx(size_t n, const float* a, float bf, const float* b, float* c) {
+    const __m256 bf_v = broadcast_f32(bf);
+    size_t i = 0;
+    for (; i + kLanes <= n; i += kLanes) {
+        store_f32(c + i, __lasx_xvfmadd_s(bf_v, load_f32(b + i), load_f32(a + i)));
+    }
+    for (; i < n; ++i) {
+        c[i] = a[i] + bf * b[i];
+    }
+}
+
+int
+fvec_madd_and_argmin_lasx(size_t n, const float* a, float bf, const float* b, float* c) {
+    fvec_madd_lasx(n, a, bf, b, c);
+    float minimum = 1e20f;
+    int minimum_index = -1;
+    for (size_t i = 0; i < n; ++i) {
+        if (c[i] < minimum) {
+            minimum = c[i];
+            minimum_index = static_cast<int>(i);
+        }
+    }
+    return minimum_index;
+}
+
+void
+fvec_inner_product_batch_4_lasx(const float* x, const float* y0, const float* y1, const float* y2, const float* y3,
+                                size_t d, float& dis0, float& dis1, float& dis2, float& dis3) {
+    __m256 sum0 = zero_f32();
+    __m256 sum1 = zero_f32();
+    __m256 sum2 = zero_f32();
+    __m256 sum3 = zero_f32();
+    size_t i = 0;
+    for (; i + kLanes <= d; i += kLanes) {
+        const __m256 x_v = load_f32(x + i);
+        sum0 = __lasx_xvfmadd_s(x_v, load_f32(y0 + i), sum0);
+        sum1 = __lasx_xvfmadd_s(x_v, load_f32(y1 + i), sum1);
+        sum2 = __lasx_xvfmadd_s(x_v, load_f32(y2 + i), sum2);
+        sum3 = __lasx_xvfmadd_s(x_v, load_f32(y3 + i), sum3);
+    }
+
+    dis0 = reduce_sum(sum0);
+    dis1 = reduce_sum(sum1);
+    dis2 = reduce_sum(sum2);
+    dis3 = reduce_sum(sum3);
+    for (; i < d; ++i) {
+        dis0 += x[i] * y0[i];
+        dis1 += x[i] * y1[i];
+        dis2 += x[i] * y2[i];
+        dis3 += x[i] * y3[i];
+    }
+}
+
+void
+fvec_L2sqr_batch_4_lasx(const float* x, const float* y0, const float* y1, const float* y2, const float* y3, size_t d,
+                        float& dis0, float& dis1, float& dis2, float& dis3) {
+    __m256 sum0 = zero_f32();
+    __m256 sum1 = zero_f32();
+    __m256 sum2 = zero_f32();
+    __m256 sum3 = zero_f32();
+    size_t i = 0;
+    for (; i + kLanes <= d; i += kLanes) {
+        const __m256 x_v = load_f32(x + i);
+        const __m256 diff0 = __lasx_xvfsub_s(x_v, load_f32(y0 + i));
+        const __m256 diff1 = __lasx_xvfsub_s(x_v, load_f32(y1 + i));
+        const __m256 diff2 = __lasx_xvfsub_s(x_v, load_f32(y2 + i));
+        const __m256 diff3 = __lasx_xvfsub_s(x_v, load_f32(y3 + i));
+        sum0 = __lasx_xvfmadd_s(diff0, diff0, sum0);
+        sum1 = __lasx_xvfmadd_s(diff1, diff1, sum1);
+        sum2 = __lasx_xvfmadd_s(diff2, diff2, sum2);
+        sum3 = __lasx_xvfmadd_s(diff3, diff3, sum3);
+    }
+
+    dis0 = reduce_sum(sum0);
+    dis1 = reduce_sum(sum1);
+    dis2 = reduce_sum(sum2);
+    dis3 = reduce_sum(sum3);
+    for (; i < d; ++i) {
+        const float diff0 = x[i] - y0[i];
+        const float diff1 = x[i] - y1[i];
+        const float diff2 = x[i] - y2[i];
+        const float diff3 = x[i] - y3[i];
+        dis0 += diff0 * diff0;
+        dis1 += diff1 * diff1;
+        dis2 += diff2 * diff2;
+        dis3 += diff3 * diff3;
+    }
+}
+
+}  // namespace faiss::cppcontrib::knowhere

--- a/src/simd/distances_lasx.h
+++ b/src/simd/distances_lasx.h
@@ -1,0 +1,64 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+
+namespace faiss::cppcontrib::knowhere {
+
+float
+fvec_inner_product_lasx(const float* x, const float* y, size_t d);
+
+float
+fvec_L2sqr_lasx(const float* x, const float* y, size_t d);
+
+float
+fvec_L1_lasx(const float* x, const float* y, size_t d);
+
+float
+fvec_Linf_lasx(const float* x, const float* y, size_t d);
+
+float
+fvec_norm_L2sqr_lasx(const float* x, size_t d);
+
+void
+fvec_L2sqr_ny_lasx(float* dis, const float* x, const float* y, size_t d, size_t ny);
+
+void
+fvec_inner_products_ny_lasx(float* ip, const float* x, const float* y, size_t d, size_t ny);
+
+void
+fvec_L2sqr_ny_transposed_lasx(float* dis, const float* x, const float* y, const float* y_sqlen, size_t d,
+                              size_t d_offset, size_t ny);
+
+size_t
+fvec_L2sqr_ny_nearest_lasx(float* distances_tmp_buffer, const float* x, const float* y, size_t d, size_t ny);
+
+size_t
+fvec_L2sqr_ny_nearest_y_transposed_lasx(float* distances_tmp_buffer, const float* x, const float* y,
+                                        const float* y_sqlen, size_t d, size_t d_offset, size_t ny);
+
+void
+fvec_madd_lasx(size_t n, const float* a, float bf, const float* b, float* c);
+
+int
+fvec_madd_and_argmin_lasx(size_t n, const float* a, float bf, const float* b, float* c);
+
+void
+fvec_inner_product_batch_4_lasx(const float* x, const float* y0, const float* y1, const float* y2, const float* y3,
+                                size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
+
+void
+fvec_L2sqr_batch_4_lasx(const float* x, const float* y0, const float* y1, const float* y2, const float* y3, size_t d,
+                        float& dis0, float& dis1, float& dis2, float& dis3);
+
+}  // namespace faiss::cppcontrib::knowhere

--- a/src/simd/distances_lsx.cc
+++ b/src/simd/distances_lsx.cc
@@ -1,0 +1,580 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "distances_lsx.h"
+
+#include <lsxintrin.h>
+
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+namespace faiss::cppcontrib::knowhere {
+namespace {
+
+constexpr size_t kLanes = 4;
+
+inline __m128
+load_f32(const float* ptr) {
+    return std::bit_cast<__m128>(__lsx_vld(const_cast<float*>(ptr), 0));
+}
+
+inline void
+store_f32(float* ptr, __m128 value) {
+    __lsx_vst(std::bit_cast<__m128i>(value), ptr, 0);
+}
+
+inline __m128
+zero_f32() {
+    return std::bit_cast<__m128>(__lsx_vldi(0));
+}
+
+inline __m128
+broadcast_f32(float value) {
+    return std::bit_cast<__m128>(__lsx_vreplgr2vr_w(std::bit_cast<int32_t>(value)));
+}
+
+inline __m128
+abs_f32(__m128 value) {
+    return std::bit_cast<__m128>(__lsx_vbitclri_w(std::bit_cast<__m128i>(value), 31));
+}
+
+inline float
+reduce_sum(__m128 value) {
+    alignas(16) float lanes[kLanes];
+    store_f32(lanes, value);
+    return lanes[0] + lanes[1] + lanes[2] + lanes[3];
+}
+
+inline float
+reduce_max(__m128 value) {
+    alignas(16) float lanes[kLanes];
+    store_f32(lanes, value);
+    float result = 0.0f;
+    for (float lane : lanes) {
+        result = std::fmax(result, lane);
+    }
+    return result;
+}
+
+template <size_t Parts>
+struct FloatVectors {
+    __m128 lanes[Parts];
+};
+
+inline FloatVectors<2>
+load_fp16(const ::knowhere::fp16* ptr) {
+    const __m128i packed = __lsx_vld(const_cast<::knowhere::fp16*>(ptr), 0);
+    return {{__lsx_vfcvtl_s_h(packed), __lsx_vfcvth_s_h(packed)}};
+}
+
+inline FloatVectors<2>
+load_bf16(const ::knowhere::bf16* ptr) {
+    const __m128i packed = __lsx_vld(const_cast<::knowhere::bf16*>(ptr), 0);
+    const __m128i zero = __lsx_vldi(0);
+    const __m128i low = __lsx_vslli_w(__lsx_vilvl_h(zero, packed), 16);
+    const __m128i high = __lsx_vslli_w(__lsx_vexth_wu_hu(packed), 16);
+    return {{std::bit_cast<__m128>(low), std::bit_cast<__m128>(high)}};
+}
+
+using i8x16 = int8_t __attribute__((vector_size(16)));
+using i8x4 = int8_t __attribute__((vector_size(4)));
+using i32x4 = int32_t __attribute__((vector_size(16)));
+
+template <int Offset>
+inline __m128i
+expand_i8_to_i32(__m128i packed) {
+    const i8x16 bytes = std::bit_cast<i8x16>(packed);
+    const i8x4 selected = __builtin_shufflevector(bytes, bytes, Offset, Offset + 1, Offset + 2, Offset + 3);
+    return std::bit_cast<__m128i>(__builtin_convertvector(selected, i32x4));
+}
+
+inline FloatVectors<4>
+load_int8(const int8_t* ptr) {
+    const __m128i packed = __lsx_vld(const_cast<int8_t*>(ptr), 0);
+    return {{std::bit_cast<__m128>(__lsx_vffint_s_w(expand_i8_to_i32<0>(packed))),
+             std::bit_cast<__m128>(__lsx_vffint_s_w(expand_i8_to_i32<4>(packed))),
+             std::bit_cast<__m128>(__lsx_vffint_s_w(expand_i8_to_i32<8>(packed))),
+             std::bit_cast<__m128>(__lsx_vffint_s_w(expand_i8_to_i32<12>(packed)))}};
+}
+
+enum class ConvertedMetric {
+    InnerProduct,
+    L2,
+};
+
+template <ConvertedMetric Metric>
+inline __m128
+accumulate(__m128 x, __m128 y, __m128 sum) {
+    if constexpr (Metric == ConvertedMetric::InnerProduct) {
+        return __lsx_vfmadd_s(x, y, sum);
+    } else {
+        const __m128 diff = __lsx_vfsub_s(x, y);
+        return __lsx_vfmadd_s(diff, diff, sum);
+    }
+}
+
+template <ConvertedMetric Metric, typename T, size_t Parts>
+float
+converted_distance(const T* x, const T* y, size_t d, FloatVectors<Parts> (*load)(const T*)) {
+    __m128 sums[Parts];
+    for (size_t part = 0; part < Parts; ++part) {
+        sums[part] = zero_f32();
+    }
+
+    constexpr size_t width = Parts * kLanes;
+    size_t i = 0;
+    for (; i + width <= d; i += width) {
+        const auto x_vectors = load(x + i);
+        const auto y_vectors = load(y + i);
+        for (size_t part = 0; part < Parts; ++part) {
+            sums[part] = accumulate<Metric>(x_vectors.lanes[part], y_vectors.lanes[part], sums[part]);
+        }
+    }
+
+    float result = 0.0f;
+    for (size_t part = 0; part < Parts; ++part) {
+        result += reduce_sum(sums[part]);
+    }
+    for (; i < d; ++i) {
+        const float x_value = static_cast<float>(x[i]);
+        const float y_value = static_cast<float>(y[i]);
+        if constexpr (Metric == ConvertedMetric::InnerProduct) {
+            result += x_value * y_value;
+        } else {
+            const float diff = x_value - y_value;
+            result += diff * diff;
+        }
+    }
+    return result;
+}
+
+template <ConvertedMetric Metric, typename T, size_t Parts>
+void
+converted_batch_4(const T* x, const T* y0, const T* y1, const T* y2, const T* y3, size_t d, float& dis0, float& dis1,
+                  float& dis2, float& dis3, FloatVectors<Parts> (*load)(const T*)) {
+    __m128 sums[4][Parts];
+    for (size_t output = 0; output < 4; ++output) {
+        for (size_t part = 0; part < Parts; ++part) {
+            sums[output][part] = zero_f32();
+        }
+    }
+
+    constexpr size_t width = Parts * kLanes;
+    size_t i = 0;
+    for (; i + width <= d; i += width) {
+        const auto x_vectors = load(x + i);
+        const FloatVectors<Parts> y_vectors[4] = {load(y0 + i), load(y1 + i), load(y2 + i), load(y3 + i)};
+        for (size_t part = 0; part < Parts; ++part) {
+            for (size_t output = 0; output < 4; ++output) {
+                sums[output][part] =
+                    accumulate<Metric>(x_vectors.lanes[part], y_vectors[output].lanes[part], sums[output][part]);
+            }
+        }
+    }
+
+    float* outputs[4] = {&dis0, &dis1, &dis2, &dis3};
+    const T* y[4] = {y0, y1, y2, y3};
+    for (size_t output = 0; output < 4; ++output) {
+        *outputs[output] = 0.0f;
+        for (size_t part = 0; part < Parts; ++part) {
+            *outputs[output] += reduce_sum(sums[output][part]);
+        }
+    }
+    for (; i < d; ++i) {
+        const float x_value = static_cast<float>(x[i]);
+        for (size_t output = 0; output < 4; ++output) {
+            const float y_value = static_cast<float>(y[output][i]);
+            if constexpr (Metric == ConvertedMetric::InnerProduct) {
+                *outputs[output] += x_value * y_value;
+            } else {
+                const float diff = x_value - y_value;
+                *outputs[output] += diff * diff;
+            }
+        }
+    }
+}
+
+}  // namespace
+
+float
+fvec_inner_product_lsx(const float* x, const float* y, size_t d) {
+    __m128 sum = zero_f32();
+    size_t i = 0;
+    for (; i + kLanes <= d; i += kLanes) {
+        sum = __lsx_vfmadd_s(load_f32(x + i), load_f32(y + i), sum);
+    }
+
+    float result = reduce_sum(sum);
+    for (; i < d; ++i) {
+        result += x[i] * y[i];
+    }
+    return result;
+}
+
+float
+fvec_L2sqr_lsx(const float* x, const float* y, size_t d) {
+    __m128 sum = zero_f32();
+    size_t i = 0;
+    for (; i + kLanes <= d; i += kLanes) {
+        const __m128 diff = __lsx_vfsub_s(load_f32(x + i), load_f32(y + i));
+        sum = __lsx_vfmadd_s(diff, diff, sum);
+    }
+
+    float result = reduce_sum(sum);
+    for (; i < d; ++i) {
+        const float diff = x[i] - y[i];
+        result += diff * diff;
+    }
+    return result;
+}
+
+float
+fvec_L1_lsx(const float* x, const float* y, size_t d) {
+    __m128 sum = zero_f32();
+    size_t i = 0;
+    for (; i + kLanes <= d; i += kLanes) {
+        const __m128 diff = __lsx_vfsub_s(load_f32(x + i), load_f32(y + i));
+        sum = __lsx_vfadd_s(sum, abs_f32(diff));
+    }
+
+    float result = reduce_sum(sum);
+    for (; i < d; ++i) {
+        result += std::fabs(x[i] - y[i]);
+    }
+    return result;
+}
+
+float
+fvec_Linf_lsx(const float* x, const float* y, size_t d) {
+    __m128 maximum = zero_f32();
+    size_t i = 0;
+    for (; i + kLanes <= d; i += kLanes) {
+        const __m128 diff = __lsx_vfsub_s(load_f32(x + i), load_f32(y + i));
+        maximum = __lsx_vfmax_s(maximum, abs_f32(diff));
+    }
+
+    float result = reduce_max(maximum);
+    for (; i < d; ++i) {
+        result = std::fmax(result, std::fabs(x[i] - y[i]));
+    }
+    return result;
+}
+
+float
+fvec_norm_L2sqr_lsx(const float* x, size_t d) {
+    __m128 sum = zero_f32();
+    size_t i = 0;
+    for (; i + kLanes <= d; i += kLanes) {
+        const __m128 value = load_f32(x + i);
+        sum = __lsx_vfmadd_s(value, value, sum);
+    }
+
+    float result = reduce_sum(sum);
+    for (; i < d; ++i) {
+        result += x[i] * x[i];
+    }
+    return result;
+}
+
+void
+fvec_L2sqr_ny_lsx(float* dis, const float* x, const float* y, size_t d, size_t ny) {
+    for (size_t i = 0; i < ny; ++i) {
+        dis[i] = fvec_L2sqr_lsx(x, y + i * d, d);
+    }
+}
+
+void
+fvec_inner_products_ny_lsx(float* ip, const float* x, const float* y, size_t d, size_t ny) {
+    for (size_t i = 0; i < ny; ++i) {
+        ip[i] = fvec_inner_product_lsx(x, y + i * d, d);
+    }
+}
+
+void
+fvec_L2sqr_ny_transposed_lsx(float* dis, const float* x, const float* y, const float* y_sqlen, size_t d,
+                             size_t d_offset, size_t ny) {
+    const float x_sqlen = fvec_norm_L2sqr_lsx(x, d);
+    const __m128 x_sqlen_v = broadcast_f32(x_sqlen);
+    size_t i = 0;
+    for (; i + kLanes <= ny; i += kLanes) {
+        __m128 dot_product = zero_f32();
+        for (size_t j = 0; j < d; ++j) {
+            dot_product = __lsx_vfmadd_s(broadcast_f32(x[j]), load_f32(y + i + j * d_offset), dot_product);
+        }
+        const __m128 squared_lengths = __lsx_vfadd_s(x_sqlen_v, load_f32(y_sqlen + i));
+        store_f32(dis + i, __lsx_vfsub_s(squared_lengths, __lsx_vfadd_s(dot_product, dot_product)));
+    }
+
+    for (; i < ny; ++i) {
+        float dot_product = 0.0f;
+        for (size_t j = 0; j < d; ++j) {
+            dot_product += x[j] * y[i + j * d_offset];
+        }
+        dis[i] = x_sqlen + y_sqlen[i] - 2.0f * dot_product;
+    }
+}
+
+size_t
+fvec_L2sqr_ny_nearest_lsx(float* distances_tmp_buffer, const float* x, const float* y, size_t d, size_t ny) {
+    fvec_L2sqr_ny_lsx(distances_tmp_buffer, x, y, d, ny);
+    size_t nearest_idx = 0;
+    float min_distance = std::numeric_limits<float>::infinity();
+    for (size_t i = 0; i < ny; ++i) {
+        if (distances_tmp_buffer[i] < min_distance) {
+            min_distance = distances_tmp_buffer[i];
+            nearest_idx = i;
+        }
+    }
+    return nearest_idx;
+}
+
+size_t
+fvec_L2sqr_ny_nearest_y_transposed_lsx(float* distances_tmp_buffer, const float* x, const float* y,
+                                       const float* y_sqlen, size_t d, size_t d_offset, size_t ny) {
+    fvec_L2sqr_ny_transposed_lsx(distances_tmp_buffer, x, y, y_sqlen, d, d_offset, ny);
+    size_t nearest_idx = 0;
+    float min_distance = std::numeric_limits<float>::infinity();
+    for (size_t i = 0; i < ny; ++i) {
+        if (distances_tmp_buffer[i] < min_distance) {
+            min_distance = distances_tmp_buffer[i];
+            nearest_idx = i;
+        }
+    }
+    return nearest_idx;
+}
+
+void
+fvec_madd_lsx(size_t n, const float* a, float bf, const float* b, float* c) {
+    const __m128 bf_v = broadcast_f32(bf);
+    size_t i = 0;
+    for (; i + kLanes <= n; i += kLanes) {
+        store_f32(c + i, __lsx_vfmadd_s(bf_v, load_f32(b + i), load_f32(a + i)));
+    }
+    for (; i < n; ++i) {
+        c[i] = a[i] + bf * b[i];
+    }
+}
+
+int
+fvec_madd_and_argmin_lsx(size_t n, const float* a, float bf, const float* b, float* c) {
+    fvec_madd_lsx(n, a, bf, b, c);
+    float minimum = 1e20f;
+    int minimum_index = -1;
+    for (size_t i = 0; i < n; ++i) {
+        if (c[i] < minimum) {
+            minimum = c[i];
+            minimum_index = static_cast<int>(i);
+        }
+    }
+    return minimum_index;
+}
+
+void
+fvec_inner_product_batch_4_lsx(const float* x, const float* y0, const float* y1, const float* y2, const float* y3,
+                               size_t d, float& dis0, float& dis1, float& dis2, float& dis3) {
+    __m128 sum0 = zero_f32();
+    __m128 sum1 = zero_f32();
+    __m128 sum2 = zero_f32();
+    __m128 sum3 = zero_f32();
+    size_t i = 0;
+    for (; i + kLanes <= d; i += kLanes) {
+        const __m128 x_v = load_f32(x + i);
+        sum0 = __lsx_vfmadd_s(x_v, load_f32(y0 + i), sum0);
+        sum1 = __lsx_vfmadd_s(x_v, load_f32(y1 + i), sum1);
+        sum2 = __lsx_vfmadd_s(x_v, load_f32(y2 + i), sum2);
+        sum3 = __lsx_vfmadd_s(x_v, load_f32(y3 + i), sum3);
+    }
+
+    dis0 = reduce_sum(sum0);
+    dis1 = reduce_sum(sum1);
+    dis2 = reduce_sum(sum2);
+    dis3 = reduce_sum(sum3);
+    for (; i < d; ++i) {
+        dis0 += x[i] * y0[i];
+        dis1 += x[i] * y1[i];
+        dis2 += x[i] * y2[i];
+        dis3 += x[i] * y3[i];
+    }
+}
+
+void
+fvec_L2sqr_batch_4_lsx(const float* x, const float* y0, const float* y1, const float* y2, const float* y3, size_t d,
+                       float& dis0, float& dis1, float& dis2, float& dis3) {
+    __m128 sum0 = zero_f32();
+    __m128 sum1 = zero_f32();
+    __m128 sum2 = zero_f32();
+    __m128 sum3 = zero_f32();
+    size_t i = 0;
+    for (; i + kLanes <= d; i += kLanes) {
+        const __m128 x_v = load_f32(x + i);
+        const __m128 diff0 = __lsx_vfsub_s(x_v, load_f32(y0 + i));
+        const __m128 diff1 = __lsx_vfsub_s(x_v, load_f32(y1 + i));
+        const __m128 diff2 = __lsx_vfsub_s(x_v, load_f32(y2 + i));
+        const __m128 diff3 = __lsx_vfsub_s(x_v, load_f32(y3 + i));
+        sum0 = __lsx_vfmadd_s(diff0, diff0, sum0);
+        sum1 = __lsx_vfmadd_s(diff1, diff1, sum1);
+        sum2 = __lsx_vfmadd_s(diff2, diff2, sum2);
+        sum3 = __lsx_vfmadd_s(diff3, diff3, sum3);
+    }
+
+    dis0 = reduce_sum(sum0);
+    dis1 = reduce_sum(sum1);
+    dis2 = reduce_sum(sum2);
+    dis3 = reduce_sum(sum3);
+    for (; i < d; ++i) {
+        const float diff0 = x[i] - y0[i];
+        const float diff1 = x[i] - y1[i];
+        const float diff2 = x[i] - y2[i];
+        const float diff3 = x[i] - y3[i];
+        dis0 += diff0 * diff0;
+        dis1 += diff1 * diff1;
+        dis2 += diff2 * diff2;
+        dis3 += diff3 * diff3;
+    }
+}
+
+int32_t
+ivec_inner_product_lsx(const int8_t* x, const int8_t* y, size_t d) {
+    __m128i sum = __lsx_vldi(0);
+    size_t i = 0;
+    for (; i + 16 <= d; i += 16) {
+        const __m128i x_values = __lsx_vld(const_cast<int8_t*>(x + i), 0);
+        const __m128i y_values = __lsx_vld(const_cast<int8_t*>(y + i), 0);
+        sum = __lsx_vadd_w(sum, __lsx_vmul_w(expand_i8_to_i32<0>(x_values), expand_i8_to_i32<0>(y_values)));
+        sum = __lsx_vadd_w(sum, __lsx_vmul_w(expand_i8_to_i32<4>(x_values), expand_i8_to_i32<4>(y_values)));
+        sum = __lsx_vadd_w(sum, __lsx_vmul_w(expand_i8_to_i32<8>(x_values), expand_i8_to_i32<8>(y_values)));
+        sum = __lsx_vadd_w(sum, __lsx_vmul_w(expand_i8_to_i32<12>(x_values), expand_i8_to_i32<12>(y_values)));
+    }
+
+    alignas(16) int32_t lanes[kLanes];
+    __lsx_vst(sum, lanes, 0);
+    int32_t result = lanes[0] + lanes[1] + lanes[2] + lanes[3];
+    for (; i < d; ++i) {
+        result += static_cast<int32_t>(x[i]) * static_cast<int32_t>(y[i]);
+    }
+    return result;
+}
+
+int32_t
+ivec_L2sqr_lsx(const int8_t* x, const int8_t* y, size_t d) {
+    __m128i sum = __lsx_vldi(0);
+    size_t i = 0;
+    for (; i + 16 <= d; i += 16) {
+        const __m128i x_values = __lsx_vld(const_cast<int8_t*>(x + i), 0);
+        const __m128i y_values = __lsx_vld(const_cast<int8_t*>(y + i), 0);
+        const __m128i diff0 = __lsx_vsub_w(expand_i8_to_i32<0>(x_values), expand_i8_to_i32<0>(y_values));
+        const __m128i diff1 = __lsx_vsub_w(expand_i8_to_i32<4>(x_values), expand_i8_to_i32<4>(y_values));
+        const __m128i diff2 = __lsx_vsub_w(expand_i8_to_i32<8>(x_values), expand_i8_to_i32<8>(y_values));
+        const __m128i diff3 = __lsx_vsub_w(expand_i8_to_i32<12>(x_values), expand_i8_to_i32<12>(y_values));
+        sum = __lsx_vadd_w(sum, __lsx_vmul_w(diff0, diff0));
+        sum = __lsx_vadd_w(sum, __lsx_vmul_w(diff1, diff1));
+        sum = __lsx_vadd_w(sum, __lsx_vmul_w(diff2, diff2));
+        sum = __lsx_vadd_w(sum, __lsx_vmul_w(diff3, diff3));
+    }
+
+    alignas(16) int32_t lanes[kLanes];
+    __lsx_vst(sum, lanes, 0);
+    int32_t result = lanes[0] + lanes[1] + lanes[2] + lanes[3];
+    for (; i < d; ++i) {
+        const int32_t diff = static_cast<int32_t>(x[i]) - static_cast<int32_t>(y[i]);
+        result += diff * diff;
+    }
+    return result;
+}
+
+float
+fp16_vec_inner_product_lsx(const ::knowhere::fp16* x, const ::knowhere::fp16* y, size_t d) {
+    return converted_distance<ConvertedMetric::InnerProduct>(x, y, d, load_fp16);
+}
+
+float
+fp16_vec_L2sqr_lsx(const ::knowhere::fp16* x, const ::knowhere::fp16* y, size_t d) {
+    return converted_distance<ConvertedMetric::L2>(x, y, d, load_fp16);
+}
+
+float
+fp16_vec_norm_L2sqr_lsx(const ::knowhere::fp16* x, size_t d) {
+    return converted_distance<ConvertedMetric::InnerProduct>(x, x, d, load_fp16);
+}
+
+void
+fp16_vec_inner_product_batch_4_lsx(const ::knowhere::fp16* x, const ::knowhere::fp16* y0, const ::knowhere::fp16* y1,
+                                   const ::knowhere::fp16* y2, const ::knowhere::fp16* y3, size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3) {
+    converted_batch_4<ConvertedMetric::InnerProduct>(x, y0, y1, y2, y3, d, dis0, dis1, dis2, dis3, load_fp16);
+}
+
+void
+fp16_vec_L2sqr_batch_4_lsx(const ::knowhere::fp16* x, const ::knowhere::fp16* y0, const ::knowhere::fp16* y1,
+                           const ::knowhere::fp16* y2, const ::knowhere::fp16* y3, size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3) {
+    converted_batch_4<ConvertedMetric::L2>(x, y0, y1, y2, y3, d, dis0, dis1, dis2, dis3, load_fp16);
+}
+
+float
+bf16_vec_inner_product_lsx(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size_t d) {
+    return converted_distance<ConvertedMetric::InnerProduct>(x, y, d, load_bf16);
+}
+
+float
+bf16_vec_L2sqr_lsx(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size_t d) {
+    return converted_distance<ConvertedMetric::L2>(x, y, d, load_bf16);
+}
+
+float
+bf16_vec_norm_L2sqr_lsx(const ::knowhere::bf16* x, size_t d) {
+    return converted_distance<ConvertedMetric::InnerProduct>(x, x, d, load_bf16);
+}
+
+void
+bf16_vec_inner_product_batch_4_lsx(const ::knowhere::bf16* x, const ::knowhere::bf16* y0, const ::knowhere::bf16* y1,
+                                   const ::knowhere::bf16* y2, const ::knowhere::bf16* y3, size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3) {
+    converted_batch_4<ConvertedMetric::InnerProduct>(x, y0, y1, y2, y3, d, dis0, dis1, dis2, dis3, load_bf16);
+}
+
+void
+bf16_vec_L2sqr_batch_4_lsx(const ::knowhere::bf16* x, const ::knowhere::bf16* y0, const ::knowhere::bf16* y1,
+                           const ::knowhere::bf16* y2, const ::knowhere::bf16* y3, size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3) {
+    converted_batch_4<ConvertedMetric::L2>(x, y0, y1, y2, y3, d, dis0, dis1, dis2, dis3, load_bf16);
+}
+
+float
+int8_vec_inner_product_lsx(const int8_t* x, const int8_t* y, size_t d) {
+    return converted_distance<ConvertedMetric::InnerProduct>(x, y, d, load_int8);
+}
+
+float
+int8_vec_L2sqr_lsx(const int8_t* x, const int8_t* y, size_t d) {
+    return converted_distance<ConvertedMetric::L2>(x, y, d, load_int8);
+}
+
+float
+int8_vec_norm_L2sqr_lsx(const int8_t* x, size_t d) {
+    return converted_distance<ConvertedMetric::InnerProduct>(x, x, d, load_int8);
+}
+
+void
+int8_vec_inner_product_batch_4_lsx(const int8_t* x, const int8_t* y0, const int8_t* y1, const int8_t* y2,
+                                   const int8_t* y3, size_t d, float& dis0, float& dis1, float& dis2, float& dis3) {
+    converted_batch_4<ConvertedMetric::InnerProduct>(x, y0, y1, y2, y3, d, dis0, dis1, dis2, dis3, load_int8);
+}
+
+void
+int8_vec_L2sqr_batch_4_lsx(const int8_t* x, const int8_t* y0, const int8_t* y1, const int8_t* y2, const int8_t* y3,
+                           size_t d, float& dis0, float& dis1, float& dis2, float& dis3) {
+    converted_batch_4<ConvertedMetric::L2>(x, y0, y1, y2, y3, d, dis0, dis1, dis2, dis3, load_int8);
+}
+
+}  // namespace faiss::cppcontrib::knowhere

--- a/src/simd/distances_lsx.h
+++ b/src/simd/distances_lsx.h
@@ -1,0 +1,128 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "knowhere/operands.h"
+
+namespace faiss::cppcontrib::knowhere {
+
+float
+fvec_inner_product_lsx(const float* x, const float* y, size_t d);
+
+float
+fvec_L2sqr_lsx(const float* x, const float* y, size_t d);
+
+float
+fvec_L1_lsx(const float* x, const float* y, size_t d);
+
+float
+fvec_Linf_lsx(const float* x, const float* y, size_t d);
+
+float
+fvec_norm_L2sqr_lsx(const float* x, size_t d);
+
+void
+fvec_L2sqr_ny_lsx(float* dis, const float* x, const float* y, size_t d, size_t ny);
+
+void
+fvec_inner_products_ny_lsx(float* ip, const float* x, const float* y, size_t d, size_t ny);
+
+void
+fvec_L2sqr_ny_transposed_lsx(float* dis, const float* x, const float* y, const float* y_sqlen, size_t d,
+                             size_t d_offset, size_t ny);
+
+size_t
+fvec_L2sqr_ny_nearest_lsx(float* distances_tmp_buffer, const float* x, const float* y, size_t d, size_t ny);
+
+size_t
+fvec_L2sqr_ny_nearest_y_transposed_lsx(float* distances_tmp_buffer, const float* x, const float* y,
+                                       const float* y_sqlen, size_t d, size_t d_offset, size_t ny);
+
+void
+fvec_madd_lsx(size_t n, const float* a, float bf, const float* b, float* c);
+
+int
+fvec_madd_and_argmin_lsx(size_t n, const float* a, float bf, const float* b, float* c);
+
+void
+fvec_inner_product_batch_4_lsx(const float* x, const float* y0, const float* y1, const float* y2, const float* y3,
+                               size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
+
+void
+fvec_L2sqr_batch_4_lsx(const float* x, const float* y0, const float* y1, const float* y2, const float* y3, size_t d,
+                       float& dis0, float& dis1, float& dis2, float& dis3);
+
+int32_t
+ivec_inner_product_lsx(const int8_t* x, const int8_t* y, size_t d);
+
+int32_t
+ivec_L2sqr_lsx(const int8_t* x, const int8_t* y, size_t d);
+
+float
+fp16_vec_inner_product_lsx(const ::knowhere::fp16* x, const ::knowhere::fp16* y, size_t d);
+
+float
+fp16_vec_L2sqr_lsx(const ::knowhere::fp16* x, const ::knowhere::fp16* y, size_t d);
+
+float
+fp16_vec_norm_L2sqr_lsx(const ::knowhere::fp16* x, size_t d);
+
+void
+fp16_vec_inner_product_batch_4_lsx(const ::knowhere::fp16* x, const ::knowhere::fp16* y0, const ::knowhere::fp16* y1,
+                                   const ::knowhere::fp16* y2, const ::knowhere::fp16* y3, size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3);
+
+void
+fp16_vec_L2sqr_batch_4_lsx(const ::knowhere::fp16* x, const ::knowhere::fp16* y0, const ::knowhere::fp16* y1,
+                           const ::knowhere::fp16* y2, const ::knowhere::fp16* y3, size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3);
+
+float
+bf16_vec_inner_product_lsx(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size_t d);
+
+float
+bf16_vec_L2sqr_lsx(const ::knowhere::bf16* x, const ::knowhere::bf16* y, size_t d);
+
+float
+bf16_vec_norm_L2sqr_lsx(const ::knowhere::bf16* x, size_t d);
+
+void
+bf16_vec_inner_product_batch_4_lsx(const ::knowhere::bf16* x, const ::knowhere::bf16* y0, const ::knowhere::bf16* y1,
+                                   const ::knowhere::bf16* y2, const ::knowhere::bf16* y3, size_t d, float& dis0,
+                                   float& dis1, float& dis2, float& dis3);
+
+void
+bf16_vec_L2sqr_batch_4_lsx(const ::knowhere::bf16* x, const ::knowhere::bf16* y0, const ::knowhere::bf16* y1,
+                           const ::knowhere::bf16* y2, const ::knowhere::bf16* y3, size_t d, float& dis0, float& dis1,
+                           float& dis2, float& dis3);
+
+float
+int8_vec_inner_product_lsx(const int8_t* x, const int8_t* y, size_t d);
+
+float
+int8_vec_L2sqr_lsx(const int8_t* x, const int8_t* y, size_t d);
+
+float
+int8_vec_norm_L2sqr_lsx(const int8_t* x, size_t d);
+
+void
+int8_vec_inner_product_batch_4_lsx(const int8_t* x, const int8_t* y0, const int8_t* y1, const int8_t* y2,
+                                   const int8_t* y3, size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
+
+void
+int8_vec_L2sqr_batch_4_lsx(const int8_t* x, const int8_t* y0, const int8_t* y1, const int8_t* y2, const int8_t* y3,
+                           size_t d, float& dis0, float& dis1, float& dis2, float& dis3);
+
+}  // namespace faiss::cppcontrib::knowhere

--- a/src/simd/hook.cc
+++ b/src/simd/hook.cc
@@ -39,6 +39,17 @@
 #include "distances_powerpc.h"
 #endif
 
+#if defined(__loongarch__)
+#include <sys/auxv.h>
+
+#if __has_include(<asm/hwcap.h>)
+#include <asm/hwcap.h>
+#endif
+
+#include "distances_lasx.h"
+#include "distances_lsx.h"
+#endif
+
 #if defined(__aarch64__) && !defined(__APPLE__)
 #include <asm/hwcap.h>
 #include <sys/auxv.h>
@@ -158,6 +169,19 @@ supports_sve() {
     return (hwcap & HWCAP_SVE) != 0;
 }
 #endif
+#endif
+
+#if defined(__loongarch__)
+bool
+cpu_support_lasx() {
+#ifdef HWCAP_LOONGARCH_LASX
+    constexpr unsigned long kHwcapLasx = HWCAP_LOONGARCH_LASX;
+#else
+    // Keep compatibility with libc headers older than the LoongArch HWCAP definitions.
+    constexpr unsigned long kHwcapLasx = 1ul << 5;
+#endif
+    return (getauxval(AT_HWCAP) & kHwcapLasx) != 0;
+}
 #endif
 
 void
@@ -513,6 +537,65 @@ fvec_hook(std::string& simd_type) {
     support_pq_fast_scan = false;
 #endif
 
+#if defined(__loongarch__)
+    fvec_inner_product = fvec_inner_product_lsx;
+    fvec_L2sqr = fvec_L2sqr_lsx;
+    fvec_L1 = fvec_L1_lsx;
+    fvec_Linf = fvec_Linf_lsx;
+    fvec_norm_L2sqr = fvec_norm_L2sqr_lsx;
+    fvec_L2sqr_ny = fvec_L2sqr_ny_lsx;
+    fvec_inner_products_ny = fvec_inner_products_ny_lsx;
+    fvec_L2sqr_ny_transposed = fvec_L2sqr_ny_transposed_lsx;
+    fvec_L2sqr_ny_nearest = fvec_L2sqr_ny_nearest_lsx;
+    fvec_L2sqr_ny_nearest_y_transposed = fvec_L2sqr_ny_nearest_y_transposed_lsx;
+    fvec_madd = fvec_madd_lsx;
+    fvec_madd_and_argmin = fvec_madd_and_argmin_lsx;
+    fvec_inner_product_batch_4 = fvec_inner_product_batch_4_lsx;
+    fvec_L2sqr_batch_4 = fvec_L2sqr_batch_4_lsx;
+
+    ivec_inner_product = ivec_inner_product_lsx;
+    ivec_L2sqr = ivec_L2sqr_lsx;
+
+    fp16_vec_inner_product = fp16_vec_inner_product_lsx;
+    fp16_vec_L2sqr = fp16_vec_L2sqr_lsx;
+    fp16_vec_norm_L2sqr = fp16_vec_norm_L2sqr_lsx;
+    fp16_vec_inner_product_batch_4 = fp16_vec_inner_product_batch_4_lsx;
+    fp16_vec_L2sqr_batch_4 = fp16_vec_L2sqr_batch_4_lsx;
+
+    bf16_vec_inner_product = bf16_vec_inner_product_lsx;
+    bf16_vec_L2sqr = bf16_vec_L2sqr_lsx;
+    bf16_vec_norm_L2sqr = bf16_vec_norm_L2sqr_lsx;
+    bf16_vec_inner_product_batch_4 = bf16_vec_inner_product_batch_4_lsx;
+    bf16_vec_L2sqr_batch_4 = bf16_vec_L2sqr_batch_4_lsx;
+
+    int8_vec_inner_product = int8_vec_inner_product_lsx;
+    int8_vec_L2sqr = int8_vec_L2sqr_lsx;
+    int8_vec_norm_L2sqr = int8_vec_norm_L2sqr_lsx;
+    int8_vec_inner_product_batch_4 = int8_vec_inner_product_batch_4_lsx;
+    int8_vec_L2sqr_batch_4 = int8_vec_L2sqr_batch_4_lsx;
+
+    if (cpu_support_lasx()) {
+        fvec_inner_product = fvec_inner_product_lasx;
+        fvec_L2sqr = fvec_L2sqr_lasx;
+        fvec_L1 = fvec_L1_lasx;
+        fvec_Linf = fvec_Linf_lasx;
+        fvec_norm_L2sqr = fvec_norm_L2sqr_lasx;
+        fvec_L2sqr_ny = fvec_L2sqr_ny_lasx;
+        fvec_inner_products_ny = fvec_inner_products_ny_lasx;
+        fvec_L2sqr_ny_transposed = fvec_L2sqr_ny_transposed_lasx;
+        fvec_L2sqr_ny_nearest = fvec_L2sqr_ny_nearest_lasx;
+        fvec_L2sqr_ny_nearest_y_transposed = fvec_L2sqr_ny_nearest_y_transposed_lasx;
+        fvec_madd = fvec_madd_lasx;
+        fvec_madd_and_argmin = fvec_madd_and_argmin_lasx;
+        fvec_inner_product_batch_4 = fvec_inner_product_batch_4_lasx;
+        fvec_L2sqr_batch_4 = fvec_L2sqr_batch_4_lasx;
+        simd_type = "LASX";
+    } else {
+        simd_type = "LSX";
+    }
+    support_pq_fast_scan = false;
+#endif
+
 // ToDo MG: include VSX intrinsics via distances_vsx once _ref tests succeed
 #if defined(__powerpc64__)
     fvec_inner_product = fvec_inner_product_ppc;
@@ -572,6 +655,14 @@ fvec_hook(std::string& simd_type) {
     if (faiss::SIMDConfig::is_simd_level_available(faiss::SIMDLevel::NONE)) {
         faiss::SIMDLevel target_level = faiss::SIMDConfig::auto_detect_simd_level();
         faiss::SIMDConfig::set_level(target_level);
+    }
+#endif
+
+#if defined(__loongarch__)
+    // Faiss has no LoongArch SIMDLevel yet. Keep its internal dispatch on the
+    // scalar backend while Knowhere's distance hooks use LSX/LASX above.
+    if (faiss::SIMDConfig::is_simd_level_available(faiss::SIMDLevel::NONE)) {
+        faiss::SIMDConfig::set_level(faiss::SIMDLevel::NONE);
     }
 #endif
 }

--- a/src/simd/hook.h
+++ b/src/simd/hook.h
@@ -155,6 +155,11 @@ bool
 supports_sve();
 #endif
 
+#if defined(__loongarch__)
+bool
+cpu_support_lasx();
+#endif
+
 void
 fvec_hook(std::string&);
 

--- a/tests/ut/test_config.cc
+++ b/tests/ut/test_config.cc
@@ -20,6 +20,7 @@
 #include "knowhere/config.h"
 #include "knowhere/index/index_factory.h"
 #include "knowhere/version.h"
+#include "simd/hook.h"
 #ifdef KNOWHERE_WITH_DISKANN
 #include "index/diskann/diskann_config.h"
 #endif
@@ -222,7 +223,15 @@ TEST_CASE("Test config json parse", "[config]") {
         CHECK(s == knowhere::Status::invalid_value_in_json);
 
         s = knowhere::Config::FormatAndCheck(scann_dvr_config, build_json2);
-        checkBuildConfig(knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, build_json2);
+        if (faiss::cppcontrib::knowhere::support_pq_fast_scan) {
+            checkBuildConfig(knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, build_json2);
+        } else {
+            std::string msg;
+            CHECK(knowhere::IndexStaticFaced<float>::ConfigCheck(knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR,
+                                                                 knowhere::Version::GetCurrentVersion().VersionNumber(),
+                                                                 build_json2,
+                                                                 msg) == knowhere::Status::invalid_instruction_set);
+        }
         CHECK(s == knowhere::Status::success);
     }
 

--- a/tests/ut/test_index_check.cc
+++ b/tests/ut/test_index_check.cc
@@ -17,6 +17,7 @@
 #include "knowhere/comp/index_param.h"
 #include "knowhere/comp/knowhere_check.h"
 #include "knowhere/index/index_factory.h"
+#include "simd/hook.h"
 
 using namespace knowhere;
 
@@ -232,7 +233,9 @@ TEST_CASE("Test index has raw data", "[IndexHasRawData]") {
         CHECK(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_IVFFLAT, ver, {}));
         CHECK(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_IVFFLAT_CC, ver, {}));
         CHECK_FALSE(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_IVFPQ, ver, {}));
-        CHECK(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_SCANN, ver, {}));
+        if (faiss::cppcontrib::knowhere::support_pq_fast_scan) {
+            CHECK(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_SCANN, ver, {}));
+        }
         CHECK_FALSE(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_IVFSQ8, ver, {}));
         CHECK_FALSE(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_IVFSQ_CC, ver, {}));
 
@@ -291,16 +294,18 @@ TEST_CASE("Test index has raw data", "[IndexHasRawData]") {
 
         CHECK_FALSE(knowhere::IndexStaticFaced<fp32>::HasRawData(
             IndexEnum::INDEX_FAISS_IDMAP, min_ver, knowhere::Json::parse(R"({"metric_type": "COSINE"})")));
-        CHECK(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_SCANN, ver, json));
+        if (faiss::cppcontrib::knowhere::support_pq_fast_scan) {
+            CHECK(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_SCANN, ver, json));
 
-        json[indexparam::WITH_RAW_DATA] = false;
-        CHECK_FALSE(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_SCANN, ver, json));
-        json[indexparam::WITH_RAW_DATA] = "true";
-        CHECK(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_SCANN, ver, json));
-        json[indexparam::WITH_RAW_DATA] = "false";
-        CHECK_FALSE(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_SCANN, ver, json));
-        json[indexparam::WITH_RAW_DATA] = 1;
-        CHECK_FALSE(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_SCANN, ver, json));
+            json[indexparam::WITH_RAW_DATA] = false;
+            CHECK_FALSE(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_SCANN, ver, json));
+            json[indexparam::WITH_RAW_DATA] = "true";
+            CHECK(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_SCANN, ver, json));
+            json[indexparam::WITH_RAW_DATA] = "false";
+            CHECK_FALSE(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_SCANN, ver, json));
+            json[indexparam::WITH_RAW_DATA] = 1;
+            CHECK_FALSE(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_FAISS_SCANN, ver, json));
+        }
 
         knowhere::Json faiss_hnsw_cfg = {{"refine", true}, {"refine_type", "bf16"}};
         CHECK_FALSE(knowhere::IndexStaticFaced<fp32>::HasRawData(IndexEnum::INDEX_HNSW_SQ, ver, faiss_hnsw_cfg));

--- a/tests/ut/test_iterator.cc
+++ b/tests/ut/test_iterator.cc
@@ -23,6 +23,7 @@
 #include "knowhere/comp/knowhere_config.h"
 #include "knowhere/index/index_factory.h"
 #include "knowhere/log.h"
+#include "simd/hook.h"
 #include "utils.h"
 
 namespace {
@@ -249,6 +250,9 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_SCANN, scann_gen2),
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ, ivfrabitq_gen),
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ, ivfrabitq_refine_flat_gen)}));
+        if (name == knowhere::IndexEnum::INDEX_FAISS_SCANN && !faiss::cppcontrib::knowhere::support_pq_fast_scan) {
+            SKIP("SCANN requires PQ fast-scan SIMD support");
+        }
         auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version).value();
         auto cfg_json = gen().dump();
         CAPTURE(name, cfg_json);
@@ -338,6 +342,9 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_SCANN, scann_gen2),
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ, ivfrabitq_gen),
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ, ivfrabitq_refine_flat_gen)}));
+        if (name == knowhere::IndexEnum::INDEX_FAISS_SCANN && !faiss::cppcontrib::knowhere::support_pq_fast_scan) {
+            SKIP("SCANN requires PQ fast-scan SIMD support");
+        }
         auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version).value();
         auto cfg_json = gen().dump();
         CAPTURE(name, cfg_json);
@@ -387,6 +394,9 @@ TEST_CASE("Test Iterator Mem Index With Float Vector", "[float metrics]") {
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_SCANN, scann_gen2),
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ, ivfrabitq_gen),
              make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFRABITQ, ivfrabitq_refine_flat_gen)}));
+        if (name == knowhere::IndexEnum::INDEX_FAISS_SCANN && !faiss::cppcontrib::knowhere::support_pq_fast_scan) {
+            SKIP("SCANN requires PQ fast-scan SIMD support");
+        }
         auto idx = knowhere::IndexFactory::Instance().Create<knowhere::fp32>(name, version).value();
         auto cfg_json = gen().dump();
         CAPTURE(name, cfg_json);

--- a/tests/ut/test_knowhere_init.cc
+++ b/tests/ut/test_knowhere_init.cc
@@ -18,6 +18,7 @@
 
 #include "catch2/catch_test_macros.hpp"
 #include "knowhere/comp/knowhere_config.h"
+#include "simd/hook.h"
 
 TEST_CASE("Knowhere global config", "[init]") {
     knowhere::KnowhereConfig::ShowVersion();
@@ -58,7 +59,7 @@ TEST_CASE("Knowhere global config", "[init]") {
 }
 
 TEST_CASE("Knowhere SIMD config", "[simd]") {
-    std::vector<std::string> v = {"AVX512", "AVX2", "SSE4_2", "GENERIC", "NEON", "SVE"};
+    std::vector<std::string> v = {"AVX512", "AVX2", "SSE4_2", "GENERIC", "NEON", "SVE", "LASX", "LSX"};
     std::unordered_set<std::string> s(v.begin(), v.end());
 
     auto res = knowhere::KnowhereConfig::SetSimdType(knowhere::KnowhereConfig::SimdType::AVX512);
@@ -71,6 +72,15 @@ TEST_CASE("Knowhere SIMD config", "[simd]") {
     REQUIRE(s.find(res) != s.end());
     res = knowhere::KnowhereConfig::SetSimdType(knowhere::KnowhereConfig::SimdType::AUTO);
     REQUIRE(s.find(res) != s.end());
+
+#ifdef __loongarch__
+    res = knowhere::KnowhereConfig::SetSimdType(knowhere::KnowhereConfig::SimdType::AUTO);
+    const auto expected = faiss::cppcontrib::knowhere::cpu_support_lasx() ? "LASX" : "LSX";
+    REQUIRE(res == expected);
+
+    res = knowhere::KnowhereConfig::SetSimdType(knowhere::KnowhereConfig::SimdType::GENERIC);
+    REQUIRE(res == expected);
+#endif
 
     // Verify faiss DD level reacts to SetSimdType
     SECTION("faiss DD level synchronization") {
@@ -105,6 +115,13 @@ TEST_CASE("Knowhere SIMD config", "[simd]") {
 #ifdef __aarch64__
         knowhere::KnowhereConfig::SetSimdType(knowhere::KnowhereConfig::SimdType::AUTO);
         REQUIRE(faiss::SIMDConfig::get_level() >= faiss::SIMDLevel::ARM_NEON);
+#endif
+
+#ifdef __loongarch__
+        knowhere::KnowhereConfig::SetSimdType(knowhere::KnowhereConfig::SimdType::AUTO);
+        REQUIRE(faiss::SIMDConfig::get_level() == faiss::SIMDLevel::NONE);
+        knowhere::KnowhereConfig::SetSimdType(knowhere::KnowhereConfig::SimdType::GENERIC);
+        REQUIRE(faiss::SIMDConfig::get_level() == faiss::SIMDLevel::NONE);
 #endif
 
         // Restore AUTO

--- a/tests/ut/test_nullable_id_map.cc
+++ b/tests/ut/test_nullable_id_map.cc
@@ -47,6 +47,7 @@
 #include "knowhere/object.h"
 #include "knowhere/thread_pool.h"
 #include "knowhere/version.h"
+#include "simd/hook.h"
 #include "utils.h"
 
 #if __has_include(<filesystem>)
@@ -1447,6 +1448,11 @@ SupportsModeBuild(const IndexRow& row, Mode mode) {
 bool
 SupportsScenario(const IndexRow& row, const Scenario& scenario) {
     const auto& caps = row.caps;
+    if ((row.index_type == knowhere::IndexEnum::INDEX_FAISS_SCANN ||
+         row.index_type == knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR) &&
+        !faiss::cppcontrib::knowhere::support_pq_fast_scan) {
+        return false;
+    }
     if (row.index_type == knowhere::IndexEnum::INDEX_HNSW && !row.requires_current_version && VersionForRow(row) < 6 &&
         scenario.nullable_ratio != NullableRatio::R0) {
         return false;
@@ -4437,6 +4443,9 @@ TEST_CASE("Nullable DataView cosine uses internal source ids and internal norms"
 }
 
 TEST_CASE("Nullable SCANN_DVR emb-list cosine rerank maps calc-dist ids", "[nullable][scann_dvr][emblist]") {
+    if (!faiss::cppcontrib::knowhere::support_pq_fast_scan) {
+        SKIP("SCANN requires PQ fast-scan SIMD support");
+    }
     IndexRow row{"SCANN_DVR", knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, DataKind::DenseFp32};
     Scenario scenario;
     scenario.mode = Mode::EmbList;
@@ -4503,6 +4512,9 @@ TEST_CASE("Nullable SCANN_DVR emb-list cosine rerank maps calc-dist ids", "[null
 }
 
 TEST_CASE("Nullable SCANN_DVR calc-dist APIs keep public and storage ids separate", "[nullable][scann_dvr][api]") {
+    if (!faiss::cppcontrib::knowhere::support_pq_fast_scan) {
+        SKIP("SCANN requires PQ fast-scan SIMD support");
+    }
     IndexRow row{"SCANN_DVR", knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, DataKind::DenseFp32};
     Scenario scenario;
     scenario.mode = Mode::Vector;
@@ -4886,6 +4898,9 @@ TEST_CASE("Nullable TokenANN GetEmbListByIds uses logical ids", "[nullable][embl
 
 TEST_CASE("Nullable SCANN_DVR TokenANN GetEmbListByIds reports unsupported raw retrieve",
           "[nullable][scann_dvr][emblist][api]") {
+    if (!faiss::cppcontrib::knowhere::support_pq_fast_scan) {
+        SKIP("SCANN requires PQ fast-scan SIMD support");
+    }
     IndexRow row{"SCANN_DVR", knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, DataKind::DenseFp32};
     Scenario scenario;
     scenario.mode = Mode::EmbList;

--- a/tests/ut/test_simd.cc
+++ b/tests/ut/test_simd.cc
@@ -262,14 +262,19 @@ TEST_CASE("Test distance") {
                               knowhere::KnowhereConfig::SimdType::AVX2, knowhere::KnowhereConfig::SimdType::SSE4_2,
                               knowhere::KnowhereConfig::SimdType::GENERIC, knowhere::KnowhereConfig::SimdType::AUTO);
     auto dim = GENERATE(as<size_t>{}, 1, 2, 4, 7, 8, 12, 14, 16, 21, 28, 32, 35, 42, 49, 56, 64, 128, 256);
+    CAPTURE(simd_type, dim);
 
     LOG_KNOWHERE_INFO_ << "simd type: " << simd_type << ", dim: " << dim;
     knowhere::KnowhereConfig::SetSimdType(simd_type);
 
     const size_t nx = 1, ny = 4;
 
-    // fp32's accuracy is 0.000001, consider the accumulation of precision loss
+    // FP32 vector reductions use a different accumulation order from the scalar reference.
+#if defined(__loongarch__)
+    const float tolerance = 0.00001f;
+#else
     const float tolerance = 0.000005f;
+#endif
     const auto x = GenRandomVector<float>(dim, nx, 314);
     const auto y = GenRandomVector<float>(dim, ny, 271);
 
@@ -544,6 +549,44 @@ TEST_CASE("Test distance") {
             REQUIRE_THAT(ip_dis[i], Catch::Matchers::WithinRel(ref_ip[i], tolerance));
             REQUIRE_THAT(l2_dis[i], Catch::Matchers::WithinRel(ref_l2[i], tolerance));
         }
+    }
+
+    SECTION("test transposed ny and nearest distance calculation") {
+        constexpr size_t transposed_ny = 13;
+        constexpr size_t d_offset = transposed_ny + 3;
+        const auto transposed_source = GenRandomVector<float>(dim, transposed_ny, 911);
+        std::vector<float> transposed_y(dim * d_offset, 0.0f);
+        std::vector<float> y_sqlen(transposed_ny);
+        for (size_t i = 0; i < transposed_ny; ++i) {
+            y_sqlen[i] = faiss::cppcontrib::knowhere::fvec_norm_L2sqr_ref(transposed_source.get() + i * dim, dim);
+            for (size_t j = 0; j < dim; ++j) {
+                transposed_y[i + j * d_offset] = transposed_source[i * dim + j];
+            }
+        }
+
+        std::vector<float> ref_distances(transposed_ny);
+        std::vector<float> distances(transposed_ny);
+        faiss::cppcontrib::knowhere::fvec_L2sqr_ny_transposed_ref(ref_distances.data(), x.get(), transposed_y.data(),
+                                                                  y_sqlen.data(), dim, d_offset, transposed_ny);
+        faiss::cppcontrib::knowhere::fvec_L2sqr_ny_transposed(distances.data(), x.get(), transposed_y.data(),
+                                                              y_sqlen.data(), dim, d_offset, transposed_ny);
+        for (size_t i = 0; i < transposed_ny; ++i) {
+            REQUIRE_THAT(distances[i], Catch::Matchers::WithinRel(ref_distances[i], tolerance));
+        }
+
+        std::vector<float> nearest_buffer(transposed_ny);
+        std::vector<float> ref_nearest_buffer(transposed_ny);
+        const size_t nearest = faiss::cppcontrib::knowhere::fvec_L2sqr_ny_nearest(
+            nearest_buffer.data(), x.get(), transposed_source.get(), dim, transposed_ny);
+        const size_t ref_nearest = faiss::cppcontrib::knowhere::fvec_L2sqr_ny_nearest_ref(
+            ref_nearest_buffer.data(), x.get(), transposed_source.get(), dim, transposed_ny);
+        REQUIRE(nearest == ref_nearest);
+
+        const size_t transposed_nearest = faiss::cppcontrib::knowhere::fvec_L2sqr_ny_nearest_y_transposed(
+            nearest_buffer.data(), x.get(), transposed_y.data(), y_sqlen.data(), dim, d_offset, transposed_ny);
+        const size_t ref_transposed_nearest = faiss::cppcontrib::knowhere::fvec_L2sqr_ny_nearest_y_transposed_ref(
+            ref_nearest_buffer.data(), x.get(), transposed_y.data(), y_sqlen.data(), dim, d_offset, transposed_ny);
+        REQUIRE(transposed_nearest == ref_transposed_nearest);
     }
 
     SECTION("test madd distance calculation") {

--- a/tests/ut/test_sparse_simd.cc
+++ b/tests/ut/test_sparse_simd.cc
@@ -17,10 +17,87 @@
 #include "catch2/generators/catch_generators.hpp"
 #include "catch2/matchers/catch_matchers_floating_point.hpp"
 #include "index/sparse/codec/simd_bitpacking_kernel.h"
+#include "index/sparse/sindi_simd.h"
 #include "simd/instruction_set.h"
 #include "simd/sparse_simd.h"
 
 using namespace knowhere::sparse;
+
+TEST_CASE("Test SINDI LSX kernels", "[sparse][simd][sindi][lsx]") {
+#if defined(__loongarch__)
+    const auto ip_kernels = knowhere::sparse::inverted::sindi::get_ip_kernels();
+    const auto bm25_kernels = knowhere::sparse::inverted::sindi::get_bm25_kernels();
+
+    constexpr size_t output_size = 257;
+    constexpr float tolerance = 0.0001f;
+    std::mt19937 rng(20260826);
+    std::uniform_real_distribution<float> value_distribution(0.0f, 10.0f);
+    for (int32_t count : {0, 1, 3, 4, 7, 8, 15, 16, 31, 65}) {
+        std::vector<knowhere::fp16> fp16_values(count);
+        std::vector<uint16_t> tf_values(count);
+        std::vector<uint16_t> ids(count);
+        std::vector<float> row_sums(output_size);
+        std::vector<float> reference(output_size);
+        for (size_t i = 0; i < output_size; ++i) {
+            row_sums[i] = value_distribution(rng) + 1.0f;
+            reference[i] = value_distribution(rng);
+        }
+        for (int32_t i = 0; i < count; ++i) {
+            fp16_values[i] = value_distribution(rng);
+            tf_values[i] = static_cast<uint16_t>(rng() % 128 + 1);
+            ids[i] = static_cast<uint16_t>((static_cast<uint32_t>(i) * 17 + 3) % output_size);
+        }
+
+        auto actual = reference;
+        const float reference_ip_max = knowhere::sparse::inverted::sindi::ip_accumulate_scalar_fp16(
+            1.25f, fp16_values.data(), ids.data(), count, reference.data());
+        const float actual_ip_max = ip_kernels.accumulate(1.25f, fp16_values.data(), ids.data(), count, actual.data());
+        REQUIRE_THAT(actual_ip_max, Catch::Matchers::WithinRel(reference_ip_max, tolerance));
+        for (size_t i = 0; i < output_size; ++i) {
+            REQUIRE_THAT(actual[i], Catch::Matchers::WithinRel(reference[i], tolerance));
+        }
+
+        reference.assign(output_size, 0.0f);
+        actual = reference;
+        const float reference_bm25_max = knowhere::sparse::inverted::sindi::bm25_accumulate_scalar_u16(
+            0.75f, tf_values.data(), ids.data(), count, reference.data(), 1.2f, 0.75f, 8.0f, row_sums.data());
+        const float actual_bm25_max = bm25_kernels.accumulate(0.75f, tf_values.data(), ids.data(), count, actual.data(),
+                                                              1.2f, 0.75f, 8.0f, row_sums.data());
+        REQUIRE_THAT(actual_bm25_max, Catch::Matchers::WithinRel(reference_bm25_max, tolerance));
+        for (size_t i = 0; i < output_size; ++i) {
+            REQUIRE_THAT(actual[i], Catch::Matchers::WithinRel(reference[i], tolerance));
+        }
+    }
+
+    constexpr size_t docid_start = 5;
+    constexpr size_t topk = 7;
+    for (size_t count : {size_t{0}, size_t{1}, size_t{3}, size_t{4}, size_t{5}, size_t{16}, size_t{17}, size_t{33}}) {
+        std::vector<float> scores(count);
+        for (size_t i = 0; i < count; ++i) {
+            scores[i] = value_distribution(rng);
+        }
+        std::vector<uint8_t> bitset_data((docid_start + count + 7) / 8);
+        if (count > 2) {
+            const size_t filtered = docid_start + 2;
+            bitset_data[filtered >> 3] |= static_cast<uint8_t>(1U << (filtered & 7));
+        }
+        const knowhere::BitsetView bitset(bitset_data.data(), docid_start + count);
+        knowhere::ResultMinHeap<float, uint32_t> reference_heap(topk);
+        knowhere::ResultMinHeap<float, uint32_t> actual_heap(topk);
+        float reference_threshold = 0.0f;
+        float actual_threshold = 0.0f;
+        knowhere::sparse::inverted::sindi::batch_insert_scalar(scores.data(), docid_start, count, reference_heap,
+                                                               reference_threshold, bitset);
+        ip_kernels.batch_insert(scores.data(), docid_start, count, actual_heap, actual_threshold, bitset);
+        reference_heap.Finalize();
+        actual_heap.Finalize();
+        REQUIRE(actual_heap.Results() == reference_heap.Results());
+        REQUIRE(actual_threshold == reference_threshold);
+    }
+#else
+    SKIP("Test only runs on LoongArch platforms");
+#endif
+}
 
 // Helper function to generate random sparse posting list data for testing
 struct PostingListTestData {


### PR DESCRIPTION
This PR adds basic support for LoongArch64. The minimum target CPU is a LoongArch64 CPU that supports LSX.

Native build and testing have passed.

- Debian forky

- GCC/G++ 14

- Conan 2.28.1

- CPU with LSX and LASX

### Cross-build validation

A separate GitHub Actions workflow successfully completed:

- GCC 14 LoongArch64 cross-build

- Sparse codec source smoke tests

- Full Knowhere build and selected unit tests

Workflow run:

https://github.com/Chris-wh233/knowhere/actions/runs/34106005065

Corresponding commit:

https://github.com/Chris-wh233/knowhere/commit/cbaeffed521d2cef34252fb4f2abba20316b1e05