### PR TITLE
enhance: Do not store raw vectors in SVS Vamana

### DIFF
--- a/src/index/svs/svs_vamana.cc
+++ b/src/index/svs/svs_vamana.cc
@@ -391,7 +391,9 @@ class SvsVamanaIndexNode : public IndexNode {
     virtual std::unique_ptr<faiss::IndexSVSVamana>
     CreateFaissIndex(int64_t dim, int64_t degree, faiss::MetricType metric, faiss::SVSStorageKind storage,
                      const SvsVamanaConfig& cfg) {
-        return std::make_unique<faiss::IndexSVSVamana>(dim, degree, metric, storage, cfg.svs_is_static.value());
+        // Knowhere does not use SVS Vamana stored vectors
+        return std::make_unique<faiss::IndexSVSVamana>(dim, degree, metric, storage, cfg.svs_is_static.value(),
+                                                       /*store_vectors=*/false);
     }
 
     std::unique_ptr<faiss::IndexSVSVamana> index_;
@@ -432,7 +434,8 @@ class SvsVamanaLvqIndexNode : public SvsVamanaIndexNode<DataType> {
     std::unique_ptr<faiss::IndexSVSVamana>
     CreateFaissIndex(int64_t dim, int64_t degree, faiss::MetricType metric, faiss::SVSStorageKind storage,
                      const SvsVamanaConfig& cfg) override {
-        return std::make_unique<faiss::IndexSVSVamanaLVQ>(dim, degree, metric, storage, cfg.svs_is_static.value());
+        return std::make_unique<faiss::IndexSVSVamanaLVQ>(dim, degree, metric, storage, cfg.svs_is_static.value(),
+                                                          /*store_vectors=*/false);
     }
 };
 
@@ -471,7 +474,7 @@ class SvsVamanaLeanVecIndexNode : public SvsVamanaIndexNode<DataType> {
             size_t leanvec_dim = lv_cfg.svs_leanvec_dim.value();
             auto idx = std::make_unique<faiss::IndexSVSVamanaLeanVec>(
                 dataset->GetDim(), lv_cfg.svs_graph_max_degree.value(), metric.value(), leanvec_dim, storage.value(),
-                lv_cfg.svs_is_static.value());
+                lv_cfg.svs_is_static.value(), /*store_vectors=*/false);
             idx->construction_window_size = lv_cfg.svs_construction_window_size.value();
             if (lv_cfg.svs_alpha.has_value()) {
                 idx->alpha = lv_cfg.svs_alpha.value();


### PR DESCRIPTION
Knowhere does not use the stored vectors in SVS Vamana. Those vectors are currently just overhead.