### PR TITLE
perf: optimize SINDI IP and BM25 SVE kernels

### DIFF
--- a/src/index/sparse/sindi_simd_sve.cc
+++ b/src/index/sparse/sindi_simd_sve.cc
@@ -7,7 +7,8 @@
 namespace knowhere::sparse::inverted::sindi {
 
 float
-ip_accumulate_sve_fp16(float qval, const knowhere::fp16* vals, const uint16_t* ids, int32_t num, float* out) {
+ip_accumulate_sve_fp16(float qval, const knowhere::fp16* __restrict vals, const uint16_t* __restrict ids, int32_t num,
+                       float* __restrict out) {
     const svfloat32_t vq32 = svdup_f32(qval);
     const uint32_t vl32 = svcntw();
     const svbool_t pg32 = svptrue_b32();
@@ -25,19 +26,21 @@ ip_accumulate_sve_fp16(float qval, const knowhere::fp16* vals, const uint16_t* i
         svfloat32_t vf_odd = svcvt_f32_f16_x(pg32, vh_shift);
 
         svuint16_t id16 = svld1_u16(pg16, ids + i);
-        svuint16_t id_even16 = svuzp1_u16(id16, id16);
-        svuint16_t id_odd16 = svuzp2_u16(id16, id16);
-        svuint32_t vidx_even = svunpklo_u32(id_even16);
-        svuint32_t vidx_odd = svunpklo_u32(id_odd16);
+        // Each 32-bit lane contains two adjacent uint16 ids. Splitting the
+        // low/high halves avoids the unzip + unpack sequence for both lanes.
+        svuint32_t id_pairs = svreinterpret_u32_u16(id16);
+        svuint32_t vidx_even = svand_n_u32_x(pg32, id_pairs, 0xffffu);
+        svuint32_t vidx_odd = svlsr_n_u32_x(pg32, id_pairs, 16);
 
+        // Issue both independent gathers before their arithmetic to expose
+        // enough memory-level parallelism for the scatter-heavy loop.
         svfloat32_t vold_even = svld1_gather_u32index_f32(pg32, out, vidx_even);
-        svfloat32_t vsum_even = svmad_f32_x(pg32, vf_even, vq32, vold_even);
-        svst1_scatter_u32index_f32(pg32, out, vidx_even, vsum_even);
-        v_max = svmax_f32_x(pg32, v_max, vsum_even);
-
         svfloat32_t vold_odd = svld1_gather_u32index_f32(pg32, out, vidx_odd);
+        svfloat32_t vsum_even = svmad_f32_x(pg32, vf_even, vq32, vold_even);
         svfloat32_t vsum_odd = svmad_f32_x(pg32, vf_odd, vq32, vold_odd);
+        svst1_scatter_u32index_f32(pg32, out, vidx_even, vsum_even);
         svst1_scatter_u32index_f32(pg32, out, vidx_odd, vsum_odd);
+        v_max = svmax_f32_x(pg32, v_max, vsum_even);
         v_max = svmax_f32_x(pg32, v_max, vsum_odd);
     }
 
@@ -59,10 +62,9 @@ ip_accumulate_sve_fp16(float qval, const knowhere::fp16* vals, const uint16_t* i
         svfloat32_t vf_odd = svcvt_f32_f16_x(pg32_odd, vh_shift);
 
         svuint16_t id16 = svld1_u16(pg16_tail, ids + i);
-        svuint16_t id_even16 = svuzp1_u16(id16, id16);
-        svuint16_t id_odd16 = svuzp2_u16(id16, id16);
-        svuint32_t vidx_even = svunpklo_u32(id_even16);
-        svuint32_t vidx_odd = svunpklo_u32(id_odd16);
+        svuint32_t id_pairs = svreinterpret_u32_u16(id16);
+        svuint32_t vidx_even = svand_n_u32_x(pg32_even, id_pairs, 0xffffu);
+        svuint32_t vidx_odd = svlsr_n_u32_x(pg32_odd, id_pairs, 16);
 
         if (n_even) {
             svfloat32_t vold_even = svld1_gather_u32index_f32(pg32_even, out, vidx_even);
@@ -95,101 +97,61 @@ bm25_accumulate_sve_u16(float qval, const uint16_t* vals, const uint16_t* ids, i
 
     const uint32_t vl32 = svcntw();
     const svbool_t pg32 = svptrue_b32();
-    const svbool_t pg16 = svptrue_b16();
-
     int32_t i = 0;
     const int32_t step = static_cast<int32_t>(vl32 * 2);
     for (; i + step <= num; i += step) {
-        svuint16_t tf16 = svld1_u16(pg16, vals + i);
+        // SVE can load halfwords directly into 32-bit lanes. This avoids the
+        // unzip + unpack sequence previously needed to widen tf and local ids.
+        svuint32_t tf0_u32 = svld1uh_u32(pg32, vals + i);
+        svuint32_t tf1_u32 = svld1uh_u32(pg32, vals + i + vl32);
+        svfloat32_t tf0 = svcvt_f32_u32_x(pg32, tf0_u32);
+        svfloat32_t tf1 = svcvt_f32_u32_x(pg32, tf1_u32);
 
-        svuint16_t tf_even16 = svuzp1_u16(tf16, tf16);
-        svuint16_t tf_odd16 = svuzp2_u16(tf16, tf16);
-        svuint32_t tf_even_u32 = svunpklo_u32(tf_even16);
-        svuint32_t tf_odd_u32 = svunpklo_u32(tf_odd16);
+        svuint32_t vidx0 = svld1uh_u32(pg32, ids + i);
+        svuint32_t vidx1 = svld1uh_u32(pg32, ids + i + vl32);
 
-        svfloat32_t tf_even = svcvt_f32_u32_x(pg32, tf_even_u32);
-        svfloat32_t tf_odd = svcvt_f32_u32_x(pg32, tf_odd_u32);
+        svfloat32_t dl0 = svld1_gather_u32index_f32(pg32, row_sums, vidx0);
+        svfloat32_t dl1 = svld1_gather_u32index_f32(pg32, row_sums, vidx1);
 
-        svuint16_t id16 = svld1_u16(pg16, ids + i);
-        svuint16_t id_even16 = svuzp1_u16(id16, id16);
-        svuint16_t id_odd16 = svuzp2_u16(id16, id16);
-        svuint32_t vidx_even = svunpklo_u32(id_even16);
-        svuint32_t vidx_odd = svunpklo_u32(id_odd16);
+        svfloat32_t numerator0 = svmul_f32_x(pg32, tf0, vqp1);
+        svfloat32_t denominator0 = svmad_f32_x(pg32, dl0, vp3, vp2);
+        denominator0 = svadd_f32_x(pg32, tf0, denominator0);
+        svfloat32_t bm25_0 = svdiv_f32_x(pg32, numerator0, denominator0);
 
-        svfloat32_t dl_even = svld1_gather_u32index_f32(pg32, row_sums, vidx_even);
-        svfloat32_t dl_odd = svld1_gather_u32index_f32(pg32, row_sums, vidx_odd);
+        svfloat32_t numerator1 = svmul_f32_x(pg32, tf1, vqp1);
+        svfloat32_t denominator1 = svmad_f32_x(pg32, dl1, vp3, vp2);
+        denominator1 = svadd_f32_x(pg32, tf1, denominator1);
+        svfloat32_t bm25_1 = svdiv_f32_x(pg32, numerator1, denominator1);
 
-        svfloat32_t num_even = svmul_f32_x(pg32, tf_even, vqp1);
-        svfloat32_t denom_even = svmad_f32_x(pg32, dl_even, vp3, vp2);
-        denom_even = svadd_f32_x(pg32, tf_even, denom_even);
-        svfloat32_t bm25_even = svdiv_f32_x(pg32, num_even, denom_even);
+        svfloat32_t old0 = svld1_gather_u32index_f32(pg32, out, vidx0);
+        svfloat32_t sum0 = svadd_f32_x(pg32, old0, bm25_0);
+        svst1_scatter_u32index_f32(pg32, out, vidx0, sum0);
+        v_max = svmax_f32_x(pg32, v_max, sum0);
 
-        svfloat32_t num_odd = svmul_f32_x(pg32, tf_odd, vqp1);
-        svfloat32_t denom_odd = svmad_f32_x(pg32, dl_odd, vp3, vp2);
-        denom_odd = svadd_f32_x(pg32, tf_odd, denom_odd);
-        svfloat32_t bm25_odd = svdiv_f32_x(pg32, num_odd, denom_odd);
-
-        svfloat32_t vold_even = svld1_gather_u32index_f32(pg32, out, vidx_even);
-        svfloat32_t vsum_even = svadd_f32_x(pg32, vold_even, bm25_even);
-        svst1_scatter_u32index_f32(pg32, out, vidx_even, vsum_even);
-        v_max = svmax_f32_x(pg32, v_max, vsum_even);
-
-        svfloat32_t vold_odd = svld1_gather_u32index_f32(pg32, out, vidx_odd);
-        svfloat32_t vsum_odd = svadd_f32_x(pg32, vold_odd, bm25_odd);
-        svst1_scatter_u32index_f32(pg32, out, vidx_odd, vsum_odd);
-        v_max = svmax_f32_x(pg32, v_max, vsum_odd);
+        svfloat32_t old1 = svld1_gather_u32index_f32(pg32, out, vidx1);
+        svfloat32_t sum1 = svadd_f32_x(pg32, old1, bm25_1);
+        svst1_scatter_u32index_f32(pg32, out, vidx1, sum1);
+        v_max = svmax_f32_x(pg32, v_max, sum1);
     }
 
-    if (i < num) {
-        int32_t remaining = num - i;
-        svbool_t pg16_tail = svwhilelt_b16(static_cast<uint32_t>(0), static_cast<uint32_t>(remaining));
+    for (; i < num; i += static_cast<int32_t>(vl32)) {
+        const uint32_t remaining = static_cast<uint32_t>(num - i);
+        svbool_t pg = svwhilelt_b32(static_cast<uint32_t>(0), remaining);
 
-        svuint16_t tf16 = svld1_u16(pg16_tail, vals + i);
-        svuint16_t tf_even16 = svuzp1_u16(tf16, tf16);
-        svuint16_t tf_odd16 = svuzp2_u16(tf16, tf16);
+        svuint32_t tf_u32 = svld1uh_u32(pg, vals + i);
+        svfloat32_t tf = svcvt_f32_u32_x(pg, tf_u32);
+        svuint32_t vidx = svld1uh_u32(pg, ids + i);
 
-        uint32_t n_even = static_cast<uint32_t>((remaining + 1) >> 1);
-        uint32_t n_odd = static_cast<uint32_t>(remaining >> 1);
+        svfloat32_t dl = svld1_gather_u32index_f32(pg, row_sums, vidx);
+        svfloat32_t numerator = svmul_f32_x(pg, tf, vqp1);
+        svfloat32_t denominator = svmad_f32_x(pg, dl, vp3, vp2);
+        denominator = svadd_f32_x(pg, tf, denominator);
+        svfloat32_t bm25 = svdiv_f32_x(pg, numerator, denominator);
 
-        svbool_t pg32_even = svwhilelt_b32(static_cast<uint32_t>(0), n_even);
-        svbool_t pg32_odd = svwhilelt_b32(static_cast<uint32_t>(0), n_odd);
-
-        svuint32_t tf_even_u32 = svunpklo_u32(tf_even16);
-        svuint32_t tf_odd_u32 = svunpklo_u32(tf_odd16);
-        svfloat32_t tf_even = svcvt_f32_u32_x(pg32_even, tf_even_u32);
-        svfloat32_t tf_odd = svcvt_f32_u32_x(pg32_odd, tf_odd_u32);
-
-        svuint16_t id16 = svld1_u16(pg16_tail, ids + i);
-        svuint16_t id_even16 = svuzp1_u16(id16, id16);
-        svuint16_t id_odd16 = svuzp2_u16(id16, id16);
-        svuint32_t vidx_even = svunpklo_u32(id_even16);
-        svuint32_t vidx_odd = svunpklo_u32(id_odd16);
-
-        if (n_even) {
-            svfloat32_t dl_even = svld1_gather_u32index_f32(pg32_even, row_sums, vidx_even);
-            svfloat32_t num_even = svmul_f32_x(pg32_even, tf_even, vqp1);
-            svfloat32_t denom_even = svmad_f32_x(pg32_even, dl_even, vp3, vp2);
-            denom_even = svadd_f32_x(pg32_even, tf_even, denom_even);
-            svfloat32_t bm25_even = svdiv_f32_x(pg32_even, num_even, denom_even);
-
-            svfloat32_t vold_even = svld1_gather_u32index_f32(pg32_even, out, vidx_even);
-            svfloat32_t vsum_even = svadd_f32_x(pg32_even, vold_even, bm25_even);
-            svst1_scatter_u32index_f32(pg32_even, out, vidx_even, vsum_even);
-            v_max = svmax_f32_m(pg32_even, v_max, vsum_even);
-        }
-
-        if (n_odd) {
-            svfloat32_t dl_odd = svld1_gather_u32index_f32(pg32_odd, row_sums, vidx_odd);
-            svfloat32_t num_odd = svmul_f32_x(pg32_odd, tf_odd, vqp1);
-            svfloat32_t denom_odd = svmad_f32_x(pg32_odd, dl_odd, vp3, vp2);
-            denom_odd = svadd_f32_x(pg32_odd, tf_odd, denom_odd);
-            svfloat32_t bm25_odd = svdiv_f32_x(pg32_odd, num_odd, denom_odd);
-
-            svfloat32_t vold_odd = svld1_gather_u32index_f32(pg32_odd, out, vidx_odd);
-            svfloat32_t vsum_odd = svadd_f32_x(pg32_odd, vold_odd, bm25_odd);
-            svst1_scatter_u32index_f32(pg32_odd, out, vidx_odd, vsum_odd);
-            v_max = svmax_f32_m(pg32_odd, v_max, vsum_odd);
-        }
+        svfloat32_t old = svld1_gather_u32index_f32(pg, out, vidx);
+        svfloat32_t sum = svadd_f32_x(pg, old, bm25);
+        svst1_scatter_u32index_f32(pg, out, vidx, sum);
+        v_max = svmax_f32_m(pg, v_max, sum);
     }
     return svmaxv_f32(svptrue_b32(), v_max);
 }


### PR DESCRIPTION
## What this PR does

issue: #1730

- Optimize the SINDI IP SVE kernel by splitting packed `uint16_t` local IDs with `and`/`lsr`, issuing independent gathers together, and marking independent pointer arguments `restrict`.
- Optimize the SINDI BM25 SVE kernel with direct zero-extending halfword loads into 32-bit lanes and a simpler predicated contiguous tail.
- Keep the implementation compatible with base SVE (`armv8.2-a+sve`); this PR does not require SVE2.

## Benchmark

Host: 8-core Arm Neoverse V2, 128-bit SVE; 256 deterministic queries, 8 search threads, one warm-up and five timed rounds. QPS values are geometric means across two benchmark processes.

`sparse_embedding.parquet` (2,751,968 rows / 616,335,749 nonzeros):

| Metric | Query NNZ | Top10 gain | Top100 gain |
|---|---:|---:|---:|
| IP | 10 | +4.10% | +7.03% |
| IP | 20 | +5.94% | +5.52% |
| IP | 50 | +4.94% | +4.80% |
| BM25 | 10 | +10.33% | +10.29% |
| BM25 | 20 | +9.93% | +11.02% |
| BM25 | 50 | +8.80% | +10.07% |

The six-case geometric-mean gain is **+5.38% for IP** and **+10.07% for BM25**. Across MS MARCO, NQ, HotpotQA, and FEVER, BM25 gains **+1.71%** on original queries and **+4.48%** on synthetic NNZ 10/20/50 queries.

## Verification

- Built `knowhere` successfully with the release configuration.
- Compiled the changed translation unit with `-march=armv8.2-a+sve`; disassembly contains no SVE2 `fcvtlt` instruction.
- IP scalar/SVE output arrays and maximum scores are exactly identical across posting-list boundary sizes through 65,535 entries.
- BM25 old/new SVE output arrays and maximum scores are exactly identical; scalar/SVE error is at most `1e-5`.
- End-to-end result ID/distance hashes are unchanged in the before/after benchmark runs.
